### PR TITLE
Faster Plot

### DIFF
--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -258,8 +258,7 @@ def compile_quiet_function(expr, arg_names, evaluation, expect_list):
                 return None
 
             return quiet_f
-
-    expr = Expression(SymbolN, expr)
+    expr = Expression(SymbolN, expr).evaluate(evaluation)
     quiet_expr = Expression(
         "Quiet",
         expr,


### PR DESCRIPTION
One of the slowest tests in `docpipeline` are the ones associated with Spherical Bessel functions. In particular, the ones that plot these functions. This was due to a wrong implementation of the numerification (is that the word?) of the functions to be plotted in
`mathics.builtin.drawing.Plot_`.
This PR
* Improves rules for SphericalBesselFunction(J/Y) to make the evaluation faster
* Fixes in the plot routine, that numerify expressions