### PR TITLE
Start converting leaves -> elements

### DIFF
--- a/mathics/algorithm/integrators.py
+++ b/mathics/algorithm/integrators.py
@@ -178,8 +178,8 @@ def apply_D_to_Integral(func, domain, var, evaluation, options, head):
     # if the integration is along several variables, take the integration of the inner
     # variables as func.
     if domain._head is SymbolSequence:
-        func = Expression(head, func, *(domain._leaves[:-1]), *options)
-        domain = domain._leaves[-1]
+        func = Expression(head, func, *(domain._elements[:-1]), *options)
+        domain = domain._elements[-1]
 
     terms = []
     # Evaluates the derivative regarding the integrand:

--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -42,7 +42,7 @@ def get_part(varlist, indices):
             if cur.is_atom():
                 raise PartDepthError(rest[0])
             pos = rest[0]
-            leaves = cur.get_leaves()
+            leaves = cur.get_elements()
             try:
                 if pos > 0:
                     part = leaves[pos - 1]
@@ -69,11 +69,11 @@ def set_part(varlist, indices, newval):
                 raise PartDepthError
             try:
                 if pos > 0:
-                    part = cur._leaves[pos - 1]
+                    part = cur._elements[pos - 1]
                 elif pos == 0:
                     part = cur.get_head()
                 else:
-                    part = cur._leaves[pos]
+                    part = cur._elements[pos]
             except IndexError:
                 raise PartRangeError
             return rec(part, rest[1:])
@@ -565,7 +565,7 @@ def deletecases_with_levelspec(expr, pattern, evaluation, levelspec=1, n=-1):
             curr_index[-1] = curr_index[-1] + 1
             continue
         else:
-            tree.append(list(curr_leave.get_leaves()))
+            tree.append(list(curr_leave.get_elements()))
             changed_marks.append([False for s in tree[-1]])
             curr_index.append(0)
     return tree[0][0]
