### PR TITLE
Faster n apply new

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -555,6 +555,7 @@ class Power(BinaryOperator, _MPMathFunction):
                 y_err = y
             else:
                 y_err = apply_N(y, evaluation)
+                y_err = y_err if y_err.is_atom() else y_err.evaluate(evaluation)
             if isinstance(y_err, Number):
                 py_y = y_err.round_to_float(permit_complex=True).real
                 if py_y > 0:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -632,6 +632,8 @@ class PossibleZeroQ(SympyFunction):
         if result is None:
             # Can't get exact answer, so try approximate equal
             numeric_val = apply_N(expr, evaluation)
+            if not isinstance(numeric_val, Number):
+                numeric_val = numeric_val.evaluate(evaluation)
             if numeric_val and hasattr(numeric_val, "is_approx_zero"):
                 result = numeric_val.is_approx_zero
             elif (

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -210,7 +210,7 @@ class CompiledCode(Atom):
         raise NotImplementedError
 
     def __hash__(self):
-        return hash(("CompiledCode", ctypes.addressof(self.cfunc)))  # XXX hack
+        return hash(("CompiledCode", self.cfunc))  # XXX hack
 
     def atom_to_boxes(self, f, evaluation):
         return CompiledCodeBox(String(self.__str__()), evaluation=evaluation)

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -294,6 +294,8 @@ class Cylinder(Builtin):
         if not isinstance(radius, (Integer, Rational, Real)):
             nradius = apply_N(radius, evaluation)
             if not isinstance(nradius, (Integer, Rational, Real)):
+                nradius = nradius.evaluate(evaluation)
+            if not isinstance(nradius, (Integer, Rational, Real)):
                 evaluation.error("Cylinder", "nrr", radius)
 
         return

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -23,6 +23,7 @@ from mathics.core.expression import (
     from_python,
     SymbolList,
     SymbolN,
+    SymbolNull,
     SymbolRule,
 )
 
@@ -270,7 +271,10 @@ def compile_quiet_function(expr, arg_names, evaluation, expect_list):
 
     def quiet_f(*args):
         vars = {arg_name: Real(arg) for arg_name, arg in zip(arg_names, args)}
-        value = dynamic_scoping(quiet_expr.evaluate, vars, evaluation)
+        try:
+            value = dynamic_scoping(quiet_expr.evaluate, vars, evaluation)
+        except:
+            return None
         if expect_list:
             if value.has_form("List", None):
                 value = [extract_pyreal(item) for item in value.leaves]
@@ -476,7 +480,6 @@ class _Plot(Builtin):
                 self.get_name(), "invmaxrec", maxrecursion, max_recursion_limit
             )
         assert isinstance(maxrecursion, int)
-
         # Exclusions Option
         # TODO: Make exclusions option work properly with ParametricPlot
         def check_exclusion(excl):
@@ -608,7 +611,6 @@ class _Plot(Builtin):
 
             # Cos of the maximum angle between successive line segments
             ang_thresh = cos(pi / 180)
-
             for line, line_xvalues in zip(points, xvalues):
                 recursion_count = 0
                 smooth = False
@@ -907,7 +909,7 @@ class PieChart(_Chart):
         sector_origin = self.get_option(options, "SectorOrigin", evaluation)
         if not sector_origin.has_form("List", 2):
             return
-        sector_origin = apply_N(sector_origin, evaluation)
+        sector_origin = apply_N(sector_origin, evaluation).evaluate(evaluation)
 
         orientation = sector_origin.leaves[0]
         if (

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -200,7 +200,9 @@ class Show(Builtin):
 
         for option in options:
             if option not in ("System`ImageSize",):
-                options[option] = apply_N(options[option], evaluation)
+                options[option] = apply_N(options[option], evaluation).evaluate(
+                    evaluation
+                )
 
         # The below could probably be done with graphics.filter..
         new_leaves = []
@@ -301,11 +303,13 @@ class Graphics(Builtin):
                                 inset._leaves[0], evaluation, opts
                             )
                         n_leaves = [inset] + [
-                            apply_N(leaf, evaluation) for leaf in content.leaves[1:]
+                            apply_N(leaf, evaluation).evaluate(evaluation)
+                            for leaf in content.leaves[1:]
                         ]
                     else:
                         n_leaves = (
-                            apply_N(leaf, evaluation) for leaf in content.leaves
+                            apply_N(leaf, evaluation).evaluate(evaluation)
+                            for leaf in content.leaves
                         )
                 else:
                     n_leaves = content.leaves
@@ -314,7 +318,9 @@ class Graphics(Builtin):
 
         for option in options:
             if option not in ("System`ImageSize",):
