### PR TITLE
List as atom

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Internals
 * A bug was fixed relating to the order in which ``mathics.core.definitions`` stores the rules
 * Improved support for ``Series`` Issue #46
 * ``Cylinder`` rendering is implemented in Asymptote
-
+* `List` expressions are stored as `ListExpression` objects, with a simpler `evaluate` method.
 
 Bugs
 ++++

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -611,6 +611,8 @@ class BoxConstruct(InstanceableBuiltin):
 
     def sameQ(self, expr) -> bool:
         """Mathics SameQ"""
+        if isinstance(expr, BoxConstruct):
+            return expr is self
         return expr.sameQ(self)
 
     def is_atom(self):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -49,6 +49,7 @@ from mathics.core.convert import from_sympy
 from mathics.core.evaluation import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
 
 from mathics.core.expression import Expression, structure
+from mathics.core.lists import ListExpression
 from mathics.core.atoms import (
     ByteArrayAtom,
     Integer,
@@ -75,7 +76,6 @@ from mathics.core.systemsymbols import (
     SymbolFailed,
     SymbolMakeBoxes,
     SymbolRule,
-    SymbolSequence,
 )
 
 from mathics.core.attributes import (
@@ -546,6 +546,13 @@ class List(Builtin):
     """
 
     attributes = locked | protected
+
+    def apply(self, items, evaluation):
+        """{items___}"""
+        if items.get_head() is SymbolSequence:
+            return ListExpression(items._leaves)
+        else:
+            return ListExpression(tuple((items,)))
 
     def apply_makeboxes(self, items, f, evaluation):
         """MakeBoxes[{items___},

--- a/mathics/core/lists.py
+++ b/mathics/core/lists.py
@@ -1,0 +1,80 @@
+# cython: language_level=3
+# -*- coding: utf-8 -*-
+
+from mathics.core.symbols import (
+    Atom,
+)
+from mathics.core.expression import Expression
+from mathics.core.symbols import SymbolList
+
+
+class ListExpression(Atom):
+    """
+    This class implements `List` expressions
+    as a simplified kind of  `Expression` that does
+    not requires to check for evaluation rules.
+
+    """
+
+    class_head_name = "System`List"
+
+    def __new__(cls, leaves):
+        # Here we could check if all the leaves are machinereal,
+        # and specialize to something like ListMachineReals
+        # or ListMachineComplex  or ListNumpy or whatever...
+        self = super().__new__(cls)
+        self._leaves = leaves
+        return self
+
+    def __str__(self) -> str:
+        return "{" + ",".join(leaf.__str__() for leaf in self._leaves) + "}"
+
+    def get_head_name(self):
+        return "System`List"
+
+    def boxes_to_text(self, **options) -> str:
+        # TODO: take into account the MakeBoxes rules...
+        raise NotImplementedError
+
+    def boxes_to_mathml(self, **options) -> str:
+        # TODO: take into account the MakeBoxes rules...
+        raise NotImplementedError
+
+    def boxes_to_tex(self, **options) -> str:
+        # TODO: take into account the MakeBoxes rules...
+        raise NotImplementedError
+
+    def to_python(self, *args, **kwargs):
+        return [leaf.to_python(*args, **kwargs) for leaf in self._leaves]
+
+    def sameQ(self, other):
+        if other is self:
+            return True
+        if isinstance(other, ListExpression):
+            if len(other._leaves) != len(self._leaves):
+                return False
+            return all(a.sameQ(b) for (a, b) in zip(self._leaves, other._leaves))
+        if isinstance(other, Expression) and other._head is SymbolList:
+            return all(a.sameQ(b) for (a, b) in zip(self._leaves, other._leaves))
+
+        return False
+
+    def evaluate(self, evaluation):
+        # TODO: handle upvalues
+        new_leaves = tuple(leaf.evaluate(evaluation) for leaf in self._leaves)
+        if all(leaf is None for leaf in new_leaves):
+            return None
+        return ListExpression(
+            tuple(
+                oldleaf if newleaf is None else newleaf
+                for newleaf, oldleaf in zip(new_leaves, self._leaves)
+            )
+        )
+
+    @property
+    def leaves(self):
+        return self._leaves
+
+    @leaves.setter
+    def leaves(self, value):
+        raise ValueError("Expression.leaves is write protected.")


### PR DESCRIPTION
In this PR, a basic proposal about how to handle `List` evaluations is implemented. Same ideas could be implemented to other frequently used symbols, or certain direct `sympy` expressions.