### PR TITLE
Stop importing __version__

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -110,10 +110,6 @@ def import_builtins(module_names: List[str], submodule_name=None) -> None:
             print(f"    mathics.builtin loads from {__file__[:-11]}")
             return None
 
-        if __version__ != module.__version__:
-            print(
-                f"Version {module.__version__} in the module does not match top-level Mathics version {__version__}"
-            )
         if module:
             modules.append(module)
 

--- a/mathics/builtin/arithfns/__init__.py
+++ b/mathics/builtin/arithfns/__init__.py
@@ -3,5 +3,3 @@ Arithmetic Functions
 
 Arithmetic Functions are functions that work on individual numbers, lists, and arrays: in either symbolic or algebraic forms.
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -6,7 +6,6 @@ The functions here are the basic arithmetic operations that you might find on a 
 
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 import sympy
 import mpmath

--- a/mathics/builtin/arithfns/sums.py
+++ b/mathics/builtin/arithfns/sums.py
@@ -5,7 +5,6 @@ Sums, Simple Statistics
 These functions perform a simple arithmetic computation over a list.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -7,7 +7,6 @@ Mathematical Functions
 Basic arithmetic functions, including complex number arithmetic.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 import sympy
 import sys

--- a/mathics/builtin/assignments/__init__.py
+++ b/mathics/builtin/assignments/__init__.py
@@ -5,5 +5,3 @@ Assigments allow you to set or clear variables, indexed variables, structure ele
 
 You can also get assignment and documentation information about symbols.
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/assignments/assign_binaryop.py
+++ b/mathics/builtin/assignments/assign_binaryop.py
@@ -12,7 +12,6 @@ Infix operators combined with assignment end in 'By', 'From', or 'To'.
 
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     BinaryOperator,

--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -3,7 +3,6 @@
 Forms of Assignment
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, BinaryOperator
 from mathics.core.rules import Rule

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -3,7 +3,6 @@
 Clearing Assignments
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     Builtin,

--- a/mathics/builtin/assignments/information.py
+++ b/mathics/builtin/assignments/information.py
@@ -3,7 +3,6 @@
 Information about Assignments
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, PrefixOperator
 

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.algorithm.parts import walk_parts
 from mathics.core.evaluation import MAX_RECURSION_DEPTH, set_python_recursion_limit

