### PR TITLE
sanity test to pass in a more aggressive sympy translation

### DIFF
--- a/test/test_calculus.py
+++ b/test/test_calculus.py
@@ -3,7 +3,7 @@
 Unit tests from builtins ... calculus.py
 """
 
-from .helper import check_evaluation
+from .helper import check_evaluation, session
 
 
 def test_calculus():
@@ -49,4 +49,5 @@ def test_calculus():
             "another sanity check for a more agressive sympy translation.",
         ),
     ):
+        session.evaluate("Clear[h]; Clear[g]; Clear[f];")
         check_evaluation(str_expr, str_expected, message)

--- a/test/test_calculus.py
+++ b/test/test_calculus.py
@@ -38,5 +38,15 @@ def test_calculus():
             "{x->1.51213}",
             "Issue #1235",
         ),
+        (
+            "g/:Integrate[g[u_],u_]:=f[u]; Integrate[g[x],x]",
+            "f[x]",
+            "This should pass after implementing an earlier sympy evaluation.",
+        ),
+        (
+            "h=x;Integrate[Do[h=x*h,{5}]; h,x]",
+            "x^7/7",
+            "another sanity check for a more agressive sympy translation.",
+        ),
     ):
         check_evaluation(str_expr, str_expected, message)


### PR DESCRIPTION
One of the ideas about how to speed up certain evaluations in Mathics would be to try to send to sympy complete expressions instead of doing several steps of partial conversions in the evaluation loop. 
The risk of doing it is that it could break the expected evaluation logic in WL. Here I propose some tests to detect this kind of bugs.