### PR TITLE
Allow using Sympy 1.9

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -12,7 +12,6 @@ from mathics.core.expression import Expression
 from mathics.core.atoms import (
     String,
     Integer,
-    Integer0,
     Integer1,
     Number,
     Rational,
@@ -28,6 +27,7 @@ from mathics.core.symbols import (
 )
 
 from mathics.core.systemsymbols import (
+    SymbolIndeterminate,
     SymbolPlus,
     SymbolPower,
     SymbolRule,
@@ -54,6 +54,8 @@ import sympy
 
 IntegerZero = Integer(0)
 IntegerMinusOne = Integer(-1)
+
+SymbolIntegrate = Symbol("Integrate")
 
 
 class D(SympyFunction):
@@ -594,9 +596,6 @@ class Integrate(SympyFunction):
 
     def apply(self, f, xs, evaluation, options):
         "Integrate[f_, xs__, OptionsPattern[]]"
-        self.patpow0 = Pattern.create(
-            Expression("Power", Integer0, Expression("Blank"))
-        )
         assuming = options["System`Assumptions"].evaluate(evaluation)
         f_sympy = f.to_sympy()
         if f_sympy is None or isinstance(f_sympy, SympyExpression):
@@ -688,7 +687,10 @@ class Integrate(SympyFunction):
             else:
                 result = Expression(result._head, cases, default)
         else:
-            result = Expression("Simplify", result, assuming).evaluate(evaluation)
+            if result.get_head() is SymbolIntegrate:
+                # Sympy returned the same expression, so it can't be evaluated.
+                return SymbolIndeterminate
+            result = Expression("Simplify", result, assuming)
         return result
 
 

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ else:
 # General Requirements
 INSTALL_REQUIRES += [
     "Mathics_Scanner>=1.2.1,<1.3.0",
-    "sympy>=1.8, <= 1.9dev",
+    "sympy>=1.8, <= 1.9",
     "mpmath>=1.2.0",
     "numpy",
     "palettable",


### PR DESCRIPTION
Sympy 1.9 is out and it seems to work without problems. Allow (but don't require) it.