### PR TITLE
rearrange from_python to first try if the argument is a BaseExpression

### DIFF
--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -1040,6 +1040,9 @@ def from_python(arg):
     from mathics.builtin.base import BoxConstruct
     from mathics.core.expression import Expression
 
+    if isinstance(arg, (BaseExpression, BoxConstruct)):
+        return arg
+
     number_type = get_type(arg)
     if arg is None:
         return SymbolNull
@@ -1071,10 +1074,6 @@ def from_python(arg):
             for key in arg
         ]
         return Expression(SymbolList, *entries)
-    elif isinstance(arg, BaseExpression):
-        return arg
-    elif isinstance(arg, BoxConstruct):
-        return arg
     elif isinstance(arg, list) or isinstance(arg, tuple):
         return Expression(SymbolList, *[from_python(leaf) for leaf in arg])
     elif isinstance(arg, bytearray) or isinstance(arg, bytes):


### PR DESCRIPTION
This is a much less drastic version of #49. This just makes that in `from_python`, the case of  Mathics expressions are tested as the first case.