### PR TITLE
Reduce unnecessary expansion & untangle imports...

### DIFF
--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -6,7 +6,7 @@ Algorithms to access and manipulate elements in nested lists / expressions
 
 
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol
+from mathics.core.symbols import Constant, Symbol
 from mathics.core.atoms import Integer
 from mathics.core.systemsymbols import SymbolInfinity
 from mathics.core.subexpression import SubExpression
@@ -18,7 +18,7 @@ from mathics.builtin.exceptions import (
     PartRangeError,
 )
 
-SymbolNothing = Symbol("Nothing")
+SymbolNothing = Constant("Nothing")
 
 # TODO: delete me
 # def join_lists(lists):

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -30,7 +30,13 @@ from mathics.core.atoms import (
     String,
     from_mpmath,
 )
-from mathics.core.symbols import Symbol, SymbolList, SymbolNull, SymbolHoldForm
+from mathics.core.symbols import (
+    Constant,
+    Symbol,
+    SymbolList,
+    SymbolNull,
+    SymbolHoldForm,
+)
 from mathics.core.systemsymbols import (
     SymbolBlank,
     SymbolComplexInfinity,
@@ -63,7 +69,7 @@ from mathics.core.attributes import (
 )
 
 
-SymbolLeft = Symbol("Left")
+SymbolLeft = Constant("Left")
 
 
 class CubeRoot(Builtin):

--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -5,7 +5,7 @@ Forms of Assignment
 
 
 from mathics.builtin.base import Builtin, BinaryOperator
-from mathics.core.symbols import Symbol
+from mathics.core.symbols import Symbol, SymbolNull
 
 from mathics.core.systemsymbols import (
     SymbolFailed,
@@ -159,7 +159,7 @@ class SetDelayed(Set):
         "lhs_ := rhs_"
 
         if self.assign(lhs, rhs, evaluation):
-            return Symbol("Null")
+            return SymbolNull
         else:
             return SymbolFailed
 

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -153,7 +153,7 @@ def find_tag_and_check(lhs, tags, evaluation):
 
 
 def unroll_patterns(lhs, rhs, evaluation):
-    if type(lhs) is Symbol:
+    if isinstance(lhs, Symbol):
         return lhs, rhs
     name = lhs.get_head_name()
     lhsleaves = lhs._leaves
@@ -171,7 +171,7 @@ def unroll_patterns(lhs, rhs, evaluation):
 
 def unroll_conditions(lhs):
     condition = None
-    if type(lhs) is Symbol:
+    if isinstance(lhs, Symbol):
         return lhs, None
     else:
         name, lhs_leaves = lhs.get_head_name(), lhs._leaves
@@ -651,7 +651,7 @@ class _SetOperator(object):
     }
 
     def assign_elementary(self, lhs, rhs, evaluation, tags=None, upset=False):
-        if type(lhs) is Symbol:
+        if isinstance(lhs, Symbol):
             name = lhs.name
         else:
             name = lhs.get_head_name()

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -12,11 +12,7 @@ from typing import Any, cast
 
 from mathics.builtin.exceptions import (
     BoxConstructError,
-    InvalidLevelspecError,
     MessageException,
-    PartError,
-    PartDepthError,
-    PartRangeError,
 )
 from mathics.core.convert import from_sympy
 from mathics.core.definitions import Definition
@@ -29,6 +25,7 @@ from mathics.core.symbols import (
     strip_context,
 )
 from mathics.core.atoms import (
+    ExpandOnce,
     Integer,
     MachineReal,
     PrecisionReal,
@@ -41,7 +38,7 @@ from mathics.core.symbols import (
     SymbolTrue,
 )
 
-from mathics.core.attributes import nothing, protected
+from mathics.core.attributes import protected
 
 
 def get_option(options, name, evaluation, pop=False, evaluate=True):
@@ -590,7 +587,7 @@ class SympyFunction(SympyObject):
         return sympy_expr
 
 
-class BoxConstruct(InstanceableBuiltin):
+class BoxConstruct(InstanceableBuiltin, ExpandOnce):
     def __new__(cls, *leaves, **kwargs):
         instance = super().__new__(cls, *leaves, **kwargs)
         instance._leaves = leaves

--- a/mathics/builtin/box/compilation.py
+++ b/mathics/builtin/box/compilation.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from mathics.builtin.base import BoxConstruct
+from mathics.core.symbols import ExpandOnce
 
 
-class CompiledCodeBox(BoxConstruct):
+class CompiledCodeBox(BoxConstruct, ExpandOnce):
     """Routines which get called when Boxing (adding formatting and bounding-box information)
     to CompiledCode.
     """

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -42,7 +42,7 @@ from mathics.core.atoms import (
     Real,
     String,
 )
-from mathics.core.symbols import SymbolList
+from mathics.core.symbols import ExpandOnce, SymbolList
 
 from mathics.core.attributes import hold_all, protected, read_protected
 
@@ -352,7 +352,7 @@ class DiskBox(_ArcBox):
     face_element = True
 
 
-class GraphicsBox(BoxConstruct):
+class GraphicsBox(BoxConstruct, ExpandOnce):
     """Boxing method which get called when Boxing (adding formatting and bounding-box information)
     Graphics.
     """

--- a/mathics/builtin/box/image.py
+++ b/mathics/builtin/box/image.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from mathics.builtin.base import BoxConstruct
+from mathics.core.symbols import ExpandOnce
 
 
-class ImageBox(BoxConstruct):
+class ImageBox(BoxConstruct, ExpandOnce):
     """Routines which get called when Boxing (adding formatting and bounding-box information)
     an Image object.
     """

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -26,7 +26,14 @@ from mathics.builtin.lists import list_boxes
 from mathics.builtin.options import options_to_rules
 
 from mathics.core.expression import Expression, BoxError
-from mathics.core.symbols import Symbol, SymbolList, SymbolTrue, SymbolFalse, SymbolNull
+from mathics.core.symbols import (
+    ExpandOnce,
+    Symbol,
+    SymbolList,
+    SymbolTrue,
+    SymbolFalse,
+    SymbolNull,
+)
 
 from mathics.core.atoms import (
     String,
@@ -752,7 +759,7 @@ def is_constant_list(list):
 
 # TODO: Inheritance of options["ColumnAlignments"] prevents us from
 # putting this in mathics.builtin.box. Figure out what's up here.
-class GridBox(BoxConstruct):
+class GridBox(BoxConstruct, ExpandOnce):
     r"""
     <dl>
     <dt>'GridBox[{{...}, {...}}]'

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -12,9 +12,9 @@ from itertools import chain
 from mathics.builtin.base import (
     BinaryOperator,
     Builtin,
-    InvalidLevelspecError,
-    PartError,
 )
+
+from mathics.builtin.exceptions import InvalidLevelspecError, PartError
 
 from mathics.builtin.lists import list_boxes
 from mathics.algorithm.parts import (

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -29,15 +29,18 @@ from mathics.algorithm.clusters import (
 from mathics.builtin.base import (
     Builtin,
     CountableInteger,
-    InvalidLevelspecError,
     MessageException,
     NegativeIntegerException,
-    PartDepthError,
-    PartError,
-    PartRangeError,
     Predefined,
     SympyFunction,
     Test,
+)
+
+from mathics.builtin.exceptions import (
+    InvalidLevelspecError,
+    PartDepthError,
+    PartError,
+    PartRangeError,
 )
 
 from mathics.builtin.numbers.algebra import cancel

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -759,11 +759,11 @@ class String_(Builtin):
 class ToString(Builtin):
     """
     <dl>
-    <dt>'ToString[$expr$]'
-        <dd>returns a string representation of $expr$.
-    <dt>'ToString[$expr$, $form$]'
-        <dd>returns a string representation of $expr$ in the form
-          $form$.
+      <dt>'ToString[$expr$]'
+      <dd>returns a string representation of $expr$.
+
+      <dt>'ToString[$expr$, $form$]'
+      <dd>returns a string representation of $expr$ in the form $form$.
     </dl>
 
     >> ToString[2]

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -10,8 +10,8 @@ from mathics.builtin.base import (
     BinaryOperator,
     Test,
     MessageException,
-    PartRangeError,
 )
+from mathics.builtin.exceptions import InvalidLevelspecError, PartRangeError
 from mathics.core.expression import Expression
 from mathics.core.symbols import (
     Symbol,
@@ -34,7 +34,6 @@ from mathics.core.rules import Pattern
 from mathics.builtin.lists import (
     python_levelspec,
     walk_levels,
-    InvalidLevelspecError,
     List,
 )
 

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -70,7 +70,17 @@ def from_mpmath(value, prec=None):
         raise TypeError(type(value))
 
 
-class Number(Atom):
+# This feels like a hack. It generalizes the method expression used in expression regarding
+# BoxConstruct.
+class ExpandOnce:
+    """Inherit from this class when you have an object that you never want expanded after
+    the initial try. BoxConstructs are like this
+    """
+
+    pass
+
+
+class Number(Atom, ExpandOnce):
     def __str__(self) -> str:
         return str(self.value)
 
@@ -125,7 +135,7 @@ _number_form_options = {
 }
 
 
-class Integer(Number):
+class Integer(Number, ExpandOnce):
     value: int
     class_head_name = "System`Integer"
 
@@ -220,7 +230,7 @@ Integer0 = Integer(0)
 Integer1 = Integer(1)
 
 
-class Rational(Number):
+class Rational(Number, ExpandOnce):
     class_head_name = "System`Rational"
 
     @lru_cache()
@@ -324,7 +334,7 @@ class Rational(Number):
 RationalOneHalf = Rational(1, 2)
 
 
-class Real(Number):
+class Real(Number, ExpandOnce):
     class_head_name = "System`Real"
 
     def __new__(cls, value, p=None) -> "Real":
@@ -715,7 +725,7 @@ class Complex(Number):
         return real_zero and imag_zero
 
 
-class String(Atom):
+class String(Atom, ExpandOnce):
     value: str
     class_head_name = "System`String"
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -15,6 +15,7 @@ from mathics.core.convert import sympy_symbol_prefix, SympyExpression
 from mathics.core.symbols import (
     Atom,
     BaseExpression,
+    ExpandOnce,
     Monomial,
     Symbol,
     SymbolList,
@@ -22,9 +23,7 @@ from mathics.core.symbols import (
     SymbolSequence,
     system_symbols,
     ensure_context,
-    strip_context,
 )
-from mathics.core.systemsymbols import SymbolSequence
 
 from mathics.core.attributes import (
     flat,
@@ -807,7 +806,6 @@ class Expression(BaseExpression):
         return expr
 
     def evaluate_next(self, evaluation) -> typing.Tuple["Expression", bool]:
-        from mathics.builtin.base import BoxConstruct
 
         head = self._head.evaluate(evaluation)
         attributes = head.get_attributes(evaluation.definitions)
@@ -909,7 +907,7 @@ class Expression(BaseExpression):
         for rule in rules():
             result = rule.apply(new, evaluation, fully=False)
             if result is not None:
-                if isinstance(result, BoxConstruct):
+                if isinstance(result, ExpandOnce):
                     return result, False
                 if result.sameQ(new):
                     new._timestamp_cache(evaluation)

--- a/mathics/core/subexpression.py
+++ b/mathics/core/subexpression.py
@@ -8,7 +8,7 @@ from mathics.core.atoms import Integer
 from mathics.builtin.base import MessageException
 
 """
-This module provides some infraestructure to deal with SubExpressions. 
+This module provides some infraestructure to deal with SubExpressions.
 
 """
 
@@ -143,7 +143,7 @@ class ExpressionPointer(object):
         parent = self.parent
         p = self.position
         if p == 0:
-            if type(parent) is Symbol:
+            if isinstance(parent, Symbol):
                 return parent
             else:
                 return parent.head.copy()

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -14,6 +14,15 @@ from mathics.core.attributes import nothing
 sympy_symbol_prefix = "_Mathics_User_"
 sympy_slot_prefix = "_Mathics_Slot_"
 
+# This feels like a hack. It generalizes the method expression used in expression regarding
+# BoxConstruct.
+class ExpandOnce:
+    """Inherit from this class when you have an object that you never want expanded after
+    the initial try. BoxConstructs are like this
+    """
+
+    pass
+
 
 # system_symbols('A', 'B', ...) -> [Symbol('System`A'), Symbol('System`B'), ...]
 def system_symbols(*symbols) -> typing.FrozenSet[str]:
@@ -807,26 +816,40 @@ class Symbol(Atom):
         return (self.name, self.sympy_dummy)
 
 
+class Constant(Symbol, ExpandOnce):
+    """For Symbols that are cannot be changed"""
+
+    def __init__(self, name, sympy_dummy=None):
+        self = super().__new__(self, name, sympy_dummy)
+
+    pass
+
+
 # Symbols used in this module.
 
-SymbolFalse = Symbol("System`False")
-SymbolGraphics = Symbol("System`Graphics")
-SymbolGraphics3D = Symbol("System`Graphics3D")
-SymbolHoldForm = Symbol("System`HoldForm")
-SymbolList = Symbol("System`List")
-SymbolMachinePrecision = Symbol("MachinePrecision")
-SymbolMakeBoxes = Symbol("System`MakeBoxes")
-SymbolMaxPrecision = Symbol("$MaxPrecision")
-SymbolMinPrecision = Symbol("$MinPrecision")
-SymbolN = Symbol("System`N")
-SymbolNull = Symbol("System`Null")
-SymbolNumberForm = Symbol("System`NumberForm")
-SymbolPostfix = Symbol("System`Postfix")
-SymbolRepeated = Symbol("System`Repeated")
-SymbolRepeatedNull = Symbol("System`RepeatedNull")
-SymbolSequence = Symbol("System`Sequence")
-SymbolTrue = Symbol("System`True")
+SymbolFalse = Constant("System`False")
+SymbolGraphics = Constant("System`Graphics")
+SymbolGraphics3D = Constant("System`Graphics3D")
+SymbolHoldForm = Constant("System`HoldForm")
+SymbolList = Constant("System`List")
+SymbolMachinePrecision = Constant("MachinePrecision")
+SymbolMakeBoxes = Constant("System`MakeBoxes")
+SymbolMaxPrecision = Constant("$MaxPrecision")
+SymbolMinPrecision = Constant("$MinPrecision")
+SymbolN = Constant("System`N")
 
+# FIXME: LinearModelFit[{{2, 1}, {3, 4}, {5, 3}, {7, 6}}, x, x] ;
+# fails if we use a Constant below. Fix whatever is making this fail.
+# SymbolNull = Constant("System`Null")
+SymbolNull = Symbol("System`Null")
+
+SymbolNumberForm = Constant("System`NumberForm")
+
+SymbolPostfix = Constant("System`Postfix")
+SymbolRepeated = Constant("System`Repeated")
+SymbolRepeatedNull = Constant("System`RepeatedNull")
+SymbolSequence = Constant("System`Sequence")
+SymbolTrue = Constant("System`True")
 
 # The available formats.
 
@@ -841,13 +864,13 @@ format_symbols = system_symbols(
 )
 
 
-SymbolInputForm = Symbol("InputForm")
-SymbolOutputForm = Symbol("OutputForm")
-SymbolStandardForm = Symbol("StandardForm")
-SymbolFullForm = Symbol("FullForm")
-SymbolTraditionalForm = Symbol("TraditionalForm")
-SymbolTeXForm = Symbol("TeXForm")
-SymbolMathMLForm = Symbol("MathMLForm")
+SymbolInputForm = Constant("InputForm")
+SymbolOutputForm = Constant("OutputForm")
+SymbolStandardForm = Constant("StandardForm")
+SymbolFullForm = Constant("FullForm")
+SymbolTraditionalForm = Constant("TraditionalForm")
+SymbolTeXForm = Constant("TeXForm")
+SymbolMathMLForm = Constant("MathMLForm")
 
 
 # Used to check if a symbol is `Numeric` without evaluation.

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -15,9 +15,9 @@ from mathics import version_string, license_string, __version__
 from mathics.builtin.trace import TraceBuiltins, traced_do_replace
 from mathics.core.definitions import autoload_files, Definitions, Symbol
 from mathics.core.evaluation import Evaluation, Output
-from mathics.core.expression import strip_context
 from mathics.core.parser import MathicsFileLineFeeder, MathicsLineFeeder
 from mathics.core.rules import BuiltinRule
+from mathics.core.symbols import strip_context, SymbolNull
 
 
 def get_srcdir():
@@ -387,7 +387,7 @@ Please contribute to Mathics!""",
             shell.print_result(
                 result, no_out_prompt=True, strict_wl_output=args.strict_wl_output
             )
-            if evaluation.exc_result is Symbol("Null"):
+            if evaluation.exc_result is SymbolNull:
                 exit_rc = 0
             elif evaluation.exc_result is Symbol("$Aborted"):
                 exit_rc = -1

--- a/test/test_custom_boxconstruct.py
+++ b/test/test_custom_boxconstruct.py
@@ -3,9 +3,10 @@ from .helper import evaluate, session
 from mathics.builtin.base import BoxConstruct, Predefined
 from mathics.builtin.graphics import GRAPHICS_OPTIONS
 from mathics.core.attributes import hold_all, protected, read_protected
+from mathics.core.symbols import ExpandOnce
 
 
-class CustomBoxConstruct(BoxConstruct):
+class CustomBoxConstruct(BoxConstruct, ExpandOnce):
     def __init__(self, evaluation):
         super().__init__(evaluation=evaluation)
         self._leaves = [1, 2, 3]
@@ -41,7 +42,7 @@ class CustomAtom(Predefined):
         return CustomBoxConstruct(evaluation=evaluation)
 
 
-class CustomGraphicsBox(BoxConstruct):
+class CustomGraphicsBox(BoxConstruct, ExpandOnce):
     """"""
 
     options = GRAPHICS_OPTIONS


### PR DESCRIPTION
A number of different kinds of atoms that can't change value unnecessarily go through an extra expansion for fixpoint check.

In particular many constants values: strings, numbers, fixed symbols e.g. True, False, N, etc.

The one place where we *do* need to check though is Symbol, because a value like "x" may change. So we separate Symbols from Constants.

Also we remove "import" of a name where that name isn't used directly in the module. This seems to happen so that some other module can find the name instead of where it was defined. This isn't helpful. In fact, it is the opposite.