### PR TITLE
BaseExpression -> BaseElement, move some methods out of BaseExpression (into Atom)

### DIFF
--- a/mathics/algorithm/optimizers.py
+++ b/mathics/algorithm/optimizers.py
@@ -16,7 +16,7 @@ from mathics.core.atoms import (
     from_python,
 )
 
-from mathics.core.symbols import SymbolTrue, BaseExpression
+from mathics.core.symbols import SymbolTrue, BaseElement
 
 from mathics.core.systemsymbols import (
     SymbolAutomatic,
@@ -362,7 +362,7 @@ native_findroot_methods = {
 
 
 def is_zero(
-    val: BaseExpression,
+    val: BaseElement,
     acc_goal: Optional[Real],
     prec_goal: Optional[Real],
     evaluation: Evaluation,
@@ -379,7 +379,7 @@ def is_zero(
     if not (acc_goal or prec_goal):
         return False
 
-    eps_expr: BaseExpression = Integer10 ** (-prec_goal) if prec_goal else Integer0
+    eps_expr: BaseElement = Integer10 ** (-prec_goal) if prec_goal else Integer0
     if acc_goal:
         eps_expr = eps_expr + Integer10 ** (-acc_goal) / abs(val)
     threeshold_expr = Expression(SymbolLog, eps_expr)

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -19,7 +19,7 @@ from mathics.core.definitions import Definition
 from mathics.core.parser.util import SystemDefinitions, PyMathicsDefinitions
 from mathics.core.rules import Rule, BuiltinRule, Pattern
 from mathics.core.symbols import (
-    BaseExpression,
+    BaseElement,
     Symbol,
     ensure_context,
     strip_context,
@@ -162,7 +162,7 @@ class Builtin(object):
                 BuiltinRule(name, pattern, function, check_options, system=True)
             )
         for pattern, replace in self.rules.items():
-            if not isinstance(pattern, BaseExpression):
+            if not isinstance(pattern, BaseElement):
                 pattern = pattern % {"name": name}
                 pattern = parse_builtin_rule(pattern, definition_class)
             replace = replace % {"name": name}
@@ -214,7 +214,7 @@ class Builtin(object):
             for form in forms:
                 if form not in formatvalues:
                     formatvalues[form] = []
-                if not isinstance(pattern, BaseExpression):
+                if not isinstance(pattern, BaseElement):
                     pattern = pattern % {"name": name}
                     pattern = parse_builtin_rule(pattern)
                 replace = replace % {"name": name}

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -470,7 +470,7 @@ class Read(Builtin):
             ["+", "-", ".", "e", "E", "^", "*"] + [str(i) for i in range(10)],
         )
 
-        from mathics.core.expression import BaseExpression
+        from mathics.core.expression import BaseElement
         from mathics_scanner.errors import IncompleteSyntaxError, InvalidSyntaxError
         from mathics.core.parser import MathicsMultiLineFeeder, parse
 
@@ -508,7 +508,7 @@ class Read(Builtin):
                             "Read", "readt", tmp, Expression("InputSteam", name, n)
                         )
                         return SymbolFailed
-                    elif isinstance(expr, BaseExpression):
+                    elif isinstance(expr, BaseElement):
                         if typ is Symbol("HoldExpression"):
                             expr = Expression("Hold", expr)
                         result.append(expr)

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -42,7 +42,7 @@ from mathics.core.number import dps, machine_epsilon
 from mathics.core.rules import Pattern
 
 from mathics.core.symbols import (
-    BaseExpression,
+    BaseElement,
     Symbol,
     SymbolFalse,
     SymbolList,
@@ -2272,7 +2272,7 @@ class NIntegrate(Builtin):
 
 
 def is_zero(
-    val: BaseExpression,
+    val: BaseElement,
     acc_goal: Optional[Real],
     prec_goal: Optional[Real],
     evaluation: Evaluation,
@@ -2289,7 +2289,7 @@ def is_zero(
     if not (acc_goal or prec_goal):
         return False
 
-    eps_expr: BaseExpression = Integer10 ** (-prec_goal) if prec_goal else Integer0
+    eps_expr: BaseElement = Integer10 ** (-prec_goal) if prec_goal else Integer0
     if acc_goal:
         eps_expr = eps_expr + Integer10 ** (-acc_goal) / abs(val)
     threeshold_expr = Expression(SymbolLog, eps_expr)

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1603,19 +1603,19 @@ class OptionsPattern(PatternObject):
         return [leaf for leaf in leaves if _match(leaf)]
 
 
-class _StopGeneratorBaseExpressionIsFree(StopGenerator):
+class _StopGeneratorBaseElementIsFree(StopGenerator):
     pass
 
 
 def item_is_free(item, form, evaluation):
     # for vars, rest in form.match(self, {}, evaluation, fully=False):
     def yield_match(vars, rest):
-        raise _StopGeneratorBaseExpressionIsFree(False)
+        raise _StopGeneratorBaseElementIsFree(False)
         # return False
 
     try:
         form.match(yield_match, item, {}, evaluation, fully=False)
-    except _StopGeneratorBaseExpressionIsFree as exc:
+    except _StopGeneratorBaseElementIsFree as exc:
         return exc.value
 
     if item.is_atom():

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 from mathics.core.formatter import encode_mathml, encode_tex, extra_operators
 from mathics.core.symbols import (
     Atom,
-    BaseExpression,
+    BaseElement,
     NumericOperators,
     Symbol,
     SymbolHoldForm,
@@ -1021,7 +1021,7 @@ def from_python(arg):
     from mathics.builtin.base import BoxConstruct
     from mathics.core.expression import Expression
 
-    if isinstance(arg, (BaseExpression, BoxConstruct)):
+    if isinstance(arg, (BaseElement, BoxConstruct)):
         return arg
 
     number_type = get_type(arg)

--- a/mathics/core/convert.py
+++ b/mathics/core/convert.py
@@ -3,7 +3,7 @@
 
 """
 Converts expressions from SymPy to Mathics expressions.
-Conversion to SymPy is handled directly in BaseExpression descendants.
+Conversion to SymPy is handled directly in BaseElement descendants.
 """
 
 import sympy

--- a/mathics/core/evaluators.py
+++ b/mathics/core/evaluators.py
@@ -12,7 +12,7 @@ algorithms.
 import sympy
 from typing import Optional
 from mathics.core.atoms import Number
-from mathics.core.symbols import BaseExpression
+from mathics.core.symbols import BaseElement
 from mathics.core.systemsymbols import SymbolMachinePrecision, SymbolN
 from mathics.core.number import get_precision, PrecisionValueError
 from mathics.core.expression import Expression
@@ -27,10 +27,10 @@ from mathics.core.attributes import (
 
 
 def apply_N(
-    expression: BaseExpression,
+    expression: BaseElement,
     evaluation: Evaluation,
-    prec: BaseExpression = SymbolMachinePrecision,
-) -> BaseExpression:
+    prec: BaseElement = SymbolMachinePrecision,
+) -> BaseElement:
     """
     Equivalent to Expression("N", expression).evaluate(evaluation)
     """
@@ -44,8 +44,8 @@ def apply_N(
 
 
 def apply_nvalues(
-    expr: BaseExpression, prec: BaseExpression, evaluation: Evaluation
-) -> Optional[BaseExpression]:
+    expr: BaseElement, prec: BaseElement, evaluation: Evaluation
+) -> Optional[BaseElement]:
     """
     Looks for the numeric value of ```expr`` with precision ``prec`` by appling NValues rules
     stored in ``evaluation.definitions``.

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -18,7 +18,7 @@ from mathics.core.interrupt import ReturnInterrupt
 from mathics.core.number import dps
 from mathics.core.symbols import (
     Atom,
-    BaseExpression,
+    BaseElement,
     Monomial,
     NumericOperators,
     Symbol,
@@ -157,12 +157,12 @@ class ExpressionCache:
         )
 
 
-class Expression(BaseExpression, NumericOperators):
+class Expression(BaseElement, NumericOperators):
     head: "Symbol"
     leaves: typing.List[Any]
     _sequences: Any
 
-    # __new__ seems to be used because BaseExpression does some
+    # __new__ seems to be used because BaseElement does some
     # questionable stuff using new.
     # See if there's a way to get rid of this, or ensure that this isn't causing
     # a garbage collection problem.
@@ -324,13 +324,13 @@ class Expression(BaseExpression, NumericOperators):
             return self._elements[0].equal2(rhs._elements[0])
         return None
 
-    # Note that the return type is some subclass of BaseExpression, it could be
-    # a Real, an Expression, etc. It probably will *not* be a BaseExpression since
+    # Note that the return type is some subclass of BaseElement, it could be
+    # a Real, an Expression, etc. It probably will *not* be a BaseElement since
     # the point of evaluation when there is not an error is to produce a concrete result.
     def evaluate(
         self,
         evaluation: Evaluation,
-    ) -> typing.Type["BaseExpression"]:
+    ) -> typing.Type["BaseElement"]:
         """Apply transformation rules and expression evaluation to `evaluation` via
         `rewrite_apply_eval_step()` until it tells us to stop or we hit some limit.
 
@@ -381,7 +381,7 @@ class Expression(BaseExpression, NumericOperators):
                 # step in the evaluation, and determines if a fixed point
                 # was reached (reevaluate->False).
                 # Notice that evaluate_next calls ``evaluate``
-                # for the other ``BaseExpression`` subclasses.
+                # for the other ``BaseElement`` subclasses.
                 expr, reevaluate = expr.rewrite_apply_eval_step(evaluation)
 
                 if not reevaluate:
@@ -1134,7 +1134,7 @@ class Expression(BaseExpression, NumericOperators):
     #  Expr8: Expression("Plus", n1,..., n1)           (nontrivial evaluation to a long expression, with just undefined symbols)
     #
 
-    def sameQ(self, other: BaseExpression) -> bool:
+    def sameQ(self, other: BaseElement) -> bool:
         """Mathics SameQ"""
         if not isinstance(other, Expression):
             return False
@@ -1564,7 +1564,7 @@ class Expression(BaseExpression, NumericOperators):
                 element.is_numeric() for element in self._elements
             )
 
-    def numerify(self, evaluation) -> "BaseExpression":
+    def numerify(self, evaluation) -> "BaseElement":
         """
         Produces a new expression equivalent to the original,
         s.t. inexact numeric elements are reduced to Real numbers with
@@ -1633,7 +1633,7 @@ def _create_expression(self, head, *elements):
     return Expression(head, *elements)
 
 
-BaseExpression.create_expression = _create_expression
+BaseElement.create_expression = _create_expression
 
 
 def get_default_value(name, evaluation, k=None, n=None):

--- a/mathics/core/subexpression.py
+++ b/mathics/core/subexpression.py
@@ -62,7 +62,7 @@ def _pspec_span_to_tuple(pspec, expr):
 class ExpressionPointer(object):
     """
     This class represents a reference to a leaf in an expression.
-    Supports a minimal part of the basic interface of `mathics.core.symbols.BaseExpression`.
+    Supports a minimal part of the basic interface of `mathics.core.symbols.BaseElement`.
     """
 
     def __init__(self, expr, pos=None):

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -75,7 +75,7 @@ def strip_context(name) -> str:
 # FIXME: move to new module element.py
 class NumericOperators:
     """
-    These methods are were intented to facilite building
+    This is a mixin class that adds methods to the class to facilite building
     ``Expression``s in Mathics code using Python syntax. For example,
     instead of writing:
         Expression("Abs", -8)
@@ -83,7 +83,7 @@ class NumericOperators:
         abs(Integer(-8))
     """
 
-    def __abs__(self) -> "BaseExpression":
+    def __abs__(self) -> "BaseElement":
         return self.create_expression("Abs", self)
 
     def __pos__(self):
@@ -92,30 +92,30 @@ class NumericOperators:
     def __neg__(self):
         return self.create_expression("Times", self, -1)
 
-    def __add__(self, other) -> "BaseExpression":
+    def __add__(self, other) -> "BaseElement":
         return self.create_expression("Plus", self, other)
 
-    def __sub__(self, other) -> "BaseExpression":
+    def __sub__(self, other) -> "BaseElement":
         return self.create_expression(
             "Plus", self, self.create_expression("Times", other, -1)
         )
 
-    def __mul__(self, other) -> "BaseExpression":
+    def __mul__(self, other) -> "BaseElement":
         return self.create_expression("Times", self, other)
 
-    def __truediv__(self, other) -> "BaseExpression":
+    def __truediv__(self, other) -> "BaseElement":
         return self.create_expression("Divide", self, other)
 
-    def __floordiv__(self, other) -> "BaseExpression":
+    def __floordiv__(self, other) -> "BaseElement":
         return self.create_expression(
             "Floor", self.create_expression("Divide", self, other)
         )
 
-    def __pow__(self, other) -> "BaseExpression":
+    def __pow__(self, other) -> "BaseElement":
         return self.create_expression("Power", self, other)
 
 
-# FIXME: figure out how to split off KeyComparible, BaseExpression and
+# FIXME: figure out how to split off KeyComparible, BaseElement and
 # Atom from Symbol which is really more "variable"-like in the more
 # conventional programming sense of the word.  Also Split off
 # SymbolLiteral (the Lisp notion of Symbol, an immutable object like a
@@ -169,11 +169,11 @@ class KeyComparable(object):
         ) or self.get_sort_key() != other.get_sort_key()
 
 
-class BaseExpression(KeyComparable):
+class BaseElement(KeyComparable):
     """
     This is the base class from which all other Expressions are
     derived from.  If you think of an Expression as tree-like, then a
-    BaseExpression is a node in the tree.
+    BaseElement is a node in the tree.
 
     This class is not complete in of itself and subclasses should adapt or fill in
     what is needed
@@ -201,7 +201,7 @@ class BaseExpression(KeyComparable):
 
     def apply_rules(
         self, rules, evaluation, level=0, options=None
-    ) -> typing.Tuple["BaseExpression", bool]:
+    ) -> typing.Tuple["BaseElement", bool]:
         """
         Tries to apply one by one the rules in `rules`.
         If one of the rules matches, returns the result and the flag True.
@@ -350,29 +350,20 @@ class BaseExpression(KeyComparable):
             return self == rhs
         return None
 
-    def evaluate(self, evaluation) -> "BaseExpression":
+    def evaluate(self, evaluation) -> "BaseElement":
         """Returns the value of the expression. The subclass must implement this"""
         raise NotImplementedError
 
     # comment @mmatera: This just makes sense if the Expression has elements...
     # rocky: however it is currently getting called when on Atoms; so more work
     # is needed to remove this, probably by fixing the callers.
-    def evaluate_elements(self, evaluation) -> "BaseExpression":
+    def evaluate_elements(self, evaluation) -> "BaseElement":
         """
         Create a new expression by evaluating the head and elements of self.
         """
         return self
 
-    def flatten(self, head, pattern_only=False, callback=None) -> "BaseExpression":
-        return self
-
-    def flatten_sequence(self, evaluation) -> "BaseExpression":
-        return self
-
-    def flatten_pattern_sequence(self, evaluation) -> "BaseExpression":
-        return self
-
-    def format(self, evaluation, form, **kwargs) -> "BaseExpression":
+    def format(self, evaluation, form, **kwargs) -> "BaseElement":
         """
         Applies formats associated to the expression, and then calls Makeboxes
         """
@@ -443,7 +434,7 @@ class BaseExpression(KeyComparable):
         If self is not an expression,
         """
         # comment @mmatera: The implementation of this is awfull.
-        # This general method (in BaseExpression) should be simpler (Numbers does not have Options).
+        # This general method (in BaseElement) should be simpler (Numbers does not have Options).
         # The implementation should be move to Symbol and Expression classes.
 
         from mathics.core.atoms import String
@@ -708,7 +699,7 @@ class Monomial(object):
         return 0
 
 
-class Atom(BaseExpression):
+class Atom(BaseElement):
     """
     Atoms are the leaves (in the common tree sense, not the Mathics
     ``_elements`` sense) and Heads of an Expression or M-Expression.
@@ -751,7 +742,7 @@ class Atom(BaseExpression):
             return None
         return self == rhs
 
-    def evaluate(self, evaluation) -> "BaseExpression":
+    def evaluate(self, evaluation) -> "BaseElement":
         """Returns the value of the expression.
 
         The value of an Atom is itself.
@@ -759,6 +750,15 @@ class Atom(BaseExpression):
         return self
 
     rewrite_apply_eval = evaluate
+
+    def flatten(self, head, pattern_only=False, callback=None) -> "BaseElement":
+        return self
+
+    def flatten_sequence(self, evaluation) -> "BaseElement":
+        return self
+
+    def flatten_pattern_sequence(self, evaluation) -> "BaseElement":
+        return self
 
     def get_atom_name(self) -> str:
         return self.__class__.__name__

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -354,11 +354,13 @@ class BaseExpression(KeyComparable):
         """Returns the value of the expression. The subclass must implement this"""
         raise NotImplementedError
 
+    # comment @mmatera: This just makes sense if the Expression has elements...
+    # rocky: however it is currently getting called when on Atoms; so more work
+    # is needed to remove this, probably by fixing the callers.
     def evaluate_elements(self, evaluation) -> "BaseExpression":
         """
         Create a new expression by evaluating the head and elements of self.
         """
-        # comment @mmatera: Just make sense if the Expression has elements...
         return self
 
     def flatten(self, head, pattern_only=False, callback=None) -> "BaseExpression":

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -354,15 +354,6 @@ class BaseElement(KeyComparable):
         """Returns the value of the expression. The subclass must implement this"""
         raise NotImplementedError
 
-    # comment @mmatera: This just makes sense if the Expression has elements...
-    # rocky: however it is currently getting called when on Atoms; so more work
-    # is needed to remove this, probably by fixing the callers.
-    def evaluate_elements(self, evaluation) -> "BaseElement":
-        """
-        Create a new expression by evaluating the head and elements of self.
-        """
-        return self
-
     def format(self, evaluation, form, **kwargs) -> "BaseElement":
         """
         Applies formats associated to the expression, and then calls Makeboxes
@@ -390,21 +381,8 @@ class BaseElement(KeyComparable):
     def get_attributes(self, definitions):
         return nothing
 
-    # Probably, this method shouldn't be here.
-    def get_elements(self):
-        return []
-
-    def has_changed(self, definitions):
-        return True
-
-    def get_head(self):
-        return None
-
     def get_head_name(self):
         raise NotImplementedError
-
-    # Compatibily with old code. Deprecated, but remove after a little bit.
-    get_leaves = get_elements
 
     def get_float_value(self, permit_complex=False):
         return None
@@ -515,6 +493,9 @@ class BaseElement(KeyComparable):
 
     def get_string_value(self):
         return None
+
+    def has_changed(self, definitions):
+        return True
 
     @property
     def is_zero(self) -> bool:
@@ -749,15 +730,22 @@ class Atom(BaseElement):
         """
         return self
 
-    rewrite_apply_eval = evaluate
-
-    def flatten(self, head, pattern_only=False, callback=None) -> "BaseElement":
+    # comment @mmatera: This just makes sense if the Expression has elements...
+    # rocky: It is currently getting called when on Atoms; so more work
+    # is needed to remove this, probably by fixing the callers.
+    def evaluate_elements(self, evaluation) -> "Atom":
+        """
+        Create a new expression by evaluating the head and elements of self.
+        """
         return self
 
-    def flatten_sequence(self, evaluation) -> "BaseElement":
+    def flatten(self, head, pattern_only=False, callback=None) -> "Atom":
         return self
 
-    def flatten_pattern_sequence(self, evaluation) -> "BaseElement":
+    def flatten_sequence(self, evaluation) -> "Atom":
+        return self
+
+    def flatten_pattern_sequence(self, evaluation) -> "Atom":
         return self
 
     def get_atom_name(self) -> str:
@@ -765,6 +753,14 @@ class Atom(BaseElement):
 
     def get_atoms(self, include_heads=True) -> typing.List["Atom"]:
         return [self]
+
+    # We seem to need this because the caller doesn't distinguish something with elements
+    # from a single atom.
+    def get_elements(self):
+        return []
+
+    # Compatibility with old code. Deprecated, but remove after a little bit.
+    get_leaves = get_elements
 
     def get_head(self) -> "Symbol":
         return Symbol(self.class_head_name)


### PR DESCRIPTION
And lastly reorder methods in the Expression class alphabetically. 

@mmatera since you asked about this, here is how this was useful in the PR alone. 

I wanted to know which methods of BaseElement are also listed in Expression. Those that are candidates for moving into Atom.

Having these two sets of methods sorted alphabetically made it possible for me to detet this. 