-                options[option] = apply_N(options[option], evaluation)
+                options[option] = apply_N(options[option], evaluation).evaluate(
+                    evaluation
+                )
 
         from mathics.builtin.box.graphics import GraphicsBox
         from mathics.builtin.box.graphics3d import Graphics3DBox

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1281,6 +1281,8 @@ def find_root_newton(f, x0, x, opts, evaluation) -> (Number, bool):
         if x1 == x0:
             break
         x0 = apply_N(x1, evaluation)
+        if not isinstance(x0, Number):
+            x0 = x0.evaluate(evaluation)
         # N required due to bug in sympy arithmetic
         count += 1
     else:
@@ -1377,6 +1379,8 @@ class FindRoot(Builtin):
         "FindRoot[f_, {x_, x0_}, OptionsPattern[]]"
         # First, determine x0 and x
         x0 = apply_N(x0, evaluation)
+        if not isinstance(x0, Number):
+            x0 = x0.evaluate(evaluation)
         if not isinstance(x0, Number):
             evaluation.message("FindRoot", "snum", x0)
             return

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -71,8 +71,9 @@ class _Constant_Common(Predefined):
     options = {"Method": "Automatic"}
 
     def apply_N(self, precision, evaluation, options={}):
-        "N[%(name)s, precision_?NumericQ, OptionsPattern[%(name)s]]"
-
+        "N[%(name)s, precision_, OptionsPattern[%(name)s]]"
+        if precision is not None and not precision.is_numeric(evaluation):
+            return
         preference = self.get_option(options, "Method", evaluation).get_string_value()
         if preference == "Automatic":
             return self.get_constant(precision, evaluation)

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -12,6 +12,7 @@ from mathics.core.expression import (
     Expression,
     Integer,
     Integer0,
+    Number,
     Rational,
     Symbol,
     from_python,
@@ -413,12 +414,16 @@ class MantissaExponent(Builtin):
 
         if n_sympy.is_constant():
             temp_n = apply_N(n, evaluation)
+            if not isinstance(temp_n, Number):
+                temp_n = temp_n.evaluate(evaluation)
             py_n = temp_n.to_python()
         else:
             return expr
 
         if b_sympy.is_constant():
             temp_b = apply_N(b, evaluation)
+            if not isinstance(temp_b, Number):
+                temp_b = temp_b.evaluate(evaluation)
             py_b = temp_b.to_python()
         else:
             return expr

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -954,6 +954,8 @@ class N(Builtin):
 
     def apply_with_prec(self, expr, prec, evaluation):
         "N[expr_, prec_]"
+        if not prec.is_numeric(evaluation):
+            return
         val = apply_N(expr, evaluation, prec)
         if not isinstance(val, Number):
             val = val.evaluate(evaluation)

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -44,6 +44,9 @@ from mathics.core.expression import (
     SymbolList,
     SymbolMachinePrecision,
     SymbolN,
+    SymbolPlus,
+    SymbolTimes,
+    SymbolPower,
     from_python,
 )
 
@@ -62,8 +65,107 @@ def log_n_b(py_n, py_b) -> int:
     return int(mpmath.ceil(mpmath.log(py_n, py_b))) if py_n != 0 and py_n != 1 else 1
 
 
-def apply_N(expression, evaluation, prec=SymbolMachinePrecision):
-    return Expression("N", expression, prec).evaluate(evaluation)
+def apply_N(expr, evaluation, prec=SymbolMachinePrecision):
+    """
+    This function applies recursively `N-value` rules for convert symbols, expressions and exact numbers
+    into Real numbers with certain precision.
+    Notice that `apply_N(expr, evaluation, prec)` is not equivalent in general to call
+    `Expression(SymbolN, expr, prec).evaluate(evaluation)`. To get the same behaviour, in general
+    is necesary to call
+    `apply_N(expr.evaluate(evaluation), evaluation, prec.evaluate(evaluation)).evaluate(evaluation)`
+    However, in many cases where this function is called from Python code, both `prec` and `expr`
+    are given in an already evaluated form, while the last evaluation is only required when
+    `apply_N` failed to return a real number.
+    """
+    try:
+        d = get_precision(prec, evaluation)
+    except PrecisionValueError:
+        return
+
+    if isinstance(expr, Number):
+        return expr.round(d)
+    if isinstance(expr, String):
+        return expr
+
+    if expr.get_head_name() in ("System`List", "System`Rule"):
+        newleaves = [apply_N(leaf, evaluation, prec) for leaf in expr.leaves]
+        return Expression(
+            expr.head,
+            *[
+                leaf if newleaf is None else newleaf
+                for newleaf, leaf in zip(newleaves, expr.leaves)
+            ],
+        )
+    # Special case for the Root builtin
+    if expr.has_form("Root", 2):
+        return from_sympy(sympy.N(expr.to_sympy(), d))
+
+    name = expr.get_lookup_name()
+    if name != "":
+        nexpr = Expression(SymbolN, expr, prec)
+        result = evaluation.definitions.get_value(
+            name, "System`NValues", nexpr, evaluation
+        )
+        if result is not None:
+            if isinstance(result, Number):
+                return result.round(d)
+            if not (result.sameQ(nexpr) or result.sameQ(expr)):
+                if result.is_atom():
+                    return result
+                if result._head.sameQ(SymbolN):
+                    if len(result.leaves) == 2 and result.leaves[1].is_numeric(
+                        evaluation
+                    ):
+                        return apply_N(result.leaves[0], evaluation, result.leaves[1])
+                    elif len(result.leaves) == 1:
+                        return apply_N(result.leaves[0], evaluation, prec)
+                    else:
+                        return result.evaluate(evaluation)
+            return result
+
+    if expr.is_atom():
+        return expr
+
+    # TODO: This special cases should be removed after figuring out
+    # why when we do it, ExpressionMantissa and FindRoot stop working...
+    head = expr.head
+    # Now, the general case for `Expression`
+    if head.sameQ(SymbolN):
+        # maybe we should handle the precision...
+        return expr
+
+    # Flag to check if N[expr] is different from expr.
+    # If it is, build a new expression. Otherwise, return it without changes.
+    changed = False
+    new_head = apply_N(head, evaluation, prec)
+    if new_head is not head:
+        head = new_head
+        changed = True
+
+    # the attributes to have into account are those associated to N[expr.head]
+    attributes = head.get_attributes(evaluation.definitions)
+    # Apply N to those arguments that are not hold. Keep them unevaluated.
+    if "System`NHoldAll" in attributes:
+        eval_range = ()
+    elif "System`NHoldFirst" in attributes:
+        eval_range = range(1, len(expr.leaves))
+    elif "System`NHoldRest" in attributes:
+        if len(expr.leaves) > 0:
+            eval_range = (0,)
+        else:
+            eval_range = ()
+    else:
+        eval_range = range(len(expr.leaves))
+
+    leaves = expr.get_mutable_leaves()
+    for index in eval_range:
+        leaf = leaves[index]
+        new_leaf = apply_N(leaf, evaluation, prec)
+        if new_leaf is not leaf:
+            changed = True
+            leaves[index] = new_leaf
+
+    return Expression(head, *leaves) if changed else expr
 
 
 def _scipy_interface(integrator, options_map, mandatory=None, adapt_func=None):
@@ -848,64 +950,21 @@ class N(Builtin):
         ),
     }
 
