### PR TITLE
SameQ tweaks -

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 CHANGES
 =======
 
+Enhancements
+============
+
+* ``SameQ`` (``===``) handles chaining, e.g. ``a == b == c`` or ``SameQ[a, b, c]``
+
+Documentation
+.............
+
+* "Testing Expressions" section added
+* "Representation of Numbers" section added
+
 New Builtins
 ============
 * ``TraceEvaluation[]`` shows expression name calls and return values of it argument. The variable ``$TraceEvalution`` when set True will show all expression evaluations.
@@ -10,10 +21,10 @@ New Builtins
 * ``$Echo`` (Issue #42).
 * Now, ``D`` can act over ``Integrate`` and  ``NIntegrate`` (fix issue #130).
 
-  
+
 Internals
 =========
-* `NIntegrate` internal algorithms and interfaces to `scipy` were moved to `mathics.algorithm.integrators` and `mathics.builtin.scipy_utils.integrators` respectively.
+* ``NIntegrate`` internal algorithms and interfaces to ``scipy`` were moved to ``mathics.algorithm.integrators`` and ``mathics.builtin.scipy_utils.integrators`` respectively.
 * To speed up attributes read, and RAM usage, attributes are now stored in a bitset instead of a tuple of strings.
 * Definitions for symbols ``CurrentContext`` and ``ContextPath[]`` are mirrored in the ``mathics.core.definitions.Definitions`` object for faster access.
 * To speed up the lookup of symbols names, `Definitions` object now have two properties: `current_context` and `context_path`. These properties stores the values of the corresponding symbols in the `builtin` definitions.
@@ -46,7 +57,8 @@ Bugs
 
 * ``First``, ``Rest`` and  ``Last`` now handle invalid arguments.
 * ``N`` now handles arbitrary precision numbers when the number of digits is not specified.
-*  `Set*`: fixed issue #128.
+*  ``Set*``: fixed issue #128.
+*  ``SameQ``: comparison with MachinePrecision only needs to be exact within the last bit Issue #148.
 
 
 4.0.1

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -280,36 +280,35 @@ class SameQ(_ComparisonOperator):
 
     <ul>
       <li>'SameQ' requires exact correspondence between expressions, expet that it still considers 'Real' numbers equal if they differ in their last binary digit.
+      <li>$e1$ === $e2$ === $e3$ gives 'True' if all the $ei$'s are identical.
       <li>'SameQ[]' and 'SameQ[$expr$]' always yield 'True'.
     </ul>
 
 
     Any object is the same as itself:
-    >> a===a
+    >> a === a
      = True
 
-    Degenerate cases of 'SameQ':
-    >> SameQ[a] === True
+    Degenerate cases of 'SameQ' showing off how you can chain '===':
+    >> SameQ[a] === SameQ[] === True
      = True
 
-    >> SameQ[] === True
-     = True
-
-    Unlike 'Equal', 'SameQ' only yields 'True' if $x$ and $y$ have the
-    same type:
+    Unlike 'Equal', 'SameQ' only yields 'True' if $x$ and $y$ have the same type:
     >> {1==1., 1===1.}
      = {True, False}
 
 
     For 'PrecisionReal', comparision can be vary a little in the last bit. But only a little bit:
-    >> 2./9. === .2222222222222222`16
+    >> 2./9. === .2222222222222222`15.9546
      = True
     >> 2./9. === .2222222222222222`17
      = False
+
+    15.9546 is the value of '$MaxPrecision'
     """
 
     operator = "==="
-    grouping = "None"
+    grouping = "None"  # Indeterminate grouping: Neither left nor right
     precedence = 290
 
     rules = {
@@ -319,13 +318,17 @@ class SameQ(_ComparisonOperator):
 
     summary_text = "literal symbolic identity"
 
-    def apply(self, lhs, rhs, evaluation):
-        "lhs_ === rhs_"
-
-        if lhs.sameQ(rhs):
+    def apply_list(self, items, evaluation):
+        "%(name)s[items___]"
+        items_sequence = items.get_sequence()
+        if len(items_sequence) <= 1:
             return SymbolTrue
-        else:
-            return SymbolFalse
+
+        first_item = items_sequence[0]
+        for item in items_sequence[1:]:
+            if not first_item.sameQ(item):
+                return SymbolFalse
+        return SymbolTrue
 
 
 class UnsameQ(BinaryOperator):

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -445,16 +445,22 @@ class MachineReal(Real):
         return self
 
     def sameQ(self, other) -> bool:
-        """Mathics SameQ"""
+        """Mathics SameQ for MachineReal.
+
+        If the other comparision value is a MachineReal, the values
+        have to be equal.  If the other value is a PrecisionReal though, then
+        the two values have to be within 1/2 ** (precision) of
+        other-value's precision.  For any other type, sameQ is False.
+        """
         if isinstance(other, MachineReal):
             return self.value == other.value
         if isinstance(other, PrecisionReal):
             other_value = other.value
+            value = self.value
+            diff = abs(value - other_value)
+            return diff < 0.5 ** (diff._prec)
         else:
             return False
-        value = self.value
-        diff = abs(value - other_value)
-        return diff < 0.5 ** (diff._prec)
 
     def is_machine_precision(self) -> bool:
         return True


### PR DESCRIPTION
* Simplify SameQ logic for MachineReal
* Hook comparison operators into documentation
* Fill out description and examples for SameQ

Note: comparison.py probably should be split out into its own subsection

As always, with regards to documentation, and sectioning there is a lot more there to  do.