### PR TITLE
Fix n method (issue #137)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,9 +29,9 @@ Internals
 * To speed up the Mathics ``Expression`` manipulation code, `Symbol`s objects are now a singleton class. This avoids a lot of unnecesary string comparisons, and calls to ``ensure_context``.
 * To speed up development, you can set ``NO_CYTHON`` to skip Cythonizing Python modules
 * A bug was fixed relating to the order in which ``mathics.core.definitions`` stores the rules
-* Improved support for ``Series`` Issue #46
-* ``Cylinder`` rendering is implemented in Asymptote
-
+* Improved support for ``Series`` Issue #46.
+* ``Cylinder`` rendering is implemented in Asymptote.
+* `N[_,_,Method->method]` was reworked (Issue #137).
 
 Compatibility
 +++++++++++++

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -73,23 +73,14 @@ class _Constant_Common(Predefined):
     nargs = 0
     options = {"Method": "Automatic"}
 
-    def apply_N(self, precision, evaluation, options={}):
-        "N[%(name)s, precision_?NumericQ, OptionsPattern[%(name)s]]"
-
-        preference = self.get_option(options, "Method", evaluation).get_string_value()
-        if preference == "Automatic":
-            return self.get_constant(precision, evaluation)
-        else:
-            return self.get_constant(precision, evaluation, preference)
-
-    def apply_N2(self, evaluation, options={}):
-        "N[%(name)s, OptionsPattern[%(name)s]]"
-        return self.apply_N(None, evaluation, options)
+    def apply_N(self, precision, evaluation):
+        "N[%(name)s, precision_?NumericQ]"
+        return self.get_constant(precision, evaluation)
 
     def is_constant(self) -> bool:
         return True
 
-    def get_constant(self, precision, evaluation, preference=None):
+    def get_constant(self, precision, evaluation):
         # first, determine the precision
         machine_d = int(0.30103 * machine_precision)
         d = None
@@ -104,15 +95,20 @@ class _Constant_Common(Predefined):
 
         # If preference not especified, determine it
         # from the precision.
+        preference = None
+        preflist = evaluation._preferred_n_method.copy()
+        while preflist:
+            pref_method = preflist.pop()
+            if pref_method in ("numpy", "mpmath", "sympy"):
+                preference = pref_method
+                break
+
         if preference is None:
             if d <= machine_d:
                 preference = "numpy"
             else:
                 preference = "mpmath"
-        # If preference is not valid, send a message and return.
-        if not (preference in ("sympy", "numpy", "mpmath")):
-            evaluation.message(f'{preference} not in ("sympy", "numpy", "mpmath")')
-            return
+
         # Try to determine the numeric value
         value = None
         if preference == "mpmath" and not hasattr(self, "mpmath_name"):
@@ -207,7 +203,7 @@ class Catalan(_MPMathConstant, _SympyConstant):
     </dl>
 
     >> Catalan // N
-     = 0.915965594177219
+     = 0.915966
 
     >> N[Catalan, 20]
      = 0.91596559417721901505
@@ -286,8 +282,8 @@ class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
             # return mpmath.degree
             return numpy.pi / 180
 
-    def apply_N(self, precision, evaluation, options={}):
-        "N[Degree, precision_, OptionsPattern[%(name)s]]"
+    def apply_N(self, precision, evaluation):
+        "N[Degree, precision_]"
         try:
             if precision:
                 d = get_precision(precision, evaluation)
@@ -328,8 +324,8 @@ class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
     numpy_name = "e"
     sympy_name = "E"
 
-    def apply_N(self, precision, evaluation, options={}):
-        "N[E, precision_, OptionsPattern[%(name)s]]"
+    def apply_N(self, precision, evaluation):
+        "N[E, precision_]"
         return self.get_constant(precision, evaluation)
 
 
@@ -360,7 +356,7 @@ class Glaisher(_MPMathConstant):
     </dl>
 
     >> N[Glaisher]
-     = 1.28242712910062
+     = 1.28243
     >> N[Glaisher, 50]
      = 1.2824271291006226368753425688697917277676889273250
      # 1.2824271291006219541941391071304678916931152343750
@@ -377,7 +373,7 @@ class GoldenRatio(_MPMathConstant, _SympyConstant):
     </dl>
 
     >> GoldenRatio // N
-     = 1.61803398874989
+     = 1.61803
     >> N[GoldenRatio, 40]
      = 1.618033988749894848204586834365638117720
     """
@@ -450,7 +446,7 @@ class Khinchin(_MPMathConstant):
     </dl>
 
     >> N[Khinchin]
-     = 2.68545200106531
+     = 2.68545
     >> N[Khinchin, 50]
      = 2.6854520010653064453097148354817956938203822939945
      # = 2.6854520010653075701156922150403261184692382812500

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -28,7 +28,6 @@ from mathics.core.systemsymbols import (
     SymbolByteArray,
     SymbolRowBox,
     SymbolRule,
-    SymbolSequence,
 )
 
 from mathics.core.number import (
@@ -145,7 +144,7 @@ class Integer(Number):
         super().__init__()
 
     def get_head_name(self):
-        return "System`Integer"
+        return self.class_head_name
 
     def boxes_to_text(self, **options) -> str:
         return str(self.value)
@@ -456,7 +455,8 @@ class MachineReal(Real):
     def is_machine_precision(self) -> bool:
         return True
 
-    def get_precision(self) -> int:
+    def get_precision(self) -> float:
+        """Returns the default specification for precision in N and other numerical functions."""
         return machine_precision
 
     def get_float_value(self, permit_complex=False) -> float:
@@ -533,8 +533,9 @@ class PrecisionReal(Real):
             return self.value == other.to_sympy()
         return False
 
-    def get_precision(self) -> int:
-        return self.value._prec + 1
+    def get_precision(self) -> float:
+        """Returns the default specification for precision in N and other numerical functions."""
+        return self.value._prec + 1.0
 
     def make_boxes(self, form):
         from mathics.builtin.inout import number_form
@@ -674,7 +675,13 @@ class Complex(Number):
         else:
             return None
 
-    def get_precision(self) -> Optional[int]:
+    def get_precision(self) -> Optional[float]:
+        """Returns the default specification for precision in N and other numerical functions.
+        When `None` is be returned no precision is has been defined and this object's value is
+        exact.
+
+        This function is called by method `is_inexact()`.
+        """
         real_prec = self.real.get_precision()
         imag_prec = self.imag.get_precision()
         if imag_prec is None or real_prec is None:

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -240,6 +240,9 @@ class Evaluation(object):
         # Necesary to handle OneIdentity on
         # lhs in assignment
         self.ignore_oneidentity = False
+        # Used in ``mathics.builtin.numbers.constants.get_constant`` and
+        # ``mathics.builtin.numeric.N``.
+        self._preferred_n_method = []
 
     def parse(self, query):
         "Parse a single expression and print the messages."

--- a/mathics/core/number.py
+++ b/mathics/core/number.py
@@ -18,8 +18,11 @@ from mathics.core.symbols import (
 C = log(10, 2)  # ~ 3.3219280948873626
 
 
-# Number of bits of machine precision
-machine_precision = 53
+# Number of bits of machine precision.
+# Note this is a float, not an int.
+# WMA uses real values for precision, to take into account the internal representation of numbers.
+# This is why $MachinePrecision is not 16, but 15.9546`
+machine_precision = 53.0
 machine_digits = int(machine_precision / C)
 
 machine_epsilon = 2 ** (1 - machine_precision)

--- a/mathics/core/number.py
+++ b/mathics/core/number.py
@@ -56,7 +56,12 @@ def _get_float_inf(value, evaluation) -> typing.Optional[float]:
     return value.round_to_float(evaluation)
 
 
-def get_precision(value, evaluation) -> typing.Optional[int]:
+def get_precision(value, evaluation, show_messages=True) -> typing.Optional[int]:
+    """
+    Returns the ``float`` in the interval     [``$MinPrecision``, ``$MaxPrecision``] closest to ``value``.
+    If ``value`` does not belongs to that interval, and ``show_messages`` is True, a Message warning is shown.
+    If ``value`` fails to be evaluated as a number, returns None.
+    """
     if value is SymbolMachinePrecision:
         return None
     else:
@@ -67,14 +72,17 @@ def get_precision(value, evaluation) -> typing.Optional[int]:
         d = value.round_to_float(evaluation)
         assert dmin is not None and dmax is not None
         if d is None:
-            evaluation.message("N", "precbd", value)
+            if show_messages:
+                evaluation.message("N", "precbd", value)
         elif d < dmin:
             dmin = int(dmin)
-            evaluation.message("N", "precsm", value, MachineReal(dmin))
+            if show_messages:
+                evaluation.message("N", "precsm", value, MachineReal(dmin))
             return dmin
         elif d > dmax:
             dmax = int(dmax)
-            evaluation.message("N", "preclg", value, MachineReal(dmax))
+            if show_messages:
+                evaluation.message("N", "preclg", value, MachineReal(dmax))
             return dmax
         else:
             return d

--- a/mathics/core/number.py
+++ b/mathics/core/number.py
@@ -56,7 +56,7 @@ def _get_float_inf(value, evaluation) -> typing.Optional[float]:
     return value.round_to_float(evaluation)
 
 
-def get_precision(value, evaluation, show_messages=True) -> typing.Optional[int]:
+def get_precision(value, evaluation, show_messages=True) -> typing.Optional[float]:
     """
     Returns the ``float`` in the interval     [``$MinPrecision``, ``$MaxPrecision``] closest to ``value``.
     If ``value`` does not belongs to that interval, and ``show_messages`` is True, a Message warning is shown.

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -381,7 +381,17 @@ class BaseExpression(KeyComparable):
     def is_inexact(self) -> bool:
         return self.get_precision() is not None
 
-    def get_precision(self):
+    def get_precision(self) -> None:
+        """Returns the default specification for precision in N and other
+        numerical functions.  It is expected to be redefined in those
+        classes that provide inexact arithmetic like PrecisionReal.
+
+        Here in the default base implementation, `None` is used to indicate that the
+        precision is either not defined, or it is exact as in the case of Integer. In either case, the
+        values is not "inexact".
+
+        This function is called by method `is_inexact()`.
+        """
         return None
 
     def get_option_values(self, evaluation, allow_symbols=False, stop_on_error=True):


### PR DESCRIPTION
In this PR a method to propagate the choice of the method used to compute constants is implemented. Also, this should clarify the interface for defining built-in `NValues` rules:  Now, all the builtin rules for ``N``  has the form ``N[expr_,prec_]``.
The only exception is  the generic ``N[expr_,prec_,OptionsValue[]]`` associated to the Builtin ``N``, which are necessarily not a `NValues` rule.
``N[expr, prec, Method->method]`` establishes the preferred method, by storing it in the queue property `_preferred_n_method` of the `Evaluation` object.