### PR TITLE
Use `apply_N` more intensively

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -33,7 +33,6 @@ from mathics.core.expression import (
     SymbolComplexInfinity,
     SymbolDirectedInfinity,
     SymbolInfinity,
-    SymbolN,
     SymbolNull,
     SymbolSequence,
     from_mpmath,
@@ -41,6 +40,8 @@ from mathics.core.expression import (
 from mathics.core.numbers import min_prec, dps
 
 from mathics.core.convert import from_sympy
+
+from mathics.builtin.numeric import apply_N
 
 
 class CubeRoot(Builtin):
@@ -553,7 +554,7 @@ class Power(BinaryOperator, _MPMathFunction):
             if isinstance(y, Number):
                 y_err = y
             else:
-                y_err = Expression(SymbolN, y).evaluate(evaluation)
+                y_err = apply_N(y, evaluation)
             if isinstance(y_err, Number):
                 py_y = y_err.round_to_float(permit_complex=True).real
                 if py_y > 0:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -33,7 +33,6 @@ from mathics.core.expression import (
     Real,
     String,
     Symbol,
-    SymbolN,
     SymbolTrue,
     SymbolFalse,
     SymbolUndefined,
@@ -632,7 +631,7 @@ class PossibleZeroQ(SympyFunction):
             result = _iszero(exprexp)
         if result is None:
             # Can't get exact answer, so try approximate equal
-            numeric_val = Expression(SymbolN, expr).evaluate(evaluation)
+            numeric_val = apply_N(expr, evaluation)
             if numeric_val and hasattr(numeric_val, "is_approx_zero"):
                 result = numeric_val.is_approx_zero
             elif (

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -13,6 +13,7 @@ from mathics.builtin.base import (
     SympyFunction,
 )
 
+from mathics.builtin.numeric import apply_N
 from mathics.builtin.numbers.constants import mp_convert_constant
 
 from mathics.core.expression import (
@@ -210,8 +211,7 @@ class _InequalityOperator(BinaryOperator):
             for item in items:
                 if not isinstance(item, Number):
                     # TODO: use $MaxExtraPrecision insterad of hard-coded 50
-                    n_expr = Expression("N", item, Integer(50))
-                    item = n_expr.evaluate(evaluation)
+                    item = apply_N(item, evaluation, Integer(50))
                 n_items.append(item)
             items = n_items
         else:

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -13,6 +13,7 @@ from mathics.version import __version__  # noqa used in loading to check consist
 
 from mathics.builtin.base import Builtin
 from mathics.builtin.box.compilation import CompiledCodeBox
+from mathics.builtin.numeric import apply_N
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import (
     Atom,
@@ -148,7 +149,7 @@ class Compile(Builtin):
                     inner_evaluation = Evaluation(definitions=evaluation.definitions)
                     vars = dict(list(zip(names, x[: len(names)])))
                     pyexpr = expr.replace_vars(vars)
-                    pyexpr = Expression("N", pyexpr).evaluate(inner_evaluation)
+                    pyexpr = apply_N(pyexpr, inner_evaluation)
                     res = pyexpr.to_python(n_evaluation=inner_evaluation)
                     return res
 

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -18,6 +18,7 @@ from mathics.builtin.graphics import (
     Style,
 )
 from mathics.builtin.lists import List
+from mathics.builtin.numeric import apply_N
 
 
 def coords3D(value):
@@ -294,7 +295,7 @@ class Cylinder(Builtin):
             # The number of points is odd, so abort.
             evaluation.error("Cylinder", "oddn", positions)
         if not isinstance(radius, (Integer, Rational, Real)):
-            nradius = Expression(SymbolN, radius).evaluate(evaluation)
+            nradius = apply_N(radius, evaluation)
             if not isinstance(nradius, (Integer, Rational, Real)):
                 evaluation.error("Cylinder", "nrr", radius)
 

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -29,7 +29,7 @@ from mathics.core.expression import (
 from mathics.builtin.base import Builtin
 from mathics.builtin.graphics import Graphics
 from mathics.builtin.drawing.graphics3d import Graphics3D
-from mathics.builtin.numeric import chop
+from mathics.builtin.numeric import chop, apply_N
 from mathics.builtin.options import options_to_rules
 from mathics.builtin.scoping import dynamic_scoping
 
@@ -907,7 +907,7 @@ class PieChart(_Chart):
         sector_origin = self.get_option(options, "SectorOrigin", evaluation)
         if not sector_origin.has_form("List", 2):
             return
-        sector_origin = Expression(SymbolN, sector_origin).evaluate(evaluation)
+        sector_origin = apply_N(sector_origin, evaluation)
 
         orientation = sector_origin.leaves[0]
         if (

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -15,6 +15,8 @@ from mathics.builtin.base import (
     BoxConstructError,
 )
 
+from mathics.builtin.numeric import apply_N
+
 from mathics.builtin.drawing.graphics_internals import (
     _GraphicsElement,
     GLOBALS,
@@ -40,7 +42,6 @@ from mathics.core.expression import (
     Real,
     Symbol,
     SymbolList,
-    SymbolN,
     SymbolMakeBoxes,
     system_symbols,
     system_symbols_dict,
@@ -224,9 +225,7 @@ class Show(Builtin):
 
         for option in options:
             if option not in ("System`ImageSize",):
-                options[option] = Expression(SymbolN, options[option]).evaluate(
-                    evaluation
-                )
+                options[option] = apply_N(options[option], evaluation)
 
         # The below could probably be done with graphics.filter..
         new_leaves = []
@@ -327,13 +326,11 @@ class Graphics(Builtin):
                                 inset._leaves[0], evaluation, opts
                             )
                         n_leaves = [inset] + [
-                            Expression(SymbolN, leaf).evaluate(evaluation)
-                            for leaf in content.leaves[1:]
+                            apply_N(leaf, evaluation) for leaf in content.leaves[1:]
                         ]
                     else:
                         n_leaves = (
-                            Expression(SymbolN, leaf).evaluate(evaluation)
-                            for leaf in content.leaves
+                            apply_N(leaf, evaluation) for leaf in content.leaves
                         )
                 else:
                     n_leaves = content.leaves
@@ -342,9 +339,7 @@ class Graphics(Builtin):
 
         for option in options:
             if option not in ("System`ImageSize",):
-                options[option] = Expression(SymbolN, options[option]).evaluate(
-                    evaluation
-                )
+                options[option] = apply_N(options[option], evaluation)
 
         from mathics.builtin.box.graphics import GraphicsBox
         from mathics.builtin.box.graphics3d import Graphics3DBox

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -41,6 +41,7 @@ from mathics.builtin.base import (
 from mathics.builtin.numbers.algebra import cancel
 from mathics.builtin.options import options_to_rules
 from mathics.builtin.scoping import dynamic_scoping
+from mathics.builtin.numeric import apply_N
 
 from mathics.core.convert import from_sympy
 from mathics.core.evaluation import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
@@ -57,7 +58,6 @@ from mathics.core.expression import (
     SymbolFailed,
     SymbolList,
     SymbolMakeBoxes,
-    SymbolN,
     SymbolRule,
     SymbolSequence,
     from_python,
@@ -2493,9 +2493,7 @@ class _PrecomputedDistances(PrecomputedDistances):
 
     def __init__(self, df, p, evaluation):
         distances_form = [df(p[i], p[j]) for i in range(len(p)) for j in range(i)]
-        distances = Expression(
-            SymbolN, Expression(SymbolList, *distances_form)
-        ).evaluate(evaluation)
+        distances = apply_N(Expression(SymbolList, *distances_form), evaluation)
         mpmath_distances = [_to_real_distance(d) for d in distances.leaves]
         super(_PrecomputedDistances, self).__init__(mpmath_distances)
 
@@ -2511,7 +2509,7 @@ class _LazyDistances(LazyDistances):
 
     def _compute_distance(self, i, j):
         p = self._p
-        d = Expression(SymbolN, self._df(p[i], p[j])).evaluate(self._evaluation)
+        d = apply_N(self._df(p[i], p[j]), self._evaluation)
         return _to_real_distance(d)
 
 

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -883,7 +883,7 @@ class N(Builtin):
             )
             if result is not None:
                 if not result.sameQ(nexpr):
-                    result = Expression(SymbolN, result, prec).evaluate(evaluation)
+                    result = apply_N(result, evaluation, prec)
                 return result
 
         if expr.is_atom():
@@ -901,12 +901,10 @@ class N(Builtin):
                     eval_range = ()
             else:
                 eval_range = range(len(expr.leaves))
-            head = Expression(SymbolN, expr.head, prec).evaluate(evaluation)
+            head = apply_N(expr.head, evaluation, prec)
             leaves = expr.get_mutable_leaves()
             for index in eval_range:
-                leaves[index] = Expression(SymbolN, leaves[index], prec).evaluate(
-                    evaluation
-                )
+                leaves[index] = apply_N(leaves[index], evaluation, prec)
             return Expression(head, *leaves)
 
 
@@ -1151,8 +1149,8 @@ class NIntegrate(Builtin):
                         (lambda u: a - z + z / u, lambda u: z * u ** (-2.0))
                     )
                 elif a.is_numeric(evaluation) and b.is_numeric(evaluation):
-                    a = Expression(SymbolN, a).evaluate(evaluation).value
-                    b = Expression(SymbolN, b).evaluate(evaluation).value
+                    a = apply_N(a, evaluation).value
+                    b = apply_N(b, evaluation).value
                     subdomain2.append([a, b])
                     coordtransform.append(None)
                 else:
@@ -1662,7 +1660,7 @@ class RealDigits(Builtin):
                 ).evaluate(evaluation)
             else:
                 if rational_no:
-                    n = Expression(SymbolN, n).evaluate(evaluation)
+                    n = apply_N(n, evaluation)
                 else:
                     return evaluation.message("RealDigits", "ndig", expr)
         py_n = abs(n.value)

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -41,6 +41,7 @@ from mathics.version import __version__  # noqa used in loading to check consist
 from mathics.builtin.base import Builtin, BinaryOperator, PostfixOperator, AtomBuiltin
 from mathics.builtin.base import PatternObject, PatternError
 from mathics.builtin.lists import python_levelspec, InvalidLevelspecError
+from mathics.builtin.numeric import apply_N
 
 from mathics.core.expression import (
     Atom,
@@ -53,7 +54,6 @@ from mathics.core.expression import (
     Real,
     SymbolFalse,
     SymbolList,
-    SymbolN,
     SymbolTrue,
 )
 from mathics.core.rules import Rule
@@ -487,7 +487,7 @@ class PatternTest(BinaryOperator, PatternObject):
         elif test == "System`RealNumberQ":
             if isinstance(candidate, (Integer, Rational, Real)):
                 return True
-            candidate = Expression(SymbolN, candidate).evaluate(evaluation)
+            candidate = apply_N(candidate, evaluation)
             return isinstance(candidate, Real)
             # pass
         elif test == "System`Positive":


### PR DESCRIPTION
Continuation of [Mathics#1582](https://github.com/mathics/Mathics/pull/1582).

Replace `Expression("N", ...).evaluate(...)` and `Expression(SymbolN, ...).evaluate(...)` by `apply_N(...)` everywhere it's possible.

This approach is faster.