### PR TITLE
Clarify "threading" in Exprs. DRY Numeric classes

### DIFF
--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -156,9 +156,6 @@ class Integer(Number):
     def __init__(self, value) -> "Integer":
         super().__init__()
 
-    def get_head_name(self):
-        return self.class_head_name
-
     def boxes_to_text(self, **options) -> str:
         return str(self.value)
 
@@ -244,9 +241,6 @@ class Rational(Number):
         self = super().__new__(cls)
         self.value = sympy.Rational(numerator, denominator)
         return self
-
-    def get_head_name(self):
-        return "System`Rational"
 
     def atom_to_boxes(self, f, evaluation):
         return self.format(evaluation, f.get_name())
@@ -363,9 +357,6 @@ class Real(Number):
         else:
             return PrecisionReal.__new__(PrecisionReal, value)
 
-    def get_head_name(self):
-        return "System`Real"
-
     def boxes_to_text(self, **options) -> str:
         return self.make_boxes("System`OutputForm").boxes_to_text(**options)
 
@@ -412,9 +403,6 @@ class Real(Number):
         # ignore last 7 binary digits when hashing
         _prec = self.get_precision()
         update(b"System`Real>" + str(self.to_sympy().n(dps(_prec))).encode("utf8"))
-
-    def get_atom_name(self) -> str:
-        return "Real"
 
 
 class MachineReal(Real):
@@ -614,9 +602,6 @@ class Complex(Number):
         self.imag = imag
         return self
 
-    def get_head_name(self):
-        return "System`Complex"
-
     def atom_to_boxes(self, f, evaluation):
         return self.format(evaluation, f.get_name())
 
@@ -765,9 +750,6 @@ class String(Atom):
 
     def __str__(self) -> str:
         return '"%s"' % self.value
-
-    def get_head_name(self):
-        return "System`String"
 
     def boxes_to_text(self, show_string_characters=False, **options) -> str:
         value = self.value

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1014,18 +1014,20 @@ class Expression(BaseExpression):
 
         new._timestamp_cache(evaluation)
 
-        # Step 5: Would the operation benefit running in separate threads?
+        # Step 5: Must we need to thread-rewrite the expression?
         #
-        # We allow threading in when head has the ``Listable``
-        # Attribute.  Here ``Expression.thread`` changes:
-        #  ``F[{a,b,c,...}]`` to:
+        # Threading is needed when head has the ``Listable``
+        # Attribute.  ``Expression.thread`` rewrites the expression:
+        #  ``F[{a,b,c,...}]`` as:
         #  ``{F[a], F[b], F[c], ...}``.
 
-        # TODO: For a small number of arguments threading is just overhead.
-        # For zero or one argument this is always the case.
-        # For two arguments, note that many listable functions are binary operators
-        # so two arguments is really the same as one argument and threading is overhead.
+        # Note: Threading here is different from Python or OS threads,
+        # even though the intent of this attribute was to allow for
+        # hardware threading to make use of more cores.
         #
+        # Right now, we do not make use of Python thread or hardware
+        # threading.  Still, we need to perform this rewrite to
+        # maintain correct semantic behavior.
         if listable & attributes:
             done, threaded = new.thread(evaluation)
             if done:


### PR DESCRIPTION
Small stuff.

With respect to `get_head_name()` this is in the class hierarchy and does the right thing (use the class name) for all of the functions removed. This function seems to be used mostly in `has_form()` but right now doesn't seem to be used very much. 

I did check that the custom functions give the same result as when they are removed.

With respect th threading, note the fact this has to do with expression transformation and is _not_ optional (as it would be for hardware threading).  Alas, right now don't do any sort of Python/OS threading so which seems to be what a large part of the motivation in the language for adding this. 