### PR TITLE
Lists overhaul

### DIFF
--- a/mathics/builtin/assignment.py
+++ b/mathics/builtin/assignment.py
@@ -23,7 +23,7 @@ from mathics.core.systemsymbols import (
 from mathics.core.atoms import String
 
 from mathics.core.definitions import PyMathicsLoadException
-from mathics.builtin.lists import walk_parts
+from mathics.algorithm.parts import walk_parts
 from mathics.core.evaluation import MAX_RECURSION_DEPTH, set_python_recursion_limit
 
 

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -11,6 +11,14 @@ from typing import Any, cast
 
 from mathics.version import __version__  # noqa used in loading to check consistency.
 
+from mathics.builtin.exceptions import (
+    BoxConstructError,
+    InvalidLevelspecError,
+    MessageException,
+    PartError,
+    PartDepthError,
+    PartRangeError,
+)
 from mathics.core.convert import from_sympy
 from mathics.core.definitions import Definition
 from mathics.core.parser.util import SystemDefinitions, PyMathicsDefinitions
@@ -593,27 +601,6 @@ class SympyFunction(SympyObject):
         return sympy_expr
 
 
-class InvalidLevelspecError(Exception):
-    pass
-
-
-class PartError(Exception):
-    pass
-
-
-class PartDepthError(PartError):
-    def __init__(self, index=0):
-        self.index = index
-
-
-class PartRangeError(PartError):
-    pass
-
-
-class BoxConstructError(Exception):
-    pass
-
-
 class BoxConstruct(InstanceableBuiltin):
     def __new__(cls, *leaves, **kwargs):
         instance = super().__new__(cls, *leaves, **kwargs)
@@ -776,14 +763,6 @@ class PatternObject(InstanceableBuiltin, Pattern):
 
     def get_attributes(self, definitions):
         return self.head.get_attributes(definitions)
-
-
-class MessageException(Exception):
-    def __init__(self, *message):
-        self._message = message
-
-    def message(self, evaluation):
-        evaluation.message(*self._message)
 
 
 class NegativeIntegerException(Exception):

--- a/mathics/builtin/exceptions.py
+++ b/mathics/builtin/exceptions.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from mathics.version import __version__  # noqa used in loading to check consistency.
+
+
+class BoxConstructError(Exception):
+    pass
+
+
+class InvalidLevelspecError(Exception):
+    pass
+
+
+class PartError(Exception):
+    pass
+
+
+class PartDepthError(PartError):
+    def __init__(self, index=0):
+        self.index = index
+
+
+class PartRangeError(PartError):
+    pass
+
+
+class MessageException(Exception):
+    def __init__(self, *message):
+        self._message = message
+
+    def message(self, evaluation):
+        evaluation.message(*self._message)

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -17,12 +17,12 @@ from mathics.builtin.base import (
     PartError,
 )
 
-from mathics.builtin.lists import (
+from mathics.builtin.lists import list_boxes
+from mathics.algorithm.parts import (
     _drop_span_selector,
     _parts,
     _take_span_selector,
     deletecases_with_levelspec,
-    list_boxes,
     python_levelspec,
     set_part,
     walk_levels,

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -13,7 +13,10 @@ from itertools import chain
 from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.algorithm.introselect import introselect
-
+from mathics.algorithm.parts import (
+    python_levelspec,
+    walk_levels,
+)
 from mathics.algorithm.clusters import (
     AutomaticMergeCriterion,
     AutomaticSplitCriterion,
@@ -69,122 +72,6 @@ from mathics.core.systemsymbols import (
     SymbolRule,
     SymbolSequence,
 )
-
-
-def deletecases_with_levelspec(expr, pattern, evaluation, levelspec=1, n=-1):
-    """
-    This function walks the expression `expr` and deleting occurrencies of `pattern`
-
-    If levelspec specifies a number, only those positions with  `levelspec` "coordinates" are return. By default, it just return occurences in the first level.
-
-    If a tuple (nmin, nmax) is provided, it just return those occurences with a number of "coordinates" between nmin and nmax.
-    n indicates the number of occurrences to return. By default, it returns all the occurences.
-    """
-    nothing = Symbol("System`Nothing")
-    from mathics.builtin.patterns import Matcher
-
-    match = Matcher(pattern)
-    match = match.match
-    if type(levelspec) is int:
-        lsmin = 1
-        lsmax = levelspec + 1
-    else:
-        lsmin = levelspec[0]
-        if levelspec[1]:
-            lsmax = levelspec[1] + 1
-        else:
-            lsmax = -1
-    tree = [[expr]]
-    changed_marks = [
-        [False],
-    ]
-    curr_index = [0]
-
-    while curr_index[0] != 1:
-        # If the end of the branch is reached, or no more elements to delete out
-        if curr_index[-1] == len(tree[-1]) or n == 0:
-            leaves = tree[-1]
-            tree.pop()
-            # check if some of the leaves was changed
-            changed = any(changed_marks[-1])
-            changed_marks.pop()
-            if changed:
-                leaves = [leaf for leaf in leaves if leaf is not nothing]
-            curr_index.pop()
-            if len(curr_index) == 0:
-                break
-            idx = curr_index[-1]
-            changed = changed or changed_marks[-1][idx]
-            changed_marks[-1][idx] = changed
-            if changed:
-                head = tree[-1][curr_index[-1]].get_head()
-                tree[-1][idx] = Expression(head, *leaves)
-            if len(curr_index) == 0:
-                break
-            curr_index[-1] = curr_index[-1] + 1
-            continue
-        curr_leave = tree[-1][curr_index[-1]]
-        if match(curr_leave, evaluation) and (len(curr_index) > lsmin):
-            tree[-1][curr_index[-1]] = nothing
-            changed_marks[-1][curr_index[-1]] = True
-            curr_index[-1] = curr_index[-1] + 1
-            n = n - 1
-            continue
-        if curr_leave.is_atom() or lsmax == len(curr_index):
-            curr_index[-1] = curr_index[-1] + 1
-            continue
-        else:
-            tree.append(list(curr_leave.get_leaves()))
-            changed_marks.append([False for l in tree[-1]])
-            curr_index.append(0)
-    return tree[0][0]
-
-
-def find_matching_indices_with_levelspec(expr, pattern, evaluation, levelspec=1, n=-1):
-    """
-    This function walks the expression `expr` looking for a pattern `pattern`
-    and returns the positions of each occurence.
-
-    If levelspec specifies a number, only those positions with  `levelspec` "coordinates" are return. By default, it just return occurences in the first level.
-
-    If a tuple (nmin, nmax) is provided, it just return those occurences with a number of "coordinates" between nmin and nmax.
-    n indicates the number of occurrences to return. By default, it returns all the occurences.
-    """
-    from mathics.builtin.patterns import Matcher
-
-    match = Matcher(pattern)
-    match = match.match
-    if type(levelspec) is int:
-        lsmin = 0
-        lsmax = levelspec
-    else:
-        lsmin = levelspec[0]
-        lsmax = levelspec[1]
-    tree = [expr.get_leaves()]
-    curr_index = [0]
-    found = []
-    while len(tree) > 0:
-        if n == 0:
-            break
-        if curr_index[-1] == len(tree[-1]):
-            curr_index.pop()
-            tree.pop()
-            if len(curr_index) != 0:
-                curr_index[-1] = curr_index[-1] + 1
-            continue
-        curr_leave = tree[-1][curr_index[-1]]
-        if match(curr_leave, evaluation) and (len(curr_index) >= lsmin):
-            found.append([from_python(i) for i in curr_index])
-            curr_index[-1] = curr_index[-1] + 1
-            n = n - 1
-            continue
-        if curr_leave.is_atom() or lsmax == len(curr_index):
-            curr_index[-1] = curr_index[-1] + 1
-            continue
-        else:
-            tree.append(curr_leave.get_leaves())
-            curr_index.append(0)
-    return found
 
 
 class All(Predefined):
@@ -251,7 +138,7 @@ class ByteArray(Builtin):
             return
         try:
             ba = bytearray([b.get_int_value() for b in values._leaves])
-        except:
+        except Exception:
             evaluation.message("ByteArray", "aotd", values)
             return
         return Expression(SymbolByteArray, ByteArrayAtom(ba))
@@ -466,7 +353,7 @@ class Delete(Builtin):
 
         # Create new python list of the positions and sort it
         positions = (
-            [l for l in positions.leaves]
+            [t for t in positions.leaves]
             if positions.leaves[0].has_form("List", None)
             else [positions]
         )
@@ -504,11 +391,11 @@ class Failure(Builtin):
     pass
 
 
-## From backports in CellsToTeX. This functions provides compatibility to WMA 10.
-##  TODO:
-##  * Add doctests
-##  * Translate to python the more complex rules
-##  * Complete the support.
+# From backports in CellsToTeX. This functions provides compatibility to WMA 10.
+#  TODO:
+#  * Add doctests
+#  * Translate to python the more complex rules
+#  * Complete the support.
 
 
 class Key(Builtin):
@@ -727,481 +614,6 @@ class None_(Predefined):
     name = "None"
 
 
-def join_lists(lists):
-    new_list = []
-    for list in lists:
-        new_list.extend(list)
-    return new_list
-
-
-def get_part(varlist, indices):
-    "Simple part extraction. indices must be a list of python integers."
-
-    def rec(cur, rest):
-        if rest:
-            if cur.is_atom():
-                raise PartDepthError(rest[0])
-            pos = rest[0]
-            leaves = cur.get_leaves()
-            try:
-                if pos > 0:
-                    part = leaves[pos - 1]
-                elif pos == 0:
-                    part = cur.get_head()
-                else:
-                    part = leaves[pos]
-            except IndexError:
-                raise PartRangeError
-            return rec(part, rest[1:])
-        else:
-            return cur
-
-    return rec(varlist, indices).copy()
-
-
-def set_part(varlist, indices, newval):
-    "Simple part replacement. indices must be a list of python integers."
-
-    def rec(cur, rest):
-        if len(rest) > 1:
-            pos = rest[0]
-            if cur.is_atom():
-                raise PartDepthError
-            try:
-                if pos > 0:
-                    part = cur._leaves[pos - 1]
-                elif pos == 0:
-                    part = cur.get_head()
-                else:
-                    part = cur._leaves[pos]
-            except IndexError:
-                raise PartRangeError
-            return rec(part, rest[1:])
-        elif len(rest) == 1:
-            pos = rest[0]
-            if cur.is_atom():
-                raise PartDepthError
-            try:
-                if pos > 0:
-                    cur.set_leaf(pos - 1, newval)
-                elif pos == 0:
-                    cur.set_head(newval)
-                else:
-                    cur.set_leaf(pos, newval)
-            except IndexError:
-                raise PartRangeError
-
-    rec(varlist, indices)
-
-
-def _parts_all_selector():
-    start = 1
-    stop = None
-    step = 1
-
-    def select(inner):
-        if inner.is_atom():
-            raise MessageException("Part", "partd")
-        py_slice = python_seq(start, stop, step, len(inner.leaves))
-        if py_slice is None:
-            raise MessageException("Part", "take", start, stop, inner)
-        return inner.leaves[py_slice]
-
-    return select
-
-
-def _parts_span_selector(pspec):
-    if len(pspec.leaves) > 3:
-        raise MessageException("Part", "span", pspec)
-    start = 1
-    stop = None
-    step = 1
-    if len(pspec.leaves) > 0:
-        start = pspec.leaves[0].get_int_value()
-    if len(pspec.leaves) > 1:
-        stop = pspec.leaves[1].get_int_value()
-        if stop is None:
-            if pspec.leaves[1].get_name() == "System`All":
-                stop = None
-            else:
-                raise MessageException("Part", "span", pspec)
-    if len(pspec.leaves) > 2:
-        step = pspec.leaves[2].get_int_value()
-
-    if start == 0 or stop == 0:
-        # index 0 is undefined
-        raise MessageException("Part", "span", 0)
-
-    if start is None or step is None:
-        raise MessageException("Part", "span", pspec)
-
-    def select(inner):
-        if inner.is_atom():
-            raise MessageException("Part", "partd")
-        py_slice = python_seq(start, stop, step, len(inner.leaves))
-        if py_slice is None:
-            raise MessageException("Part", "take", start, stop, inner)
-        return inner.leaves[py_slice]
-
-    return select
-
-
-def _parts_sequence_selector(pspec):
-    if not isinstance(pspec, (tuple, list)):
-        indices = [pspec]
-    else:
-        indices = pspec
-
-    for index in indices:
-        if not isinstance(index, Integer):
-            raise MessageException("Part", "pspec", pspec)
-
-    def select(inner):
-        if inner.is_atom():
-            raise MessageException("Part", "partd")
-
-        leaves = inner.leaves
-        n = len(leaves)
-
-        for index in indices:
-            int_index = index.value
-
-            if int_index == 0:
-                yield inner.head
-            elif 1 <= int_index <= n:
-                yield leaves[int_index - 1]
-            elif -n <= int_index <= -1:
-                yield leaves[int_index]
-            else:
-                raise MessageException("Part", "partw", index, inner)
-
-    return select
-
-
-def _part_selectors(indices):
-    for index in indices:
-        if index.has_form("Span", None):
-            yield _parts_span_selector(index)
-        elif index.get_name() == "System`All":
-            yield _parts_all_selector()
-        elif index.has_form("List", None):
-            yield _parts_sequence_selector(index.leaves)
-        elif isinstance(index, Integer):
-            yield _parts_sequence_selector(index), lambda x: x[0]
-        else:
-            raise MessageException("Part", "pspec", index)
-
-
-def _list_parts(items, selectors, heads, evaluation, assignment):
-    if not selectors:
-        for item in items:
-            yield item
-    else:
-        selector = selectors[0]
-        if isinstance(selector, tuple):
-            select, unwrap = selector
-        else:
-            select = selector
-            unwrap = None
-
-        for item in items:
-            selected = list(select(item))
-
-            picked = list(
-                _list_parts(selected, selectors[1:], heads, evaluation, assignment)
-            )
-
-            if unwrap is None:
-                if assignment:
-                    expr = Expression(item.head, *picked)
-                    expr.original = None
-                    expr.set_positions()
-                else:
-                    expr = item.restructure(item.head, picked, evaluation)
-
-                yield expr
-            else:
-                yield unwrap(picked)
-
-
-def _parts(items, selectors, evaluation, assignment=False):
-    heads = {}
-    return list(_list_parts([items], list(selectors), heads, evaluation, assignment))[0]
-
-
-def walk_parts(list_of_list, indices, evaluation, assign_list=None):
-    walk_list = list_of_list[0]
-
-    if assign_list is not None:
-        # this double copying is needed to make the current logic in
-        # the assign_list and its access to original work.
-
-        walk_list = walk_list.copy()
-        walk_list.set_positions()
-        list_of_list = [walk_list]
-
-        walk_list = walk_list.copy()
-        walk_list.set_positions()
-
-    indices = [index.evaluate(evaluation) for index in indices]
-
-    try:
-        result = _parts(
-            walk_list, _part_selectors(indices), evaluation, assign_list is not None
-        )
-    except MessageException as e:
-        e.message(evaluation)
-        return False
-
-    if assign_list is not None:
-
-        def replace_item(all, item, new):
-            if item.position is None:
-                all[0] = new
-            else:
-                item.position.replace(new)
-
-        def process_level(item, assignment):
-            if item.is_atom():
-                replace_item(list_of_list, item.original, assignment)
-            elif assignment.get_head_name() != "System`List" or len(item.leaves) != len(
-                assignment.leaves
-            ):
-                if item.original:
-                    replace_item(list_of_list, item.original, assignment)
-                else:
-                    for leaf in item.leaves:
-                        process_level(leaf, assignment)
-            else:
-                for sub_item, sub_assignment in zip(item.leaves, assignment.leaves):
-                    process_level(sub_item, sub_assignment)
-
-        process_level(result, assign_list)
-
-        result = list_of_list[0]
-        result.clear_cache()
-
-    return result
-
-
-def is_in_level(current, depth, start=1, stop=None):
-    if stop is None:
-        stop = current
-    if start < 0:
-        start += current + depth + 1
-    if stop < 0:
-        stop += current + depth + 1
-    return start <= current <= stop
-
-
-def walk_levels(
-    expr,
-    start=1,
-    stop=None,
-    current=0,
-    heads=False,
-    callback=lambda l: l,
-    include_pos=False,
-    cur_pos=[],
-):
-    if expr.is_atom():
-        depth = 0
-        new_expr = expr
-    else:
-        depth = 0
-        if heads:
-            head, head_depth = walk_levels(
-                expr.head,
-                start,
-                stop,
-                current + 1,
-                heads,
-                callback,
-                include_pos,
-                cur_pos + [0],
-            )
-        else:
-            head = expr.head
-        leaves = []
-        for index, leaf in enumerate(expr.leaves):
-            leaf, leaf_depth = walk_levels(
-                leaf,
-                start,
-                stop,
-                current + 1,
-                heads,
-                callback,
-                include_pos,
-                cur_pos + [index + 1],
-            )
-            if leaf_depth + 1 > depth:
-                depth = leaf_depth + 1
-            leaves.append(leaf)
-        new_expr = Expression(head, *leaves)
-    if is_in_level(current, depth, start, stop):
-        if include_pos:
-            new_expr = callback(new_expr, cur_pos)
-        else:
-            new_expr = callback(new_expr)
-    return new_expr, depth
-
-
-def python_levelspec(levelspec):
-    def value_to_level(expr):
-        value = expr.get_int_value()
-        if value is None:
-            if expr == Expression("DirectedInfinity", 1):
-                return None
-            else:
-                raise InvalidLevelspecError
-        else:
-            return value
-
-    if levelspec.has_form("List", None):
-        values = [value_to_level(leaf) for leaf in levelspec.leaves]
-        if len(values) == 1:
-            return values[0], values[0]
-        elif len(values) == 2:
-            return values[0], values[1]
-        else:
-            raise InvalidLevelspecError
-    elif isinstance(levelspec, Symbol) and levelspec.get_name() == "System`All":
-        return 0, None
-    else:
-        return 1, value_to_level(levelspec)
-
-
-def python_seq(start, stop, step, length):
-    """
-    Converts mathematica sequence tuple to python slice object.
-
-    Based on David Mashburn's generic slice:
-    https://gist.github.com/davidmashburn/9764309
-    """
-    if step == 0:
-        return None
-
-    # special empty case
-    if stop is None and length is not None:
-        empty_stop = length
-    else:
-        empty_stop = stop
-    if start is not None and empty_stop + 1 == start and step > 0:
-        return slice(0, 0, 1)
-
-    if start == 0 or stop == 0:
-        return None
-
-    # wrap negative values to postive and convert from 1-based to 0-based
-    if start < 0:
-        start += length
-    else:
-        start -= 1
-
-    if stop is None:
-        if step < 0:
-            stop = 0
-        else:
-            stop = length - 1
-    elif stop < 0:
-        stop += length
-    else:
-        assert stop > 0
-        stop -= 1
-
-    # check bounds
-    if (
-        not 0 <= start < length
-        or not 0 <= stop < length
-        or step > 0
-        and start - stop > 1
-        or step < 0
-        and stop - start > 1
-    ):  # nopep8
-        return None
-
-    # include the stop value
-    if step > 0:
-        stop += 1
-    else:
-        stop -= 1
-        if stop == -1:
-            stop = None
-        if start == 0:
-            start = None
-
-    return slice(start, stop, step)
-
-
-def convert_seq(seq):
-    """
-    converts a sequence specification into a (start, stop, step) tuple.
-    returns None on failure
-    """
-    start, stop, step = 1, None, 1
-    name = seq.get_name()
-    value = seq.get_int_value()
-    if name == "System`All":
-        pass
-    elif name == "System`None":
-        stop = 0
-    elif value is not None:
-        if value > 0:
-            stop = value
-        else:
-            start = value
-    elif seq.has_form("List", 1, 2, 3):
-        if len(seq.leaves) == 1:
-            start = stop = seq.leaves[0].get_int_value()
-            if stop is None:
-                return None
-        else:
-            start = seq.leaves[0].get_int_value()
-            stop = seq.leaves[1].get_int_value()
-            if start is None or stop is None:
-                return None
-        if len(seq.leaves) == 3:
-            step = seq.leaves[2].get_int_value()
-            if step is None:
-                return None
-    else:
-        return None
-    return (start, stop, step)
-
-
-def _drop_take_selector(name, seq, sliced):
-    seq_tuple = convert_seq(seq)
-    if seq_tuple is None:
-        raise MessageException(name, "seqs", seq)
-
-    def select(inner):
-        start, stop, step = seq_tuple
-        if inner.is_atom():
-            py_slice = None
-        else:
-            py_slice = python_seq(start, stop, step, len(inner.leaves))
-        if py_slice is None:
-            if stop is None:
-                stop = Symbol("Infinity")
-            raise MessageException(name, name.lower(), start, stop, inner)
-        return sliced(inner.leaves, py_slice)
-
-    return select
-
-
-def _take_span_selector(seq):
-    return _drop_take_selector("Take", seq, lambda x, s: x[s])
-
-
-def _drop_span_selector(seq):
-    def sliced(x, s):
-        y = list(x[:])
-        del y[s]
-        return y
-
-    return _drop_take_selector("Drop", seq, sliced)
-
-
 class Split(Builtin):
     """
     <dl>
@@ -1268,7 +680,7 @@ class Split(Builtin):
 
         inner = structure("List", mlist, evaluation)
         outer = structure(mlist.head, inner, evaluation)
-        return outer([inner(l) for l in result])
+        return outer([inner(t) for t in result])
 
 
 class SplitBy(Builtin):
@@ -1306,7 +718,7 @@ class SplitBy(Builtin):
             evaluation.message("Select", "normal", 1, expr)
             return
 
-        plist = [l for l in mlist.leaves]
+        plist = [t for t in mlist.leaves]
 
         result = [[plist[0]]]
         prev = Expression(func, plist[0]).evaluate(evaluation)
@@ -1320,7 +732,7 @@ class SplitBy(Builtin):
 
         inner = structure("List", mlist, evaluation)
         outer = structure(mlist.head, inner, evaluation)
-        return outer([inner(l) for l in result])
+        return outer([inner(t) for t in result])
 
     def apply_multiple(self, mlist, funcs, evaluation):
         "SplitBy[mlist_, funcs_List]"
@@ -1927,8 +1339,8 @@ class _Rectangular(Builtin):
     # A helper for Builtins X that allow X[{a1, a2, ...}, {b1, b2, ...}, ...] to be evaluated
     # as {X[{a1, b1, ...}, {a1, b2, ...}, ...]}.
 
-    def rect(self, l):
-        lengths = [len(leaf.leaves) for leaf in l.leaves]
+    def rect(self, leaf):
+        lengths = [len(leaf.leaves) for leaf in leaf.leaves]
         if all(length == 0 for length in lengths):
             return  # leave as is, without error
 
@@ -1936,7 +1348,9 @@ class _Rectangular(Builtin):
         if any(length != n_columns for length in lengths[1:]):
             raise _NotRectangularException()
 
-        transposed = [[leaf.leaves[i] for leaf in l.leaves] for i in range(n_columns)]
+        transposed = [
+            [sleaf.leaves[i] for sleaf in leaf.leaves] for i in range(n_columns)
+        ]
 
         return Expression(
             "List",
@@ -1964,15 +1378,15 @@ class RankedMin(Builtin):
         "rank": "The specified rank `1` is not between 1 and `2`.",
     }
 
-    def apply(self, l, n, evaluation):
-        "RankedMin[l_List, n_Integer]"
+    def apply(self, leaf, n, evaluation):
+        "RankedMin[leaf_List, n_Integer]"
         py_n = n.get_int_value()
         if py_n < 1:
-            evaluation.message("RankedMin", "intpm", Expression("RankedMin", l, n))
-        elif py_n > len(l.leaves):
-            evaluation.message("RankedMin", "rank", py_n, len(l.leaves))
+            evaluation.message("RankedMin", "intpm", Expression("RankedMin", leaf, n))
+        elif py_n > len(leaf.leaves):
+            evaluation.message("RankedMin", "rank", py_n, len(leaf.leaves))
         else:
-            return introselect(l.get_mutable_leaves(), py_n - 1)
+            return introselect(leaf.get_mutable_leaves(), py_n - 1)
 
 
 class RankedMax(Builtin):
@@ -1992,15 +1406,15 @@ class RankedMax(Builtin):
         "rank": "The specified rank `1` is not between 1 and `2`.",
     }
 
-    def apply(self, l, n, evaluation):
-        "RankedMax[l_List, n_Integer]"
+    def apply(self, leaf, n, evaluation):
+        "RankedMax[leaf_List, n_Integer]"
         py_n = n.get_int_value()
         if py_n < 1:
-            evaluation.message("RankedMax", "intpm", Expression("RankedMax", l, n))
-        elif py_n > len(l.leaves):
-            evaluation.message("RankedMax", "rank", py_n, len(l.leaves))
+            evaluation.message("RankedMax", "intpm", Expression("RankedMax", leaf, n))
+        elif py_n > len(leaf.leaves):
+            evaluation.message("RankedMax", "rank", py_n, len(leaf.leaves))
         else:
-            return introselect(l.get_mutable_leaves(), len(l.leaves) - py_n)
+            return introselect(leaf.get_mutable_leaves(), len(leaf.leaves) - py_n)
 
 
 class Quartiles(Builtin):
@@ -2029,7 +1443,7 @@ class _RankedTake(Builtin):
         "ExcludedForms": "Automatic",
     }
 
-    def _compute(self, l, n, evaluation, options, f=None):
+    def _compute(self, t, n, evaluation, options, f=None):
         try:
             limit = CountableInteger.from_expression(n)
         except MessageException as e:
@@ -2037,9 +1451,9 @@ class _RankedTake(Builtin):
             return
         except NegativeIntegerException:
             if f:
-                args = (3, Expression(self.get_name(), l, f, n))
+                args = (3, Expression(self.get_name(), t, f, n))
             else:
-                args = (2, Expression(self.get_name(), l, n))
+                args = (2, Expression(self.get_name(), t, n))
             evaluation.message(self.get_name(), "intpm", *args)
             return
 
@@ -2078,9 +1492,9 @@ class _RankedTake(Builtin):
                             .is_true()
                         )
 
-                filtered = [leaf for leaf in l.leaves if not exclude(leaf)]
+                filtered = [leaf for leaf in t.leaves if not exclude(leaf)]
             else:
-                filtered = l.leaves
+                filtered = t.leaves
 
             if limit > len(filtered):
                 if not limit.is_upper_limit():
@@ -2111,7 +1525,7 @@ class _RankedTake(Builtin):
             else:
                 result = self._get_n(py_n, heap)
 
-            return l.restructure("List", [x[leaf_pos] for x in result], evaluation)
+            return t.restructure("List", [x[leaf_pos] for x in result], evaluation)
 
 
 class _RankedTakeSmallest(_RankedTake):
@@ -2150,9 +1564,9 @@ class TakeLargest(_RankedTakeLargest):
      = {Missing[abc], 150}
     """
 
-    def apply(self, l, n, evaluation, options):
-        "TakeLargest[l_List, n_, OptionsPattern[TakeLargest]]"
-        return self._compute(l, n, evaluation, options)
+    def apply(self, leaf, n, evaluation, options):
+        "TakeLargest[leaf_List, n_, OptionsPattern[TakeLargest]]"
+        return self._compute(leaf, n, evaluation, options)
 
 
 class TakeLargestBy(_RankedTakeLargest):
@@ -2172,9 +1586,9 @@ class TakeLargestBy(_RankedTakeLargest):
      = {abc}
     """
 
-    def apply(self, l, f, n, evaluation, options):
-        "TakeLargestBy[l_List, f_, n_, OptionsPattern[TakeLargestBy]]"
-        return self._compute(l, n, evaluation, options, f=f)
+    def apply(self, leaf, f, n, evaluation, options):
+        "TakeLargestBy[leaf_List, f_, n_, OptionsPattern[TakeLargestBy]]"
+        return self._compute(leaf, n, evaluation, options, f=f)
 
 
 class TakeSmallest(_RankedTakeSmallest):
@@ -2190,9 +1604,9 @@ class TakeSmallest(_RankedTakeSmallest):
      = {-1, 10}
     """
 
-    def apply(self, l, n, evaluation, options):
-        "TakeSmallest[l_List, n_, OptionsPattern[TakeSmallest]]"
-        return self._compute(l, n, evaluation, options)
+    def apply(self, leaf, n, evaluation, options):
+        "TakeSmallest[leaf_List, n_, OptionsPattern[TakeSmallest]]"
+        return self._compute(leaf, n, evaluation, options)
 
 
 class TakeSmallestBy(_RankedTakeSmallest):
@@ -2212,9 +1626,9 @@ class TakeSmallestBy(_RankedTakeSmallest):
      = {x}
     """
 
-    def apply(self, l, f, n, evaluation, options):
-        "TakeSmallestBy[l_List, f_, n_, OptionsPattern[TakeSmallestBy]]"
-        return self._compute(l, n, evaluation, options, f=f)
+    def apply(self, leaf, f, n, evaluation, options):
+        "TakeSmallestBy[leaf_List, f_, n_, OptionsPattern[TakeSmallestBy]]"
+        return self._compute(leaf, n, evaluation, options, f=f)
 
 
 class _IllegalPaddingDepth(Exception):
@@ -2253,10 +1667,10 @@ class _Pad(Builtin):
         return dims
 
     @staticmethod
-    def _build(l, n, x, m, level, mode):  # mode < 0 for left pad, > 0 for right pad
+    def _build(leaf, n, x, m, level, mode):  # mode < 0 for left pad, > 0 for right pad
         if not n:
-            return l
-        if not isinstance(l, Expression):
+            return leaf
+        if not isinstance(leaf, Expression):
             raise _IllegalPaddingDepth(level)
 
         if isinstance(m, (list, tuple)):
@@ -2285,7 +1699,7 @@ class _Pad(Builtin):
             else:
                 return clip(x * (1 + amount // len(x)), amount, sign)
 
-        leaves = l.leaves
+        leaves = leaf.leaves
         d = n[0] - len(leaves)
         if d < 0:
             new_leaves = clip(leaves, d, mode)
@@ -2319,7 +1733,7 @@ class _Pad(Builtin):
         else:
             parts = (padding_margin, new_leaves, padding_main)
 
-        return Expression(l.get_head(), *list(chain(*parts)))
+        return Expression(leaf.get_head(), *list(chain(*parts)))
 
     def _pad(self, in_l, in_n, in_x, in_m, evaluation, expr):
         if not isinstance(in_l, Expression):
@@ -2330,8 +1744,8 @@ class _Pad(Builtin):
         if isinstance(in_n, Symbol) and in_n.get_name() == "System`Automatic":
             py_n = _Pad._find_dims(in_l)
         elif in_n.get_head_name() == "System`List":
-            if all(isinstance(leaf, Integer) for leaf in in_n.leaves):
-                py_n = [leaf.get_int_value() for leaf in in_n.leaves]
+            if all(isinstance(sleaf, Integer) for sleaf in in_n.leaves):
+                py_n = [sleaf.get_int_value() for sleaf in in_n.leaves]
         elif isinstance(in_n, Integer):
             py_n = [in_n.get_int_value()]
 
@@ -2372,32 +1786,37 @@ class _Pad(Builtin):
             )
             return None
 
-    def apply_zero(self, l, n, evaluation):
-        "%(name)s[l_, n_]"
+    def apply_zero(self, leaf, n, evaluation):
+        "%(name)s[leaf_, n_]"
         return self._pad(
-            l,
+            leaf,
             n,
             Integer0,
             Integer0,
             evaluation,
-            lambda: Expression(self.get_name(), l, n),
+            lambda: Expression(self.get_name(), leaf, n),
         )
 
-    def apply(self, l, n, x, evaluation):
-        "%(name)s[l_, n_, x_]"
+    def apply(self, leaf, n, x, evaluation):
+        "%(name)s[leaf_, n_, x_]"
         return self._pad(
-            l,
+            leaf,
             n,
             x,
             Integer0,
             evaluation,
-            lambda: Expression(self.get_name(), l, n, x),
+            lambda: Expression(self.get_name(), leaf, n, x),
         )
 
-    def apply_margin(self, l, n, x, m, evaluation):
-        "%(name)s[l_, n_, x_, m_]"
+    def apply_margin(self, leaf, n, x, m, evaluation):
+        "%(name)s[leaf_, n_, x_, m_]"
         return self._pad(
-            l, n, x, m, evaluation, lambda: Expression(self.get_name(), l, n, x, m)
+            leaf,
+            n,
+            x,
+            m,
+            evaluation,
+            lambda: Expression(self.get_name(), leaf, n, x, m),
         )
 
 
@@ -3066,13 +2485,13 @@ def delete_one(expr, pos):
     leaves = expr.leaves
     if pos == 0:
         return Expression(Symbol("System`Sequence"), *leaves)
-    l = len(leaves)
+    s = len(leaves)
     truepos = pos
     if truepos < 0:
-        truepos = l + truepos
+        truepos = s + truepos
     else:
         truepos = truepos - 1
-    if truepos < 0 or truepos >= l:
+    if truepos < 0 or truepos >= s:
         raise PartRangeError
     leaves = leaves[:truepos] + (Expression("System`Sequence"),) + leaves[truepos + 1 :]
     return Expression(expr.get_head(), *leaves)
@@ -3085,15 +2504,15 @@ def delete_rec(expr, pos):
     if truepos == 0 or expr.is_atom():
         raise PartDepthError(pos[0])
     leaves = expr.leaves
-    l = len(leaves)
+    s = len(leaves)
     if truepos < 0:
-        truepos = truepos + l
+        truepos = truepos + s
         if truepos < 0:
             raise PartRangeError
         newleaf = delete_rec(leaves[truepos], pos[1:])
         leaves = leaves[:truepos] + (newleaf,) + leaves[truepos + 1 :]
     else:
-        if truepos > l:
+        if truepos > s:
             raise PartRangeError
         newleaf = delete_rec(leaves[truepos - 1], pos[1:])
         leaves = leaves[: truepos - 1] + (newleaf,) + leaves[truepos:]

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -1710,7 +1710,7 @@ class CoefficientArrays(_CoefficientHandler):
 
     def apply_list(self, polys, varlist, evaluation, options):
         "%(name)s[polys_, varlist_, OptionsPattern[]]"
-        from mathics.builtin.lists import walk_parts
+        from mathics.algorithm.parts import walk_parts
 
         if polys.has_form("List", None):
             list_polys = polys.leaves

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -40,7 +40,8 @@ The attributes 'Flat', 'Orderless', and 'OneIdentity' affect pattern matching.
 from mathics.version import __version__  # noqa used in loading to check consistency.
 from mathics.builtin.base import Builtin, BinaryOperator, PostfixOperator, AtomBuiltin
 from mathics.builtin.base import PatternObject, PatternError
-from mathics.builtin.lists import python_levelspec, InvalidLevelspecError
+from mathics.algorithm.parts import python_levelspec
+from mathics.builtin.lists import InvalidLevelspecError
 from mathics.builtin.numeric import apply_N
 
 from mathics.core.symbols import (

--- a/mathics/builtin/sparse.py
+++ b/mathics/builtin/sparse.py
@@ -6,7 +6,7 @@ SparseArray Functions
 
 
 from mathics.version import __version__  # noqa used in loading to check consistency.
-from mathics.builtin.lists import walk_parts
+from mathics.algorithm.parts import walk_parts
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -25,7 +25,7 @@ from mathics.core.atoms import (
     String,
     from_python,
 )
-from mathics.builtin.lists import python_seq, convert_seq
+from mathics.algorithm.parts import python_seq, convert_seq
 from mathics.builtin.strings import (
     _StringFind,
     _evaluate_match,

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -25,7 +25,7 @@ from mathics.core.systemsymbols import (
 )
 from mathics.core.rules import Pattern
 
-from mathics.builtin.lists import get_part
+from mathics.algorithm.parts import get_part
 
 
 def get_default_distance(p):

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ else:
     EXTENSIONS_DICT = {
         "core": ("expression", "numbers", "rules", "pattern"),
         "builtin": ["arithmetic", "numeric", "patterns", "graphics"],
+        "algorithm": ["parts"],
     }
     EXTENSIONS = [
         Extension(

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ else:
     EXTENSIONS_DICT = {
         "core": ("expression", "numbers", "rules", "pattern"),
         "builtin": ["arithmetic", "numeric", "patterns", "graphics"],
-        "algorithm": ["parts"],
     }
     EXTENSIONS = [
         Extension(


### PR DESCRIPTION
* move all the "algorithmic" routines in `mathics.core.lists` to an independent module in `mathics.algorithm.parts`
* cithonize `mathics.algorithm.parts`
* fix all the warnings produced by flake8
* Move `Exception` classes from `mathics.builtin.base` to `mathics.builtin.exceptions` to avoid circular references.