### PR TITLE
fix N (Issue #103)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,8 +35,8 @@ Internals
 Bugs
 ++++
 
-* ``First``, ``Rest`` and  ``Last`` now handle invalid arguments.
-  
+* ``First``, ``Rest`` and  ``Last`` now handle invalid arguments (issue #104).
+* ``N`` now handles properly the conversion of large integers to PrecisionReal (issue #103).
   
 4.0.1
 -----

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -165,9 +165,11 @@ class Integer(Number):
 
     def round(self, d=None) -> typing.Union["MachineReal", "PrecisionReal"]:
         if d is None:
-            return MachineReal(float(self.value))
-        else:
-            return PrecisionReal(sympy.Float(self.value, d))
+            try:
+                return MachineReal(float(self.value))
+            except:
+                d = 15
+        return PrecisionReal(sympy.Float(self.value, d))
 
     def get_int_value(self) -> int:
         return self.value


### PR DESCRIPTION
The evaluation is still slow, but this avoids the overflow. There are two things that could be improved:
* to check the size of the number before the conversion, to avoid using an exception.
* the default value of `d` could be taken from `mathics.core.number`  instead of hardcoding it to 15.