--- a/mathics/builtin/assignments/types.py
+++ b/mathics/builtin/assignments/types.py
@@ -5,7 +5,6 @@
 Types of Values
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/assignments/upvalues.py
+++ b/mathics/builtin/assignments/upvalues.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import BinaryOperator
 from mathics.core.symbols import Symbol

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -9,7 +9,6 @@ The builtin-attributes having a predefined meaning in \Mathics which are describ
 However in contrast to \Mathematica, you can set any symbol as an attribute.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Predefined, Builtin
 from mathics.core.expression import Expression

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -9,7 +9,6 @@ from itertools import chain
 import typing
 from typing import Any, cast
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.exceptions import (
     BoxConstructError,

--- a/mathics/builtin/colors/__init__.py
+++ b/mathics/builtin/colors/__init__.py
@@ -4,5 +4,3 @@ Colors
 Programmatic support for symbolic colors.
 
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/colors/color_directives.py
+++ b/mathics/builtin/colors/color_directives.py
@@ -6,7 +6,6 @@ There are many different way to specify color; we support all of the color forma
 
 from math import atan2, cos, exp, pi, radians, sin, sqrt
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.colors.color_internals import convert_color
 

--- a/mathics/builtin/colors/color_internals.py
+++ b/mathics/builtin/colors/color_internals.py
@@ -6,7 +6,6 @@
 
 from math import pi
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.numpy_utils import (
     sqrt,

--- a/mathics/builtin/colors/color_operations.py
+++ b/mathics/builtin/colors/color_operations.py
@@ -4,7 +4,6 @@
 Functions for manipulating colors and color images.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 import itertools
 from math import floor

--- a/mathics/builtin/colors/named_colors.py
+++ b/mathics/builtin/colors/named_colors.py
@@ -8,8 +8,6 @@ from mathics.builtin.base import Builtin
 
 from mathics.core.symbols import strip_context
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 
 class _ColorObject(Builtin):
     text_name = None

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 from typing import Optional, Any
 
 import sympy

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -9,7 +9,6 @@ When LLVM and Python libraries are available, compilation produces LLVM code.
 
 import ctypes
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 from mathics.builtin.box.compilation import CompiledCodeBox

--- a/mathics/builtin/compress.py
+++ b/mathics/builtin/compress.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 import base64
 import zlib

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -14,7 +14,6 @@ import re
 import sys
 import time
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.core.expression import Expression
 from mathics.core.atoms import (

--- a/mathics/builtin/distance/__init__.py
+++ b/mathics/builtin/distance/__init__.py
@@ -3,5 +3,3 @@ Distance and Similarity Measures
 
 Different measures of distance or similarity for different types of analysis.
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/distance/stringdata.py
+++ b/mathics/builtin/distance/stringdata.py
@@ -7,7 +7,6 @@ import unicodedata
 
 from typing import Callable
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/drawing/__init__.py
+++ b/mathics/builtin/drawing/__init__.py
@@ -9,5 +9,3 @@ Showing something visually can be don in a number of ways:
   <li>Compute the points of the space using a function. This is done using functions like 'Plot' and 'ListPlot'.
 </ul>
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -5,7 +5,6 @@
 Functions for working with 3D graphics.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.core.atoms import Real, Integer, Rational
 

--- a/mathics/builtin/drawing/graphics_internals.py
+++ b/mathics/builtin/drawing/graphics_internals.py
@@ -3,7 +3,6 @@
 # No external builtins appear here.
 # Also no docstring which may confuse the doc system
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     InstanceableBuiltin,

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -4,7 +4,7 @@ Image[] and image related functions
 
 Note that you (currently) need scikit-image installed in order for this module to work.
 """
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 
 from mathics.builtin.base import Builtin, AtomBuiltin, Test, String
 from mathics.builtin.box.image import ImageBox

--- a/mathics/builtin/drawing/image_internals.py
+++ b/mathics/builtin/drawing/image_internals.py
@@ -6,7 +6,6 @@
 # Signals to Mathics doc processing not to include this module in its documentation.
 no_doc = True
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 import numpy
 

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -11,7 +11,7 @@ import numbers
 import itertools
 import palettable
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.core.expression import Expression
 from mathics.core.atoms import (
     Real,

--- a/mathics/builtin/drawing/splines.py
+++ b/mathics/builtin/drawing/splines.py
@@ -6,7 +6,6 @@ A Spline is a mathematical function used for interpolation or smoothing. Splines
 """
 
 from mathics.builtin.base import Builtin
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 
 # For a more generic implementation in Python using scipy,

--- a/mathics/builtin/drawing/uniform_polyhedra.py
+++ b/mathics/builtin/drawing/uniform_polyhedra.py
@@ -6,7 +6,6 @@ Uniform Polyhedra
 Uniform polyhedra is the grouping of platonic solids, Archimedean solids, and regular star polyhedra.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Predefined, Builtin
 from mathics.core.atoms import Integer

--- a/mathics/builtin/exceptions.py
+++ b/mathics/builtin/exceptions.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 
 class BoxConstructError(Exception):

--- a/mathics/builtin/fileformats/__init__.py
+++ b/mathics/builtin/fileformats/__init__.py
@@ -8,6 +8,3 @@ Built-in Importers.
 # The Built-in Functions are defined in a separate context under the
 # System`. For example System`HTML` and System`XML.  This is done to not
 # pollute the System` namespace.
-
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/fileformats/htmlformat.py
+++ b/mathics/builtin/fileformats/htmlformat.py
@@ -8,8 +8,6 @@ Basic implementation for a HTML importer
 
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 
 from mathics.builtin.base import Builtin
 from mathics.builtin.files_io.files import MathicsOpen

--- a/mathics/builtin/fileformats/xmlformat.py
+++ b/mathics/builtin/fileformats/xmlformat.py
@@ -5,8 +5,6 @@ XML
 """
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 from mathics.builtin.base import Builtin
 from mathics.builtin.files_io.files import MathicsOpen
 from mathics.core.expression import Expression

--- a/mathics/builtin/files_io/__init__.py
+++ b/mathics/builtin/files_io/__init__.py
@@ -1,5 +1,3 @@
 """
 Input/Output, Files, and Filesystem
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -17,7 +17,6 @@ from io import BytesIO
 import os.path as osp
 from itertools import chain
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics_scanner import TranslateError
 from mathics.core.parser import MathicsFileLineFeeder, parse

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -12,7 +12,6 @@ import time
 
 import os.path as osp
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.core.expression import Expression
 from mathics.core.atoms import Real, Integer, String, from_python

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -4,7 +4,6 @@
 Importing and Exporting
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.core.atoms import (
     ByteArrayAtom,

--- a/mathics/builtin/files_io/mainloop.py
+++ b/mathics/builtin/files_io/mainloop.py
@@ -20,7 +20,6 @@ If you assign a function to the global variable '$PreRead' it will be applied wi
 Similarly, if you assign a function to global variable '$Pre', it will be applied with the input before processing the input, the second step listed above.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -10,7 +10,7 @@ It is made richer by expressions like $f$[$x$] being treating as symbolic data.
 
 from itertools import chain
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin, PostfixOperator
 from mathics.core.expression import Expression
 

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -8,7 +8,6 @@ Drawing Graphics
 
 from math import sqrt
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     Builtin,

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.core.expression import Expression
 from mathics.core.symbols import (

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -10,7 +10,6 @@ import mpmath
 import typing
 from typing import Any
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.box.inout import RowBox
 

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -8,8 +8,6 @@ It is closely related to many other areas of mathematics and has many applicatio
 """
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.atoms import Integer

--- a/mathics/builtin/intfns/divlike.py
+++ b/mathics/builtin/intfns/divlike.py
@@ -7,7 +7,7 @@ Division-Related Functions
 import sympy
 from itertools import combinations
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin, Test, SympyFunction
 from mathics.core.expression import Expression
 from mathics.core.atoms import Integer

--- a/mathics/builtin/intfns/recurrence.py
+++ b/mathics/builtin/intfns/recurrence.py
@@ -7,7 +7,7 @@ A recurrence relation is an equation that recursively defines a sequence or mult
 
 
 from sympy.functions.combinatorial.numbers import stirling
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import Integer

--- a/mathics/builtin/list/__init__.py
+++ b/mathics/builtin/list/__init__.py
@@ -5,5 +5,3 @@ S-Expressions make up a core part of Mathics. The parsed and internal representa
 
 As a result, there about a hundred list functions.
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/list/associations.py
+++ b/mathics/builtin/list/associations.py
@@ -6,8 +6,6 @@ Associations
 An Association maps keys to values and is similar to a dictionary in Python; it is often sparse in that their key space is much larger than the number of actual keys found in the collection.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 
 from mathics.builtin.base import (
     Builtin,

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -8,7 +8,6 @@ Functions for constructing lists of various sizes and structure.
 
 from itertools import permutations
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, Pattern
 

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -8,7 +8,6 @@ Functions for accessing elements of lists using either indices, positions, or pa
 
 from itertools import chain
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     BinaryOperator,

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -10,8 +10,6 @@ import functools
 from itertools import chain
 from typing import Callable
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 
 from mathics.builtin.base import (
     Builtin,

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -10,7 +10,6 @@ import sympy
 from collections import defaultdict
 from itertools import chain
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.algorithm.introselect import introselect
 from mathics.algorithm.parts import (

--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import BinaryOperator, Predefined, PrefixOperator, Builtin
 from mathics.builtin.lists import InvalidLevelspecError, python_levelspec, walk_levels
 from mathics.core.expression import Expression

--- a/mathics/builtin/manipulate.py
+++ b/mathics/builtin/manipulate.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics import settings
 from mathics.core.evaluation import Output

--- a/mathics/builtin/moments/__init__.py
+++ b/mathics/builtin/moments/__init__.py
@@ -3,5 +3,3 @@ Statistics, Moments, and Generating Functions
 
 Moments or combinations of moments are used to summarize a distribution or data. Mean is used to indicate a center location, variance and standard deviation are used to indicate dispersion and covariance, and correlation to indicate dependence.
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/moments/basic.py
+++ b/mathics/builtin/moments/basic.py
@@ -4,7 +4,6 @@
 Basic statistics
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.algorithm.introselect import introselect
 

--- a/mathics/builtin/moments/special.py
+++ b/mathics/builtin/moments/special.py
@@ -4,7 +4,6 @@
 Special Moments
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/numbers/__init__.py
+++ b/mathics/builtin/numbers/__init__.py
@@ -1,5 +1,3 @@
 """
 Integer and Number-Theoretical Functions
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -4,8 +4,6 @@ Algebraic Manipulation
 """
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -3,7 +3,7 @@
 """
 Calculus
 """
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 
 from mathics.builtin.base import Builtin, PostfixOperator, SympyFunction
 from mathics.core.expression import Expression

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -11,7 +11,6 @@ import mpmath
 import numpy
 import sympy
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Predefined, SympyObject
 from mathics.core.symbols import (

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -9,8 +9,6 @@ from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.convert import from_sympy
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 
 class DSolve(Builtin):
     """

--- a/mathics/builtin/numbers/exptrig.py
+++ b/mathics/builtin/numbers/exptrig.py
@@ -10,7 +10,6 @@ Numerical values and derivatives can be computed; however, most special exact va
 
 import mpmath
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression

--- a/mathics/builtin/numbers/integer.py
+++ b/mathics/builtin/numbers/integer.py
@@ -8,7 +8,6 @@ Integer Functions
 import sympy
 import string
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, SympyFunction
 from mathics.core.convert import from_sympy

--- a/mathics/builtin/numbers/linalg.py
+++ b/mathics/builtin/numbers/linalg.py
@@ -8,7 +8,7 @@ import sympy
 from sympy import re, im
 from mpmath import mp
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin
 from mathics.core.convert import from_sympy
 from mathics.core.expression import Expression

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -6,7 +6,7 @@ Number theoretic functions
 
 import sympy
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin, SympyFunction
 from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol

--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -13,7 +13,7 @@ import hashlib
 from operator import mul as operator_mul
 from functools import reduce
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin
 from mathics.builtin.numpy_utils import instantiate_elements, stack
 from mathics.core.atoms import Integer, String, Real, Complex

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -12,7 +12,7 @@ Support for numeric evaluation with arbitrary precision is just a proof-of-conce
 Precision is not "guarded" through the evaluation process. Only integer precision is supported.
 However, things like 'N[Pi, 100]' should work as expected.
 """
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 import sympy
 import mpmath
 import numpy as np

--- a/mathics/builtin/optimization.py
+++ b/mathics/builtin/optimization.py
@@ -8,7 +8,7 @@ Optimization problems of sorts arise in all quantitative disciplines from comput
 We intend to provide local and global optimization techniques, both numeric and symbolic.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.atoms import from_python

--- a/mathics/builtin/optiondoc.py
+++ b/mathics/builtin/optiondoc.py
@@ -16,8 +16,6 @@ The various common Plot and Graphics options, along with the meaning of specific
 
 from mathics.builtin.base import Builtin
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 
 class Automatic(Builtin):
     """

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -4,7 +4,6 @@
 Options and Default Arguments
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, Test, get_option
 from mathics.core.symbols import (

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -37,7 +37,6 @@ The attributes 'Flat', 'Orderless', and 'OneIdentity' affect pattern matching.
 """
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 from mathics.builtin.base import Builtin, BinaryOperator, PostfixOperator, AtomBuiltin
 from mathics.builtin.base import PatternObject, PatternError
 from mathics.algorithm.parts import python_levelspec

--- a/mathics/builtin/physchemdata.py
+++ b/mathics/builtin/physchemdata.py
@@ -9,7 +9,7 @@ import os
 
 from csv import reader as csvreader
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol, strip_context

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -11,8 +11,6 @@ Procedural functions are integrated into Mathics symbolic programming environmen
 """
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 from mathics.builtin.base import Builtin, BinaryOperator
 from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol

--- a/mathics/builtin/quantities.py
+++ b/mathics/builtin/quantities.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin, Test
 from mathics.core.expression import Expression
 from mathics.core.atoms import (

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -6,7 +6,7 @@ Solving Recurrence Equations
 
 
 import sympy
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.convert import sympy_symbol_prefix, from_sympy

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import Builtin, Predefined
 from mathics.core.expression import Expression
 from mathics.core.symbols import (

--- a/mathics/builtin/sparse.py
+++ b/mathics/builtin/sparse.py
@@ -5,7 +5,6 @@ SparseArray Functions
 """
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 from mathics.algorithm.parts import walk_parts
 
 from mathics.builtin.base import Builtin

--- a/mathics/builtin/specialfns/__init__.py
+++ b/mathics/builtin/specialfns/__init__.py
@@ -10,5 +10,3 @@ A number of special functions can be evaluated for arbitrary complex values of t
 For example, integral representations of functions are only valid when the integral exists, but the functions can usually be defined b by analytic continuation.
 
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/specialfns/bessel.py
+++ b/mathics/builtin/specialfns/bessel.py
@@ -5,8 +5,6 @@ Bessel and Related Functions
 import mpmath
 
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
-
 from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import from_mpmath

--- a/mathics/builtin/specialfns/erf.py
+++ b/mathics/builtin/specialfns/erf.py
@@ -4,7 +4,6 @@
 Error Function and Related Functions
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.arithmetic import _MPMathFunction, _MPMathMultiFunction
 

--- a/mathics/builtin/specialfns/expintegral.py
+++ b/mathics/builtin/specialfns/expintegral.py
@@ -4,7 +4,6 @@
 Exponential Integral and Special Functions
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.arithmetic import _MPMathFunction
 

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -2,7 +2,6 @@
 Gamma and Related Functions
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.arithmetic import _MPMathMultiFunction
 from mathics.builtin.base import SympyFunction

--- a/mathics/builtin/specialfns/othogonal.py
+++ b/mathics/builtin/specialfns/othogonal.py
@@ -2,7 +2,6 @@
 Orthogonal Polynomials
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.core.atoms import Integer0

--- a/mathics/builtin/specialfns/zeta.py
+++ b/mathics/builtin/specialfns/zeta.py
@@ -6,7 +6,6 @@ Exponential Integral and Special Functions
 
 import mpmath
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.core.atoms import from_mpmath

--- a/mathics/builtin/string/__init__.py
+++ b/mathics/builtin/string/__init__.py
@@ -2,5 +2,3 @@
 Strings and Characters
 
 """
-
-from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/string/characters.py
+++ b/mathics/builtin/string/characters.py
@@ -3,7 +3,6 @@
 Characters in Strings
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, Test
 

--- a/mathics/builtin/string/charcodes.py
+++ b/mathics/builtin/string/charcodes.py
@@ -4,7 +4,7 @@ Character Codes
 """
 
 import sys
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -6,7 +6,6 @@ Operations on Strings
 
 import re
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     BinaryOperator,

--- a/mathics/builtin/string/patterns.py
+++ b/mathics/builtin/string/patterns.py
@@ -5,7 +5,6 @@ String Patterns
 
 import re
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import BinaryOperator, Builtin
 

--- a/mathics/builtin/string/regexp.py
+++ b/mathics/builtin/string/regexp.py
@@ -3,7 +3,6 @@
 Regular Expressions
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -10,7 +10,6 @@ from binascii import hexlify, unhexlify
 from heapq import heappush, heappop
 from typing import Any, List
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import (
     Builtin,

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -3,7 +3,7 @@
 Structural Operations
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
+
 from mathics.builtin.base import (
     Builtin,
     Predefined,

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -10,7 +10,6 @@ There are many types of tensors, including scalars and vectors (which are the si
 Mathics represents tensors of vectors and matrices as lists; tensors of any rank can be handled.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin, BinaryOperator
 from mathics.core.expression import Expression

--- a/mathics/builtin/trace.py
+++ b/mathics/builtin/trace.py
@@ -8,7 +8,6 @@ Built-in Function Tracing provides one high-level way understand where the time 
 With this it may be possible for both users and implementers to figure out how to speed up running expressions.
 """
 
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 from mathics.builtin.base import Builtin
 from mathics.core.rules import BuiltinRule


### PR DESCRIPTION
That was ued for checking consistency in loading, but that isn't
necessary in all files as Python wouldn't mess with just some
files, that'd be either no files or all files.