### PR TITLE
timing TraceEvaluation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Enhancements
 ============
 
 * ``SameQ`` (``===``) handles chaining, e.g. ``a == b == c`` or ``SameQ[a, b, c]``
+* ``TraceEvaluation`` now prints at each step the time (in seconds) since the evaluation started.
 
 Documentation
 .............

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -131,16 +131,28 @@ class TraceEvaluation(Builtin):
     >> TraceEvaluation[(x + x)^2]
      | ...
      = ...
+
+    >> TraceEvaluation[(x + x)^2, ShowTimeBySteps->True]
+     | ...
+     = ...
     """
 
     attributes = hold_all | protected
+    options = {
+        "System`ShowTimeBySteps": "False",
+    }
 
-    def apply(self, expr, evaluation):
-        "TraceEvaluation[expr_]"
+    def apply(self, expr, evaluation, options):
+        "TraceEvaluation[expr_, OptionsPattern[]]"
         curr_trace_evaluation = evaluation.definitions.trace_evaluation
+        curr_time_by_steps = evaluation.definitions.timing_trace_evaluation
         evaluation.definitions.trace_evaluation = True
+        evaluation.definitions.timing_trace_evaluation = (
+            options["System`ShowTimeBySteps"] is SymbolTrue
+        )
         result = expr.evaluate(evaluation)
         evaluation.definitions.trace_evaluation = curr_trace_evaluation
+        evaluation.definitions.timing_trace_evaluation = curr_time_by_steps
         return result
 
 

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -99,7 +99,7 @@ class Definitions(object):
             "System`",
         )
         self.trace_evaluation = False
-
+        self.timing_trace_evaluation = False
         if add_builtin:
             from mathics.builtin import modules, contribute
             from mathics.settings import ROOT_DIR

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from queue import Queue
+import time
+
 
 import os
 import sys
@@ -283,6 +285,7 @@ class Evaluation(object):
         from mathics.core.expression import Expression
         from mathics.core.rules import Rule
 
+        self.start_time = time.time()
         self.recursion_depth = 0
         self.timeout = False
         self.stopped = False

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -794,7 +794,8 @@ class Expression(BaseExpression):
         old_options = evaluation.options
         evaluation.inc_recursion_depth()
         if evaluation.definitions.trace_evaluation:
-            evaluation.print_out(time.time() - evaluation.start_time)
+            if evaluation.definitions.timing_trace_evaluation:
+                evaluation.print_out(time.time() - evaluation.start_time)
             evaluation.print_out(
                 "  " * evaluation.recursion_depth + "Evaluating: %s" % expr
             )

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -3,6 +3,7 @@
 
 import sympy
 import math
+import time
 
 import typing
 from typing import Any, Optional
@@ -793,6 +794,7 @@ class Expression(BaseExpression):
         old_options = evaluation.options
         evaluation.inc_recursion_depth()
         if evaluation.definitions.trace_evaluation:
+            evaluation.print_out(time.time() - evaluation.start_time)
             evaluation.print_out(
                 "  " * evaluation.recursion_depth + "Evaluating: %s" % expr
             )

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sympy
-
+import time
 import typing
 from typing import Any, Optional
 
@@ -949,6 +949,7 @@ class Symbol(Atom):
         recursively.
         """
         if evaluation.definitions.trace_evaluation:
+            evaluation.print_out(time.time() - evaluation.start_time)
             evaluation.print_out(
                 "  " * evaluation.recursion_depth + "  Evaluating: %s" % self
             )

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -949,7 +949,8 @@ class Symbol(Atom):
         recursively.
         """
         if evaluation.definitions.trace_evaluation:
-            evaluation.print_out(time.time() - evaluation.start_time)
+            if evaluation.definitions.timing_trace_evaluation:
+                evaluation.print_out(time.time() - evaluation.start_time)
             evaluation.print_out(
                 "  " * evaluation.recursion_depth + "  Evaluating: %s" % self
             )


### PR DESCRIPTION
Trying to understand the problem in #154, I realized that it would be useful to record how long each evaluation step takes, so here is a PR that implements that. 