### PR TITLE
remove trailing exit() from debugging

### DIFF
--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -256,7 +256,6 @@ def process_assign_context(self, lhs, rhs, evaluation, tags, upset):
         new_context, allow_initial_backquote=True
     ):
         evaluation.message(lhs_name, "cxset", rhs)
-        exit()
         raise AssignmentException(lhs, None)
 
     # With $Context in Mathematica you can do some strange


### PR DESCRIPTION
This PR removes a line I put when I was debugging the `mathics.builtin.assignment` module, and produces that if we try to set an invalid value to `$Context`, the interpreter is killed instead of showing an error message and continue.