### PR TITLE
Allow a developer to overide to running Cython

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,5 +31,4 @@ jobs:
         make develop-full
     - name: Test Mathics
       run: |
-        pip install -r requirements-dev.txt
         make -j3 check

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    env:
+      NO_CYTHON: 1
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -24,8 +24,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install Mathics with full dependencies
       run: |
-        make develop-full
+        make develop-full-cython
     - name: Test Mathics
       run: |
-        pip install -r requirements-dev.txt
         make -j3 check

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -1,4 +1,4 @@
-name: Mathics (Windows)
+name: Mathics (ubuntu full with Cython)
 
 on:
   push:
@@ -8,13 +8,10 @@ on:
 
 jobs:
   build:
-    env:
-      NO_CYTHON: 1
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [windows]
-        python-version: [3.7, 3.8]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -23,17 +20,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
-        python -m pip install wheel
-        choco install llvm
-        set LLVM_DIR="C:\Program Files\LLVM"
-        pip install -e .
-    - name: Install Mathics
+    - name: Install Mathics with full dependencies
       run: |
-        python setup.py install
+        make develop-full
     - name: Test Mathics
       run: |
-        pip install -e .[full]
         pip install -r requirements-dev.txt
-        set PYTEST_WORKERS="-n3"
-        make check
+        make -j3 check

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,8 +26,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install Mathics with full dependencies
       run: |
-        make develop
+        make develop-full
     - name: Test Mathics
       run: |
-        pip install -r requirements-dev.txt
         make -j3 check

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    env:
+      NO_CYTHON: 1
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -24,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install Mathics with full dependencies
       run: |
-        make develop-full
+        make develop
     - name: Test Mathics
       run: |
         pip install -r requirements-dev.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,7 +33,6 @@ jobs:
         python setup.py install
     - name: Test Mathics
       run: |
-        pip install -e .[full]
-        pip install -r requirements-dev.txt
+        pip install -e .[dev,full]
         set PYTEST_WORKERS="-n3"
         make check

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,11 @@ CHANGES
 Internals
 =========
 
-* now `Expression.is_numeric()` accepts an `Evaluation` object as a parameter,
-  to use the definitions.
-* To numerify expressions, the function `apply_N` was introduced in the module `mathics.builtin.numeric` to avoid the idiom
-  `Expression("N", expr, prec).evaluate(evaluation)`. The idea is to avoid when it is possible to call the Pattern matching routines to obtain the numeric value of an expression.
-* A bug comming from a failure in the order in which `mathics.core.definitions` stores the rules was fixed.
+* To speed up development, you can set ``NO_CYTHON`` to skip Cythonizing Python modules
+* ``Expression.is_numeric()`` accepts an ``Evaluation`` object as a parameter;  the definitions attribute of that is used.
+* ``apply_N`` was introduced in module ``mathics.builtin.numeric`` was used to speed up critically used built-in function ``N``. Its use reduces the use of
+  ``Expression("N", expr, prec).evaluate(evaluation)`` which is slower.
+* A bug was fixed relating to the order in which ``mathics.core.definitions`` stores the rules
 
 
 4.0.1

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,15 @@ build:
 
 #: Set up to run from the source tree
 develop:
-	$(PIP) install -e .
+	$(PIP) install -e .[dev]
 
 #: Set up to run from the source tree with full dependencies
 develop-full:
-	$(PIP) install -e .[full]
+	$(PIP) install -e .[dev,full]
+
+#: Set up to run from the source tree with full dependencies and Cython
+develop-full-cython:
+	$(PIP) install -e .[dev,full,cython]
 
 
 #: Make distirbution: wheels, eggs, tarball

--- a/requirements-cython.txt
+++ b/requirements-cython.txt
@@ -1,0 +1,2 @@
+# Optional packages which add functionality or speed things up
+cython # To speed up building

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ For the easiest installation:
 
     pip install -e .
 
+For full installation:
+
+    pip install -e .[full]
+
+
 This will install the library in the default location. For instructions on
 how to customize the install procedure read the output of:
 
@@ -59,7 +64,7 @@ INSTALL_REQUIRES = ["Mathics-Scanner >= 1.2.1,<1.3.0"]
 exec(compile(open("mathics/version.py").read(), "mathics/version.py", "exec"))
 
 EXTRAS_REQUIRE = {}
-for kind in ("dev", "full"):
+for kind in ("dev", "full", "cython"):
     extras_require = []
     requirements_file = f"requirements-{kind}.txt"
     for line in open(requirements_file).read().split("\n"):

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,8 @@ else:
         }
         EXTENSIONS = [
             Extension(
-                "mathics.%s.%s" % (parent, module), ["mathics/%s/%s.py" % (parent, module)]
+                "mathics.%s.%s" % (parent, module),
+                ["mathics/%s/%s.py" % (parent, module)],
             )
             for parent, modules in EXTENSIONS_DICT.items()
             for module in modules

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,12 @@ To get a full list of avaiable commands, read the output of:
 
 """
 
-import re
-import sys
+import os
 import os.path as osp
 import platform
+import re
+import sys
+
 from setuptools import setup, Extension
 
 # Ensure user has the correct Python version
@@ -70,25 +72,30 @@ DEPENDENCY_LINKS = []
 #     "http://github.com/Mathics3/mathics-scanner/tarball/master#egg=Mathics_Scanner-1.0.0.dev"
 # ]
 
+# What should be run through Cython?
+EXTENSIONS = []
+CMDCLASS = {}
+
 try:
     if is_PyPy:
         raise ImportError
     from Cython.Distutils import build_ext
 except ImportError:
-    EXTENSIONS = []
-    CMDCLASS = {}
+    pass
 else:
-    EXTENSIONS_DICT = {
-        "core": ("expression", "number", "rules", "pattern"),
-        "builtin": ["arithmetic", "numeric", "patterns", "graphics"],
-    }
-    EXTENSIONS = [
-        Extension(
-            "mathics.%s.%s" % (parent, module), ["mathics/%s/%s.py" % (parent, module)]
-        )
-        for parent, modules in EXTENSIONS_DICT.items()
-        for module in modules
-    ]
+    if not os.environ.get("NO_CYTHON", False):
+        print("Running Cython over code base")
+        EXTENSIONS_DICT = {
+            "core": ("expression", "number", "rules", "pattern"),
+            "builtin": ["arithmetic", "numeric", "patterns", "graphics"],
+        }
+        EXTENSIONS = [
+            Extension(
+                "mathics.%s.%s" % (parent, module), ["mathics/%s/%s.py" % (parent, module)]
+            )
+            for parent, modules in EXTENSIONS_DICT.items()
+            for module in modules
+        ]
     # EXTENSIONS_SUBDIR_DICT = {
     #     "builtin": [("numbers", "arithmetic"), ("numbers", "numeric"), ("drawing", "graphics")],
     # }


### PR DESCRIPTION
Set environment variable NO_CYTHON before running setup.py to avoid
running Cython even if it is installed.