### PR TITLE
List fullform

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -541,7 +541,7 @@ class List(Builtin):
 
     def apply_makeboxes(self, items, f, evaluation):
         """MakeBoxes[{items___},
-        f:StandardForm|TraditionalForm|OutputForm|InputForm]"""
+        f:StandardForm|TraditionalForm|OutputForm|InputForm|FullForm]"""
 
         items = items.get_sequence()
         return Expression(

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -824,7 +824,7 @@ class Solve(Builtin):
      = {{x -> -1}, {x -> 1}}
 
     #> Solve[x^2 +1 == 0, x] // FullForm
-     = List[List[Rule[x, Complex[0, -1]]], List[Rule[x, Complex[0, 1]]]]
+     = {{Rule[x, Complex[0, -1]]},{Rule[x, Complex[0, 1]]}}
 
     #> Solve[x^5==x,x]
      = {{x -> -1}, {x -> 0}, {x -> 1}, {x -> -I}, {x -> I}}

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -50,7 +50,7 @@ class DSolve(Builtin):
     ##  = DSolve[f[2 x] == Sin[f'[x]], f, x]
 
     #> DSolve[f'[x] == f[x], f, x] // FullForm
-     = List[List[Rule[f, Function[List[x], Times[C[1], Power[E, x]]]]]]
+     = {{Rule[f, Function[{x}, Times[C[1], Power[E, x]]]]}}
 
     #> DSolve[f'[x] == f[x], f, x] /. {C[1] -> 1}
      = {{f -> (Function[{x}, 1 E ^ x])}}

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -405,8 +405,12 @@ Nested calculations are nested function calls:
   = Plus[a, Times[b, Plus[c, d]]]
 
 Even lists are function calls of the function 'List':
+  >> Head[{1, 2, 3}]
+  = List
+
+However, its full form is presented with ${\ldots}$
   >> FullForm[{1, 2, 3}]
-  = List[1, 2, 3]
+   = {1,2,3}
 
  The head of an expression can be determined with 'Head':
   >> Head[a + b + c]


### PR DESCRIPTION
This PR changes the behavior of MakeBoxes[List[___], FullForm] to make it closer to WMA. 
```
In[1] := FullForm[List[1,2,3]]
Out[1]:= {1,2,3}
```
This also helps to debug some code like the one in ``Series``, which can produce several nested lists.