@@ -591,7 +591,7 @@ def find_matching_indices_with_levelspec(expr, pattern, evaluation, levelspec=1,
     else:
         lsmin = levelspec[0]
         lsmax = levelspec[1]
-    tree = [expr.get_leaves()]
+    tree = [expr.get_elements()]
     curr_index = [0]
     found = []
     while len(tree) > 0:
@@ -613,6 +613,6 @@ def find_matching_indices_with_levelspec(expr, pattern, evaluation, levelspec=1,
             curr_index[-1] = curr_index[-1] + 1
             continue
         else:
-            tree.append(curr_leave.get_leaves())
+            tree.append(curr_leave.get_elements())
             curr_index.append(0)
     return found

--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -554,18 +554,18 @@ def deletecases_with_levelspec(expr, pattern, evaluation, levelspec=1, n=-1):
                 break
             curr_index[-1] = curr_index[-1] + 1
             continue
-        curr_leave = tree[-1][curr_index[-1]]
-        if match(curr_leave, evaluation) and (len(curr_index) > lsmin):
+        curr_element = tree[-1][curr_index[-1]]
+        if match(curr_element, evaluation) and (len(curr_index) > lsmin):
             tree[-1][curr_index[-1]] = nothing
             changed_marks[-1][curr_index[-1]] = True
             curr_index[-1] = curr_index[-1] + 1
             n = n - 1
             continue
-        if curr_leave.is_atom() or lsmax == len(curr_index):
+        if curr_element.is_atom() or lsmax == len(curr_index):
             curr_index[-1] = curr_index[-1] + 1
             continue
         else:
-            tree.append(list(curr_leave.get_elements()))
+            tree.append(list(curr_element.get_elements()))
             changed_marks.append([False for s in tree[-1]])
             curr_index.append(0)
     return tree[0][0]
@@ -603,16 +603,16 @@ def find_matching_indices_with_levelspec(expr, pattern, evaluation, levelspec=1,
             if len(curr_index) != 0:
                 curr_index[-1] = curr_index[-1] + 1
             continue
-        curr_leave = tree[-1][curr_index[-1]]
-        if match(curr_leave, evaluation) and (len(curr_index) >= lsmin):
+        curr_element = tree[-1][curr_index[-1]]
+        if match(curr_element, evaluation) and (len(curr_index) >= lsmin):
             found.append([Integer(i) for i in curr_index])
             curr_index[-1] = curr_index[-1] + 1
             n = n - 1
             continue
-        if curr_leave.is_atom() or lsmax == len(curr_index):
+        if curr_element.is_atom() or lsmax == len(curr_index):
             curr_index[-1] = curr_index[-1] + 1
             continue
         else:
-            tree.append(curr_leave.get_elements())
+            tree.append(curr_element.get_elements())
             curr_index.append(0)
     return found

--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -42,14 +42,14 @@ def get_part(varlist, indices):
             if cur.is_atom():
                 raise PartDepthError(rest[0])
             pos = rest[0]
-            leaves = cur.get_elements()
+            elements = cur.get_elements()
             try:
                 if pos > 0:
-                    part = leaves[pos - 1]
+                    part = elements[pos - 1]
                 elif pos == 0:
                     part = cur.get_head()
                 else:
-                    part = leaves[pos]
+                    part = elements[pos]
             except IndexError:
                 raise PartRangeError
             return rec(part, rest[1:])

--- a/mathics/algorithm/series.py
+++ b/mathics/algorithm/series.py
@@ -208,7 +208,7 @@ def series_times_series(series1, series2):
                 data[pos] = Expression(SymbolTimes, c1, c2)
             elif data[pos].get_head() is SymbolPlus:
                 data[pos] = Expression(
-                    SymbolPlus, Expression(SymbolTimes, c1, c2), *(data[pos]._leaves)
+                    SymbolPlus, Expression(SymbolTimes, c1, c2), *(data[pos]._elements)
                 )
             else:
                 data[pos] = Expression(
@@ -319,9 +319,9 @@ def reduce_series_plus(series, terms, x, x0):
             other_terms.append(term)
             continue
         term_head = term.head
-        term_leaves = term.leaves
+        term_elements = term.leaves
         if term_head is SymbolSeriesData:
-            y, y0, data, nummin, nummax, den = term_leaves
+            y, y0, data, nummin, nummax, den = term_elements
             if not x.sameQ(y):
                 data = Expression(SymbolList, *[term])
                 y = x

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -386,7 +386,7 @@ class Plus(BinaryOperator, SympyFunction):
                     for leaf in item.leaves:
                         if isinstance(leaf, Number):
                             count = leaf.to_sympy()
-                            rest = item.get_mutable_leaves()
+                            rest = item.get_mutable_elements()
                             rest.remove(leaf)
                             if len(rest) == 1:
                                 rest = rest[0]

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -110,7 +110,7 @@ class _MPMathFunction(SympyFunction):
             result = self.prepare_mathics(result)
             result = from_sympy(result)
             # evaluate leaves to convert e.g. Plus[2, I] -> Complex[2, 1]
-            return result.evaluate_leaves(evaluation)
+            return result.evaluate_elements(evaluation)
         elif mpmath_function is None:
             return
 
@@ -285,14 +285,14 @@ class DirectedInfinity(SympyFunction):
     }
 
     def to_sympy(self, expr, **kwargs):
-        if len(expr._leaves) == 1:
+        if len(expr._elements) == 1:
             dir = expr.leaves[0].get_int_value()
             if dir == 1:
                 return sympy.oo
             elif dir == -1:
                 return -sympy.oo
             else:
-                return sympy.Mul((expr._leaves[0].to_sympy()), sympy.zoo)
+                return sympy.Mul((expr._elements[0].to_sympy()), sympy.zoo)
         else:
             return sympy.zoo
 
@@ -1373,7 +1373,7 @@ class Assuming(Builtin):
         elif assumptions.is_symbol() or not assumptions.has_form("List", None):
             cond = [assumptions]
         else:
-            cond = assumptions._leaves
+            cond = assumptions._elements
         cond = tuple(cond) + get_assumptions_list(evaluation)
         list_cond = Expression("List", *cond)
         # TODO: reduce the list of predicates
@@ -1428,7 +1428,7 @@ class ConditionalExpression(Builtin):
         # cond as a predicate, using assumptions.
         # Let's delegate this to the And (and Or) symbols...
         if not cond.is_atom() and cond._head is SymbolList:
-            cond = Expression("System`And", *(cond._leaves))
+            cond = Expression("System`And", *(cond._elements))
         else:
             cond = Expression("System`And", cond)
         if cond is None:

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -90,7 +90,7 @@ class Clear(Builtin):
         if isinstance(symbols, Symbol):
             symbols = [symbols]
         elif isinstance(symbols, Expression):
-            symbols = symbols.get_leaves()
+            symbols = symbols.get_elements()
         elif isinstance(symbols, String):
             symbols = [symbols]
         else:

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -100,23 +100,23 @@ def is_protected(tag, defin):
 
 
 def repl_pattern_by_symbol(expr):
-    leaves = expr.get_elements()
-    if len(leaves) == 0:
+    elements = expr.get_elements()
+    if len(elements) == 0:
         return expr
 
     headname = expr.get_head_name()
     if headname == "System`Pattern":
-        return leaves[0]
+        return elements[0]
 
     changed = False
-    newleaves = []
-    for leave in leaves:
+    newelements = []
+    for leave in elements:
         leaf = repl_pattern_by_symbol(leave)
         if not (leaf is leave):
             changed = True
-        newleaves.append(leaf)
+        newelements.append(leaf)
     if changed:
-        return Expression(headname, *newleaves)
+        return Expression(headname, *newelements)
     else:
         return expr
 
@@ -638,20 +638,24 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
             tags.append(name)
     else:
         allowed_names = [focus.get_lookup_name()]
-        for leaf in focus.get_elements():
-            if not leaf.is_symbol() and leaf.get_head_name() in ("System`HoldPattern",):
-                leaf = leaf.leaves[0]
-            if not leaf.is_symbol() and leaf.get_head_name() in ("System`Pattern",):
-                leaf = leaf.leaves[1]
-            if not leaf.is_symbol() and leaf.get_head_name() in (
+        for element in focus.get_elements():
+            if not element.is_symbol() and element.get_head_name() in (
+                "System`HoldPattern",
+            ):
+                element = element.leaves[0]
+            if not element.is_symbol() and element.get_head_name() in (
+                "System`Pattern",
+            ):
+                element = element.leaves[1]
+            if not element.is_symbol() and element.get_head_name() in (
                 "System`Blank",
                 "System`BlankSequence",
                 "System`BlankNullSequence",
             ):
-                if len(leaf.leaves) == 1:
-                    leaf = leaf.leaves[0]
+                if len(element.leaves) == 1:
+                    element = element.leaves[0]
 
-            allowed_names.append(leaf.get_lookup_name())
+            allowed_names.append(element.get_lookup_name())
         for name in tags:
             if name not in allowed_names:
                 evaluation.message(self.get_name(), "tagnfd", Symbol(name))

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -100,7 +100,7 @@ def is_protected(tag, defin):
 
 
 def repl_pattern_by_symbol(expr):
-    leaves = expr.get_leaves()
+    leaves = expr.get_elements()
     if len(leaves) == 0:
         return expr
 
@@ -159,7 +159,7 @@ def unroll_patterns(lhs, rhs, evaluation):
     if isinstance(lhs, Atom):
         return lhs, rhs
     name = lhs.get_head_name()
-    lhsleaves = lhs._leaves
+    lhsleaves = lhs._elements
     if name == "System`Pattern":
         lhs = lhsleaves[1]
         rulerepl = (lhsleaves[0], repl_pattern_by_symbol(lhs))
@@ -177,16 +177,16 @@ def unroll_conditions(lhs):
     if type(lhs) is Symbol:
         return lhs, None
     else:
-        name, lhs_leaves = lhs.get_head_name(), lhs._leaves
+        name, lhs_elements = lhs.get_head_name(), lhs._elements
     condition = []
     # This handle the case of many sucesive conditions:
     # f[x_]/; cond1 /; cond2 ... ->  f[x_]/; And[cond1, cond2, ...]
     while name == "System`Condition" and len(lhs.leaves) == 2:
-        condition.append(lhs_leaves[1])
-        lhs = lhs_leaves[0]
+        condition.append(lhs_elements[1])
+        lhs = lhs_elements[0]
         if isinstance(lhs, Atom):
             break
-        name, lhs_leaves = lhs.get_head_name(), lhs._leaves
+        name, lhs_elements = lhs.get_head_name(), lhs._elements
     if len(condition) == 0:
         return lhs, None
     if len(condition) > 1:
@@ -288,7 +288,7 @@ def process_assign_context(self, lhs, rhs, evaluation, tags, upset):
 def process_assign_context_path(self, lhs, rhs, evaluation, tags, upset):
     lhs_name = lhs.get_name()
     currContext = evaluation.definitions.get_current_context()
-    context_path = [s.get_string_value() for s in rhs.get_leaves()]
+    context_path = [s.get_string_value() for s in rhs.get_elements()]
     context_path = [
         s if (s is None or s[0] != "`") else currContext[:-1] + s for s in context_path
     ]
@@ -343,14 +343,14 @@ def process_assign_definition_values(self, lhs, rhs, evaluation, tags, upset):
 
 
 def process_assign_options(self, lhs, rhs, evaluation, tags, upset):
-    lhs_leaves = lhs.leaves
+    lhs_elements = lhs.leaves
     name = lhs.get_head_name()
-    if len(lhs_leaves) != 1:
-        evaluation.message_args(name, len(lhs_leaves), 1)
+    if len(lhs_elements) != 1:
+        evaluation.message_args(name, len(lhs_elements), 1)
         raise AssignmentException(lhs, rhs)
-    tag = lhs_leaves[0].get_name()
+    tag = lhs_elements[0].get_name()
     if not tag:
-        evaluation.message(name, "sym", lhs_leaves[0], 1)
+        evaluation.message(name, "sym", lhs_elements[0], 1)
         raise AssignmentException(lhs, rhs)
     if tags is not None and tags != [tag]:
         evaluation.message(name, "tag", Symbol(name), Symbol(tag))
@@ -593,7 +593,7 @@ def process_tags_and_upset_dont_allow_custom(tags, upset, self, lhs, focus, eval
     # this kind of things, but otherwise we need to work on rebuild the pattern
     # matching mechanism...
     flag_ioi, evaluation.ignore_oneidentity = evaluation.ignore_oneidentity, True
-    focus = focus.evaluate_leaves(evaluation)
+    focus = focus.evaluate_elements(evaluation)
     evaluation.ignore_oneidentity = flag_ioi
     name = lhs.get_head_name()
     if tags is None and not upset:
@@ -620,7 +620,7 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
     name = lhs.get_head_name()
     focus = lhs
     flag_ioi, evaluation.ignore_oneidentity = evaluation.ignore_oneidentity, True
-    focus = focus.evaluate_leaves(evaluation)
+    focus = focus.evaluate_elements(evaluation)
     evaluation.ignore_oneidentity = flag_ioi
     if tags is None and not upset:
         name = focus.get_lookup_name()
@@ -638,7 +638,7 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
             tags.append(name)
     else:
         allowed_names = [focus.get_lookup_name()]
-        for leaf in focus.get_leaves():
+        for leaf in focus.get_elements():
             if not leaf.is_symbol() and leaf.get_head_name() in ("System`HoldPattern",):
                 leaf = leaf.leaves[0]
             if not leaf.is_symbol() and leaf.get_head_name() in ("System`Pattern",):

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -83,7 +83,7 @@ def get_symbol_values(symbol, func_name, position, evaluation):
         definition = evaluation.definitions.get_definition(name)
     else:
         definition = evaluation.definitions.get_user_definition(name)
-    leaves = []
+    elements = []
     for rule in definition.get_values_list(position):
         if isinstance(rule, Rule):
             pattern = rule.pattern
@@ -91,8 +91,8 @@ def get_symbol_values(symbol, func_name, position, evaluation):
                 pattern = pattern.expr
             else:
                 pattern = Expression("HoldPattern", pattern.expr)
-            leaves.append(Expression("RuleDelayed", pattern, rule.replace))
-    return Expression("List", *leaves)
+            elements.append(Expression("RuleDelayed", pattern, rule.replace))
+    return Expression("List", *elements)
 
 
 def is_protected(tag, defin):
@@ -109,14 +109,14 @@ def repl_pattern_by_symbol(expr):
         return elements[0]
 
     changed = False
-    newelements = []
-    for leave in elements:
-        leaf = repl_pattern_by_symbol(leave)
-        if not (leaf is leave):
+    new_elements = []
+    for element in elements:
+        element = repl_pattern_by_symbol(element)
+        if not (element is element):
             changed = True
-        newelements.append(leaf)
+        new_elements.append(element)
     if changed:
-        return Expression(headname, *newelements)
+        return Expression(headname, *new_elements)
     else:
         return expr
 
@@ -159,15 +159,15 @@ def unroll_patterns(lhs, rhs, evaluation):
     if isinstance(lhs, Atom):
         return lhs, rhs
     name = lhs.get_head_name()
-    lhsleaves = lhs._elements
+    lhs_elements = lhs._elements
     if name == "System`Pattern":
-        lhs = lhsleaves[1]
-        rulerepl = (lhsleaves[0], repl_pattern_by_symbol(lhs))
+        lhs = lhs_elements[1]
+        rulerepl = (lhs_elements[0], repl_pattern_by_symbol(lhs))
         rhs, status = rhs.apply_rules([Rule(*rulerepl)], evaluation)
         name = lhs.get_head_name()
 
     if name == "System`HoldPattern":
-        lhs = lhsleaves[0]
+        lhs = lhs_elements[0]
         name = lhs.get_head_name()
     return lhs, rhs
 

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -1037,7 +1037,7 @@ class Transliterate(Builtin):
 def _pattern_search(name, string, patt, evaluation, options, matched):
     # Get the pattern list and check validity for each
     if patt.has_form("List", None):
-        patts = patt.get_leaves()
+        patts = patt.get_elements()
     else:
         patts = [patt]
     re_patts = []

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -214,7 +214,7 @@ class Protect(Builtin):
             symbols = [symbols]
         elif isinstance(symbols, Expression):
             if symbols.get_head_name() in ("System`Sequence", "System`List"):
-                symbols = symbols.get_leaves()
+                symbols = symbols.get_elements()
             else:
                 evaluation.message("Protect", "ssym", symbols)
                 return SymbolNull
@@ -265,7 +265,7 @@ class Unprotect(Builtin):
         if isinstance(symbols, Symbol):
             symbols = [symbols]
         elif isinstance(symbols, Expression):
-            symbols = symbols.get_leaves()
+            symbols = symbols.get_elements()
         elif isinstance(symbols, String):
             symbols = [symbols]
         else:

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -581,21 +581,21 @@ class SympyFunction(SympyObject):
         except TypeError:
             pass
 
-    def from_sympy(self, sympy_name, leaves):
-        return Expression(self.get_name(), *leaves)
+    def from_sympy(self, sympy_name, elements):
+        return Expression(self.get_name(), *elements)
 
     def prepare_mathics(self, sympy_expr):
         return sympy_expr
 
 
 class BoxConstruct(InstanceableBuiltin):
-    def __new__(cls, *leaves, **kwargs):
-        instance = super().__new__(cls, *leaves, **kwargs)
-        instance._elements = leaves
+    def __new__(cls, *elements, **kwargs):
+        instance = super().__new__(cls, *elements, **kwargs)
+        instance._elements = elements
         return instance
 
     def evaluate(self, evaluation):
-        # THINK about: Should we evaluate the leaves here?
+        # THINK about: Should we evaluate the elements here?
         return
 
     def get_head_name(self):

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -591,7 +591,7 @@ class SympyFunction(SympyObject):
 class BoxConstruct(InstanceableBuiltin):
     def __new__(cls, *leaves, **kwargs):
         instance = super().__new__(cls, *leaves, **kwargs)
-        instance._leaves = leaves
+        instance._elements = leaves
         return instance
 
     def evaluate(self, evaluation):
@@ -633,7 +633,7 @@ class BoxConstruct(InstanceableBuiltin):
 
     @property
     def leaves(self):
-        return self._leaves
+        return self._elements
 
     @leaves.setter
     def leaves(self, value):
@@ -660,7 +660,7 @@ class BoxConstruct(InstanceableBuiltin):
         if not leaf_counts:
             return False
         if leaf_counts and leaf_counts[0] is not None:
-            count = len(self._leaves)
+            count = len(self._elements)
             if count not in leaf_counts:
                 if (
                     len(leaf_counts) == 2

--- a/mathics/builtin/box/compilation.py
+++ b/mathics/builtin/box/compilation.py
@@ -8,17 +8,17 @@ class CompiledCodeBox(BoxConstruct):
     to CompiledCode.
     """
 
-    def boxes_to_text(self, leaves=None, **options):
-        if leaves is None:
-            leaves = self._elements
-        return leaves[0].value
+    def boxes_to_text(self, elements=None, **options):
+        if elements is None:
+            elements = self._elements
+        return elements[0].value
 
-    def boxes_to_mathml(self, leaves=None, **options):
-        if leaves is None:
-            leaves = self._elements
-        return leaves[0].value
+    def boxes_to_mathml(self, elements=None, **options):
+        if elements is None:
+            elements = self._elements
+        return elements[0].value
 
-    def boxes_to_tex(self, leaves=None, **options):
-        if leaves is None:
-            leaves = self._elements
-        return leaves[0].value
+    def boxes_to_tex(self, elements=None, **options):
+        if elements is None:
+            elements = self._elements
+        return elements[0].value

--- a/mathics/builtin/box/compilation.py
+++ b/mathics/builtin/box/compilation.py
@@ -10,15 +10,15 @@ class CompiledCodeBox(BoxConstruct):
 
     def boxes_to_text(self, leaves=None, **options):
         if leaves is None:
-            leaves = self._leaves
+            leaves = self._elements
         return leaves[0].value
 
     def boxes_to_mathml(self, leaves=None, **options):
         if leaves is None:
-            leaves = self._leaves
+            leaves = self._elements
         return leaves[0].value
 
     def boxes_to_tex(self, leaves=None, **options):
         if leaves is None:
-            leaves = self._leaves
+            leaves = self._elements
         return leaves[0].value

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -668,7 +668,7 @@ class GraphicsBox(BoxConstruct):
         svg_body = format_fn(self, leaves, data=data, **options)
         return svg_body
 
-    def boxes_to_tex(self, leaves=None, **options) -> str:
+    def boxes_to_tex(self, elements=None, **options) -> str:
         """This is the top-level function that converts a Mathics Expression
         in to something suitable for LaTeX.  (Yes, the name "tex" is
         perhaps misleading of vague.)
@@ -677,9 +677,9 @@ class GraphicsBox(BoxConstruct):
         that seems to be the package of choice in general for LaTeX.
         """
 
-        if not leaves:
-            leaves = self._elements
-            fields = self._prepare_elements(leaves, options, max_width=450)
+        if not elements:
+            elements = self._elements
+            fields = self._prepare_elements(elements, options, max_width=450)
             if len(fields) == 2:
                 elements, calc_dimensions = fields
             else:

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -52,7 +52,7 @@ class _RoundBox(_GraphicsElement):
 
     def init(self, graphics, style, item):
         super(_RoundBox, self).init(graphics, item, style)
-        if len(item._leaves) not in (1, 2):
+        if len(item._elements) not in (1, 2):
             raise BoxConstructError
         self.edge_color, self.face_color = style.get_style(
             _Color, face_element=self.face_element
@@ -657,7 +657,7 @@ class GraphicsBox(BoxConstruct):
         in to something suitable for SVG rendering.
         """
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
 
         elements, calc_dimensions = self._prepare_elements(leaves, options, neg_y=True)
         xmin, xmax, ymin, ymax, w, h, self.width, self.height = calc_dimensions()
@@ -678,7 +678,7 @@ class GraphicsBox(BoxConstruct):
         """
 
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
             fields = self._prepare_elements(leaves, options, max_width=450)
             if len(fields) == 2:
                 elements, calc_dimensions = fields
@@ -742,7 +742,7 @@ clip(%s);
 
     def boxes_to_text(self, leaves=None, **options) -> str:
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
 
         self._prepare_elements(leaves, options)  # to test for Box errors
         return "-Graphics-"

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -740,11 +740,11 @@ clip(%s);
 
         return tex
 
-    def boxes_to_text(self, leaves=None, **options) -> str:
-        if not leaves:
-            leaves = self._elements
+    def boxes_to_text(self, elements=None, **options) -> str:
+        if not elements:
+            elements = self._elements
 
-        self._prepare_elements(leaves, options)  # to test for Box errors
+        self._prepare_elements(elements, options)  # to test for Box errors
         return "-Graphics-"
 
     def create_axes(self, elements, graphics_options, xmin, xmax, ymin, ymax):

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -342,7 +342,7 @@ class Graphics3DBox(GraphicsBox):
         the caller will do that if it is needed.
         """
         if not leaves:
-            leaves = self._elements
+            elements = self._elements
 
         (
             elements,
@@ -351,7 +351,7 @@ class Graphics3DBox(GraphicsBox):
             ticks_style,
             calc_dimensions,
             boxscale,
-        ) = self._prepare_elements(leaves, options)
+        ) = self._prepare_elements(elements, options)
 
         js_ticks_style = [s.to_js() for s in ticks_style]
 
@@ -388,16 +388,16 @@ class Graphics3DBox(GraphicsBox):
 
         return json_repr
 
-    def boxes_to_mathml(self, leaves=None, **options) -> str:
+    def boxes_to_mathml(self, elements=None, **options) -> str:
         """Turn the Graphics3DBox into a MathML string"""
-        json_repr = self.boxes_to_json(leaves, **options)
+        json_repr = self.boxes_to_json(elements, **options)
         mathml = f'<graphics3d data="{html.escape(json_repr)}" />'
         mathml = f"<mtable><mtr><mtd>{mathml}</mtd></mtr></mtable>"
         return mathml
 
-    def boxes_to_tex(self, leaves=None, **options):
-        if not leaves:
-            leaves = self._elements
+    def boxes_to_tex(self, elements=None, **options):
+        if not elements:
+            elements = self._elements
 
         (
             elements,
@@ -406,7 +406,7 @@ class Graphics3DBox(GraphicsBox):
             ticks_style,
             calc_dimensions,
             boxscale,
-        ) = self._prepare_elements(leaves, options, max_width=450)
+        ) = self._prepare_elements(elements, options, max_width=450)
 
         elements._apply_boxscaling(boxscale)
 
@@ -600,9 +600,9 @@ currentlight=light(rgb(0.5,0.5,1), specular=red, (2,0,2), (2,2,2), (0,2,2));
         )
         return tex
 
-    def boxes_to_text(self, leaves=None, **options):
-        if not leaves:
-            leaves = self._elements
+    def boxes_to_text(self, elements=None, **options):
+        if not elements:
+            elements = self._elements
         return "-Graphics3D-"
 
     def create_axes(

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -342,7 +342,7 @@ class Graphics3DBox(GraphicsBox):
         the caller will do that if it is needed.
         """
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
 
         (
             elements,
@@ -397,7 +397,7 @@ class Graphics3DBox(GraphicsBox):
 
     def boxes_to_tex(self, leaves=None, **options):
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
 
         (
             elements,
@@ -602,7 +602,7 @@ currentlight=light(rgb(0.5,0.5,1), specular=red, (2,0,2), (2,2,2), (0,2,2));
 
     def boxes_to_text(self, leaves=None, **options):
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
         return "-Graphics3D-"
 
     def create_axes(

--- a/mathics/builtin/box/image.py
+++ b/mathics/builtin/box/image.py
@@ -13,7 +13,7 @@ class ImageBox(BoxConstruct):
 
     def boxes_to_mathml(self, leaves=None, **options):
         if leaves is None:
-            leaves = self._leaves
+            leaves = self._elements
         # see https://tools.ietf.org/html/rfc2397
         return '<mglyph src="%s" width="%dpx" height="%dpx" />' % (
             leaves[0].get_string_value(),

--- a/mathics/builtin/box/image.py
+++ b/mathics/builtin/box/image.py
@@ -8,18 +8,18 @@ class ImageBox(BoxConstruct):
     an Image object.
     """
 
-    def boxes_to_text(self, leaves=None, **options):
+    def boxes_to_text(self, elements=None, **options):
         return "-Image-"
 
-    def boxes_to_mathml(self, leaves=None, **options):
-        if leaves is None:
-            leaves = self._elements
+    def boxes_to_mathml(self, elements=None, **options):
+        if elements is None:
+            elements = self._elements
         # see https://tools.ietf.org/html/rfc2397
         return '<mglyph src="%s" width="%dpx" height="%dpx" />' % (
-            leaves[0].get_string_value(),
-            leaves[1].get_int_value(),
-            leaves[2].get_int_value(),
+            elements[0].get_string_value(),
+            elements[1].get_int_value(),
+            elements[2].get_int_value(),
         )
 
-    def boxes_to_tex(self, leaves=None, **options):
+    def boxes_to_tex(self, elements=None, **options):
         return "-Image-"

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -102,9 +102,9 @@ class _EqualityOperator(_InequalityOperator):
         same_heads = lhs.get_head().sameQ(rhs.get_head())
         if not same_heads:
             return None
-        if len(lhs._leaves) != len(rhs._leaves):
+        if len(lhs._elements) != len(rhs._elements):
             return
-        for l, r in zip(lhs._leaves, rhs._leaves):
+        for l, r in zip(lhs._elements, rhs._elements):
             tst = self.equal2(l, r, max_extra_prec)
             if not tst:
                 return tst
@@ -116,11 +116,11 @@ class _EqualityOperator(_InequalityOperator):
         if not lhs.get_head().sameQ(SymbolDirectedInfinity):
             return None
         if rhs.sameQ(SymbolInfinity) or rhs.sameQ(SymbolComplexInfinity):
-            if len(lhs._leaves) == 0:
+            if len(lhs._elements) == 0:
                 return True
             else:
                 return self.equal2(
-                    Expression("Sign", lhs._leaves[0]), Integer1, max_extra_prec
+                    Expression("Sign", lhs._elements[0]), Integer1, max_extra_prec
                 )
         if rhs.is_numeric():
             return False
@@ -128,10 +128,10 @@ class _EqualityOperator(_InequalityOperator):
             return None
         if rhs.get_head().sameQ(lhs.get_head()):
             dir1 = dir2 = Integer1
-            if len(lhs._leaves) == 1:
-                dir1 = lhs._leaves[0]
-            if len(rhs._leaves) == 1:
-                dir2 = rhs._leaves[0]
+            if len(lhs._elements) == 1:
+                dir1 = lhs._elements[0]
+            if len(rhs._elements) == 1:
+                dir2 = rhs._elements[0]
             if self.equal2(dir1, dir2, max_extra_prec):
                 return True
             # Now, compare the signs:

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -186,9 +186,9 @@ class CompiledCode(Atom):
             return "-PythonizedCode-"
         return "-CompiledCode-"
 
-    def boxes_to_text(self, leaves=None, **options):
-        if not leaves:
-            leaves = self._elements
+    def boxes_to_text(self, elements=None, **options):
+        if not elements:
+            elements = self._elements
         return "-CompiledCode-"
 
     def do_copy(self):

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -117,13 +117,13 @@ class Compile(Builtin):
             return evaluation.message("Compile", "invars")
         args = []
         names = []
-        for var in vars.get_leaves():
+        for var in vars.get_elements():
             if isinstance(var, Symbol):
                 symb = var
                 name = symb.get_name()
                 typ = real_type
             elif var.has_form("List", 2):
-                symb, typ = var.get_leaves()
+                symb, typ = var.get_elements()
                 if isinstance(symb, Symbol) and typ in permitted_types:
                     name = symb.get_name()
                     typ = permitted_types[typ]
@@ -188,7 +188,7 @@ class CompiledCode(Atom):
 
     def boxes_to_text(self, leaves=None, **options):
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
         return "-CompiledCode-"
 
     def do_copy(self):

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -19,7 +19,7 @@ def single_real_arg(f):
     """
 
     def wrapped_f(self, expr):
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         if len(leaves) != 1:
             raise CompileError()
         arg = self._gen_ir(leaves[0])
@@ -40,7 +40,7 @@ def int_real_args(minargs):
 
     def wraps(f):
         def wrapped_f(self, expr):
-            leaves = expr.get_leaves()
+            leaves = expr.get_elements()
             if len(leaves) < minargs:
                 raise CompileError()
             args = [self._gen_ir(leaf) for leaf in leaves]
@@ -70,7 +70,7 @@ def int_args(f):
     """
 
     def wrapped_f(self, expr):
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         args = [self._gen_ir(leaf) for leaf in leaves]
         for arg in args:
             if arg.type == void_type:
@@ -92,7 +92,7 @@ def bool_args(f):
     """
 
     def wrapped_f(self, expr):
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         args = [self._gen_ir(leaf) for leaf in leaves]
         for arg in args:
             if arg.type == void_type:
@@ -246,7 +246,7 @@ class IRGenerator(object):
             raise CompileError()
 
         builder = self.builder
-        args = expr.get_leaves()
+        args = expr.get_elements()
 
         # condition
         cond = self._gen_ir(args[0])
@@ -306,7 +306,7 @@ class IRGenerator(object):
         return result
 
     def _gen_Return(self, expr):
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         if len(leaves) != 1:
             raise CompileError()
 
@@ -346,7 +346,7 @@ class IRGenerator(object):
 
     def _gen_Power(self, expr):
         # TODO (int_type, int_type) power
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         if len(leaves) != 2:
             raise CompileError()
 

--- a/mathics/builtin/compile/ir.py
+++ b/mathics/builtin/compile/ir.py
@@ -19,10 +19,10 @@ def single_real_arg(f):
     """
 
     def wrapped_f(self, expr):
-        leaves = expr.get_elements()
-        if len(leaves) != 1:
+        elements = expr.get_elements()
+        if len(elements) != 1:
             raise CompileError()
-        arg = self._gen_ir(leaves[0])
+        arg = self._gen_ir(elements[0])
         if arg.type == void_type:
             return arg
         elif arg.type == int_type:
@@ -40,10 +40,10 @@ def int_real_args(minargs):
 
     def wraps(f):
         def wrapped_f(self, expr):
-            leaves = expr.get_elements()
-            if len(leaves) < minargs:
+            elements = expr.get_elements()
+            if len(elements) < minargs:
                 raise CompileError()
-            args = [self._gen_ir(leaf) for leaf in leaves]
+            args = [self._gen_ir(element) for element in elements]
             for arg in args:
                 if arg.type == void_type:
                     return arg
@@ -70,8 +70,8 @@ def int_args(f):
     """
 
     def wrapped_f(self, expr):
-        leaves = expr.get_elements()
-        args = [self._gen_ir(leaf) for leaf in leaves]
+        elements = expr.get_elements()
+        args = [self._gen_ir(element) for element in elements]
         for arg in args:
             if arg.type == void_type:
                 return arg
@@ -92,8 +92,8 @@ def bool_args(f):
     """
 
     def wrapped_f(self, expr):
-        leaves = expr.get_elements()
-        args = [self._gen_ir(leaf) for leaf in leaves]
+        elements = expr.get_elements()
+        args = [self._gen_ir(element) for element in elements]
         for arg in args:
             if arg.type == void_type:
                 return arg
@@ -306,11 +306,11 @@ class IRGenerator(object):
         return result
 
     def _gen_Return(self, expr):
-        leaves = expr.get_elements()
-        if len(leaves) != 1:
+        elements = expr.get_elements()
+        if len(elements) != 1:
             raise CompileError()
 
-        arg = self._gen_ir(leaves[0])
+        arg = self._gen_ir(elements[0])
         if arg.type == void_type:
             return arg
 
@@ -346,27 +346,27 @@ class IRGenerator(object):
 
     def _gen_Power(self, expr):
         # TODO (int_type, int_type) power
-        leaves = expr.get_elements()
-        if len(leaves) != 2:
+        elements = expr.get_elements()
+        if len(elements) != 2:
             raise CompileError()
 
         # convert exponent
-        exponent = self._gen_ir(leaves[1])
+        exponent = self._gen_ir(elements[1])
         if exponent.type == int_type:
             exponent = self.int_to_real(exponent)
         elif exponent.type == void_type:
             return exponent
 
         # E ^ exponent
-        if leaves[0].sameQ(Symbol("E")) and exponent.type == real_type:
+        if elements[0].sameQ(Symbol("E")) and exponent.type == real_type:
             return self.call_fp_intr("llvm.exp", [exponent])
 
         # 2 ^ exponent
-        if leaves[0].get_int_value() == 2 and exponent.type == real_type:
+        if elements[0].get_int_value() == 2 and exponent.type == real_type:
             return self.call_fp_intr("llvm.exp2", [exponent])
 
         # convert base
-        base = self._gen_ir(leaves[0])
+        base = self._gen_ir(elements[0])
         if base.type == int_type:
             base = self.int_to_real(base)
         elif base.type == void_type:

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -606,8 +606,8 @@ class DateObject(_DateFormat):
                 options[args.leaves[0].get_name()] = args.leaves[1]
                 args = Expression("AbsoluteTime").evaluate(evaluation)
             elif args.get_head_name() == "System`DateObject":
-                datelist = args._leaves[0]
-                tz = args._leaves[3]
+                datelist = args._elements[0]
+                tz = args._elements[3]
 
         if datelist is None:
             datelist = self.to_datelist(args, evaluation)

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -235,7 +235,7 @@ class Cone(Builtin):
     def apply_check(self, positions, radius, evaluation):
         "Cone[positions_List, radius_]"
 
-        if len(positions.get_leaves()) % 2 == 1:
+        if len(positions.get_elements()) % 2 == 1:
             # The number of points is odd, so abort.
             evaluation.error("Cone", "oddn", positions)
         if not isinstance(radius, (Integer, Rational, Real)):
@@ -291,7 +291,7 @@ class Cuboid(Builtin):
     def apply_check(self, positions, evaluation):
         "Cuboid[positions_List]"
 
-        if len(positions.get_leaves()) % 2 == 1:
+        if len(positions.get_elements()) % 2 == 1:
             # The number of points is odd, so abort.
             evaluation.error("Cuboid", "oddn", positions)
 
@@ -331,7 +331,7 @@ class Cylinder(Builtin):
     def apply_check(self, positions, radius, evaluation):
         "Cylinder[positions_List, radius_]"
 
-        if len(positions.get_leaves()) % 2 == 1:
+        if len(positions.get_elements()) % 2 == 1:
             # The number of points is odd, so abort.
             evaluation.error("Cylinder", "oddn", positions)
         if not isinstance(radius, (Integer, Rational, Real)):

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -7,6 +7,9 @@ Functions for working with 3D graphics.
 
 
 from mathics.core.evaluators import apply_N
+from mathics.core.expression import Expression
+from mathics.core.symbols import SymbolN
+
 from mathics.builtin.base import Builtin
 from mathics.builtin.colors.color_directives import RGBColor
 from mathics.builtin.graphics import (

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -425,7 +425,7 @@ class Read(Builtin):
 
         # Wrap types in a list (if it isn't already one)
         if types.has_form("List", None):
-            types = types._leaves
+            types = types._elements
         else:
             types = (types,)
 
@@ -1209,7 +1209,7 @@ class BinaryWrite(Builtin):
 
         # Check Type
         if typ.has_form("List", None):
-            types = typ.get_leaves()
+            types = typ.get_elements()
         else:
             types = [typ]
 
@@ -1567,7 +1567,7 @@ class BinaryRead(Builtin):
             return expr
 
         if typ.has_form("List", None):
-            types = typ.get_leaves()
+            types = typ.get_elements()
         else:
             types = [typ]
 
@@ -2358,7 +2358,7 @@ class Close(Builtin):
         "Close[channel_]"
 
         if channel.has_form(("InputStream", "OutputStream"), 2):
-            [name, n] = channel.get_leaves()
+            [name, n] = channel.get_elements()
             py_n = n.get_int_value()
             stream = stream_manager.lookup_stream(py_n)
         else:

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -1195,7 +1195,7 @@ class FileNames(Builtin):
         # Building a list of forms
         if forms.get_head_name() == "System`List":
             str_forms = []
-            for p in forms._leaves:
+            for p in forms._elements:
                 if self.fmtmaps.get(p, None):
                     str_forms.append(self.fmtmaps[p])
                 else:
@@ -1209,7 +1209,7 @@ class FileNames(Builtin):
             str_paths = [paths.value]
         elif paths.get_head_name() == "System`List":
             str_paths = []
-            for p in paths._leaves:
+            for p in paths._elements:
                 if p.get_head_name() == "System`String":
                     str_paths.append(p.value)
                 else:

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -1776,11 +1776,11 @@ class Export(Builtin):
             return SymbolFailed
 
         # Process elems {comp* format?, elem1*}
-        leaves = elems.get_elements()
+        elements = elems.get_elements()
 
         format_spec, elems_spec = [], []
         found_form = False
-        for leaf in leaves[::-1]:
+        for leaf in elements[::-1]:
             leaf_str = leaf.get_string_value()
 
             if not found_form and leaf_str in EXPORTERS:
@@ -1915,10 +1915,10 @@ class ExportString(Builtin):
     def apply_elements(self, expr, elems, evaluation, **options):
         "ExportString[expr_, elems_List?(AllTrue[#, NotOptionQ]&), OptionsPattern[ExportString]]"
         # Process elems {comp* format?, elem1*}
-        leaves = elems.get_elements()
+        elements = elems.get_elements()
         format_spec, elems_spec = [], []
         found_form = False
-        for leaf in leaves[::-1]:
+        for leaf in elements[::-1]:
             leaf_str = leaf.get_string_value()
 
             if not found_form and leaf_str in EXPORTERS:

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -1096,23 +1096,23 @@ class RegisterImport(Builtin):
         OptionsPattern[ImportExport`RegisterImport]]"""
 
         if function.has_form("List", None):
-            leaves = function.get_elements()
+            elements = function.get_elements()
         else:
-            leaves = [function]
+            elements = [function]
 
         if not (
-            len(leaves) >= 1
-            and isinstance(leaves[-1], Symbol)
-            and all(x.has_form("RuleDelayed", None) for x in leaves[:-1])
+            len(elements) >= 1
+            and isinstance(elements[-1], Symbol)
+            and all(x.has_form("RuleDelayed", None) for x in elements[:-1])
         ):
             # TODO: Message
             return SymbolFailed
 
         conditionals = {
             elem.get_string_value(): expr
-            for (elem, expr) in (x.get_elements() for x in leaves[:-1])
+            for (elem, expr) in (x.get_elements() for x in elements[:-1])
         }
-        default = leaves[-1]
+        default = elements[-1]
         posts = {}
 
         IMPORTERS[formatname.get_string_value()] = (

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -1096,7 +1096,7 @@ class RegisterImport(Builtin):
         OptionsPattern[ImportExport`RegisterImport]]"""
 
         if function.has_form("List", None):
-            leaves = function.get_leaves()
+            leaves = function.get_elements()
         else:
             leaves = [function]
 
@@ -1110,7 +1110,7 @@ class RegisterImport(Builtin):
 
         conditionals = {
             elem.get_string_value(): expr
-            for (elem, expr) in (x.get_leaves() for x in leaves[:-1])
+            for (elem, expr) in (x.get_elements() for x in leaves[:-1])
         }
         default = leaves[-1]
         posts = {}
@@ -1369,7 +1369,7 @@ class Import(Builtin):
         current_predetermined_out = evaluation.predetermined_out
         # Check elements
         if elements.has_form("List", None):
-            elements = elements.get_leaves()
+            elements = elements.get_elements()
         else:
             elements = [elements]
 
@@ -1457,16 +1457,16 @@ class Import(Builtin):
                 # TODO message
                 evaluation.predetermined_out = current_predetermined_out
                 return SymbolFailed
-            tmp = tmp.get_leaves()
+            tmp = tmp.get_elements()
             if not all(expr.has_form("Rule", None) for expr in tmp):
                 evaluation.predetermined_out = current_predetermined_out
                 return None
 
             # return {a.get_string_value() : b for (a,b) in map(lambda x:
-            # x.get_leaves(), tmp)}
+            # x.get_elements(), tmp)}
             evaluation.predetermined_out = current_predetermined_out
             return dict(
-                (a.get_string_value(), b) for (a, b) in [x.get_leaves() for x in tmp]
+                (a.get_string_value(), b) for (a, b) in [x.get_elements() for x in tmp]
             )
 
         # Perform the import
@@ -1776,7 +1776,7 @@ class Export(Builtin):
             return SymbolFailed
 
         # Process elems {comp* format?, elem1*}
-        leaves = elems.get_leaves()
+        leaves = elems.get_elements()
 
         format_spec, elems_spec = [], []
         found_form = False
@@ -1915,7 +1915,7 @@ class ExportString(Builtin):
     def apply_elements(self, expr, elems, evaluation, **options):
         "ExportString[expr_, elems_List?(AllTrue[#, NotOptionQ]&), OptionsPattern[ExportString]]"
         # Process elems {comp* format?, elem1*}
-        leaves = elems.get_leaves()
+        leaves = elems.get_elements()
         format_spec, elems_spec = [], []
         found_form = False
         for leaf in leaves[::-1]:
@@ -2172,7 +2172,7 @@ class B64Encode(Builtin):
         if isinstance(expr, String):
             stringtocodify = expr.get_string_value()
         elif expr.get_head_name() == "System`ByteArray":
-            return String(expr._leaves[0].__str__())
+            return String(expr._elements[0].__str__())
         else:
             stringtocodify = (
                 Expression("ToString", expr).evaluate(evaluation).get_string_value()

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -212,16 +212,16 @@ class Show(Builtin):
                 options[option] = apply_N(options[option], evaluation)
 
         # The below could probably be done with graphics.filter..
-        new_leaves = []
+        new_elements = []
         options_set = set(options.keys())
         for leaf in graphics.leaves:
             leaf_name = leaf.get_head_name()
             if leaf_name == "System`Rule" and str(leaf.leaves[0]) in options_set:
                 continue
-            new_leaves.append(leaf)
+            new_elements.append(leaf)
 
-        new_leaves += options_to_rules(options)
-        graphics = graphics.restructure(graphics.head, new_leaves, evaluation)
+        new_elements += options_to_rules(options)
+        graphics = graphics.restructure(graphics.head, new_elements, evaluation)
 
         return graphics
 
@@ -305,20 +305,20 @@ class Graphics(Builtin):
                         inset = content.leaves[0]
                         if inset.get_head() is Symbol("System`Graphics"):
                             opts = {}
-                            # opts = dict(opt._leaves[0].name:opt_leaves[1]   for opt in  inset._leaves[1:])
+                            # opts = dict(opt._elements[0].name:opt_elements[1]   for opt in  inset._elements[1:])
                             inset = self.apply_makeboxes(
-                                inset._leaves[0], evaluation, opts
+                                inset._elements[0], evaluation, opts
                             )
-                        n_leaves = [inset] + [
+                        n_elements = [inset] + [
                             apply_N(leaf, evaluation) for leaf in content.leaves[1:]
                         ]
                     else:
-                        n_leaves = (
+                        n_elements = (
                             apply_N(leaf, evaluation) for leaf in content.leaves
                         )
                 else:
-                    n_leaves = content.leaves
-                return Expression(head.name + self.box_suffix, *n_leaves)
+                    n_elements = content.leaves
+                return Expression(head.name + self.box_suffix, *n_elements)
             return content
 
         for option in options:

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -173,8 +173,8 @@ def logical_expand_assumptions(assumptions_list, evaluation):
                     new_assumptions_list.append(Expression("Not", leaf))
                 continue
             if sentence.has_form("And", None):
-                leaves = (Expression("Not", leaf) for leaf in sentence._elements)
-                new_assumptions_list.append(Expression("Or", *leaves))
+                elements = (Expression("Not", leaf) for leaf in sentence._elements)
+                new_assumptions_list.append(Expression("Or", *elements))
                 continue
             if sentence.has_form("Implies", 2):
                 changed = True

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -126,7 +126,7 @@ def get_assumptions_list(evaluation):
     if assumptions.is_atom() or not assumptions.has_form("List", None):
         assumptions = (assumptions,)
     else:
-        assumptions = assumptions._leaves
+        assumptions = assumptions._elements
 
     return assumptions
 
@@ -166,20 +166,20 @@ def logical_expand_assumptions(assumptions_list, evaluation):
                 new_assumptions_list.append(leaf)
             continue
         if assumption.has_form("Not", 1):
-            sentence = assumption._leaves[0]
+            sentence = assumption._elements[0]
             if sentence.has_form("Or", None):
                 changed = True
-                for leaf in sentence._leaves:
+                for leaf in sentence._elements:
                     new_assumptions_list.append(Expression("Not", leaf))
                 continue
             if sentence.has_form("And", None):
-                leaves = (Expression("Not", leaf) for leaf in sentence._leaves)
+                leaves = (Expression("Not", leaf) for leaf in sentence._elements)
                 new_assumptions_list.append(Expression("Or", *leaves))
                 continue
             if sentence.has_form("Implies", 2):
                 changed = True
-                new_assumptions_list.append(sentence._leaves[0])
-                new_assumptions_list.append(Expression("Not", sentence._leaves[1]))
+                new_assumptions_list.append(sentence._elements[0])
+                new_assumptions_list.append(Expression("Not", sentence._elements[1]))
         if assumption.has_form("Nor", None):
             changed = True
             for leaf in assumption.leaves:
@@ -215,13 +215,13 @@ def algebraic_expand_assumptions(assumptions_list, evaluation):
     for assumption in assumptions_list:
         if assumption.has_form("Not", 1):
             nas, local_change = algebraic_expand_assumptions(
-                [assumption._leaves[0]], evaluation
+                [assumption._elements[0]], evaluation
             )
             if local_change:
                 changed = local_change
                 for na in nas:
                     if na.has_form("Not", 1):
-                        new_assumptions_list.append(na._leaves[0])
+                        new_assumptions_list.append(na._elements[0])
                     else:
                         new_assumptions_list.append(Expression("Not", na))
             else:
@@ -289,7 +289,7 @@ def get_assumption_rules_dispatch(evaluation):
         value = True
         while pat.has_form("Not", 1):
             value = not value
-            pat = pat._leaves[0]
+            pat = pat._elements[0]
 
         if value:
             symbol_value = SymbolTrue
@@ -298,38 +298,38 @@ def get_assumption_rules_dispatch(evaluation):
 
         if pat.has_form("Equal", 2):
             if value:
-                lhs, rhs = pat._leaves
+                lhs, rhs = pat._elements
                 if lhs.is_numeric(evaluation):
                     assumption_rules.append(Rule(rhs, lhs))
                 else:
                     assumption_rules.append(Rule(lhs, rhs))
             else:
                 assumption_rules.append(Rule(pat, SymbolFalse))
-                symm_pat = Expression(pat._head, pat._leaves[1], pat._leaves[0])
+                symm_pat = Expression(pat._head, pat._elements[1], pat._elements[0])
                 assumption_rules.append(Rule(symm_pat, SymbolFalse))
         elif pat.has_form("Equivalent", 2):
             assumption_rules.append(Rule(pat, symbol_value))
-            symm_pat = Expression(pat._head, pat._leaves[1], pat._leaves[0])
+            symm_pat = Expression(pat._head, pat._elements[1], pat._elements[0])
             assumption_rules.append(Rule(symm_pat, symbol_value))
         elif pat.has_form("Less", 2):
             if value:
                 assumption_rules.append(Rule(pat, SymbolTrue))
                 assumption_rules.append(
                     Rule(
-                        Expression(pat._head, pat._leaves[1], pat._leaves[0]),
+                        Expression(pat._head, pat._elements[1], pat._elements[0]),
                         SymbolFalse,
                     )
                 )
                 for head in ("Equal", "Equivalent"):
                     assumption_rules.append(
                         Rule(
-                            Expression(head, pat._leaves[0], pat._leaves[1]),
+                            Expression(head, pat._elements[0], pat._elements[1]),
                             SymbolFalse,
                         )
                     )
                     assumption_rules.append(
                         Rule(
-                            Expression(head, pat._leaves[1], pat._leaves[0]),
+                            Expression(head, pat._elements[1], pat._elements[0]),
                             SymbolFalse,
                         )
                     )
@@ -350,7 +350,8 @@ def evaluate_predicate(pred, evaluation):
 
     if pred.has_form(("List", "Sequence"), None):
         return Expression(
-            pred._head, *[evaluate_predicate(subp, evaluation) for subp in pred._leaves]
+            pred._head,
+            *[evaluate_predicate(subp, evaluation) for subp in pred._elements]
         )
 
     debug_logical_expr("reducing ", pred, evaluation)

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -622,9 +622,9 @@ class MakeBoxes(Builtin):
 
         precedence = prec.get_int_value()
 
-        leaves = expr.get_elements()
-        if len(leaves) == 1:
-            leaf = leaves[0]
+        elements = expr.get_elements()
+        if len(elements) == 1:
+            leaf = elements[0]
             leaf_boxes = MakeBoxes(leaf, f)
             leaf = parenthesize(precedence, leaf, leaf_boxes, True)
             if p.get_name() == "System`Postfix":
@@ -658,15 +658,15 @@ class MakeBoxes(Builtin):
         precedence = prec.get_int_value()
         grouping = grouping.get_name()
 
-        leaves = expr.get_elements()
-        if len(leaves) > 1:
-            if h.has_form("List", len(leaves) - 1):
+        elements = expr.get_elements()
+        if len(elements) > 1:
+            if h.has_form("List", len(elements) - 1):
                 ops = [get_op(op) for op in h.leaves]
             else:
-                ops = [get_op(h)] * (len(leaves) - 1)
-            return make_boxes_infix(leaves, ops, precedence, grouping, f)
-        elif len(leaves) == 1:
-            return MakeBoxes(leaves[0], f)
+                ops = [get_op(h)] * (len(elements) - 1)
+            return make_boxes_infix(elements, ops, precedence, grouping, f)
+        elif len(elements) == 1:
+            return MakeBoxes(elements[0], f)
         else:
             return MakeBoxes(expr, f)
 
@@ -822,11 +822,11 @@ class GridBox(BoxConstruct):
         result += r"\end{array}"
         return result
 
-    def boxes_to_mathml(self, leaves=None, **box_options) -> str:
-        if not leaves:
-            leaves = self._elements
+    def boxes_to_mathml(self, elements=None, **box_options) -> str:
+        if not elements:
+            elements = self._elements
         evaluation = box_options.get("evaluation")
-        items, options = self.get_array(leaves, evaluation)
+        items, options = self.get_array(elements, evaluation)
         attrs = {}
         column_alignments = options["System`ColumnAlignments"].get_name()
         try:
@@ -850,11 +850,11 @@ class GridBox(BoxConstruct):
         result += "</mtable>"
         return result
 
-    def boxes_to_text(self, leaves=None, **box_options) -> str:
-        if not leaves:
-            leaves = self._elements
+    def boxes_to_text(self, elements=None, **box_options) -> str:
+        if not elements:
+            elements = self._elements
         evaluation = box_options.get("evaluation")
-        items, options = self.get_array(leaves, evaluation)
+        items, options = self.get_array(elements, evaluation)
         result = ""
         if not items:
             return ""

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -622,7 +622,7 @@ class MakeBoxes(Builtin):
 
         precedence = prec.get_int_value()
 
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         if len(leaves) == 1:
             leaf = leaves[0]
             leaf_boxes = MakeBoxes(leaf, f)
@@ -658,7 +658,7 @@ class MakeBoxes(Builtin):
         precedence = prec.get_int_value()
         grouping = grouping.get_name()
 
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         if len(leaves) > 1:
             if h.has_form("List", len(leaves) - 1):
                 ops = [get_op(op) for op in h.leaves]
@@ -793,7 +793,7 @@ class GridBox(BoxConstruct):
 
     def boxes_to_tex(self, leaves=None, **box_options) -> str:
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
         evaluation = box_options.get("evaluation")
         items, options = self.get_array(leaves, evaluation)
         new_box_options = box_options.copy()
@@ -824,7 +824,7 @@ class GridBox(BoxConstruct):
 
     def boxes_to_mathml(self, leaves=None, **box_options) -> str:
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
         evaluation = box_options.get("evaluation")
         items, options = self.get_array(leaves, evaluation)
         attrs = {}
@@ -852,7 +852,7 @@ class GridBox(BoxConstruct):
 
     def boxes_to_text(self, leaves=None, **box_options) -> str:
         if not leaves:
-            leaves = self._leaves
+            leaves = self._elements
         evaluation = box_options.get("evaluation")
         items, options = self.get_array(leaves, evaluation)
         result = ""
@@ -1329,7 +1329,7 @@ class Message(Builtin):
 def check_message(expr) -> bool:
     "checks if an expression is a valid message"
     if expr.has_form("MessageName", 2):
-        symbol, tag = expr.get_leaves()
+        symbol, tag = expr.get_elements()
         if symbol.get_name() and tag.get_string_value():
             return True
     return False

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -74,12 +74,12 @@ class Multinomial(Builtin):
         "Multinomial[values___]"
 
         values = values.get_sequence()
-        leaves = []
+        elements = []
         total = []
         for value in values:
             total.append(value)
-            leaves.append(Expression("Binomial", Expression("Plus", *total), value))
-        return Expression("Times", *leaves)
+            elements.append(Expression("Binomial", Expression("Plus", *total), value))
+        return Expression("Times", *elements)
 
 
 class _NoBoolVector(Exception):

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -76,7 +76,7 @@ class Array(Builtin):
         "Array[f_, dimsexpr_, origins_:1, head_:List]"
 
         if dimsexpr.has_form("List", None):
-            dims = dimsexpr.get_mutable_leaves()
+            dims = dimsexpr.get_mutable_elements()
         else:
             dims = [dimsexpr]
         for index, dim in enumerate(dims):
@@ -89,7 +89,7 @@ class Array(Builtin):
             if len(origins.leaves) != len(dims):
                 evaluation.message("Array", "plen", dimsexpr, origins)
                 return
-            origins = origins.get_mutable_leaves()
+            origins = origins.get_mutable_elements()
         else:
             origins = [origins] * len(dims)
         for index, origin in enumerate(origins):

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -81,7 +81,7 @@ class Append(Builtin):
 
         return expr.restructure(
             expr.head,
-            list(chain(expr.get_leaves(), [item])),
+            list(chain(expr.get_elements(), [item])),
             evaluation,
             deps=(expr, item),
         )
@@ -935,7 +935,7 @@ class Part(Builtin):
                 idx = idx.get_int_value()
                 if idx == 0:
                     return Symbol("System`ByteArray")
-                data = list._leaves[0].value
+                data = list._elements[0].value
                 lendata = len(data)
                 if idx < 0:
                     idx = data - idx
@@ -1042,7 +1042,7 @@ class Prepend(Builtin):
 
         return expr.restructure(
             expr.head,
-            list(chain([item], expr.get_leaves())),
+            list(chain([item], expr.get_elements())),
             evaluation,
             deps=(expr, item),
         )
@@ -1177,7 +1177,7 @@ class ReplacePart(Builtin):
             position = replacement.leaves[0]
             replace = replacement.leaves[1]
             if position.has_form("List", None):
-                position = position.get_mutable_leaves()
+                position = position.get_mutable_elements()
             else:
                 position = [position]
             for index, pos in enumerate(position):

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -120,12 +120,14 @@ class _Rotate(Builtin):
             return expr
 
         index = (self._sign * n[0]) % len(leaves)  # with Python's modulo: index >= 1
-        new_leaves = chain(leaves[index:], leaves[:index])
+        new_elements = chain(leaves[index:], leaves[:index])
 
         if len(n) > 1:
-            new_leaves = [self._rotate(item, n[1:], evaluation) for item in new_leaves]
+            new_elements = [
+                self._rotate(item, n[1:], evaluation) for item in new_elements
+            ]
 
-        return expr.restructure(expr.head, new_leaves, evaluation)
+        return expr.restructure(expr.head, new_elements, evaluation)
 
     def apply_one(self, expr, evaluation):
         "%(name)s[expr_]"
@@ -655,9 +657,9 @@ class Riffle(Builtin):
         "Riffle[list_List, sep_]"
 
         if sep.has_form("List", None):
-            result = riffle_lists(list.get_leaves(), sep.leaves)
+            result = riffle_lists(list.get_elements(), sep.leaves)
         else:
-            result = riffle_lists(list.get_leaves(), [sep])
+            result = riffle_lists(list.get_elements(), [sep])
 
         return list.restructure("List", result, evaluation, deps=(list, sep))
 

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -153,7 +153,7 @@ class ByteArray(Builtin):
         if not values.has_form("List", None):
             return
         try:
-            ba = bytearray([b.get_int_value() for b in values._leaves])
+            ba = bytearray([b.get_int_value() for b in values._elements])
         except Exception:
             evaluation.message("ByteArray", "aotd", values)
             return
@@ -376,7 +376,7 @@ class Delete(Builtin):
         positions.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
         newexpr = expr
         for position in positions:
-            pos = [p.get_int_value() for p in position.get_leaves()]
+            pos = [p.get_int_value() for p in position.get_elements()]
             if None in pos:
                 return evaluation.message(
                     "Delete", "psl", position.leaves[pos.index(None)], expr
@@ -1148,7 +1148,7 @@ class Insert(Builtin):
         "Insert[expr_List, elem_, n_Integer]"
 
         py_n = n.to_python()
-        new_list = list(expr.get_leaves())
+        new_list = list(expr.get_elements())
 
         position = py_n - 1 if py_n > 0 else py_n + 1
         new_list.insert(position, elem)
@@ -1402,7 +1402,7 @@ class RankedMin(Builtin):
         elif py_n > len(leaf.leaves):
             evaluation.message("RankedMin", "rank", py_n, len(leaf.leaves))
         else:
-            return introselect(leaf.get_mutable_leaves(), py_n - 1)
+            return introselect(leaf.get_mutable_elements(), py_n - 1)
 
 
 class RankedMax(Builtin):
@@ -1430,7 +1430,7 @@ class RankedMax(Builtin):
         elif py_n > len(leaf.leaves):
             evaluation.message("RankedMax", "rank", py_n, len(leaf.leaves))
         else:
-            return introselect(leaf.get_mutable_leaves(), len(leaf.leaves) - py_n)
+            return introselect(leaf.get_mutable_elements(), len(leaf.leaves) - py_n)
 
 
 class Quartiles(Builtin):
@@ -1718,21 +1718,21 @@ class _Pad(Builtin):
         leaves = leaf.leaves
         d = n[0] - len(leaves)
         if d < 0:
-            new_leaves = clip(leaves, d, mode)
+            new_elements = clip(leaves, d, mode)
             padding_main = []
         elif d >= 0:
-            new_leaves = leaves
+            new_elements = leaves
             padding_main = padding(d, mode)
 
         if current_m > 0:
             padding_margin = padding(
-                min(current_m, len(new_leaves) + len(padding_main)), -mode
+                min(current_m, len(new_elements) + len(padding_main)), -mode
             )
 
             if len(padding_margin) > len(padding_main):
                 padding_main = []
-                new_leaves = clip(
-                    new_leaves, -(len(padding_margin) - len(padding_main)), mode
+                new_elements = clip(
+                    new_elements, -(len(padding_margin) - len(padding_main)), mode
                 )
             elif len(padding_margin) > 0:
                 padding_main = clip(padding_main, -len(padding_margin), mode)
@@ -1740,14 +1740,14 @@ class _Pad(Builtin):
             padding_margin = []
 
         if len(n) > 1:
-            new_leaves = (
-                _Pad._build(e, n[1:], x, next_m, level + 1, mode) for e in new_leaves
+            new_elements = (
+                _Pad._build(e, n[1:], x, next_m, level + 1, mode) for e in new_elements
             )
 
         if mode < 0:
-            parts = (padding_main, new_leaves, padding_margin)
+            parts = (padding_main, new_elements, padding_margin)
         else:
-            parts = (padding_margin, new_leaves, padding_main)
+            parts = (padding_margin, new_elements, padding_main)
 
         return Expression(leaf.get_head(), *list(chain(*parts)))
 

--- a/mathics/builtin/moments/basic.py
+++ b/mathics/builtin/moments/basic.py
@@ -49,7 +49,7 @@ class Median(_Rectangular):
             except _NotRectangularException:
                 evaluation.message("Median", "rectn", Expression("Median", l))
         elif all(leaf.is_numeric(evaluation) for leaf in l.leaves):
-            v = l.get_mutable_leaves()  # copy needed for introselect
+            v = l.get_mutable_elements()  # copy needed for introselect
             n = len(v)
             if n % 2 == 0:  # even number of elements?
                 i = n // 2
@@ -116,7 +116,7 @@ class Quantile(Builtin):
         """Quantile[l_List, qs_List, {{a_, b_}, {c_, d_}}]"""
 
         n = len(l.leaves)
-        partially_sorted = l.get_mutable_leaves()
+        partially_sorted = l.get_mutable_elements()
 
         def ranked(i):
             return introselect(partially_sorted, min(max(0, i - 1), n - 1))

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -439,9 +439,9 @@ class Simplify(Builtin):
         if expr.is_atom():
             return expr
         # else, use sympy:
-        leaves = [self.apply(element, evaluation) for element in expr._elements]
+        elements = [self.apply(element, evaluation) for element in expr._elements]
         head = self.apply(expr.get_head(), evaluation)
-        expr = Expression(head, *leaves)
+        expr = Expression(head, *elements)
 
         sympy_expr = expr.to_sympy()
         if sympy_expr is None:

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -204,7 +204,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
 
     def convert_sympy(expr):
         "converts top-level to sympy"
-        leaves = expr.get_elements()
+        elements = expr.get_elements()
         if isinstance(expr, Integer):
             return sympy.Integer(expr.get_int_value())
         if target_pat is not None and not isinstance(expr, Number):
@@ -213,14 +213,14 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
         if expr.has_form("Power", 2):
             # sympy won't expand `(a + b) / x` to `a / x + b / x` if denom is False
             # if denom is False we store negative powers to prevent this.
-            n1 = leaves[1].get_int_value()
+            n1 = elements[1].get_int_value()
             if not denom and n1 is not None and n1 < 0:
                 return store_sub_expr(expr)
-            return sympy.Pow(*[convert_sympy(leaf) for leaf in leaves])
+            return sympy.Pow(*[convert_sympy(leaf) for leaf in elements])
         elif expr.has_form("Times", 2, None):
-            return sympy.Mul(*[convert_sympy(leaf) for leaf in leaves])
+            return sympy.Mul(*[convert_sympy(leaf) for leaf in elements])
         elif expr.has_form("Plus", 2, None):
-            return sympy.Add(*[convert_sympy(leaf) for leaf in leaves])
+            return sympy.Add(*[convert_sympy(leaf) for leaf in elements])
         else:
             return store_sub_expr(expr)
 
@@ -232,7 +232,8 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
                 return expr
         else:
             return Expression(
-                expr.head, *[unconvert_subexprs(leaf) for leaf in expr.get_elements()]
+                expr.head,
+                *[unconvert_subexprs(element) for element in expr.get_elements()]
             )
 
     sympy_expr = convert_sympy(expr)
@@ -244,32 +245,34 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
         ) in enumerate(sub_exprs):
             if not sub_expr.is_atom():
                 head = _expand(sub_expr.head)  # also expand head
-                leaves = sub_expr.get_elements()
+                elements = sub_expr.get_elements()
                 if target_pat:
-                    leaves = [
-                        leaf if leaf.is_free(target_pat, evaluation) else _expand(leaf)
-                        for leaf in leaves
+                    elements = [
+                        element
+                        if element.is_free(target_pat, evaluation)
+                        else _expand(element)
+                        for element in elements
                     ]
                 else:
-                    leaves = [_expand(leaf) for leaf in leaves]
-                sub_exprs[i] = Expression(head, *leaves)
+                    elements = [_expand(element) for element in elements]
+                sub_exprs[i] = Expression(head, *elements)
     else:
         # thread over Lists etc.
         threaded_heads = ("List", "Rule")
         for i, sub_expr in enumerate(sub_exprs):
             for head in threaded_heads:
                 if sub_expr.has_form(head, None):
-                    leaves = sub_expr.get_elements()
+                    elements = sub_expr.get_elements()
                     if target_pat:
-                        leaves = [
-                            leaf
-                            if leaf.is_free(target_pat, evaluation)
-                            else _expand(leaf)
-                            for leaf in leaves
+                        elements = [
+                            element
+                            if element.is_free(target_pat, evaluation)
+                            else _expand(element)
+                            for element in elements
                         ]
                     else:
-                        leaves = [_expand(leaf) for leaf in leaves]
-                    sub_exprs[i] = Expression(head, *leaves)
+                        elements = [_expand(element) for element in elements]
+                    sub_exprs[i] = Expression(head, *elements)
                     break
 
     hints = {
@@ -436,7 +439,7 @@ class Simplify(Builtin):
         if expr.is_atom():
             return expr
         # else, use sympy:
-        leaves = [self.apply(leaf, evaluation) for leaf in expr._elements]
+        leaves = [self.apply(element, evaluation) for element in expr._elements]
         head = self.apply(expr.get_head(), evaluation)
         expr = Expression(head, *leaves)
 

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -204,7 +204,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
 
     def convert_sympy(expr):
         "converts top-level to sympy"
-        leaves = expr.get_leaves()
+        leaves = expr.get_elements()
         if isinstance(expr, Integer):
             return sympy.Integer(expr.get_int_value())
         if target_pat is not None and not isinstance(expr, Number):
@@ -232,7 +232,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
                 return expr
         else:
             return Expression(
-                expr.head, *[unconvert_subexprs(leaf) for leaf in expr.get_leaves()]
+                expr.head, *[unconvert_subexprs(leaf) for leaf in expr.get_elements()]
             )
 
     sympy_expr = convert_sympy(expr)
@@ -244,7 +244,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
         ) in enumerate(sub_exprs):
             if not sub_expr.is_atom():
                 head = _expand(sub_expr.head)  # also expand head
-                leaves = sub_expr.get_leaves()
+                leaves = sub_expr.get_elements()
                 if target_pat:
                     leaves = [
                         leaf if leaf.is_free(target_pat, evaluation) else _expand(leaf)
@@ -259,7 +259,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
         for i, sub_expr in enumerate(sub_exprs):
             for head in threaded_heads:
                 if sub_expr.has_form(head, None):
-                    leaves = sub_expr.get_leaves()
+                    leaves = sub_expr.get_elements()
                     if target_pat:
                         leaves = [
                             leaf
@@ -436,7 +436,7 @@ class Simplify(Builtin):
         if expr.is_atom():
             return expr
         # else, use sympy:
-        leaves = [self.apply(leaf, evaluation) for leaf in expr._leaves]
+        leaves = [self.apply(leaf, evaluation) for leaf in expr._elements]
         head = self.apply(expr.get_head(), evaluation)
         expr = Expression(head, *leaves)
 
@@ -1513,17 +1513,17 @@ class _CoefficientHandler(Builtin):
                         return powers
             if pf.has_form("Sqrt", 1):
                 for i, pat in enumerate(var_pats):
-                    if match(pf._leaves[0], pat, evaluation):
+                    if match(pf._elements[0], pat, evaluation):
                         powers[i] = RationalOneHalf
                         return powers
             if pf.has_form("Power", 2):
                 for i, pat in enumerate(var_pats):
-                    matchval = match(pf._leaves[0], pat, evaluation)
+                    matchval = match(pf._elements[0], pat, evaluation)
                     if matchval:
-                        powers[i] = pf._leaves[1]
+                        powers[i] = pf._elements[1]
                         return powers
             if pf.has_form("Times", None):
-                contrib = [powers_list(factor) for factor in pf._leaves]
+                contrib = [powers_list(factor) for factor in pf._elements]
                 for i in range(len(var_pats)):
                     powers[i] = Expression(
                         SymbolPlus, *[c[i] for c in contrib]
@@ -1557,7 +1557,7 @@ class _CoefficientHandler(Builtin):
                         powers.append(factor)
                     elif (
                         factor.has_form("Power", 2) or factor.has_form("Sqrt", 1)
-                    ) and match(factor._leaves[0], target_pat, evaluation):
+                    ) and match(factor._elements[0], target_pat, evaluation):
                         powers.append(factor)
                     else:
                         coeffs.append(factor)
@@ -1639,7 +1639,7 @@ class _CoefficientHandler(Builtin):
             coeff_dict = {}
             powers_dict = {}
             powers_order = {}
-            for term in expr._leaves:
+            for term in expr._elements:
                 coeff, powers = split_coeff_pow(term)
                 if (
                     form != "expr"
@@ -1735,7 +1735,7 @@ class CoefficientArrays(_CoefficientHandler):
         if varlist.is_symbol():
             var_exprs = [varlist]
         elif varlist.has_form("List", None):
-            var_exprs = varlist.get_leaves()
+            var_exprs = varlist.get_elements()
         else:
             var_exprs = [varlist]
 
@@ -1828,7 +1828,7 @@ class Collect(_CoefficientHandler):
         if varlst.is_symbol():
             var_exprs = [varlst]
         elif varlst.has_form("List", None):
-            var_exprs = varlst.get_leaves()
+            var_exprs = varlst.get_elements()
         else:
             var_exprs = [varlst]
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -639,8 +639,8 @@ class Integrate(SympyFunction):
                 args.append(leaf.leaves[0])
             else:
                 args.append(leaf)
-        new_leaves = [leaves[0]] + args
-        return Expression(self.get_name(), *new_leaves)
+        new_elements = [leaves[0]] + args
+        return Expression(self.get_name(), *new_elements)
 
     def apply(self, f, xs, evaluation, options):
         "Integrate[f_, xs__, OptionsPattern[]]"
@@ -698,18 +698,18 @@ class Integrate(SympyFunction):
         # use ConditionalExpression.
         # This does not work now because the form sympy returns the values
         if result.get_head_name() == "System`Piecewise":
-            cases = result._leaves[0]._leaves
-            if len(result._leaves) == 1:
-                if cases[-1]._leaves[1].is_true():
-                    default = cases[-1]._leaves[0]
-                    cases = result._leaves[0]._leaves[:-1]
+            cases = result._elements[0]._elements
+            if len(result._elements) == 1:
+                if cases[-1]._elements[1].is_true():
+                    default = cases[-1]._elements[0]
+                    cases = result._elements[0]._elements[:-1]
                 else:
                     default = SymbolUndefined
             else:
-                cases = result._leaves[0]._leaves
-                default = result._leaves[1]
+                cases = result._elements[0]._elements
+                default = result._elements[1]
             if default.has_form("Integrate", None):
-                if default._leaves[0] == f:
+                if default._elements[0] == f:
                     default = SymbolUndefined
 
             simplified_cases = []
@@ -717,28 +717,28 @@ class Integrate(SympyFunction):
                 # TODO: if something like 0^n or 1/expr appears,
                 # put the condition n!=0 or expr!=0 accordingly in the list of
                 # conditions...
-                cond = Expression("Simplify", case._leaves[1], assuming).evaluate(
+                cond = Expression("Simplify", case._elements[1], assuming).evaluate(
                     evaluation
                 )
-                resif = Expression("Simplify", case._leaves[0], assuming).evaluate(
+                resif = Expression("Simplify", case._elements[0], assuming).evaluate(
                     evaluation
                 )
                 if cond.is_true():
                     return resif
                 if resif.has_form("ConditionalExpression", 2):
-                    cond = Expression("And", resif._leaves[1], cond)
+                    cond = Expression("And", resif._elements[1], cond)
                     cond = Expression("Simplify", cond, assuming).evaluate(evaluation)
-                    resif = resif._leaves[0]
+                    resif = resif._elements[0]
                 simplified_cases.append(Expression(SymbolList, resif, cond))
             cases = simplified_cases
             if default is SymbolUndefined and len(cases) == 1:
                 cases = cases[0]
-                result = Expression("ConditionalExpression", *(cases._leaves))
+                result = Expression("ConditionalExpression", *(cases._elements))
             else:
                 result = Expression(result._head, cases, default)
         else:
             if result.get_head() is SymbolIntegrate:
-                if result._leaves[0].evaluate(evaluation).sameQ(f):
+                if result._elements[0].evaluate(evaluation).sameQ(f):
                     # Sympy returned the same expression, so it can't be evaluated.
                     return
             result = Expression("Simplify", result, assuming)
@@ -1311,8 +1311,8 @@ class _BaseFinder(Builtin):
         x0 = apply_N(x0, evaluation)
         # deal with non 1D problems.
         if isinstance(x0, Expression) and x0._head is SymbolList:
-            options["_x0"] = x0._leaves
-            x0 = x0._leaves[0]
+            options["_x0"] = x0._elements
+            x0 = x0._elements[0]
         if not isinstance(x0, Number):
             evaluation.message(self.get_name(), "snum", x0)
             return
@@ -1337,7 +1337,7 @@ class _BaseFinder(Builtin):
         method = options["System`Method"]
         if isinstance(method, Expression):
             if method.get_head() is SymbolList:
-                method = method._leaves[0]
+                method = method._elements[0]
         if isinstance(method, Symbol):
             method = method.get_name().split("`")[-1]
         elif isinstance(method, String):
@@ -1638,10 +1638,10 @@ class Series(Builtin):
 
     def apply_multivariate_series(self, f, varspec, evaluation):
         """Series[f_,varspec__List]"""
-        lastvar = varspec._leaves[-1]
+        lastvar = varspec._elements[-1]
         if not lastvar.has_form("List", 3):
             return None
-        # inner = build_series(f, *(lastvar._leaves), evaluation)
+        # inner = build_series(f, *(lastvar._elements), evaluation)
         inner = Expression(SymbolSeries, f, lastvar).evaluate(evaluation)
         if inner:
             if len(varspec.leaves) == 1:
@@ -1692,7 +1692,7 @@ class SeriesData(Builtin):
             else:
                 return Integer0
         # if data has trailing zeros, the method tries to remove them.
-        coeffs = data._leaves
+        coeffs = data._elements
         len_coeffs = len(coeffs)
         # If the series is trivial, do not do anything:
         if len_coeffs == 0:
@@ -1720,7 +1720,7 @@ class SeriesData(Builtin):
                 SymbolSeriesData,
                 x,
                 x0,
-                data._leaves[nonzeroidx_left:(-nonzeroidx_right)],
+                data._elements[nonzeroidx_left:(-nonzeroidx_right)],
                 nummin,
                 nummax,
                 den,
@@ -1730,7 +1730,7 @@ class SeriesData(Builtin):
                 SymbolSeriesData,
                 x,
                 x0,
-                data._leaves[nonzeroidx_left:],
+                data._elements[nonzeroidx_left:],
                 nummin,
                 nummax,
                 den,

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -120,7 +120,7 @@ class DSolve(Builtin):
         if x.is_symbol():
             syms = [x]
         elif x.has_form("List", 1, None):
-            syms = sorted(x.get_leaves())
+            syms = sorted(x.get_elements())
         else:
             return evaluation.message("DSolve", "dsvar", x)
 

--- a/mathics/builtin/optimization.py
+++ b/mathics/builtin/optimization.py
@@ -376,8 +376,8 @@ class Maximize(Builtin):
 
         solutions = []
         for dual_solution in dual_solutions:
-            solution_leaves = dual_solution.leaves
-            solutions.append([solution_leaves[0] * -1, solution_leaves[1]])
+            solution_elements = dual_solution.leaves
+            solutions.append([solution_elements[0] * -1, solution_elements[1]])
 
         return from_python(solutions)
 
@@ -393,7 +393,7 @@ class Maximize(Builtin):
 
         solutions = []
         for dual_solution in dual_solutions:
-            solution_leaves = dual_solution.leaves
-            solutions.append([solution_leaves[0] * -1, solution_leaves[1]])
+            solution_elements = dual_solution.leaves
+            solutions.append([solution_elements[0] * -1, solution_elements[1]])
 
         return from_python(solutions)

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -202,17 +202,17 @@ class OptionValue(Builtin):
                 if f.get_head_name() in ("System`Rule", "System`RuleDelayed"):
                     f = Expression("List", f)
                 if f.get_head_name() == "System`List":
-                    for leave in f.get_elements():
-                        if leave.is_symbol():
+                    for element in f.get_elements():
+                        if element.is_symbol():
                             val = get_option(
-                                evaluation.definitions.get_options(leave.get_name()),
+                                evaluation.definitions.get_options(element.get_name()),
                                 name,
                                 evaluation,
                             )
                             if val:
                                 break
                         else:
-                            values = leave.get_option_values(evaluation)
+                            values = element.get_option_values(evaluation)
                             val = get_option(values, name, evaluation)
                             if val:
                                 break

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -202,7 +202,7 @@ class OptionValue(Builtin):
                 if f.get_head_name() in ("System`Rule", "System`RuleDelayed"):
                     f = Expression("List", f)
                 if f.get_head_name() == "System`List":
-                    for leave in f.get_leaves():
+                    for leave in f.get_elements():
                         if leave.is_symbol():
                             val = get_option(
                                 evaluation.definitions.get_options(leave.get_name()),
@@ -312,7 +312,7 @@ class OptionQ(Test):
         if not expr.has_form("List", None):
             expr = [expr]
         else:
-            expr = expr.get_leaves()
+            expr = expr.get_elements()
         return all(
             e.has_form("Rule", None) or e.has_form("RuleDelayed", 2) for e in expr
         )
@@ -342,7 +342,7 @@ class NotOptionQ(Test):
         if not expr.has_form("List", None):
             expr = [expr]
         else:
-            expr = expr.get_leaves()
+            expr = expr.get_elements()
         return not all(
             e.has_form("Rule", None) or e.has_form("RuleDelayed", 2) for e in expr
         )

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1361,15 +1361,15 @@ class Repeated(PostfixOperator, PatternObject):
         self.max = None
         self.min = min
         if len(expr.leaves) == 2:
-            leaf_1 = expr.leaves[1]
+            element_1 = expr.leaves[1]
             allnumbers = not any(
-                leaf.get_int_value() is None for leaf in leaf_1.get_elements()
+                element.get_int_value() is None for element in element_1.get_elements()
             )
-            if leaf_1.has_form("List", 1, 2) and allnumbers:
-                self.max = leaf_1.leaves[-1].get_int_value()
-                self.min = leaf_1.leaves[0].get_int_value()
-            elif leaf_1.get_int_value():
-                self.max = leaf_1.get_int_value()
+            if element_1.has_form("List", 1, 2) and allnumbers:
+                self.max = element_1.leaves[-1].get_int_value()
+                self.min = element_1.leaves[0].get_int_value()
+            elif element_1.get_int_value():
+                self.max = element_1.get_int_value()
             else:
                 self.error("range", 2, expr)
 

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -647,10 +647,10 @@ class NestWhile(Builtin):
         results = [expr]
         while True:
             if m.get_name() == "All":
-                test_leaves = results
+                test_elements = results
             else:
-                test_leaves = results[-m.value :]
-            test_expr = Expression(test, *test_leaves)
+                test_elements = results[-m.value :]
+            test_expr = Expression(test, *test_elements)
             test_result = test_expr.evaluate(evaluation)
             if test_result.is_true():
                 next = Expression(f, results[-1])

--- a/mathics/builtin/scipy_utils/optimizers.py
+++ b/mathics/builtin/scipy_utils/optimizers.py
@@ -65,7 +65,7 @@ def compile_fn(f, x, opts, evaluation):
     if opts["_isfindmaximum"]:
         f = -f
     comp_func = Expression("Compile", Expression(SymbolList, x), f).evaluate(evaluation)
-    return comp_func._leaves[2].cfunc
+    return comp_func._elements[2].cfunc
 
 
 def process_result_1d_opt(result, opts, evaluation):

--- a/mathics/builtin/string/charcodes.py
+++ b/mathics/builtin/string/charcodes.py
@@ -240,11 +240,11 @@ class FromCharacterCode(Builtin):
                 # if we're dealing with nested lists.
                 elif n.get_elements()[0].has_form("List", None):
                     list_of_strings = []
-                    for leaf in n.get_elements():
-                        if leaf.has_form("List", None):
-                            stringi = convert_codepoint_list(leaf.get_elements())
+                    for element in n.get_elements():
+                        if element.has_form("List", None):
+                            stringi = convert_codepoint_list(element.get_elements())
                         else:
-                            stringi = convert_codepoint_list([leaf])
+                            stringi = convert_codepoint_list([element])
                         list_of_strings.append(String(stringi))
                     return Expression(SymbolList, *list_of_strings)
                 else:

--- a/mathics/builtin/string/charcodes.py
+++ b/mathics/builtin/string/charcodes.py
@@ -233,22 +233,22 @@ class FromCharacterCode(Builtin):
 
         try:
             if n.has_form("List", None):
-                if not n.get_leaves():
+                if not n.get_elements():
                     return String("")
                 # Mathematica accepts FromCharacterCode[{{100}, 101}],
                 # so to match this, just check the first leaf to see
                 # if we're dealing with nested lists.
-                elif n.get_leaves()[0].has_form("List", None):
+                elif n.get_elements()[0].has_form("List", None):
                     list_of_strings = []
-                    for leaf in n.get_leaves():
+                    for leaf in n.get_elements():
                         if leaf.has_form("List", None):
-                            stringi = convert_codepoint_list(leaf.get_leaves())
+                            stringi = convert_codepoint_list(leaf.get_elements())
                         else:
                             stringi = convert_codepoint_list([leaf])
                         list_of_strings.append(String(stringi))
                     return Expression(SymbolList, *list_of_strings)
                 else:
-                    return String(convert_codepoint_list(n.get_leaves()))
+                    return String(convert_codepoint_list(n.get_elements()))
             else:
                 pyn = n.get_int_value()
                 if not (isinstance(pyn, int) and pyn > 0 and pyn < sys.maxsize):

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -386,11 +386,11 @@ class StringInsert(Builtin):
         # Check and create list of position
         listpos = []
         if pos.has_form("List", None):
-            leaves = pos.get_elements()
-            if not leaves:
+            elements = pos.get_elements()
+            if not elements:
                 return strsource
             else:
-                for i, posi in enumerate(leaves):
+                for i, posi in enumerate(elements):
                     py_posi = posi.get_int_value()
                     if py_posi is None:
                         return evaluation.message("StringInsert", "psl", pos, exp)

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -386,7 +386,7 @@ class StringInsert(Builtin):
         # Check and create list of position
         listpos = []
         if pos.has_form("List", None):
-            leaves = pos.get_leaves()
+            leaves = pos.get_elements()
             if not leaves:
                 return strsource
             else:
@@ -601,7 +601,7 @@ class StringPosition(Builtin):
 
         # convert patterns
         if patt.has_form("List", None):
-            patts = patt.get_leaves()
+            patts = patt.get_elements()
         else:
             patts = [patt]
         re_patts = []
@@ -986,7 +986,9 @@ class StringSplit(Builtin):
         "StringSplit[string_, patt_, OptionsPattern[%(name)s]]"
 
         if string.get_head_name() == "System`List":
-            leaves = [self.apply(s, patt, evaluation, options) for s in string._leaves]
+            leaves = [
+                self.apply(s, patt, evaluation, options) for s in string._elements
+            ]
             return Expression(SymbolList, *leaves)
 
         py_string = string.get_string_value()
@@ -997,7 +999,7 @@ class StringSplit(Builtin):
             )
 
         if patt.has_form("List", None):
-            patts = patt.get_leaves()
+            patts = patt.get_elements()
         else:
             patts = [patt]
         re_patts = []

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -80,8 +80,8 @@ class Sort(Builtin):
         if list.is_atom():
             evaluation.message("Sort", "normal")
         else:
-            new_leaves = sorted(list.leaves)
-            return list.restructure(list.head, new_leaves, evaluation)
+            new_elements = sorted(list.leaves)
+            return list.restructure(list.head, new_elements, evaluation)
 
     def apply_predicate(self, list, p, evaluation):
         "Sort[list_, p_]"
@@ -101,8 +101,8 @@ class Sort(Builtin):
                         .is_true()
                     )
 
-            new_leaves = sorted(list.leaves, key=Key)
-            return list.restructure(list.head, new_leaves, evaluation)
+            new_elements = sorted(list.leaves, key=Key)
+            return list.restructure(list.head, new_elements, evaluation)
 
 
 class SortBy(Builtin):
@@ -171,8 +171,8 @@ class SortBy(Builtin):
 
             # we sort a list of indices. after sorting, we reorder the leaves.
             new_indices = sorted(list(range(len(raw_keys))), key=Key)
-            new_leaves = [raw_keys[i] for i in new_indices]  # reorder leaves
-            return l.restructure(l.head, new_leaves, evaluation)
+            new_elements = [raw_keys[i] for i in new_indices]  # reorder leaves
+            return l.restructure(l.head, new_elements, evaluation)
 
 
 class BinarySearch(Builtin):
@@ -568,30 +568,30 @@ class MapAt(Builtin):
                 j = m + i
             else:
                 raise PartRangeError
-            replace_leaf = new_leaves[j]
+            replace_leaf = new_elements[j]
             if hasattr(replace_leaf, "head") and replace_leaf.head is Symbol(
                 "System`Rule"
             ):
-                new_leaves[j] = Expression(
+                new_elements[j] = Expression(
                     "System`Rule",
                     replace_leaf.leaves[0],
                     Expression(f, replace_leaf.leaves[1]),
                 )
             else:
-                new_leaves[j] = Expression(f, replace_leaf)
-            return new_leaves
+                new_elements[j] = Expression(f, replace_leaf)
+            return new_elements
 
         a = args.to_python()
         if isinstance(a, int):
-            new_leaves = list(expr.leaves)
-            new_leaves = map_at_one(a, new_leaves)
-            return List(*new_leaves)
+            new_elements = list(expr.leaves)
+            new_elements = map_at_one(a, new_elements)
+            return List(*new_elements)
         elif isinstance(a, list):
-            new_leaves = list(expr.leaves)
+            new_elements = list(expr.leaves)
             for l in a:
                 if len(l) == 1 and isinstance(l[0], int):
-                    new_leaves = map_at_one(l[0], new_leaves)
-            return List(*new_leaves)
+                    new_elements = map_at_one(l[0], new_elements)
+            return List(*new_elements)
 
 
 class Scan(Builtin):
@@ -794,7 +794,7 @@ class MapThread(Builtin):
         if not expr.has_form("List", None):
             return evaluation.message("MapThread", "list", 2, full_expr)
 
-        heads = expr.get_leaves()
+        heads = expr.get_elements()
 
         def walk(args, depth=0):
             "walk all trees concurrently and build result"
@@ -1057,24 +1057,24 @@ class Flatten(Builtin):
             # e.g. [((0, 0), a), ((0, 1), b), ((1, 0), c), ((1, 1), d)]
             # -> [[(0, a), (1, b)], [(0, c), (1, d)]]
             leading_index = None
-            grouped_leaves = []
+            grouped_elements = []
             for index, leaf in leaves:
                 if index[0] == leading_index:
-                    grouped_leaves[-1].append((index[1:], leaf))
+                    grouped_elements[-1].append((index[1:], leaf))
                 else:
                     leading_index = index[0]
-                    grouped_leaves.append([(index[1:], leaf)])
+                    grouped_elements.append([(index[1:], leaf)])
             # for each group of leaves we either insert them into the current level
             # or make a new level and recurse
-            new_leaves = []
-            for group in grouped_leaves:
+            new_elements = []
+            for group in grouped_elements:
                 if len(group[0][0]) == 0:  # bottom level leaf
                     assert len(group) == 1
-                    new_leaves.append(group[0][1])
+                    new_elements.append(group[0][1])
                 else:
-                    new_leaves.append(Expression(h, *insert_leaf(group)))
+                    new_elements.append(Expression(h, *insert_leaf(group)))
 
-            return new_leaves
+            return new_elements
 
         return Expression(h, *insert_leaf(leaves))
 

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -137,7 +137,7 @@ class ArrayQ(Builtin):
 
         pattern = Pattern.create(pattern)
 
-        dims = [len(expr.get_leaves())]  # to ensure an atom is not an array
+        dims = [len(expr.get_elements())]  # to ensure an atom is not an array
 
         def check(level, expr):
             if not expr.has_form("List", None):

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -68,10 +68,10 @@ class SympyExpression(BasicSympy):
             # called with Mathics argument
             expr = exprs[0]
             sympy_head = expr.head.to_sympy()
-            sympy_leaves = [leaf.to_sympy() for leaf in expr.leaves]
-            if sympy_head is None or None in sympy_leaves:
+            sympy_elements = [leaf.to_sympy() for leaf in expr.leaves]
+            if sympy_head is None or None in sympy_elements:
                 return None
-            obj = BasicSympy.__new__(cls, sympy_head, *sympy_leaves)
+            obj = BasicSympy.__new__(cls, sympy_head, *sympy_elements)
             obj.expr = expr
         else:
             raise TypeError

--- a/mathics/core/evaluators.py
+++ b/mathics/core/evaluators.py
@@ -55,7 +55,7 @@ def apply_nvalues(expr, prec, evaluation):
         leaves = expr.leaves
         result = Expression(expr.head)
         newleaves = [apply_nvalues(leaf, prec, evaluation) for leaf in expr.leaves]
-        result._leaves = tuple(
+        result._elements = tuple(
             newleaf if newleaf else leaf for leaf, newleaf in zip(leaves, newleaves)
         )
         return result
@@ -81,7 +81,7 @@ def apply_nvalues(expr, prec, evaluation):
     else:
         attributes = expr.head.get_attributes(evaluation.definitions)
         head = expr.head
-        leaves = expr.get_mutable_leaves()
+        leaves = expr.get_mutable_elements()
         if n_hold_all & attributes:
             eval_range = ()
         elif n_hold_first & attributes:
@@ -103,7 +103,7 @@ def apply_nvalues(expr, prec, evaluation):
                 leaves[index] = newleaf
 
         result = Expression(head)
-        result._leaves = tuple(leaves)
+        result._elements = tuple(leaves)
         return result
 
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -707,8 +707,8 @@ class Expression(BaseExpression):
         if len(self._elements) != len(other.get_elements()):
             return False
         return all(
-            (id(leaf) == id(oleaf) or leaf.sameQ(oleaf))
-            for leaf, oleaf in zip(self._elements, other.get_elements())
+            (id(element) == id(oelement) or element.sameQ(oelement))
+            for element, oelement in zip(self._elements, other.get_elements())
         )
 
     def flatten(
@@ -720,26 +720,26 @@ class Expression(BaseExpression):
             return self
         sub_level = None if level is None else level - 1
         do_flatten = False
-        for leaf in self._elements:
-            if leaf.get_head().sameQ(head) and (
-                not pattern_only or leaf.pattern_sequence
+        for element in self._elements:
+            if element.get_head().sameQ(head) and (
+                not pattern_only or element.pattern_sequence
             ):
                 do_flatten = True
                 break
         if do_flatten:
             new_elements = []
-            for leaf in self._elements:
-                if leaf.get_head().sameQ(head) and (
-                    not pattern_only or leaf.pattern_sequence
+            for element in self._elements:
+                if element.get_head().sameQ(head) and (
+                    not pattern_only or element.pattern_sequence
                 ):
-                    new_leaf = leaf.flatten(
+                    new_element = element.flatten(
                         head, pattern_only, callback, level=sub_level
                     )
                     if callback is not None:
-                        callback(new_leaf._elements, leaf)
-                    new_elements.extend(new_leaf._elements)
+                        callback(new_element._elements, element)
+                    new_elements.extend(new_element._elements)
                 else:
-                    new_elements.append(leaf)
+                    new_elements.append(element)
             return Expression(self._head, *new_elements)
         else:
             return self

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -408,6 +408,9 @@ class Expression(BaseExpression):
     def get_elements(self):
         return self._elements
 
+    # Compatibily with old code. Deprecated, but remove after a little bit
+    get_leaves = get_elements
+
     def get_mutable_elements(self):  # shallow, mutable copy of the leaves array
         return list(self._elements)
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -165,7 +165,7 @@ class Expression(BaseExpression):
         if isinstance(head, str):
             head = Symbol(head)
         self._head = head
-        self._leaves = tuple(from_python(leaf) for leaf in leaves)
+        self._elements = tuple(from_python(leaf) for leaf in leaves)
         self._sequences = None
         self._format_cache = None
         return self
@@ -180,7 +180,7 @@ class Expression(BaseExpression):
 
     @property
     def leaves(self):
-        return self._leaves
+        return self._elements
 
     @leaves.setter
     def leaves(self, value):
@@ -203,15 +203,15 @@ class Expression(BaseExpression):
             return equal_heads
         # From here, we can assume that both heads are the same
         if head in (SymbolList, SymbolSequence):
-            if len(self._leaves) != len(rhs._leaves):
+            if len(self._elements) != len(rhs._elements):
                 return False
-            for item1, item2 in zip(self._leaves, rhs._leaves):
+            for item1, item2 in zip(self._elements, rhs._elements):
                 result = item1.equal2(item2)
                 if not result:
                     return result
             return True
         elif head in (SymbolDirectedInfinity,):
-            return self._leaves[0].equal2(rhs._leaves[0])
+            return self._elements[0].equal2(rhs._elements[0])
         return None
 
     def slice(self, head, py_slice, evaluation):
@@ -267,7 +267,7 @@ class Expression(BaseExpression):
         if not indices:
             return self
 
-        leaves = self._leaves
+        leaves = self._elements
 
         flattened = []
         extend = flattened.extend
@@ -284,7 +284,7 @@ class Expression(BaseExpression):
     def flatten_sequence(self, evaluation):
         def sequence(leaf):
             if leaf.get_head_name() == "System`Sequence":
-                return leaf._leaves
+                return leaf._elements
             else:
                 return [leaf]
 
@@ -294,7 +294,7 @@ class Expression(BaseExpression):
         def sequence(leaf):
             flattened = leaf.flatten_pattern_sequence(evaluation)
             if leaf.get_head() is SymbolSequence and leaf.pattern_sequence:
-                return flattened._leaves
+                return flattened._elements
             else:
                 return [flattened]
 
@@ -318,7 +318,7 @@ class Expression(BaseExpression):
         sym = set((self.get_head_name(),))
         seq = []
 
-        for i, leaf in enumerate(self._leaves):
+        for i, leaf in enumerate(self._elements):
             if isinstance(leaf, Expression):
                 leaf_symbols = leaf._rebuild_cache().symbols
                 sym.update(leaf_symbols)
@@ -352,7 +352,7 @@ class Expression(BaseExpression):
 
     def copy(self, reevaluate=False) -> "Expression":
         expr = Expression(self._head.copy(reevaluate))
-        expr._leaves = tuple(leaf.copy(reevaluate) for leaf in self._leaves)
+        expr._elements = tuple(leaf.copy(reevaluate) for leaf in self._elements)
         if not reevaluate:
             # rebuilding the cache in self speeds up large operations, e.g.
             # First[Timing[Fold[#1+#2&, Range[750]]]]
@@ -387,7 +387,7 @@ class Expression(BaseExpression):
         # this is a minimal, shallow copy: head, leaves are shared with
         # the original, only the Expression instance is new.
         expr = Expression(self._head)
-        expr._leaves = self._leaves
+        expr._elements = self._elements
         # rebuilding the cache in self speeds up large operations, e.g.
         # First[Timing[Fold[#1+#2&, Range[750]]]]
         expr._cache = self._rebuild_cache()
@@ -405,30 +405,30 @@ class Expression(BaseExpression):
         self._head = head
         self._cache = None
 
-    def get_leaves(self):
-        return self._leaves
+    def get_elements(self):
+        return self._elements
 
-    def get_mutable_leaves(self):  # shallow, mutable copy of the leaves array
-        return list(self._leaves)
+    def get_mutable_elements(self):  # shallow, mutable copy of the leaves array
+        return list(self._elements)
 
     def set_leaf(self, index, value):  # leaves are removed, added or replaced
-        leaves = list(self._leaves)
+        leaves = list(self._elements)
         leaves[index] = value
-        self._leaves = tuple(leaves)
+        self._elements = tuple(leaves)
         self._cache = None
 
-    def set_reordered_leaves(self, leaves):  # same leaves, but in a different order
-        self._leaves = tuple(leaves)
+    def set_reordered_elements(self, leaves):  # same leaves, but in a different order
+        self._elements = tuple(leaves)
         if self._cache:
             self._cache = self._cache.reordered()
 
     def get_attributes(self, definitions):
-        if self._head is SymbolFunction and len(self._leaves) > 2:
-            res = self._leaves[2]
+        if self._head is SymbolFunction and len(self._elements) > 2:
+            res = self._elements[2]
             if res.is_symbol():
                 return (str(res),)
             elif res.has_form("List", None):
-                return set(str(a) for a in res._leaves)
+                return set(str(a) for a in res._elements)
         return nothing
 
     def get_lookup_name(self) -> bool:
@@ -459,7 +459,7 @@ class Expression(BaseExpression):
         if not leaf_counts:
             return False
         if leaf_counts and leaf_counts[0] is not None:
-            count = len(self._leaves)
+            count = len(self._elements)
             if count not in leaf_counts:
                 if (
                     len(leaf_counts) == 2
@@ -475,7 +475,7 @@ class Expression(BaseExpression):
         if self._no_symbol(symbol_name):
             return False
         return self._head.has_symbol(symbol_name) or any(
-            leaf.has_symbol(symbol_name) for leaf in self._leaves
+            leaf.has_symbol(symbol_name) for leaf in self._elements
         )
 
     def _as_sympy_function(self, **kwargs) -> sympy.Function:
@@ -497,8 +497,8 @@ class Expression(BaseExpression):
 
         if "converted_functions" in kwargs:
             functions = kwargs["converted_functions"]
-            if len(self._leaves) > 0 and self.get_head_name() in functions:
-                sym_args = [leaf.to_sympy() for leaf in self._leaves]
+            if len(self._elements) > 0 and self.get_head_name() in functions:
+                sym_args = [leaf.to_sympy() for leaf in self._elements]
                 if None in sym_args:
                     return None
                 func = sympy.Function(str(sympy_symbol_prefix + self.get_head_name()))(
@@ -535,28 +535,28 @@ class Expression(BaseExpression):
         head = self._head
         if n_evaluation is not None:
             if head is SymbolFunction:
-                compiled = Expression(SymbolCompile, *(self._leaves))
+                compiled = Expression(SymbolCompile, *(self._elements))
                 compiled = compiled.evaluate(n_evaluation)
                 if compiled.get_head() is SymbolCompiledFunction:
                     return compiled.leaves[2].cfunc
             value = Expression(SymbolN, self).evaluate(n_evaluation)
             return value.to_python()
 
-        if head is SymbolDirectedInfinity and len(self._leaves) == 1:
-            direction = self._leaves[0].get_int_value()
+        if head is SymbolDirectedInfinity and len(self._elements) == 1:
+            direction = self._elements[0].get_int_value()
             if direction == 1:
                 return math.inf
             if direction == -1:
                 return -math.inf
         elif head is SymbolList:
-            return [leaf.to_python(*args, **kwargs) for leaf in self._leaves]
+            return [leaf.to_python(*args, **kwargs) for leaf in self._elements]
 
         head_name = head.get_name()
         if head_name in mathics_to_python:
             py_obj = mathics_to_python[head_name]
             # Start here
             # if inspect.isfunction(py_obj) or inspect.isbuiltin(py_obj):
-            #     args = [leaf.to_python(*args, **kwargs) for leaf in self._leaves]
+            #     args = [leaf.to_python(*args, **kwargs) for leaf in self._elements]
             #     return ast.Call(
             #         func=py_obj.__name__,
             #         args=args,
@@ -590,7 +590,7 @@ class Expression(BaseExpression):
             elif head is SymbolBlankNullSequence:
                 pattern = 3
             if pattern > 0:
-                if self._leaves:
+                if self._elements:
                     pattern += 10
                 else:
                     pattern += 20
@@ -602,38 +602,38 @@ class Expression(BaseExpression):
                     1,
                     0,
                     head.get_sort_key(True),
-                    tuple(leaf.get_sort_key(True) for leaf in self._leaves),
+                    tuple(leaf.get_sort_key(True) for leaf in self._elements),
                     1,
                 ]
 
             if head is SymbolPatternTest:
-                if len(self._leaves) != 2:
-                    return [3, 0, 0, 0, 0, head, self._leaves, 1]
-                sub = self._leaves[0].get_sort_key(True)
+                if len(self._elements) != 2:
+                    return [3, 0, 0, 0, 0, head, self._elements, 1]
+                sub = self._elements[0].get_sort_key(True)
                 sub[2] = 0
                 return sub
             elif head is SymbolCondition:
-                if len(self._leaves) != 2:
-                    return [3, 0, 0, 0, 0, head, self._leaves, 1]
-                sub = self._leaves[0].get_sort_key(True)
+                if len(self._elements) != 2:
+                    return [3, 0, 0, 0, 0, head, self._elements, 1]
+                sub = self._elements[0].get_sort_key(True)
                 sub[7] = 0
                 return sub
             elif head is SymbolPattern:
-                if len(self._leaves) != 2:
-                    return [3, 0, 0, 0, 0, head, self._leaves, 1]
-                sub = self._leaves[1].get_sort_key(True)
+                if len(self._elements) != 2:
+                    return [3, 0, 0, 0, 0, head, self._elements, 1]
+                sub = self._elements[1].get_sort_key(True)
                 sub[3] = 0
                 return sub
             elif head is SymbolOptional:
-                if len(self._leaves) not in (1, 2):
-                    return [3, 0, 0, 0, 0, head, self._leaves, 1]
-                sub = self._leaves[0].get_sort_key(True)
+                if len(self._elements) not in (1, 2):
+                    return [3, 0, 0, 0, 0, head, self._elements, 1]
+                sub = self._elements[0].get_sort_key(True)
                 sub[4] = 1
                 return sub
             elif head is SymbolAlternatives:
                 min_key = [4]
                 min = None
-                for leaf in self._leaves:
+                for leaf in self._elements:
                     key = leaf.get_sort_key(True)
                     if key < min_key:
                         min = leaf
@@ -643,11 +643,11 @@ class Expression(BaseExpression):
                     return [2, 1]
                 return min_key
             elif head is SymbolVerbatim:
-                if len(self._leaves) != 1:
-                    return [3, 0, 0, 0, 0, head, self._leaves, 1]
-                return self._leaves[0].get_sort_key(True)
+                if len(self._elements) != 1:
+                    return [3, 0, 0, 0, 0, head, self._elements, 1]
+                return self._elements[0].get_sort_key(True)
             elif head is SymbolOptionsPattern:
-                return [2, 40, 0, 1, 1, 0, head, self._leaves, 1]
+                return [2, 40, 0, 1, 1, 0, head, self._elements, 1]
             else:
                 # Append [4] to leaves so that longer expressions have higher
                 # precedence
@@ -660,7 +660,7 @@ class Expression(BaseExpression):
                     head.get_sort_key(True),
                     tuple(
                         chain(
-                            (leaf.get_sort_key(True) for leaf in self._leaves), ([4],)
+                            (leaf.get_sort_key(True) for leaf in self._elements), ([4],)
                         )
                     ),
                     1,
@@ -669,18 +669,18 @@ class Expression(BaseExpression):
             exps = {}
             head = self._head
             if head is SymbolTimes:
-                for leaf in self._leaves:
+                for leaf in self._elements:
                     name = leaf.get_name()
                     if leaf.has_form("Power", 2):
-                        var = leaf._leaves[0].get_name()
-                        exp = leaf._leaves[1].round_to_float()
+                        var = leaf._elements[0].get_name()
+                        exp = leaf._elements[1].round_to_float()
                         if var and exp is not None:
                             exps[var] = exps.get(var, 0) + exp
                     elif name:
                         exps[name] = exps.get(name, 0) + 1
             elif self.has_form("Power", 2):
-                var = self._leaves[0].get_name()
-                exp = self._leaves[1].round_to_float()
+                var = self._elements[0].get_name()
+                exp = self._elements[1].round_to_float()
                 if var and exp is not None:
                     exps[var] = exps.get(var, 0) + exp
             if exps:
@@ -690,11 +690,11 @@ class Expression(BaseExpression):
                     Monomial(exps),
                     1,
                     head,
-                    self._leaves,
+                    self._elements,
                     1,
                 ]
             else:
-                return [1 if self.is_numeric() else 2, 3, head, self._leaves, 1]
+                return [1 if self.is_numeric() else 2, 3, head, self._elements, 1]
 
     def sameQ(self, other: BaseExpression) -> bool:
         """Mathics SameQ"""
@@ -704,11 +704,11 @@ class Expression(BaseExpression):
             return True
         if not self._head.sameQ(other.get_head()):
             return False
-        if len(self._leaves) != len(other.get_leaves()):
+        if len(self._elements) != len(other.get_elements()):
             return False
         return all(
             (id(leaf) == id(oleaf) or leaf.sameQ(oleaf))
-            for leaf, oleaf in zip(self._leaves, other.get_leaves())
+            for leaf, oleaf in zip(self._elements, other.get_elements())
         )
 
     def flatten(
@@ -720,15 +720,15 @@ class Expression(BaseExpression):
             return self
         sub_level = None if level is None else level - 1
         do_flatten = False
-        for leaf in self._leaves:
+        for leaf in self._elements:
             if leaf.get_head().sameQ(head) and (
                 not pattern_only or leaf.pattern_sequence
             ):
                 do_flatten = True
                 break
         if do_flatten:
-            new_leaves = []
-            for leaf in self._leaves:
+            new_elements = []
+            for leaf in self._elements:
                 if leaf.get_head().sameQ(head) and (
                     not pattern_only or leaf.pattern_sequence
                 ):
@@ -736,11 +736,11 @@ class Expression(BaseExpression):
                         head, pattern_only, callback, level=sub_level
                     )
                     if callback is not None:
-                        callback(new_leaf._leaves, leaf)
-                    new_leaves.extend(new_leaf._leaves)
+                        callback(new_leaf._elements, leaf)
+                    new_elements.extend(new_leaf._elements)
                 else:
-                    new_leaves.append(leaf)
-            return Expression(self._head, *new_leaves)
+                    new_elements.append(leaf)
+            return Expression(self._head, *new_elements)
         else:
             return self
 
@@ -846,7 +846,7 @@ class Expression(BaseExpression):
 
         head = self._head.evaluate(evaluation)
         attributes = head.get_attributes(evaluation.definitions)
-        leaves = self.get_mutable_leaves()
+        leaves = self.get_mutable_elements()
 
         def rest_range(indices):
             if not hold_all_complete & attributes:
@@ -879,32 +879,32 @@ class Expression(BaseExpression):
             # rest_range(range(0, 0))
 
         new = Expression(head)
-        new._leaves = tuple(leaves)
+        new._elements = tuple(leaves)
 
         if not (sequence_hold | hold_all_complete) & attributes:
             new = new.flatten_sequence(evaluation)
-            leaves = new._leaves
+            leaves = new._elements
 
         for leaf in leaves:
             leaf.unevaluated = False
 
         if not hold_all_complete & attributes:
-            dirty_leaves = None
+            dirty_elements = None
 
             for index, leaf in enumerate(leaves):
                 if leaf.has_form("Unevaluated", 1):
-                    if dirty_leaves is None:
-                        dirty_leaves = list(leaves)
-                    dirty_leaves[index] = leaf._leaves[0]
-                    dirty_leaves[index].unevaluated = True
+                    if dirty_elements is None:
+                        dirty_elements = list(leaves)
+                    dirty_elements[index] = leaf._elements[0]
+                    dirty_elements[index].unevaluated = True
 
-            if dirty_leaves:
+            if dirty_elements:
                 new = Expression(head)
-                new._leaves = tuple(dirty_leaves)
-                leaves = dirty_leaves
+                new._elements = tuple(dirty_elements)
+                leaves = dirty_elements
 
-        def flatten_callback(new_leaves, old):
-            for leaf in new_leaves:
+        def flatten_callback(new_elements, old):
+            for leaf in new_elements:
                 leaf.unevaluated = old.unevaluated
 
         if flat & attributes:
@@ -952,32 +952,32 @@ class Expression(BaseExpression):
                 else:
                     return result, True
 
-        dirty_leaves = None
+        dirty_elements = None
 
         # Expression did not change, re-apply Unevaluated
-        for index, leaf in enumerate(new._leaves):
+        for index, leaf in enumerate(new._elements):
             if leaf.unevaluated:
-                if dirty_leaves is None:
-                    dirty_leaves = list(new._leaves)
-                dirty_leaves[index] = Expression("Unevaluated", leaf)
+                if dirty_elements is None:
+                    dirty_elements = list(new._elements)
+                dirty_elements[index] = Expression("Unevaluated", leaf)
 
-        if dirty_leaves:
+        if dirty_elements:
             new = Expression(head)
-            new._leaves = tuple(dirty_leaves)
+            new._elements = tuple(dirty_elements)
 
         new.unformatted = self.unformatted
         new._timestamp_cache(evaluation)
         return new, False
 
-    def evaluate_leaves(self, evaluation) -> "Expression":
-        leaves = [leaf.evaluate(evaluation) for leaf in self._leaves]
-        head = self._head.evaluate_leaves(evaluation)
+    def evaluate_elements(self, evaluation) -> "Expression":
+        leaves = [leaf.evaluate(evaluation) for leaf in self._elements]
+        head = self._head.evaluate_elements(evaluation)
         return Expression(head, *leaves)
 
     def __str__(self) -> str:
         return "%s[%s]" % (
             self._head,
-            ", ".join([leaf.__str__() for leaf in self._leaves]),
+            ", ".join([leaf.__str__() for leaf in self._elements]),
         )
 
     def __repr__(self) -> str:
@@ -985,19 +985,19 @@ class Expression(BaseExpression):
 
     def process_style_box(self, options):
         if self.has_form("StyleBox", 1, None):
-            rules = self._leaves[1:]
+            rules = self._elements[1:]
             for rule in rules:
                 if rule.has_form("Rule", 2):
-                    name = rule._leaves[0].get_name()
-                    value = rule._leaves[1]
+                    name = rule._elements[0].get_name()
+                    value = rule._elements[1]
                     if name == "System`ShowStringCharacters":
                         value = value.is_true()
                         options = options.copy()
                         options["show_string_characters"] = value
                     elif name == "System`ImageSizeMultipliers":
                         if value.has_form("List", 2):
-                            m1 = value._leaves[0].round_to_float()
-                            m2 = value._leaves[1].round_to_float()
+                            m1 = value._elements[0].round_to_float()
+                            m2 = value._elements[1].round_to_float()
                             if m1 is not None and m2 is not None:
                                 options = options.copy()
                                 options["image_size_multipliers"] = (m1, m2)
@@ -1008,18 +1008,21 @@ class Expression(BaseExpression):
     def boxes_to_text(self, **options) -> str:
         is_style, options = self.process_style_box(options)
         if is_style:
-            return self._leaves[0].boxes_to_text(**options)
-        if self.has_form("RowBox", 1) and self._leaves[0].has_form(  # nopep8
+            return self._elements[0].boxes_to_text(**options)
+        if self.has_form("RowBox", 1) and self._elements[0].has_form(  # nopep8
             "List", None
         ):
             return "".join(
-                [leaf.boxes_to_text(**options) for leaf in self._leaves[0]._leaves]
+                [leaf.boxes_to_text(**options) for leaf in self._elements[0]._elements]
             )
         elif self.has_form("SuperscriptBox", 2):
-            return "^".join([leaf.boxes_to_text(**options) for leaf in self._leaves])
+            return "^".join([leaf.boxes_to_text(**options) for leaf in self._elements])
         elif self.has_form("FractionBox", 2):
             return "/".join(
-                [" ( " + leaf.boxes_to_text(**options) + " ) " for leaf in self._leaves]
+                [
+                    " ( " + leaf.boxes_to_text(**options) + " ) "
+                    for leaf in self._elements
+                ]
             )
         else:
             raise BoxError(self, "text")
@@ -1027,12 +1030,12 @@ class Expression(BaseExpression):
     def boxes_to_mathml(self, **options) -> str:
         is_style, options = self.process_style_box(options)
         if is_style:
-            return self._leaves[0].boxes_to_mathml(**options)
+            return self._elements[0].boxes_to_mathml(**options)
         name = self._head.get_name()
         if (
             name == "System`RowBox"
-            and len(self._leaves) == 1
-            and self._leaves[0].get_head() is SymbolList  # nopep8
+            and len(self._elements) == 1
+            and self._elements[0].get_head() is SymbolList  # nopep8
         ):
             result = []
             inside_row = options.get("inside_row")
@@ -1041,23 +1044,23 @@ class Expression(BaseExpression):
 
             def is_list_interior(content):
                 if content.has_form("List", None) and all(
-                    leaf.get_string_value() == "," for leaf in content._leaves[1::2]
+                    leaf.get_string_value() == "," for leaf in content._elements[1::2]
                 ):
                     return True
                 return False
 
             is_list_row = False
             if (
-                len(self._leaves[0]._leaves) == 3
-                and self._leaves[0]._leaves[0].get_string_value() == "{"  # nopep8
-                and self._leaves[0]._leaves[2].get_string_value() == "}"
-                and self._leaves[0]._leaves[1].has_form("RowBox", 1)
+                len(self._elements[0]._elements) == 3
+                and self._elements[0]._elements[0].get_string_value() == "{"  # nopep8
+                and self._elements[0]._elements[2].get_string_value() == "}"
+                and self._elements[0]._elements[1].has_form("RowBox", 1)
             ):
-                content = self._leaves[0]._leaves[1]._leaves[0]
+                content = self._elements[0]._elements[1]._elements[0]
                 if is_list_interior(content):
                     is_list_row = True
 
-            if not inside_row and is_list_interior(self._leaves[0]):
+            if not inside_row and is_list_interior(self._elements[0]):
                 is_list_row = True
 
             if is_list_row:
@@ -1065,39 +1068,39 @@ class Expression(BaseExpression):
             else:
                 options["inside_row"] = True
 
-            for leaf in self._leaves[0].get_leaves():
+            for leaf in self._elements[0].get_elements():
                 result.append(leaf.boxes_to_mathml(**options))
             return "<mrow>%s</mrow>" % " ".join(result)
         else:
             options = options.copy()
             options["inside_row"] = True
-            if name == "System`SuperscriptBox" and len(self._leaves) == 2:
+            if name == "System`SuperscriptBox" and len(self._elements) == 2:
                 return "<msup>%s %s</msup>" % (
-                    self._leaves[0].boxes_to_mathml(**options),
-                    self._leaves[1].boxes_to_mathml(**options),
+                    self._elements[0].boxes_to_mathml(**options),
+                    self._elements[1].boxes_to_mathml(**options),
                 )
-            if name == "System`SubscriptBox" and len(self._leaves) == 2:
+            if name == "System`SubscriptBox" and len(self._elements) == 2:
                 return "<msub>%s %s</msub>" % (
-                    self._leaves[0].boxes_to_mathml(**options),
-                    self._leaves[1].boxes_to_mathml(**options),
+                    self._elements[0].boxes_to_mathml(**options),
+                    self._elements[1].boxes_to_mathml(**options),
                 )
-            if name == "System`SubsuperscriptBox" and len(self._leaves) == 3:
+            if name == "System`SubsuperscriptBox" and len(self._elements) == 3:
                 return "<msubsup>%s %s %s</msubsup>" % (
-                    self._leaves[0].boxes_to_mathml(**options),
-                    self._leaves[1].boxes_to_mathml(**options),
-                    self._leaves[2].boxes_to_mathml(**options),
+                    self._elements[0].boxes_to_mathml(**options),
+                    self._elements[1].boxes_to_mathml(**options),
+                    self._elements[2].boxes_to_mathml(**options),
                 )
-            elif name == "System`FractionBox" and len(self._leaves) == 2:
+            elif name == "System`FractionBox" and len(self._elements) == 2:
                 return "<mfrac>%s %s</mfrac>" % (
-                    self._leaves[0].boxes_to_mathml(**options),
-                    self._leaves[1].boxes_to_mathml(**options),
+                    self._elements[0].boxes_to_mathml(**options),
+                    self._elements[1].boxes_to_mathml(**options),
                 )
-            elif name == "System`SqrtBox" and len(self._leaves) == 1:
+            elif name == "System`SqrtBox" and len(self._elements) == 1:
                 return "<msqrt>%s</msqrt>" % (
-                    self._leaves[0].boxes_to_mathml(**options)
+                    self._elements[0].boxes_to_mathml(**options)
                 )
             elif name == "System`GraphBox":
-                return "<mi>%s</mi>" % (self._leaves[0].boxes_to_mathml(**options))
+                return "<mi>%s</mi>" % (self._elements[0].boxes_to_mathml(**options))
             else:
                 raise BoxError(self, "xml")
 
@@ -1113,19 +1116,22 @@ class Expression(BaseExpression):
 
         is_style, options = self.process_style_box(options)
         if is_style:
-            return self._leaves[0].boxes_to_tex(**options)
+            return self._elements[0].boxes_to_tex(**options)
         name = self._head.get_name()
         if (
             name == "System`RowBox"
-            and len(self._leaves) == 1
-            and self._leaves[0].get_head_name() == "System`List"  # nopep8
+            and len(self._elements) == 1
+            and self._elements[0].get_head_name() == "System`List"  # nopep8
         ):
             return "".join(
-                [leaf.boxes_to_tex(**options) for leaf in self._leaves[0].get_leaves()]
+                [
+                    leaf.boxes_to_tex(**options)
+                    for leaf in self._elements[0].get_elements()
+                ]
             )
-        elif name == "System`SuperscriptBox" and len(self._leaves) == 2:
-            tex1 = self._leaves[0].boxes_to_tex(**options)
-            sup_string = self._leaves[1].get_string_value()
+        elif name == "System`SuperscriptBox" and len(self._elements) == 2:
+            tex1 = self._elements[0].boxes_to_tex(**options)
+            sup_string = self._elements[1].get_string_value()
             if sup_string == "\u2032":
                 return "%s'" % tex1
             elif sup_string == "\u2032\u2032":
@@ -1133,52 +1139,56 @@ class Expression(BaseExpression):
             else:
                 return "%s^%s" % (
                     block(tex1, True),
-                    block(self._leaves[1].boxes_to_tex(**options)),
+                    block(self._elements[1].boxes_to_tex(**options)),
                 )
-        elif name == "System`SubscriptBox" and len(self._leaves) == 2:
+        elif name == "System`SubscriptBox" and len(self._elements) == 2:
             return "%s_%s" % (
-                block(self._leaves[0].boxes_to_tex(**options), True),
-                block(self._leaves[1].boxes_to_tex(**options)),
+                block(self._elements[0].boxes_to_tex(**options), True),
+                block(self._elements[1].boxes_to_tex(**options)),
             )
-        elif name == "System`SubsuperscriptBox" and len(self._leaves) == 3:
+        elif name == "System`SubsuperscriptBox" and len(self._elements) == 3:
             return "%s_%s^%s" % (
-                block(self._leaves[0].boxes_to_tex(**options), True),
-                block(self._leaves[1].boxes_to_tex(**options)),
-                block(self._leaves[2].boxes_to_tex(**options)),
+                block(self._elements[0].boxes_to_tex(**options), True),
+                block(self._elements[1].boxes_to_tex(**options)),
+                block(self._elements[2].boxes_to_tex(**options)),
             )
-        elif name == "System`FractionBox" and len(self._leaves) == 2:
+        elif name == "System`FractionBox" and len(self._elements) == 2:
             return "\\frac{%s}{%s}" % (
-                self._leaves[0].boxes_to_tex(**options),
-                self._leaves[1].boxes_to_tex(**options),
+                self._elements[0].boxes_to_tex(**options),
+                self._elements[1].boxes_to_tex(**options),
             )
-        elif name == "System`SqrtBox" and len(self._leaves) == 1:
-            return "\\sqrt{%s}" % self._leaves[0].boxes_to_tex(**options)
+        elif name == "System`SqrtBox" and len(self._elements) == 1:
+            return "\\sqrt{%s}" % self._elements[0].boxes_to_tex(**options)
         else:
             raise BoxError(self, "tex")
 
     def default_format(self, evaluation, form) -> str:
         return "%s[%s]" % (
             self._head.default_format(evaluation, form),
-            ", ".join([leaf.default_format(evaluation, form) for leaf in self._leaves]),
+            ", ".join(
+                [leaf.default_format(evaluation, form) for leaf in self._elements]
+            ),
         )
 
     def sort(self, pattern=False):
         "Sort the leaves according to internal ordering."
-        leaves = list(self._leaves)
+        leaves = list(self._elements)
         if pattern:
             leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
         else:
             leaves.sort()
-        self.set_reordered_leaves(leaves)
+        self.set_reordered_elements(leaves)
 
-    def filter_leaves(self, head_name):
+    def filter_elements(self, head_name):
         # TODO: should use sorting
         head_name = ensure_context(head_name)
 
         if self._no_symbol(head_name):
             return []
         else:
-            return [leaf for leaf in self._leaves if leaf.get_head_name() == head_name]
+            return [
+                leaf for leaf in self._elements if leaf.get_head_name() == head_name
+            ]
 
     def apply_rules(self, rules, evaluation, level=0, options=None):
         """for rule in rules:
@@ -1195,7 +1205,9 @@ class Expression(BaseExpression):
             return new
 
         def descend(expr):
-            return Expression(expr._head, *[apply_leaf(leaf) for leaf in expr._leaves])
+            return Expression(
+                expr._head, *[apply_leaf(leaf) for leaf in expr._elements]
+            )
 
         if options is None:  # default ReplaceAll mode; replace breadth first
             result, applied = super().apply_rules(rules, evaluation, level, options)
@@ -1203,7 +1215,7 @@ class Expression(BaseExpression):
                 return result, True
             head, applied = self._head.apply_rules(rules, evaluation, level, options)
             new_applied[0] = applied
-            return descend(Expression(head, *self._leaves)), new_applied[0]
+            return descend(Expression(head, *self._elements)), new_applied[0]
         else:  # Replace mode; replace depth first
             expr = descend(self)
             expr, applied = super(Expression, expr).apply_rules(
@@ -1216,7 +1228,7 @@ class Expression(BaseExpression):
                     rules, evaluation, level + 1, options
                 )
                 new_applied[0] = new_applied[0] or applied
-                expr = Expression(head, *expr._leaves)
+                expr = Expression(head, *expr._elements)
             return expr, new_applied[0]
 
     def replace_vars(
@@ -1228,11 +1240,11 @@ class Expression(BaseExpression):
             if (
                 self._head.get_name()
                 in ("System`Module", "System`Block", "System`With")
-                and len(self._leaves) > 0
+                and len(self._elements) > 0
             ):  # nopep8
 
                 scoping_vars = set(
-                    name for name, new_def in get_scoping_vars(self._leaves[0])
+                    name for name, new_def in get_scoping_vars(self._elements[0])
                 )
                 """for var in new_vars:
                     if var in scoping_vars:
@@ -1241,26 +1253,29 @@ class Expression(BaseExpression):
                     var: value for var, value in vars.items() if var not in scoping_vars
                 }
 
-        leaves = self._leaves
+        leaves = self._elements
         if in_function:
             if (
                 self._head is SymbolFunction
-                and len(self._leaves) > 1
+                and len(self._elements) > 1
                 and (
-                    self._leaves[0].has_form("List", None) or self._leaves[0].get_name()
+                    self._elements[0].has_form("List", None)
+                    or self._elements[0].get_name()
                 )
             ):
-                if self._leaves[0].get_name():
-                    func_params = [self._leaves[0].get_name()]
+                if self._elements[0].get_name():
+                    func_params = [self._elements[0].get_name()]
                 else:
-                    func_params = [leaf.get_name() for leaf in self._leaves[0]._leaves]
+                    func_params = [
+                        leaf.get_name() for leaf in self._elements[0]._elements
+                    ]
                 if "" not in func_params:
-                    body = self._leaves[1]
+                    body = self._elements[1]
                     replacement = {name: Symbol(name + "$") for name in func_params}
                     func_params = [Symbol(name + "$") for name in func_params]
                     body = body.replace_vars(replacement, options, in_scoping)
                     leaves = chain(
-                        [Expression(SymbolList, *func_params), body], self._leaves[2:]
+                        [Expression(SymbolList, *func_params), body], self._elements[2:]
                     )
 
         if not vars:  # might just be a symbol set via Set[] we looked up here
@@ -1276,30 +1291,30 @@ class Expression(BaseExpression):
 
     def replace_slots(self, slots, evaluation):
         if self._head is SymbolSlot:
-            if len(self._leaves) != 1:
-                evaluation.message_args("Slot", len(self._leaves), 1)
+            if len(self._elements) != 1:
+                evaluation.message_args("Slot", len(self._elements), 1)
             else:
-                slot = self._leaves[0].get_int_value()
+                slot = self._elements[0].get_int_value()
                 if slot is None or slot < 0:
-                    evaluation.message("Function", "slot", self._leaves[0])
+                    evaluation.message("Function", "slot", self._elements[0])
                 elif slot > len(slots) - 1:
                     evaluation.message("Function", "slotn", slot)
                 else:
                     return slots[int(slot)]
         elif self._head is SymbolSlotSequence:
-            if len(self._leaves) != 1:
-                evaluation.message_args("SlotSequence", len(self._leaves), 1)
+            if len(self._elements) != 1:
+                evaluation.message_args("SlotSequence", len(self._elements), 1)
             else:
-                slot = self._leaves[0].get_int_value()
+                slot = self._elements[0].get_int_value()
                 if slot is None or slot < 1:
-                    evaluation.error("Function", "slot", self._leaves[0])
+                    evaluation.error("Function", "slot", self._elements[0])
             return Expression(SymbolSequence, *slots[slot:])
-        elif self._head is SymbolFunction and len(self._leaves) == 1:
+        elif self._head is SymbolFunction and len(self._elements) == 1:
             # do not replace Slots in nested Functions
             return self
         return Expression(
             self._head.replace_slots(slots, evaluation),
-            *[leaf.replace_slots(slots, evaluation) for leaf in self._leaves]
+            *[leaf.replace_slots(slots, evaluation) for leaf in self._elements]
         )
 
     def thread(self, evaluation, head=None) -> typing.Tuple[bool, "Expression"]:
@@ -1308,17 +1323,17 @@ class Expression(BaseExpression):
 
         items = []
         dim = None
-        for leaf in self._leaves:
+        for leaf in self._elements:
             if leaf.get_head().sameQ(head):
                 if dim is None:
-                    dim = len(leaf._leaves)
-                    items = [(items + [innerleaf]) for innerleaf in leaf._leaves]
-                elif len(leaf._leaves) != dim:
+                    dim = len(leaf._elements)
+                    items = [(items + [innerleaf]) for innerleaf in leaf._elements]
+                elif len(leaf._elements) != dim:
                     evaluation.message("Thread", "tdlen")
                     return True, self
                 else:
                     for index in range(dim):
-                        items[index].append(leaf._leaves[index])
+                        items[index].append(leaf._elements[index])
             else:
                 if dim is None:
                     items.append(leaf)
@@ -1337,27 +1352,27 @@ class Expression(BaseExpression):
                 self._head.get_name()
             ):
                 return False
-            for leaf in self._leaves:
+            for leaf in self._elements:
                 if not leaf.is_numeric(evaluation):
                     return False
             return True
-            # return all(leaf.is_numeric(evaluation) for leaf in self._leaves)
+            # return all(leaf.is_numeric(evaluation) for leaf in self._elements)
         else:
             return self._head in symbols_arithmetic_operations and all(
-                leaf.is_numeric() for leaf in self._leaves
+                leaf.is_numeric() for leaf in self._elements
             )
 
     def numerify(self, evaluation) -> "Expression":
         _prec = None
-        for leaf in self._leaves:
+        for leaf in self._elements:
             if leaf.is_inexact():
                 leaf_prec = leaf.get_precision()
                 if _prec is None or leaf_prec < _prec:
                     _prec = leaf_prec
         if _prec is not None:
-            new_leaves = self.get_mutable_leaves()
-            for index in range(len(new_leaves)):
-                leaf = new_leaves[index]
+            new_elements = self.get_mutable_elements()
+            for index in range(len(new_elements)):
+                leaf = new_elements[index]
                 # Don't "numerify" numbers: they should be numerified
                 # automatically by the processing function,
                 # and we don't want to lose exactness in e.g. 1.0+I.
@@ -1365,8 +1380,8 @@ class Expression(BaseExpression):
                     n_expr = Expression(SymbolN, leaf, Integer(dps(_prec)))
                     n_result = n_expr.evaluate(evaluation)
                     if isinstance(n_result, Number):
-                        new_leaves[index] = n_result
-            return Expression(self._head, *new_leaves)
+                        new_elements[index] = n_result
+            return Expression(self._head, *new_elements)
         else:
             return self
 
@@ -1375,20 +1390,20 @@ class Expression(BaseExpression):
             atoms = self._head.get_atoms()
         else:
             atoms = []
-        for leaf in self._leaves:
+        for leaf in self._elements:
             atoms.extend(leaf.get_atoms())
         return atoms
 
     def __hash__(self):
-        return hash(("Expression", self._head) + tuple(self._leaves))
+        return hash(("Expression", self._head) + tuple(self._elements))
 
     def user_hash(self, update):
-        update(("%s>%d>" % (self.get_head_name(), len(self._leaves))).encode("utf8"))
-        for leaf in self._leaves:
+        update(("%s>%d>" % (self.get_head_name(), len(self._elements))).encode("utf8"))
+        for leaf in self._elements:
             leaf.user_hash(update)
 
     def __getnewargs__(self):
-        return (self._head, self._leaves)
+        return (self._head, self._elements)
 
 
 def _create_expression(self, head, *leaves):
@@ -1497,14 +1512,14 @@ class UnlinkedStructure(Structure):
 
     def __call__(self, leaves):
         expr = Expression(self._head)
-        expr._leaves = tuple(leaves)
+        expr._elements = tuple(leaves)
         return expr
 
     def filter(self, expr, cond):
-        return self([leaf for leaf in expr._leaves if cond(leaf)])
+        return self([leaf for leaf in expr._elements if cond(leaf)])
 
     def slice(self, expr, py_slice):
-        leaves = expr._leaves
+        leaves = expr._elements
         lower, upper, step = py_slice.indices(len(leaves))
         if step != 1:
             raise ValueError("Structure.slice only supports slice steps of 1")
@@ -1523,21 +1538,21 @@ class LinkedStructure(Structure):
 
     def __call__(self, leaves):
         expr = Expression(self._head)
-        expr._leaves = tuple(leaves)
+        expr._elements = tuple(leaves)
         expr._cache = self._cache.reordered()
         return expr
 
     def filter(self, expr, cond):
-        return self([leaf for leaf in expr._leaves if cond(leaf)])
+        return self([leaf for leaf in expr._elements if cond(leaf)])
 
     def slice(self, expr, py_slice):
-        leaves = expr._leaves
+        leaves = expr._elements
         lower, upper, step = py_slice.indices(len(leaves))
         if step != 1:
             raise ValueError("Structure.slice only supports slice steps of 1")
 
         new = Expression(self._head)
-        new._leaves = tuple(leaves[lower:upper])
+        new._elements = tuple(leaves[lower:upper])
         if expr._cache:
             new._cache = expr._cache.sliced(lower, upper)
 
@@ -1602,7 +1617,7 @@ def atom_list_constructor(evaluation, head, *atom_names):
 
         def construct(leaves):
             expr = Expression(head)
-            expr._leaves = list(leaves)
+            expr._elements = list(leaves)
             sym = set(chain([head.get_name()], full_atom_names))
             expr._cache = ExpressionCache(evaluation.definitions.now, sym, None)
             return expr
@@ -1611,7 +1626,7 @@ def atom_list_constructor(evaluation, head, *atom_names):
 
         def construct(leaves):
             expr = Expression(head)
-            expr._leaves = list(leaves)
+            expr._elements = list(leaves)
             return expr
 
     return construct

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -267,17 +267,17 @@ class Expression(BaseExpression):
         if not indices:
             return self
 
-        leaves = self._elements
+        elements = self._elements
 
         flattened = []
         extend = flattened.extend
 
         k = 0
         for i in indices:
-            extend(leaves[k:i])
-            extend(sequence(leaves[i]))
+            extend(elements[k:i])
+            extend(sequence(elements[i]))
             k = i + 1
-        extend(leaves[k:])
+        extend(elements[k:])
 
         return self.restructure(self._head, flattened, evaluation)
 
@@ -384,7 +384,7 @@ class Expression(BaseExpression):
         return expr
 
     def shallow_copy(self) -> "Expression":
-        # this is a minimal, shallow copy: head, leaves are shared with
+        # this is a minimal, shallow copy: head, elements are shared with
         # the original, only the Expression instance is new.
         expr = Expression(self._head)
         expr._elements = self._elements
@@ -970,9 +970,9 @@ class Expression(BaseExpression):
         return new, False
 
     def evaluate_elements(self, evaluation) -> "Expression":
-        leaves = [leaf.evaluate(evaluation) for leaf in self._elements]
+        elements = [leaf.evaluate(evaluation) for leaf in self._elements]
         head = self._head.evaluate_elements(evaluation)
-        return Expression(head, *leaves)
+        return Expression(head, *elements)
 
     def __str__(self) -> str:
         return "%s[%s]" % (
@@ -1171,13 +1171,13 @@ class Expression(BaseExpression):
         )
 
     def sort(self, pattern=False):
-        "Sort the leaves according to internal ordering."
-        leaves = list(self._elements)
+        "Sort the elements according to internal ordering."
+        elements = list(self._elements)
         if pattern:
-            leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
+            elements.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
         else:
-            leaves.sort()
-        self.set_reordered_elements(leaves)
+            elements.sort()
+        self.set_reordered_elements(elements)
 
     def filter_elements(self, head_name):
         # TODO: should use sorting
@@ -1257,7 +1257,7 @@ class Expression(BaseExpression):
                     var: value for var, value in vars.items() if var not in scoping_vars
                 }
 
-        leaves = self._elements
+        elements = self._elements
         if in_function:
             if (
                 self._head is SymbolFunction
@@ -1278,7 +1278,7 @@ class Expression(BaseExpression):
                     replacement = {name: Symbol(name + "$") for name in func_params}
                     func_params = [Symbol(name + "$") for name in func_params]
                     body = body.replace_vars(replacement, options, in_scoping)
-                    leaves = chain(
+                    elements = chain(
                         [Expression(SymbolList, *func_params), body], self._elements[2:]
                     )
 
@@ -1289,7 +1289,7 @@ class Expression(BaseExpression):
             self._head.replace_vars(vars, options=options, in_scoping=in_scoping),
             *[
                 element.replace_vars(vars, options=options, in_scoping=in_scoping)
-                for element in leaves
+                for element in elements
             ]
         )
 
@@ -1349,8 +1349,8 @@ class Expression(BaseExpression):
         if dim is None:
             return False, self
         else:
-            leaves = [Expression(self._head, *item) for item in items]
-            return True, Expression(head, *leaves)
+            elements = [Expression(self._head, *item) for item in items]
+            return True, Expression(head, *elements)
 
     def is_numeric(self, evaluation=None) -> bool:
         if evaluation:
@@ -1412,8 +1412,8 @@ class Expression(BaseExpression):
         return (self._head, self._elements)
 
 
-def _create_expression(self, head, *leaves):
-    return Expression(head, *leaves)
+def _create_expression(self, head, *elements):
+    return Expression(head, *elements)
 
 
 BaseExpression.create_expression = _create_expression
@@ -1491,9 +1491,9 @@ def _is_neutral_head(head, cache, evaluation):
 
 
 class Structure(object):
-    def __call__(self, leaves):
-        # create an Expression with the given list "leaves" as leaves.
-        # NOTE: the caller guarantees that "leaves" only contains items that are from "origins".
+    def __call__(self, elements):
+        # create an Expression with the given list "elements" as elements.
+        # NOTE: the caller guarantees that "elements" only contains items that are from "origins".
         raise NotImplementedError
 
     def filter(self, expr, cond):

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -128,8 +128,8 @@ class Pattern:
     def get_head(self):
         return self.expr.get_head()
 
-    def get_leaves(self):
-        return self.expr.get_leaves()
+    def get_elements(self):
+        return self.expr.get_elements()
 
     def get_sort_key(self, pattern_sort=False):
         return self.expr.get_sort_key(pattern_sort=pattern_sort)
@@ -247,11 +247,11 @@ class ExpressionPattern(Pattern):
             # ordering of the leaves!
             # if self.leaves:
             #    next_leaf = self.leaves[0]
-            #    next_leaves = self.leaves[1:]
+            #    next_elements = self.leaves[1:]
 
             def yield_choice(pre_vars):
                 next_leaf = self.leaves[0]
-                next_leaves = self.leaves[1:]
+                next_elements = self.leaves[1:]
 
                 # "leading_blanks" below handles expressions with leading Blanks H[x_, y_, ...]
                 # much more efficiently by not calling get_match_candidates_count() on leaves
@@ -268,7 +268,7 @@ class ExpressionPattern(Pattern):
                 # without "leading_blanks", Range[5000] will be tested against {a__, b_} in a
                 # call to get_match_candidates_count(), which is slow.
 
-                unmatched_leaves = expression.leaves
+                unmatched_elements = expression.leaves
                 leading_blanks = not orderless & attributes
 
                 for leaf in self.leaves:
@@ -279,19 +279,19 @@ class ExpressionPattern(Pattern):
                             1,
                             1,
                         ):  # Blank? (i.e. length exactly 1?)
-                            if not unmatched_leaves:
+                            if not unmatched_elements:
                                 raise StopGenerator_ExpressionPattern_match()
                             if not leaf.does_match(
-                                unmatched_leaves[0], evaluation, pre_vars
+                                unmatched_elements[0], evaluation, pre_vars
                             ):
                                 raise StopGenerator_ExpressionPattern_match()
-                            unmatched_leaves = unmatched_leaves[1:]
+                            unmatched_elements = unmatched_elements[1:]
                         else:
                             leading_blanks = False
 
                     if not leading_blanks:
                         candidates = leaf.get_match_candidates_count(
-                            unmatched_leaves,
+                            unmatched_elements,
                             expression,
                             attributes,
                             evaluation,
@@ -310,7 +310,7 @@ class ExpressionPattern(Pattern):
                 self.match_leaf(
                     yield_func,
                     next_leaf,
-                    next_leaves,
+                    next_elements,
                     ([], expression.leaves),
                     pre_vars,
                     expression,
@@ -387,7 +387,7 @@ class ExpressionPattern(Pattern):
     def get_pre_choices(self, yield_func, expression, attributes, vars):
         if orderless & attributes:
             self.sort()
-            patterns = self.filter_leaves("Pattern")
+            patterns = self.filter_elements("Pattern")
             groups = {}
             prev_pattern = prev_name = None
             for pattern in patterns:
@@ -485,7 +485,7 @@ class ExpressionPattern(Pattern):
         self.leaves = [Pattern.create(leaf) for leaf in expr.leaves]
         self.expr = expr
 
-    def filter_leaves(self, head_name):
+    def filter_elements(self, head_name):
         head_name = ensure_context(head_name)
         return [leaf for leaf in self.leaves if leaf.get_head_name() == head_name]
 
@@ -524,7 +524,7 @@ class ExpressionPattern(Pattern):
         self,
         yield_func,
         leaf,
-        rest_leaves,
+        rest_elements,
         rest_expression,
         vars,
         expression,
@@ -576,7 +576,7 @@ class ExpressionPattern(Pattern):
             flat & attributes and leaf.get_head() == expression.head
         )
 
-        less_first = len(rest_leaves) > 0
+        less_first = len(rest_elements) > 0
 
         if orderless & attributes:
             # we only want leaf_candidates to be a set if we're orderless.
@@ -624,9 +624,9 @@ class ExpressionPattern(Pattern):
                 *set_lengths
             )
 
-        if rest_leaves:
-            next_leaf = rest_leaves[0]
-            next_rest_leaves = rest_leaves[1:]
+        if rest_elements:
+            next_leaf = rest_elements[0]
+            next_rest_elements = rest_elements[1:]
         next_depth = depth + 1
         next_index = leaf_index + 1
 
@@ -656,11 +656,11 @@ class ExpressionPattern(Pattern):
                     )
 
             def match_yield(new_vars, _):
-                if rest_leaves:
+                if rest_elements:
                     self.match_leaf(
                         leaf_yield,
                         next_leaf,
-                        next_rest_leaves,
+                        next_rest_elements,
                         items_rest,
                         new_vars,
                         expression,

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -131,6 +131,9 @@ class Pattern:
     def get_elements(self):
         return self.expr.get_elements()
 
+    # Compatibily with old code. Deprecated, but remove after a little bit
+    get_leaves = get_elements
+
     def get_sort_key(self, pattern_sort=False):
         return self.expr.get_sort_key(pattern_sort=pattern_sort)
 

--- a/mathics/core/read.py
+++ b/mathics/core/read.py
@@ -106,7 +106,7 @@ def read_name_and_stream_from_channel(channel, evaluation):
     if strm is None:
         return None, None, None
 
-    name, n = strm.get_leaves()
+    name, n = strm.get_elements()
 
     stream = stream_manager.lookup_stream(n.get_int_value())
     if stream is None:
@@ -127,7 +127,7 @@ def read_list_from_types(read_types):
 
     # Trun read_types into a list if it isn't already one.
     if read_types.has_form("List", None):
-        read_types = read_types._leaves
+        read_types = read_types._elements
     else:
         read_types = (read_types,)
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -43,7 +43,7 @@ class BaseRule(KeyComparable):
         def yield_match(vars, rest):
             if rest is None:
                 rest = ([], [])
-            if 0 < len(rest[0]) + len(rest[1]) == len(expression.get_leaves()):
+            if 0 < len(rest[0]) + len(rest[1]) == len(expression.get_elements()):
                 # continue
                 return
             options = {}

--- a/mathics/core/subexpression.py
+++ b/mathics/core/subexpression.py
@@ -178,7 +178,7 @@ class ExpressionPointer(object):
                 if i == 0:
                     parent = parent._head
                 else:
-                    parent = parent._leaves[i - 1]
+                    parent = parent._elements[i - 1]
                 i = pos.pop()
         except Exception:
             raise MessageException("Part", "span", pos)
@@ -241,7 +241,7 @@ class SubExpression(object):
         elif type(pos) is tuple:
             self = super(SubExpression, cls).__new__(cls)
             self._headp = ExpressionPointer(expr.head, 0)
-            self._leavesp = [
+            self._elementsp = [
                 SubExpression(ExpressionPointer(expr, k + 1), rem_pos) for k in pos
             ]
             return self
@@ -273,7 +273,7 @@ class SubExpression(object):
 
     @property
     def leaves(self):
-        return self._leavesp
+        return self._elementsp
 
     @leaves.setter
     def leaves(self, value):
@@ -282,7 +282,7 @@ class SubExpression(object):
     def to_expression(self):
         return Expression(
             self._headp.to_expression(),
-            *(leaf.to_expression() for leaf in self._leavesp)
+            *(leaf.to_expression() for leaf in self._elementsp)
         )
 
     def replace(self, new):
@@ -291,9 +291,9 @@ class SubExpression(object):
         """
         if (new.has_form("List", None) or new.get_head_name() == "System`List") and len(
             new.leaves
-        ) == len(self._leavesp):
-            for leaf, sub_new in zip(self._leavesp, new.leaves):
+        ) == len(self._elementsp):
+            for leaf, sub_new in zip(self._elementsp, new.leaves):
                 leaf.replace(sub_new)
         else:
-            for leaf in self._leavesp:
+            for leaf in self._elementsp:
                 leaf.replace(new)

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -227,7 +227,7 @@ class BaseExpression(KeyComparable):
     def get_head_name(self):
         raise NotImplementedError
 
-    def get_leaves(self):
+    def get_elements(self):
         return []
 
     def get_int_value(self):
@@ -279,7 +279,7 @@ class BaseExpression(KeyComparable):
         else:
             return [self]
 
-    def evaluate_leaves(self, evaluation) -> "BaseExpression":
+    def evaluate_elements(self, evaluation) -> "BaseExpression":
         return self
 
     def apply_rules(
@@ -312,7 +312,7 @@ class BaseExpression(KeyComparable):
         try:
             expr = self
             head = self.get_head()
-            leaves = self.get_leaves()
+            leaves = self.get_elements()
             include_form = False
             # If the expression is enclosed by a Format
             # takes the form from the expression and
@@ -395,9 +395,11 @@ class BaseExpression(KeyComparable):
                 and head is not SymbolGraphics3D
             ):
                 # print("Not inside graphics or numberform, and not is atom")
-                new_leaves = [leaf.do_format(evaluation, form) for leaf in expr.leaves]
+                new_elements = [
+                    leaf.do_format(evaluation, form) for leaf in expr.leaves
+                ]
                 expr = self.create_expression(
-                    expr.head.do_format(evaluation, form), *new_leaves
+                    expr.head.do_format(evaluation, form), *new_elements
                 )
 
             if include_form:
@@ -625,7 +627,7 @@ class Monomial(object):
 class Atom(BaseExpression):
     """
     Atoms are the leaves (in the common tree sense, not the Mathics
-    ``_leaves`` sense) and Heads of an Expression or S-Expression.
+    ``_elements`` sense) and Heads of an Expression or S-Expression.
 
     In other words, they are the units of an expression that we cannot
     dig down deeper structurally.  Various object primitives i.e.

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -230,6 +230,9 @@ class BaseExpression(KeyComparable):
     def get_elements(self):
         return []
 
+    # Compatibily with old code. Deprecated, but remove after a little bit
+    get_leaves = get_elements
+
     def get_int_value(self):
         return None
 

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -221,7 +221,7 @@ add_conversion_fn(FilledCurveBox, filled_curve_box)
 def graphics_box(self, leaves=None, **options) -> str:
 
     if not leaves:
-        leaves = self._leaves
+        leaves = self._elements
 
     data = options.get("data", None)
     if data:

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -35,7 +35,7 @@ def show_echo(query, evaluation):
     if not isinstance(echovar, Expression) or not echovar.has_form("List", None):
         return
 
-    for leaf in echovar._leaves:
+    for leaf in echovar._elements:
         if isinstance(leaf, String) and leaf.get_string_value() == "stdout":
             stream = stream_manager.lookup_stream(1)
         else:

--- a/test/test_custom_boxconstruct.py
+++ b/test/test_custom_boxconstruct.py
@@ -8,22 +8,22 @@ from mathics.core.attributes import hold_all, protected, read_protected
 class CustomBoxConstruct(BoxConstruct):
     def __init__(self, evaluation):
         super().__init__(evaluation=evaluation)
-        self._leaves = [1, 2, 3]
+        self._elements = [1, 2, 3]
 
     def boxes_to_text(self, leaves=None, **options):
         if not leaves:
-            leaves = self._leaves
-        return "CustomBoxConstruct<<" + self._leaves.__str__() + ">>"
+            leaves = self._elements
+        return "CustomBoxConstruct<<" + self._elements.__str__() + ">>"
 
     def boxes_to_mathml(self, leaves=None, **options):
         if not leaves:
-            leaves = self._leaves
-        return "CustomBoxConstruct<<" + self._leaves.__str__() + ">>"
+            leaves = self._elements
+        return "CustomBoxConstruct<<" + self._elements.__str__() + ">>"
 
     def boxes_to_tex(self, leaves=None, **options):
         if not leaves:
-            leaves = self._leaves
-        return "CustomBoxConstruct<<" + int(self._leaves) + ">>"
+            leaves = self._elements
+        return "CustomBoxConstruct<<" + int(self._elements) + ">>"
 
 
 class CustomAtom(Predefined):
@@ -50,22 +50,30 @@ class CustomGraphicsBox(BoxConstruct):
     def apply_box(self, elems, evaluation, options):
         """System`MakeBoxes[System`Graphics[elems_, System`OptionsPattern[System`Graphics]],
         System`StandardForm|System`TraditionalForm|System`OutputForm]"""
-        instance = CustomGraphicsBox(*(elems._leaves), evaluation=evaluation)
+        instance = CustomGraphicsBox(*(elems._elements), evaluation=evaluation)
         return instance
 
     def boxes_to_text(self, leaves=None, **options):
         if leaves:
-            self._leaves = leaves
-        return "--custom graphics--: I should plot " + self._leaves.__str__() + " items"
+            self._elements = leaves
+        return (
+            "--custom graphics--: I should plot " + self._elements.__str__() + " items"
+        )
 
     def boxes_to_tex(self, leaves=None, **options):
-        return "--custom graphics--: I should plot " + self._leaves.__str__() + " items"
+        return (
+            "--custom graphics--: I should plot " + self._elements.__str__() + " items"
+        )
 
     def boxes_to_mathml(self, leaves=None, **options):
-        return "--custom graphics--: I should plot " + self._leaves.__str__() + " items"
+        return (
+            "--custom graphics--: I should plot " + self._elements.__str__() + " items"
+        )
 
     def boxes_to_svg(self, evaluation):
-        return "--custom graphics--: I should plot " + self._leaves.__str__() + " items"
+        return (
+            "--custom graphics--: I should plot " + self._elements.__str__() + " items"
+        )
 
 
 def test_custom_boxconstruct():

--- a/test/test_formatter/test_svg.py
+++ b/test/test_formatter/test_svg.py
@@ -39,7 +39,7 @@ def get_svg(expression):
 
     # Would be nice to DRY this boilerplate from boxes_to_mathml
 
-    leaves = boxes._leaves
+    leaves = boxes._elements
     elements, calc_dimensions = boxes._prepare_elements(
         leaves, options=options, neg_y=True
     )


### PR DESCRIPTION
I realize when other change X to Y it seems silly. But here X (leaves) is just plain wrong and Y (elements) is correct.

"elements" is the term Mathematica uses and it  is a perfectly appropriate term. 

"leaves" is just plain wrong. I don't know why but its bone headedness annoys me. It may have to do with this being at the level we find ourselves having to document, and then rework the code in the near future so we can get reasonable performance. Or maybe it is because I thought we were really talking about leaves of a tree and I now find this isn't correct and I am annoyed about having been confused by such a thoughtless kind of thing.

We have in the existing code running AtomQ on a "leaf" so see if it has children. This is confused/confusing.

It may seem a small thing, but if we can't think clearly about the code I think it is going to be harder to discuss it and improve it. 