### PR TITLE
Allow white 3d points

### DIFF
--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -21,6 +21,7 @@ from mathics.builtin.drawing.graphics_internals import GLOBALS3D
 from mathics.builtin.drawing.graphics3d import (
     Coords3D,
     Graphics3DElements,
+    Style3D,
 )
 
 from mathics.builtin.drawing.graphics_internals import get_class
@@ -838,8 +839,17 @@ class Line3DBox(LineBox):
 
 
 class Point3DBox(PointBox):
+    def get_default_face_color(self):
+        return RGBColor(components=(0, 0, 0, 1))
+
     def init(self, *args, **kwargs):
+        # The default color isn't white as it's for the other 3d primitives
+        # here it's black.
+        get_default_face_color_copy = Style3D.get_default_face_color
+
+        Style3D.get_default_face_color = self.get_default_face_color
         super(Point3DBox, self).init(*args, **kwargs)
+        Style3D.get_default_face_color = get_default_face_color_copy
 
     def process_option(self, name, value):
         super(Point3DBox, self).process_option(name, value)

--- a/mathics/format/json.py
+++ b/mathics/format/json.py
@@ -157,10 +157,7 @@ def point_3d_box(self) -> list:
     """
     # TODO: account for point size
 
-    # Tempoary bug fix: default Point color should be black not white
     face_color = self.face_color.to_rgba()
-    if face_color[:3] == (1, 1, 1):
-        face_color = (0, 0, 0, face_color[3])
 
     point_size, _ = self.style.get_style(PointSize, face_element=False)
     relative_point_size = 0.01 if point_size is None else point_size.value


### PR DESCRIPTION
This replaces a temporary fix in the JSON function of the 3d Point
by a function-replacement in Point3DBox.
The temporary fix was converting the color from white to black. This was
done because the default color is white, and it should be black for the
points.