### PR TITLE
Use Builtin class summary_text in `?`

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -975,7 +975,7 @@ class Definition(Builtin):
         return self.format_definition(symbol, evaluation, grid=False)
 
 
-def _get_usage_string(symbol, evaluation, htmlout=False):
+def _get_usage_string(symbol, evaluation, is_long_form: bool, htmlout=False):
     """
     Returns a python string with the documentation associated to a given symbol.
     """
@@ -1000,6 +1000,8 @@ def _get_usage_string(symbol, evaluation, htmlout=False):
         bio = builtins.get(definition.name)
 
     if bio is not None:
+        if not is_long_form and hasattr(bio.builtin.__class__, "summary_text"):
+            return bio.builtin.__class__.summary_text
         from mathics.doc.common_doc import XMLDoc
 
         docstr = bio.builtin.__class__.__doc__
@@ -1063,11 +1065,12 @@ class Information(PrefixOperator):
             evaluation.message("Information", "notfound", symbol)
             return ret
         # Print the "usage" message if available.
-        usagetext = _get_usage_string(symbol, evaluation)
+        is_long_form = self.get_option(options, "LongForm", evaluation).to_python()
+        usagetext = _get_usage_string(symbol, evaluation, is_long_form)
         if usagetext is not None:
             lines.append(usagetext)
 
-        if self.get_option(options, "LongForm", evaluation).to_python():
+        if is_long_form:
             self.show_definitions(symbol, evaluation, lines)
 
         if grid:

--- a/test/test_assignment.py
+++ b/test/test_assignment.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from .helper import check_evaluation
-import pytest
 
 from mathics_scanner.errors import IncompleteSyntaxError
 

--- a/test/test_help.py
+++ b/test/test_help.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from .helper import check_evaluation, evaluate
+from mathics.builtin.base import Builtin
+from mathics.core.expression import Integer0
+
+
+class Builtin1(Builtin):
+    summary_text = "short description"
+
+
+class Builtin2(Builtin):
+    "long description"
+
+
+def test_short_description():
+    check_evaluation("?Builtin1", "Null", "short description")
+
+
+def test_long_description():
+    check_evaluation("??Builtin2", "Null", "long description")


### PR DESCRIPTION
Recenty we have been filling out `summary_text` for Built-in Functions.

This text currently appears in Django when it is listed in a group. See for example "Operations on Strings".

This PR expands that use so that this short text also appears when `?xxx` or `Information[xxx, LongForm->False]` is requested.