### PR TITLE
clean imports, reduce expression module, ...

### DIFF
--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -47,10 +47,6 @@ from mathics.builtin.options import options_to_rules
 from mathics.builtin.scoping import dynamic_scoping
 from mathics.builtin.numeric import apply_N
 
-from mathics.core.convert import from_sympy
-from mathics.core.evaluation import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
-
-from mathics.core.expression import Expression, structure
 from mathics.core.atoms import (
     ByteArrayAtom,
     Integer,
@@ -63,13 +59,16 @@ from mathics.core.atoms import (
     min_prec,
 )
 
+from mathics.core.convert import from_sympy
+from mathics.core.expression import Expression, structure
+
+from mathics.core.interrupt import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
 from mathics.core.symbols import (
     Symbol,
     SymbolList,
     strip_context,
     SymbolTrue,
     SymbolFalse,
-    SymbolSequence,
 )
 
 from mathics.core.systemsymbols import (

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -12,19 +12,22 @@ Procedural functions are integrated into Mathics symbolic programming environmen
 
 
 from mathics.builtin.base import Builtin, BinaryOperator
-from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol
+
 from mathics.core.atoms import from_python
-from mathics.core.symbols import (
-    SymbolTrue,
-    SymbolFalse,
-)
-from mathics.core.evaluation import (
+from mathics.core.expression import Expression
+
+from mathics.core.interrupt import (
     AbortInterrupt,
     BreakInterrupt,
     ContinueInterrupt,
     ReturnInterrupt,
     WLThrowInterrupt,
+)
+
+from mathics.core.symbols import (
+    Symbol,
+    SymbolTrue,
+    SymbolFalse,
 )
 from mathics.builtin.lists import _IterationFunction
 from mathics.builtin.patterns import match

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -12,14 +12,20 @@ from typing import Tuple
 from mathics_scanner import TranslateError
 
 from mathics import settings
-from mathics.core.symbols import (
-    ensure_context,
-    KeyComparable,
+from mathics.core.interrupt import (
+    AbortInterrupt,
+    BreakInterrupt,
+    ContinueInterrupt,
+    ReturnInterrupt,
+    TimeoutInterrupt,
+    WLThrowInterrupt,
 )
 
 from mathics.core.symbols import (
+    KeyComparable,
     SymbolList,
     SymbolNull,
+    ensure_context,
 )
 
 from mathics.core.systemsymbols import SymbolAborted
@@ -35,37 +41,6 @@ FORMATS = [
     "MatrixForm",
     "TableForm",
 ]
-
-
-class EvaluationInterrupt(Exception):
-    pass
-
-
-class AbortInterrupt(EvaluationInterrupt):
-    pass
-
-
-class TimeoutInterrupt(EvaluationInterrupt):
-    pass
-
-
-class ReturnInterrupt(EvaluationInterrupt):
-    def __init__(self, expr):
-        self.expr = expr
-
-
-class BreakInterrupt(EvaluationInterrupt):
-    pass
-
-
-class ContinueInterrupt(EvaluationInterrupt):
-    pass
-
-
-class WLThrowInterrupt(EvaluationInterrupt):
-    def __init__(self, value, tag=None):
-        self.tag = tag
-        self.value = value
 
 
 def _thread_target(request, queue) -> None:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -742,11 +742,29 @@ class Expression(BaseExpression):
         else:
             return self
 
-    # When we allow 3.9 only, the return type chould become type[Expression]
+    # When we allow 3.9 only, the return type could become type[Expression]
     # See https://adamj.eu/tech/2021/05/16/python-type-hints-return-class-not-instance/
-    def evaluate(self, evaluation) -> typing.Type["Expression"]:
-        """
-        Evaluate until reach a fixed point.
+    # Note that the return type is some subclass of BaseExpression, it could be
+    # a Real, an Expression, etc. It probably will *not* be a BaseExpression since
+    # the point of evaluation when there is not an error is to produce a concrete result.
+    def evaluate(
+        self, evaluation: typing.Type["BaseExpression"]
+    ) -> typing.Type["BaseExpression"]:
+        """Pattern match and replace subexpressions evaluating the resulting
+        expression until either we are told not to go further, or
+        until we determine that the result of an evaluation cannot
+        produce a resulting expression that is different from the one
+        we started out with.
+
+        Some ways that we might be told not to do further are:
+        * a  limit of some sort is hit: timeout or iteration count
+        * some other exception occurs
+        * the result of evaluation indicates not to go futher
+
+        Some ways that a we determine the result of another evaluation cannot produce a different result:
+        * The result was exactly the same as the last time, and there were no definition changes
+        * the result of an evaluation indicates that we have the final value (sort of the same thing
+          as the last case in the list item above).
         """
         if evaluation.timeout:
             return

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -10,9 +10,11 @@ from itertools import chain
 from bisect import bisect_left
 
 from mathics.core.atoms import from_python, Number, Integer
+from mathics.core.convert import sympy_symbol_prefix, SympyExpression
+from mathics.core.evaluation import Evaluation
+
 from mathics.core.interrupt import ReturnInterrupt
 from mathics.core.number import dps
-from mathics.core.convert import sympy_symbol_prefix, SympyExpression
 from mathics.core.symbols import (
     Atom,
     BaseExpression,
@@ -748,23 +750,14 @@ class Expression(BaseExpression):
     # a Real, an Expression, etc. It probably will *not* be a BaseExpression since
     # the point of evaluation when there is not an error is to produce a concrete result.
     def evaluate(
-        self, evaluation: typing.Type["BaseExpression"]
+        self,
+        evaluation: Evaluation,
     ) -> typing.Type["BaseExpression"]:
-        """Pattern match and replace subexpressions evaluating the resulting
-        expression until either we are told not to go further, or
-        until we determine that the result of an evaluation cannot
-        produce a resulting expression that is different from the one
-        we started out with.
+        """Apply transformation rules and expression evaluation to `evaluation` via
+        `evaluate_next()` until it tells us to stop or we hit some limit.
+        `evaluate_next()` may call us recusively.
 
-        Some ways that we might be told not to do further are:
-        * a  limit of some sort is hit: timeout or iteration count
-        * some other exception occurs
-        * the result of evaluation indicates not to go futher
-
-        Some ways that a we determine the result of another evaluation cannot produce a different result:
-        * The result was exactly the same as the last time, and there were no definition changes
-        * the result of an evaluation indicates that we have the final value (sort of the same thing
-          as the last case in the list item above).
+        Limits are either an evaluation iteration count or a timeout value.
         """
         if evaluation.timeout:
             return

--- a/mathics/core/interrupt.py
+++ b/mathics/core/interrupt.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Evaluation interrupts"""
+
+
+class EvaluationInterrupt(Exception):
+    pass
+
+
+class AbortInterrupt(EvaluationInterrupt):
+    pass
+
+
+class TimeoutInterrupt(EvaluationInterrupt):
+    pass
+
+
+class ReturnInterrupt(EvaluationInterrupt):
+    def __init__(self, expr):
+        self.expr = expr
+
+
+class BreakInterrupt(EvaluationInterrupt):
+    pass
+
+
+class ContinueInterrupt(EvaluationInterrupt):
+    pass
+
+
+class WLThrowInterrupt(EvaluationInterrupt):
+    def __init__(self, value, tag=None):
+        self.tag = tag
+        self.value = value

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -15,9 +15,9 @@ from mathics import version_string, license_string, __version__
 from mathics.builtin.trace import TraceBuiltins, traced_do_replace
 from mathics.core.definitions import autoload_files, Definitions, Symbol
 from mathics.core.evaluation import Evaluation, Output
-from mathics.core.expression import strip_context
 from mathics.core.parser import MathicsFileLineFeeder, MathicsLineFeeder
 from mathics.core.rules import BuiltinRule
+from mathics.core.symbols import strip_context
 
 
 def get_srcdir():


### PR DESCRIPTION
* Interrupt exceptions moved ot of evaluation.py and into expression.py
* Correct return type of Expression.evaluate()
* remove unused imports including those that are imported improperly
  elsewhere
* import from a module only once