-    rules = {
-        "N[expr_]": "N[expr, MachinePrecision]",
-    }
-
     summary_text = "numerical evaluation to specified precision and accuracy"
 
     def apply_with_prec(self, expr, prec, evaluation):
         "N[expr_, prec_]"
+        val = apply_N(expr, evaluation, prec)
+        if not isinstance(val, Number):
+            val = val.evaluate(evaluation)
+        return val
 
-        try:
-            d = get_precision(prec, evaluation)
-        except PrecisionValueError:
-            return
-
-        if expr.get_head_name() in ("System`List", "System`Rule"):
-            return Expression(
-                expr.head,
-                *[self.apply_with_prec(leaf, prec, evaluation) for leaf in expr.leaves],
-            )
-
-        # Special case for the Root builtin
-        if expr.has_form("Root", 2):
-            return from_sympy(sympy.N(expr.to_sympy(), d))
-
-        if isinstance(expr, Number):
-            return expr.round(d)
-
-        name = expr.get_lookup_name()
-        if name != "":
-            nexpr = Expression(SymbolN, expr, prec)
-            result = evaluation.definitions.get_value(
-                name, "System`NValues", nexpr, evaluation
-            )
-            if result is not None:
-                if not result.sameQ(nexpr):
-                    result = apply_N(result, evaluation, prec)
-                return result
-
-        if expr.is_atom():
-            return expr
-        else:
-            attributes = expr.head.get_attributes(evaluation.definitions)
-            if "System`NHoldAll" in attributes:
-                eval_range = ()
-            elif "System`NHoldFirst" in attributes:
-                eval_range = range(1, len(expr.leaves))
-            elif "System`NHoldRest" in attributes:
-                if len(expr.leaves) > 0:
-                    eval_range = (0,)
-                else:
-                    eval_range = ()
-            else:
-                eval_range = range(len(expr.leaves))
-            head = apply_N(expr.head, evaluation, prec)
-            leaves = expr.get_mutable_leaves()
-            for index in eval_range:
-                leaves[index] = apply_N(leaves[index], evaluation, prec)
-            return Expression(head, *leaves)
+    def apply(self, expr, evaluation):
+        "N[expr_]"
+        val = apply_N(expr, evaluation)
+        if not isinstance(val, Number):
+            val = val.evaluate(evaluation)
+        return val
 
 
 class NIntegrate(Builtin):

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -730,7 +730,7 @@ def get_tag_position(pattern, name) -> typing.Optional[str]:
         head_name = pattern.get_head_name()
         if head_name == name:
             return "down"
