### PR TITLE
allowing singletonize Symbols

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1982,7 +1982,7 @@ class Symbol(Atom):
             self = super(Symbol, cls).__new__(cls)
             self.name = name
             self.sympy_dummy = sympy_dummy
-            # cls.defined_symbols[name] = self
+            cls.defined_symbols[name] = self
         return self
 
     def __str__(self) -> str:


### PR DESCRIPTION
@rocky, maybe you can help me with this. For some reason, all the test pass if I enable the line that singletonizes the `Symbol` class, except for one test in  `combinatorica`. As you know better that code, could you help me investigating why this happens?

If this starts to work, I guess that we can get an improvement in performance if we use the `id()` of the symbols instead of the string name the symbol in the pattern matching routines.

