### PR TITLE
load mathics.builtin.box

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -152,6 +152,7 @@ disable_file_module_names = (
 for subdir in (
     "arithfns",
     "assignments",
+    "box",
     "colors",
     "distance",
     "drawing",


### PR DESCRIPTION
This PR fixes some flakiness I found during the `Definitions` refactoring: `mathics.builtin.box.*` was not loaded during the startup.