### PR TITLE
Fix the distortion in Plot3D

### DIFF
--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -273,11 +273,11 @@ class Graphics3DBox(GraphicsBox):
 
             boxscale = [1.0, 1.0, 1.0]
             if boxratios[0] != "System`Automatic":
-                boxscale[0] /= xmax - xmin
+                boxscale[0] = boxratios[0] / (xmax - xmin)
             if boxratios[1] != "System`Automatic":
-                boxscale[1] /= ymax - ymin
+                boxscale[1] = boxratios[1] / (ymax - ymin)
             if boxratios[2] != "System`Automatic":
-                boxscale[2] /= zmax - zmin
+                boxscale[2] = boxratios[2] / (zmax - zmin)
 
             if final_pass:
                 xmin *= boxscale[0]


### PR DESCRIPTION
The bug was introduced in 0575f3d8eb574daf12eadf60b0786ea60839eb3c (thanks @rocky for finding it).
Plot3D was always drawing cube plots, even if the height was between -0.5 and 0.5 (supposing the range is -1 and 1), it was "distorted" to -1 and 1.

---

I know, it doesn't make any sense, I wish there were sense. Where did all the sense go?