-        elif head_name == "System`N" and len(pattern.leaves) == 2:
+        elif head_name == "System`N" and 2 <= len(pattern.leaves) <= 3:
             return "n"
         elif head_name == "System`Condition" and len(pattern.leaves) > 0:
             return get_tag_position(pattern.leaves[0], name)
@@ -848,6 +848,6 @@ class Definition(object):
 
     def __repr__(self) -> str:
         s = "<Definition: name: {}, downvalues: {}, formats: {}, attributes: {}>".format(
-            self.name, self.downvalues, self.formatvalues, self.attributes
+            self.name, self.downvalues, self.nvalues, self.formatvalues, self.attributes
         )
         return s

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -594,11 +594,8 @@ class BaseExpression(KeyComparable):
         if evaluation is None:
             value = self
         elif isinstance(evaluation, sympy.core.numbers.NaN):
-            print(
-                "why an evaluation parameter would be set to sympy.NaN and this should happend? "
-            )
-            assert False
-            return None
+            RuntimeError("evaluation should not be sympy.Nan")
+            # return None
         else:
             value = Expression(SymbolN, self).evaluate(evaluation)
         if isinstance(value, Number):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -594,6 +594,10 @@ class BaseExpression(KeyComparable):
         if evaluation is None:
             value = self
         elif isinstance(evaluation, sympy.core.numbers.NaN):
+            print(
+                "why an evaluation parameter would be set to sympy.NaN and this should happend? "
+            )
+            assert False
             return None
         else:
             value = Expression(SymbolN, self).evaluate(evaluation)
@@ -1439,6 +1443,11 @@ class Expression(BaseExpression):
                             rules_names.add(name)
                             for rule in evaluation.definitions.get_upvalues(name):
                                 yield rule
+            if new.get_head_name() == "System`N":
+                lookup_name = leaves[0].get_lookup_name()
+                for rule in evaluation.definitions.get_nvalues(lookup_name):
+                    yield rule
+
             lookup_name = new.get_lookup_name()
             if lookup_name == new.get_head_name():
                 for rule in evaluation.definitions.get_downvalues(lookup_name):
@@ -1456,6 +1465,18 @@ class Expression(BaseExpression):
                     new._timestamp_cache(evaluation)
                     return new, False
                 else:
+                    if new._head.sameQ(SymbolN) and not (
+                        isinstance(result, (Real, Complex))
+                        or (
+                            not isinstance(result, Atom)
+                            and result.get_head().sameQ(SymbolN)
+                        )
+                        or result.sameQ(new._leaves[0])
+                    ):
+
+                        result = Expression(
+                            SymbolN, result, *(new._leaves[1:])
+                        ).evaluate(evaluation)
                     return result, True
 
         dirty_leaves = None
@@ -2116,18 +2137,22 @@ SymbolComplexInfinity = Symbol("ComplexInfinity")
 SymbolDirectedInfinity = Symbol("DirectedInfinity")
 SymbolFailed = Symbol("$Failed")
 SymbolFalse = Symbol("False")
+SymbolGreater = Symbol("Greater")
+SymbolI = Symbol("I")
 SymbolInfinity = Symbol("Infinity")
+SymbolLess = Symbol("Less")
 SymbolList = Symbol("List")
 SymbolMachinePrecision = Symbol("MachinePrecision")
 SymbolMakeBoxes = Symbol("MakeBoxes")
 SymbolN = Symbol("N")
 SymbolNull = Symbol("Null")
+SymbolPlus = Symbol("Plus")
+SymbolPower = Symbol("Power")
 SymbolRule = Symbol("Rule")
 SymbolSequence = Symbol("Sequence")
+SymbolTimes = Symbol("Times")
 SymbolTrue = Symbol("True")
 SymbolUndefined = Symbol("Undefined")
-SymbolLess = Symbol("Less")
-SymbolGreater = Symbol("Greater")
 
 
 @lru_cache(maxsize=1024)


### PR DESCRIPTION
This PR inverts the roles of `N.apply` and `apply_N`, in a way that calling this last one does not imply passing through the pattern matching mechanism.
This PR also fixes a few bugs in the `Definition` object.