### PR TITLE
Mostly untangle imports

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -12,11 +12,7 @@ from typing import Any, cast
 
 from mathics.builtin.exceptions import (
     BoxConstructError,
-    InvalidLevelspecError,
     MessageException,
-    PartError,
-    PartDepthError,
-    PartRangeError,
 )
 from mathics.core.convert import from_sympy
 from mathics.core.definitions import Definition
@@ -41,7 +37,7 @@ from mathics.core.symbols import (
     SymbolTrue,
 )
 
-from mathics.core.attributes import nothing, protected
+from mathics.core.attributes import protected
 
 
 def get_option(options, name, evaluation, pop=False, evaluate=True):

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -12,9 +12,9 @@ from itertools import chain
 from mathics.builtin.base import (
     BinaryOperator,
     Builtin,
-    InvalidLevelspecError,
-    PartError,
 )
+
+from mathics.builtin.exceptions import InvalidLevelspecError, PartError
 
 from mathics.builtin.lists import list_boxes
 from mathics.algorithm.parts import (

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 List Functions - Miscellaneous
 """
@@ -29,15 +28,18 @@ from mathics.algorithm.clusters import (
 from mathics.builtin.base import (
     Builtin,
     CountableInteger,
-    InvalidLevelspecError,
     MessageException,
     NegativeIntegerException,
-    PartDepthError,
-    PartError,
-    PartRangeError,
     Predefined,
     SympyFunction,
     Test,
+)
+
+from mathics.builtin.exceptions import (
+    InvalidLevelspecError,
+    PartDepthError,
+    PartError,
+    PartRangeError,
 )
 
 from mathics.builtin.numbers.algebra import cancel

--- a/mathics/builtin/strings.py
+++ b/mathics/builtin/strings.py
@@ -759,11 +759,11 @@ class String_(Builtin):
 class ToString(Builtin):
     """
     <dl>
-    <dt>'ToString[$expr$]'
-        <dd>returns a string representation of $expr$.
-    <dt>'ToString[$expr$, $form$]'
-        <dd>returns a string representation of $expr$ in the form
-          $form$.
+      <dt>'ToString[$expr$]'
+      <dd>returns a string representation of $expr$.
+
+      <dt>'ToString[$expr$, $form$]'
+      <dd>returns a string representation of $expr$ in the form $form$.
     </dl>
 
     >> ToString[2]

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -10,8 +10,8 @@ from mathics.builtin.base import (
     BinaryOperator,
     Test,
     MessageException,
-    PartRangeError,
 )
+from mathics.builtin.exceptions import InvalidLevelspecError, PartRangeError
 from mathics.core.expression import Expression
 from mathics.core.symbols import (
     Symbol,
@@ -34,7 +34,6 @@ from mathics.core.rules import Pattern
 from mathics.builtin.lists import (
     python_levelspec,
     walk_levels,
-    InvalidLevelspecError,
     List,
 )
 

--- a/mathics/core/subexpression.py
+++ b/mathics/core/subexpression.py
@@ -3,12 +3,12 @@
 
 
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol, Atom
+from mathics.core.symbols import Symbol
 from mathics.core.atoms import Integer
 from mathics.builtin.base import MessageException
 
 """
-This module provides some infraestructure to deal with SubExpressions. 
+This module provides some infrastructure to deal with SubExpressions.
 
 """
 


### PR DESCRIPTION
Don't use imports as a way to reexport a name that isn't used in the module.

Some other small changes were made as well.