### PR TITLE
Reduce BaseElement interface

### DIFF
--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -6,7 +6,7 @@ Algorithms to access and manipulate elements in nested lists / expressions
 
 
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol
+from mathics.core.symbols import Atom, Symbol
 from mathics.core.atoms import Integer
 from mathics.core.systemsymbols import SymbolInfinity
 from mathics.core.subexpression import SubExpression
@@ -39,7 +39,7 @@ def get_part(varlist, indices):
 
     def rec(cur, rest):
         if rest:
-            if cur.is_atom():
+            if isinstance(cur, Atom):
                 raise PartDepthError(rest[0])
             pos = rest[0]
             elements = cur.get_elements()
@@ -65,7 +65,7 @@ def set_part(varlist, indices, newval):
     def rec(cur, rest):
         if len(rest) > 1:
             pos = rest[0]
-            if cur.is_atom():
+            if isinstance(cur, Atom):
                 raise PartDepthError
             try:
                 if pos > 0:
@@ -79,7 +79,7 @@ def set_part(varlist, indices, newval):
             return rec(part, rest[1:])
         elif len(rest) == 1:
             pos = rest[0]
-            if cur.is_atom():
+            if isinstance(cur, Atom):
                 raise PartDepthError
             try:
                 if pos > 0:
@@ -103,7 +103,7 @@ def _parts_all_selector():
     step = 1
 
     def select(inner):
-        if inner.is_atom():
+        if isinstance(inner, Atom):
             raise MessageException("Part", "partd")
         py_slice = python_seq(start, stop, step, len(inner.leaves))
         if py_slice is None:
@@ -142,7 +142,7 @@ def _parts_span_selector(pspec):
         raise MessageException("Part", "span", pspec)
 
     def select(inner):
-        if inner.is_atom():
+        if isinstance(inner, Atom):
             raise MessageException("Part", "partd")
         py_slice = python_seq(start, stop, step, len(inner.leaves))
         if py_slice is None:
@@ -166,7 +166,7 @@ def _parts_sequence_selector(pspec):
             raise MessageException("Part", "pspec", pspec)
 
     def select(inner):
-        if inner.is_atom():
+        if isinstance(inner, Atom):
             raise MessageException("Part", "partd")
 
         leaves = inner.leaves
@@ -304,7 +304,7 @@ def walk_levels(
     include_pos=False,
     cur_pos=[],
 ):
-    if expr.is_atom():
+    if isinstance(expr, Atom):
         depth = 0
         new_expr = expr
     else:
@@ -476,7 +476,7 @@ def _drop_take_selector(name, seq, sliced):
 
     def select(inner):
         start, stop, step = seq_tuple
-        if inner.is_atom():
+        if isinstance(inner, Atom):
             py_slice = None
         else:
             py_slice = python_seq(start, stop, step, len(inner.leaves))
@@ -561,7 +561,7 @@ def deletecases_with_levelspec(expr, pattern, evaluation, levelspec=1, n=-1):
             curr_index[-1] = curr_index[-1] + 1
             n = n - 1
             continue
-        if curr_element.is_atom() or lsmax == len(curr_index):
+        if isinstance(curr_element, Atom) or lsmax == len(curr_index):
             curr_index[-1] = curr_index[-1] + 1
             continue
         else:
@@ -609,7 +609,7 @@ def find_matching_indices_with_levelspec(expr, pattern, evaluation, levelspec=1,
             curr_index[-1] = curr_index[-1] + 1
             n = n - 1
             continue
-        if curr_element.is_atom() or lsmax == len(curr_index):
+        if isinstance(curr_element, Atom) or lsmax == len(curr_index):
             curr_index[-1] = curr_index[-1] + 1
             continue
         else:

--- a/mathics/algorithm/series.py
+++ b/mathics/algorithm/series.py
@@ -1,4 +1,4 @@
-from mathics.core.symbols import Symbol, SymbolList
+from mathics.core.symbols import Atom, Symbol, SymbolList
 from mathics.core.atoms import Integer, Integer0, Rational
 from mathics.core.expression import Expression
 from mathics.core.rules import Pattern
@@ -42,7 +42,7 @@ def to_series_term(series, term, x, x0):
     coeff = None
     power = None
     reminder = None
-    if term.is_atom():
+    if isinstance(term, Atom):
         if term.sameQ(x):
             coeff = Integer1
             power = 1
@@ -80,7 +80,7 @@ def to_series_term(series, term, x, x0):
             for leaf in leaves:
                 if x.sameQ(leaf):
                     coeffs_x.append(x)
-                elif leaf.is_atom():
+                elif isinstance(leaf, Atom):
                     coeffs_free.append(leaf)
                 elif leaf.get_head() is SymbolPower:
                     coeffs_powers.append(leaf)
@@ -315,7 +315,7 @@ def reduce_series_plus(series, terms, x, x0):
     for term in terms:
         if term.is_zero:
             continue
-        if term.is_atom():
+        if isinstance(term, Atom):
             other_terms.append(term)
             continue
         term_head = term.head

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -40,7 +40,7 @@ from mathics.core.atoms import (
     from_mpmath,
     from_python,
 )
-from mathics.core.symbols import Symbol, SymbolFalse, SymbolList, SymbolTrue
+from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolList, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolUndefined,
 )
@@ -1427,7 +1427,7 @@ class ConditionalExpression(Builtin):
         # What we need here is a way to evaluate
         # cond as a predicate, using assumptions.
         # Let's delegate this to the And (and Or) symbols...
-        if not cond.is_atom() and cond._head is SymbolList:
+        if not isinstance(cond, Atom) and cond._head is SymbolList:
             cond = Expression("System`And", *(cond._elements))
         else:
             cond = Expression("System`And", cond)

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1370,7 +1370,7 @@ class Assuming(Builtin):
         assumptions = assumptions.evaluate(evaluation)
         if assumptions.is_true():
             cond = []
-        elif assumptions.is_symbol() or not assumptions.has_form("List", None):
+        elif isinstance(assumptions, Symbol) or not assumptions.has_form("List", None):
             cond = [assumptions]
         else:
             cond = assumptions._elements

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -10,6 +10,7 @@ from mathics.builtin.base import (
 )
 from mathics.core.expression import Expression
 from mathics.core.symbols import (
+    Atom,
     Symbol,
     system_symbols,
 )
@@ -270,7 +271,7 @@ class Unset(PostfixOperator):
             evaluation.message("Unset", "usraw", expr)
             return SymbolFailed
         if not evaluation.definitions.unset(name, expr):
-            if not expr.is_atom():
+            if not isinstance(expr, Atom):
                 evaluation.message("Unset", "norep", expr, Symbol(name))
                 return SymbolFailed
         return Symbol("Null")

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -630,7 +630,7 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
         tags = [name]
     elif upset:
         tags = []
-        if focus.is_atom():
+        if isinstance(focus, Atom):
             evaluation.message(self.get_name(), "normal")
             raise AssignmentException(lhs, None)
         for leaf in focus.leaves:

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -639,15 +639,15 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
     else:
         allowed_names = [focus.get_lookup_name()]
         for element in focus.get_elements():
-            if not element.is_symbol() and element.get_head_name() in (
+            if not isinstance(element, Symbol) and element.get_head_name() in (
                 "System`HoldPattern",
             ):
                 element = element.leaves[0]
-            if not element.is_symbol() and element.get_head_name() in (
+            if not isinstance(element, Symbol) and element.get_head_name() in (
                 "System`Pattern",
             ):
                 element = element.leaves[1]
-            if not element.is_symbol() and element.get_head_name() in (
+            if not isinstance(element, Symbol) and element.get_head_name() in (
                 "System`Blank",
                 "System`BlankSequence",
                 "System`BlankNullSequence",

--- a/mathics/builtin/atomic/atomic.py
+++ b/mathics/builtin/atomic/atomic.py
@@ -8,6 +8,8 @@ from mathics.builtin.base import (
     Test,
 )
 
+from mathics.core.atoms import Atom
+
 
 class AtomQ(Test):
     """
@@ -56,7 +58,7 @@ class AtomQ(Test):
     summary_text = "tests whether an expression is an atom"
 
     def test(self, expr):
-        return expr.is_atom()
+        return isinstance(expr, Atom)
 
 
 class Head(Builtin):

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -611,9 +611,6 @@ class BoxConstruct(InstanceableBuiltin):
         """Mathics SameQ"""
         return expr.sameQ(self)
 
-    def is_atom(self):
-        return False
-
     def do_format(self, evaluation, format):
         return self
 

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -24,12 +24,11 @@ from mathics.core.expression import Expression
 from mathics.core.atoms import (
     COMPARE_PREC,
     Complex,
-    Integer,
     Integer0,
     Integer1,
     Number,
 )
-from mathics.core.symbols import Symbol, SymbolFalse, SymbolTrue
+from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolDirectedInfinity,
     SymbolInfinity,
@@ -125,7 +124,7 @@ class _EqualityOperator(_InequalityOperator):
                 )
         if rhs.is_numeric():
             return False
-        elif rhs.is_atom():
+        elif isinstance(rhs, Atom):
             return None
         if rhs.get_head().sameQ(lhs.get_head()):
             dir1 = dir2 = Integer1

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -661,7 +661,16 @@ class ImageRotate(_ImageBuiltin):
 
     def apply(self, image, angle, evaluation):
         "ImageRotate[image_Image, angle_]"
-        py_angle = angle.round_to_float(evaluation)
+
+        # FIXME: this test I suppose is okay in that it checks more or less what is needed.
+        # However there might be a better test like for Real-valued-ness which could be used
+        # instead.
+        py_angle = (
+            angle.round_to_float(evaluation)
+            if hasattr(angle, "round_to_float")
+            else None
+        )
+
         if py_angle is None:
             return evaluation.message("ImageRotate", "imgang", angle)
 

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -381,7 +381,7 @@ class _Plot(Builtin):
     def apply(self, functions, x, start, stop, evaluation, options):
         """%(name)s[functions_, {x_Symbol, start_, stop_},
         OptionsPattern[%(name)s]]"""
-        if functions.is_symbol() and functions.name is not x.get_name():
+        if isinstance(functions, Symbol) and functions.name is not x.get_name():
             rules = evaluation.definitions.get_ownvalues(functions.name)
             for rule in rules:
                 functions = rule.apply(functions, evaluation, fully=True)
@@ -389,7 +389,7 @@ class _Plot(Builtin):
         if functions.get_head_name() == "List":
             functions_param = self.get_functions_param(functions)
             for index, f in enumerate(functions_param):
-                if f.is_symbol() and f.name is not x.get_name():
+                if isinstance(f, Symbol) and f.name is not x.get_name():
                     rules = evaluation.definitions.get_ownvalues(f.name)
                     for rule in rules:
                         f = rule.apply(f, evaluation, fully=True)

--- a/mathics/builtin/functional.py
+++ b/mathics/builtin/functional.py
@@ -15,6 +15,7 @@ from mathics.builtin.base import Builtin, PostfixOperator
 from mathics.core.expression import Expression
 
 from mathics.core.attributes import flat, hold_all, n_hold_all, one_identity, protected
+from mathics.core.symbols import Symbol
 
 
 class Function(PostfixOperator):
@@ -87,7 +88,7 @@ class Function(PostfixOperator):
         else:
             vars = [vars]
 
-        # print([v.get_head_name()=="System`Pattern" or v.is_symbol() for v in vars])
+        # print([v.get_head_name()=="System`Pattern" or isinstance(v, Symbol) for v in vars])
         args = args.get_sequence()
         if len(vars) > len(args):
             evaluation.message("Function", "fpct")
@@ -96,7 +97,7 @@ class Function(PostfixOperator):
             # this is not included in WL, and here does not have any impact, but it is needed for
             # translating the function to a compiled version.
             var_names = (
-                var.get_name() if var.is_symbol() else var.leaves[0].get_name()
+                var.get_name() if isinstance(var, Symbol) else var.leaves[0].get_name()
                 for var in vars
             )
             vars = dict(list(zip(var_names, args[: len(vars)])))

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -3,6 +3,7 @@
 
 from mathics.core.expression import Expression
 from mathics.core.symbols import (
+    Atom,
     SymbolTrue,
     SymbolFalse,
 )
@@ -123,7 +124,7 @@ def get_assumptions_list(evaluation):
     if assumptions is None:
         return None
 
-    if assumptions.is_atom() or not assumptions.has_form("List", None):
+    if isinstance(assumptions, Atom) or not assumptions.has_form("List", None):
         assumptions = (assumptions,)
     else:
         assumptions = assumptions._elements

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -12,6 +12,7 @@ from mathics.core.rules import Rule
 from mathics.core.parser.util import SystemDefinitions
 
 from mathics.core.parser import parse_builtin_rule
+from mathics.core.symbols import Symbol
 
 # TODO: Extend these rules?
 
@@ -147,7 +148,7 @@ def logical_expand_assumptions(assumptions_list, evaluation):
     new_assumptions_list = []
     changed = False
     for assumption in assumptions_list:
-        if assumption.is_symbol():
+        if isinstance(assumption, Symbol):
             if assumption.is_true():
                 changed = True
                 continue

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -27,7 +27,14 @@ from mathics.builtin.lists import list_boxes
 from mathics.builtin.options import options_to_rules
 
 from mathics.core.expression import Expression, BoxError
-from mathics.core.symbols import Symbol, SymbolList, SymbolTrue, SymbolFalse, SymbolNull
+from mathics.core.symbols import (
+    Atom,
+    Symbol,
+    SymbolList,
+    SymbolTrue,
+    SymbolFalse,
+    SymbolNull,
+)
 
 from mathics.core.atoms import (
     String,
@@ -580,7 +587,7 @@ class MakeBoxes(Builtin):
         """MakeBoxes[expr_,
         f:TraditionalForm|StandardForm|OutputForm|InputForm|FullForm]"""
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return expr.atom_to_boxes(f, evaluation)
         else:
             head = expr.head

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -11,7 +11,7 @@ It is closely related to many other areas of mathematics and has many applicatio
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.atoms import Integer
-from mathics.core.symbols import Symbol, SymbolFalse, SymbolTrue
+from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolTrue
 from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.core.attributes import listable, numeric_function, orderless, protected
 from itertools import combinations
@@ -395,7 +395,7 @@ class Subsets(Builtin):
 
         return (
             evaluation.message("Subsets", "normal", Expression("Subsets", list))
-            if list.is_atom()
+            if isinstance(list, Atom)
             else self.apply_1(list, Integer(len(list.leaves)), evaluation)
         )
 
@@ -403,7 +403,7 @@ class Subsets(Builtin):
         "Subsets[list_, n_]"
 
         expr = Expression("Subsets", list, n)
-        if list.is_atom():
+        if isinstance(list, Atom):
             return evaluation.message("Subsets", "normal", expr)
         else:
             head_t = list.head
@@ -426,7 +426,7 @@ class Subsets(Builtin):
 
         expr = Expression("Subsets", list, n)
 
-        if list.is_atom():
+        if isinstance(list, Atom):
             return evaluation.message("Subsets", "normal", expr)
         else:
             head_t = list.head

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -23,7 +23,7 @@ from mathics.core.expression import (
     structure,
 )
 from mathics.core.atoms import Integer
-from mathics.core.symbols import SymbolList
+from mathics.core.symbols import Atom, SymbolList
 
 from mathics.core.attributes import hold_first, listable, protected
 
@@ -148,7 +148,7 @@ class Normal(Builtin):
 
     def apply_general(self, expr, evaluation):
         "Normal[expr_]"
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return
         return Expression(
             expr.get_head(), *[Expression("Normal", leaf) for leaf in expr.leaves]
@@ -470,7 +470,7 @@ class Tuples(Builtin):
     def apply_n(self, expr, n, evaluation):
         "Tuples[expr_, n_Integer]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             evaluation.message("Tuples", "normal")
             return
         n = n.get_int_value()
@@ -499,7 +499,7 @@ class Tuples(Builtin):
         items = []
         for expr in exprs:
             evaluation.check_stopped()
-            if expr.is_atom():
+            if isinstance(expr, Atom):
                 evaluation.message("Tuples", "normal")
                 return
             items.append(expr.leaves)

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -32,7 +32,7 @@ from mathics.builtin.base import MessageException
 
 from mathics.core.expression import Expression
 from mathics.core.atoms import Integer, Integer0
-from mathics.core.symbols import Symbol, SymbolList, SymbolNull
+from mathics.core.symbols import Atom, Symbol, SymbolList, SymbolNull
 from mathics.core.systemsymbols import (
     SymbolFailed,
     SymbolMakeBoxes,
@@ -77,7 +77,7 @@ class Append(Builtin):
     def apply(self, expr, item, evaluation):
         "Append[expr_, item_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return evaluation.message("Append", "normal")
 
         return expr.restructure(
@@ -129,7 +129,7 @@ class AppendTo(Builtin):
         if s == resolved_s:
             return evaluation.message("AppendTo", "rvalue", s)
 
-        if not resolved_s.is_atom():
+        if not isinstance(resolved_s, Atom):
             result = Expression("Set", s, Expression("Append", resolved_s, item))
             return result.evaluate(evaluation)
 
@@ -195,7 +195,7 @@ class Cases(Builtin):
 
     def apply(self, items, pattern, ls, evaluation, options):
         "Cases[items_, pattern_, ls_:{1}, OptionsPattern[]]"
-        if items.is_atom():
+        if isinstance(items, Atom):
             return Expression(SymbolList)
 
         from mathics.builtin.patterns import Matcher
@@ -296,7 +296,7 @@ class DeleteCases(Builtin):
     def apply_ls_n(self, items, pattern, levelspec, n, evaluation):
         "DeleteCases[items_, pattern_, levelspec_:1, n_:System`Infinity]"
 
-        if items.is_atom():
+        if isinstance(items, Atom):
             evaluation.message("Select", "normal")
             return
         # If levelspec is specified to a non-trivial value,
@@ -401,7 +401,7 @@ class Drop(Builtin):
 
         seqs = seqs.get_sequence()
 
-        if items.is_atom():
+        if isinstance(items, Atom):
             return evaluation.message(
                 "Drop", "normal", 1, Expression("Drop", items, *seqs)
             )
@@ -441,7 +441,7 @@ class First(Builtin):
     def apply(self, expr, evaluation):
         "First[expr_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             evaluation.message("First", "normal")
             return
         if len(expr.leaves) == 0:
@@ -687,7 +687,7 @@ class Last(Builtin):
     def apply(self, expr, evaluation):
         "Last[expr_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             evaluation.message("Last", "normal")
             return
         if len(expr.leaves) == 0:
@@ -729,7 +729,7 @@ class Length(Builtin):
     def apply(self, expr, evaluation):
         "Length[expr_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return Integer0
         else:
             return Integer(len(expr.leaves))
@@ -784,7 +784,7 @@ class Most(Builtin):
     def apply(self, expr, evaluation):
         "Most[expr_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             evaluation.message("Most", "normal")
             return
         return expr.slice(expr.head, slice(0, -1), evaluation)
@@ -986,7 +986,7 @@ class Pick(Builtin):
             for x, s in zip(items, sel):
                 if match(s):
                     yield x
-                elif not x.is_atom() and not s.is_atom():
+                elif not isinstance(x, Atom) and not isinstance(s, Atom):
                     yield x.restructure(x.head, pick(x.leaves, s.leaves), evaluation)
 
         r = list(pick([items0], [sel0]))
@@ -1038,7 +1038,7 @@ class Prepend(Builtin):
     def apply(self, expr, item, evaluation):
         "Prepend[expr_, item_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return evaluation.message("Prepend", "normal")
 
         return expr.restructure(
@@ -1102,7 +1102,7 @@ class PrependTo(Builtin):
         if s == resolved_s:
             return evaluation.message("PrependTo", "rvalue", s)
 
-        if not resolved_s.is_atom():
+        if not isinstance(resolved_s, Atom):
             result = Expression("Set", s, Expression("Prepend", resolved_s, item))
             return result.evaluate(evaluation)
 
@@ -1231,7 +1231,7 @@ class Rest(Builtin):
     def apply(self, expr, evaluation):
         "Rest[expr_]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             evaluation.message("Rest", "normal")
             return
         if len(expr.leaves) == 0:
@@ -1349,7 +1349,7 @@ class Take(Builtin):
 
         seqs = seqs.get_sequence()
 
-        if items.is_atom():
+        if isinstance(items, Atom):
             return evaluation.message(
                 "Take", "normal", 1, Expression("Take", items, *seqs)
             )
@@ -1388,7 +1388,7 @@ class Select(Builtin):
     def apply(self, items, expr, evaluation):
         "Select[items_, expr_]"
 
-        if items.is_atom():
+        if isinstance(items, Atom):
             evaluation.message("Select", "normal")
             return
 

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -23,7 +23,7 @@ from mathics.core.expression import (
     structure,
 )
 from mathics.core.atoms import Integer
-from mathics.core.symbols import Atom, SymbolList
+from mathics.core.symbols import Atom, Symbol, SymbolList
 
 from mathics.core.attributes import flat, one_identity, protected
 
@@ -31,7 +31,7 @@ from mathics.core.attributes import flat, one_identity, protected
 def _is_sameq(same_test):
     # System`SameQ is protected, so nobody should ever be able to change
     # it (see Set::wrsym). We just check for its name here thus.
-    return same_test.is_symbol() and same_test.get_name() == "System`SameQ"
+    return isinstance(same_test, Symbol) and same_test.get_name() == "System`SameQ"
 
 
 class _DeleteDuplicatesBin:

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -23,7 +23,7 @@ from mathics.core.expression import (
     structure,
 )
 from mathics.core.atoms import Integer
-from mathics.core.symbols import SymbolList
+from mathics.core.symbols import Atom, SymbolList
 
 from mathics.core.attributes import flat, one_identity, protected
 
@@ -78,7 +78,7 @@ class _GatherOperation(Builtin):
             )
 
     def _check_list(self, values, arg2, evaluation):
-        if values.is_atom():
+        if isinstance(values, Atom):
             expr = Expression(self.get_name(), values, arg2)
             evaluation.message(self.get_name(), "normal", 1, expr)
             return False
@@ -182,7 +182,7 @@ class _SetOperation(Builtin):
         seq = lists.get_sequence()
 
         for pos, e in enumerate(seq):
-            if e.is_atom():
+            if isinstance(e, Atom):
                 return evaluation.message(
                     self.get_name(),
                     "normal",
@@ -445,7 +445,7 @@ class Join(Builtin):
         sequence = lists.get_sequence()
 
         for list in sequence:
-            if list.is_atom():
+            if isinstance(list, Atom):
                 return
             if head is not None and list.get_head() != head:
                 evaluation.message("Join", "heads", head, list.get_head())

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1211,7 +1211,8 @@ def _test_pair(test, a, b, evaluation, name):
     test_expr = Expression(test, a, b)
     result = test_expr.evaluate(evaluation)
     if not (
-        result.is_symbol() and (result.has_symbol("True") or result.has_symbol("False"))
+        isinstance(result, Symbol)
+        and (result.has_symbol("True") or result.has_symbol("False"))
     ):
         evaluation.message(name, "smtst", test_expr, result)
     return result.is_true()

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -65,6 +65,7 @@ from mathics.core.expression import Expression, structure
 
 from mathics.core.interrupt import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
 from mathics.core.symbols import (
+    Atom,
     Symbol,
     SymbolList,
     strip_context,
@@ -76,7 +77,6 @@ from mathics.core.systemsymbols import (
     SymbolByteArray,
     SymbolFailed,
     SymbolMakeBoxes,
-    SymbolRowBox,
     SymbolRule,
     SymbolSequence,
 )
@@ -556,7 +556,7 @@ class List(Builtin):
 
         items = items.get_sequence()
         return Expression(
-            SymbolRowBox, Expression(SymbolList, *list_boxes(items, f, "{", "}"))
+            "RowBox", Expression(SymbolList, *list_boxes(items, f, "{", "}"))
         )
 
 
@@ -607,7 +607,7 @@ def list_boxes(items, f, open=None, close=None):
         sep = ","
     result = riffle(result, String(sep))
     if len(items) > 1:
-        result = Expression(SymbolRowBox, Expression(SymbolList, *result))
+        result = Expression("RowBox", Expression(SymbolList, *result))
     elif items:
         result = result[0]
     if result:
@@ -680,7 +680,7 @@ class Split(Builtin):
 
         expr = Expression("Split", mlist, test)
 
-        if mlist.is_atom():
+        if isinstance(mlist, Atom):
             evaluation.message("Select", "normal", 1, expr)
             return
 
@@ -731,7 +731,7 @@ class SplitBy(Builtin):
 
         expr = Expression("Split", mlist, func)
 
-        if mlist.is_atom():
+        if isinstance(mlist, Atom):
             evaluation.message("Select", "normal", 1, expr)
             return
 
@@ -755,7 +755,7 @@ class SplitBy(Builtin):
         "SplitBy[mlist_, funcs_List]"
         expr = Expression("Split", mlist, funcs)
 
-        if mlist.is_atom():
+        if isinstance(mlist, Atom):
             evaluation.message("Select", "normal", 1, expr)
             return
 
@@ -1117,7 +1117,7 @@ class Join(Builtin):
         sequence = lists.get_sequence()
 
         for list in sequence:
-            if list.is_atom():
+            if isinstance(list, Atom):
                 return
             if head is not None and list.get_head() != head:
                 evaluation.message("Join", "heads", head, list.get_head())
@@ -2469,7 +2469,7 @@ class SubsetQ(Builtin):
     def apply(self, expr, subset, evaluation):
         "SubsetQ[expr_, subset___]"
 
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return evaluation.message(
                 "SubsetQ", "normal", Integer(1), Expression("SubsetQ", expr, subset)
             )
@@ -2481,7 +2481,7 @@ class SubsetQ(Builtin):
             return evaluation.message("SubsetQ", "argr")
 
         subset = subset[0]
-        if subset.is_atom():
+        if isinstance(subset, Atom):
             return evaluation.message(
                 "SubsetQ", "normal", Integer(2), Expression("SubsetQ", expr, subset)
             )
@@ -2497,7 +2497,7 @@ class SubsetQ(Builtin):
 
 
 def delete_one(expr, pos):
-    if expr.is_atom():
+    if isinstance(expr, Atom):
         raise PartDepthError(pos)
     leaves = expr.leaves
     if pos == 0:
@@ -2518,7 +2518,7 @@ def delete_rec(expr, pos):
     if len(pos) == 1:
         return delete_one(expr, pos[0])
     truepos = pos[0]
-    if truepos == 0 or expr.is_atom():
+    if truepos == 0 or isinstance(expr, Atom):
         raise PartDepthError(pos[0])
     leaves = expr.leaves
     s = len(leaves)

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -227,7 +227,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
             return store_sub_expr(expr)
 
     def unconvert_subexprs(expr):
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             if isinstance(expr, Symbol):
                 return get_sub_expr(expr)
             else:
@@ -245,7 +245,7 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
             i,
             sub_expr,
         ) in enumerate(sub_exprs):
-            if not sub_expr.is_atom():
+            if not isinstance(sub_expr, Atom):
                 head = _expand(sub_expr.head)  # also expand head
                 elements = sub_expr.get_elements()
                 if target_pat:
@@ -324,7 +324,7 @@ def find_all_vars(expr):
                 return
             if not (a_sympy.is_constant()) and b_sympy.is_rational:
                 find_vars(a, a_sympy)
-        elif not (e.is_atom()):
+        elif not (isinstance(e, Atom)):
             variables.add(e)
 
     exprs = expr.leaves if expr.has_form("List", None) else [expr]
@@ -477,7 +477,7 @@ class Simplify(Builtin):
         expr = evaluate_predicate(expr, evaluation)
 
         # If we get an atom, return it.
-        if expr.is_atom():
+        if isinstance(expr, Atom):
             return expr
 
         # Now, try to simplify the elements.

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -310,7 +310,7 @@ def find_all_vars(expr):
         assert e_sympy is not None
         if e_sympy.is_constant():
             return
-        elif e.is_symbol():
+        elif isinstance(e, Symbol):
             variables.add(e)
         elif e.has_form(("Plus", "Times"), None):
             for l in e.leaves:
@@ -1561,7 +1561,7 @@ class _CoefficientHandler(Builtin):
             powers = [Integer0 for i, p in enumerate(var_pats)]
             if pf is None:
                 return powers
-            if pf.is_symbol():
+            if isinstance(pf, Symbol):
                 for i, pat in enumerate(var_pats):
                     if match(pf, pat, evaluation):
                         powers[i] = Integer(1)
@@ -1599,7 +1599,7 @@ class _CoefficientHandler(Builtin):
             if term.is_free(target_pat, evaluation):
                 coeffs.append(term)
             elif (
-                term.is_symbol()
+                isinstance(term, Symbol)
                 or term.has_form("Power", 2)
                 or term.has_form("Sqrt", 1)
             ):
@@ -1652,7 +1652,7 @@ class _CoefficientHandler(Builtin):
             else:
                 return [(powers_list(None), expr)]
         elif (
-            expr.is_symbol()
+            isinstance(expr, Symbol)
             or match(expr, target_pat, evaluation)
             or expr.has_form("Power", 2)
             or expr.has_form("Sqrt", 1)
@@ -1787,7 +1787,7 @@ class CoefficientArrays(_CoefficientHandler):
         else:
             list_polys = [polys]
 
-        if varlist.is_symbol():
+        if isinstance(varlist, Symbol):
             var_exprs = [varlist]
         elif varlist.has_form("List", None):
             var_exprs = varlist.get_elements()
@@ -1873,18 +1873,18 @@ class Collect(_CoefficientHandler):
     """
 
     rules = {
-        "Collect[expr_, varlst_]": "Collect[expr, varlst, Identity]",
+        "Collect[expr_, varlist_]": "Collect[expr, varlist, Identity]",
     }
 
-    def apply_var_filter(self, expr, varlst, filt, evaluation):
-        """Collect[expr_, varlst_, filt_]"""
+    def apply_var_filter(self, expr, varlist, filt, evaluation):
+        """Collect[expr_, varlist_, filt_]"""
         if filt is Symbol("Identity"):
             filt = None
-        if varlst.is_symbol():
-            var_exprs = [varlst]
-        elif varlst.has_form("List", None):
-            var_exprs = varlst.get_elements()
+        if isinstance(varlist, Symbol):
+            var_exprs = [varlist]
+        elif varlist.has_form("List", None):
+            var_exprs = varlist.get_elements()
         else:
-            var_exprs = [varlst]
+            var_exprs = [varlist]
 
         return self.coeff_power_internal(expr, var_exprs, filt, evaluation, "expr")

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -959,7 +959,7 @@ class Solve(Builtin):
             vars = [vars]
         for var in vars:
             if (
-                (isinstance(var, Atom) and not var.is_symbol())
+                (isinstance(var, Atom) and not isinstance(var, Symbol))
                 or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
                 or constant & var.get_attributes(evaluation.definitions)
             ):

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -42,6 +42,7 @@ from mathics.core.number import dps, machine_epsilon
 from mathics.core.rules import Pattern
 
 from mathics.core.symbols import (
+    Atom,
     BaseElement,
     Symbol,
     SymbolFalse,
@@ -219,7 +220,7 @@ class D(SympyFunction):
             return Integer0
         elif f == x:
             return Integer1
-        elif f.is_atom():  # Shouldn't happen
+        elif isinstance(f, Atom):  # Shouldn't happen
             1 / 0
             return
         # So, this is not an atom...
@@ -263,7 +264,7 @@ class D(SympyFunction):
                     )
                 )
             if not exp.is_free(x_pattern, evaluation):
-                if base.is_atom() and base.get_name() == "System`E":
+                if isinstance(base, Atom) and base.get_name() == "System`E":
                     terms.append(Expression(SymbolTimes, f, Expression("D", exp, x)))
                 else:
                     terms.append(
@@ -958,7 +959,7 @@ class Solve(Builtin):
             vars = [vars]
         for var in vars:
             if (
-                (var.is_atom() and not var.is_symbol())
+                (isinstance(var, Atom) and not var.is_symbol())
                 or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
                 or constant & var.get_attributes(evaluation.definitions)
             ):

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -14,6 +14,7 @@ import sympy
 
 from mathics.builtin.base import Predefined, SympyObject
 from mathics.core.symbols import (
+    Atom,
     Symbol,
     strip_context,
 )
@@ -185,7 +186,7 @@ class _SympyConstant(_Constant_Common, SympyObject):
     sympy_name = None
 
     def to_sympy(self, expr=None, **kwargs):
-        if expr is None or expr.is_atom():
+        if expr is None or isinstance(expr, Atom):
             result = getattr(sympy, self.sympy_name)
             if kwargs.get("evaluate", False):
                 result = mp_convert_constant(result, **kwargs)

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -8,7 +8,7 @@ import sympy
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.convert import from_sympy
-from mathics.core.symbols import Atom
+from mathics.core.symbols import Atom, Symbol
 
 
 class DSolve(Builtin):
@@ -118,7 +118,7 @@ class DSolve(Builtin):
             evaluation.message("DSolve", "deqn", eqn)
             return
 
-        if x.is_symbol():
+        if isinstance(x, Symbol):
             syms = [x]
         elif x.has_form("List", 1, None):
             syms = sorted(x.get_elements())

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -8,6 +8,7 @@ import sympy
 from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.convert import from_sympy
+from mathics.core.symbols import Atom
 
 
 class DSolve(Builtin):
@@ -133,7 +134,7 @@ class DSolve(Builtin):
             func = Expression(y, *syms)
             function_form = Expression("List", *syms)
 
-        if func.is_atom():
+        if isinstance(func, Atom):
             evaluation.message("DSolve", "dsfun", y)
             return
 

--- a/mathics/builtin/optimization.py
+++ b/mathics/builtin/optimization.py
@@ -16,6 +16,7 @@ from mathics.core.atoms import from_python
 from mathics.core.convert import from_sympy
 from mathics.core.expression import Expression
 from mathics.core.attributes import constant, protected, read_protected
+from mathics.core.symbols import Atom
 
 
 class Minimize(Builtin):
@@ -78,7 +79,7 @@ class Minimize(Builtin):
         vars = vars.leaves
         for var in vars:
             if (
-                (var.is_atom() and not var.is_symbol())
+                (isinstance(var, Atom) and not var.is_symbol())
                 or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
                 or constant & var.get_attributes(evaluation.definitions)
             ):
@@ -157,7 +158,7 @@ class Minimize(Builtin):
         vars = vars.leaves
         for var in vars:
             if (
-                (var.is_atom() and not var.is_symbol())
+                (isinstance(var, Atom) and not var.is_symbol())
                 or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
                 or constant & var.get_attributes(evaluation.definitions)
             ):

--- a/mathics/builtin/optimization.py
+++ b/mathics/builtin/optimization.py
@@ -16,7 +16,7 @@ from mathics.core.atoms import from_python
 from mathics.core.convert import from_sympy
 from mathics.core.expression import Expression
 from mathics.core.attributes import constant, protected, read_protected
-from mathics.core.symbols import Atom
+from mathics.core.symbols import Atom, Symbol
 
 
 class Minimize(Builtin):
@@ -79,7 +79,7 @@ class Minimize(Builtin):
         vars = vars.leaves
         for var in vars:
             if (
-                (isinstance(var, Atom) and not var.is_symbol())
+                (isinstance(var, Atom) and not isinstance(var, Symbol))
                 or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
                 or constant & var.get_attributes(evaluation.definitions)
             ):
@@ -158,7 +158,7 @@ class Minimize(Builtin):
         vars = vars.leaves
         for var in vars:
             if (
-                (isinstance(var, Atom) and not var.is_symbol())
+                (isinstance(var, Atom) and not isinstance(var, Symbol))
                 or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
                 or constant & var.get_attributes(evaluation.definitions)
             ):

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -194,7 +194,7 @@ class OptionValue(Builtin):
             val = None
         # then, if not found, look at $f$. It could be a symbol, or a list of symbols, rules, and list of rules...
         if val is None:
-            if f.is_symbol():
+            if isinstance(f, Symbol):
                 val = get_option(
                     evaluation.definitions.get_options(f.get_name()), name, evaluation
                 )
@@ -203,7 +203,7 @@ class OptionValue(Builtin):
                     f = Expression("List", f)
                 if f.get_head_name() == "System`List":
                     for element in f.get_elements():
-                        if element.is_symbol():
+                        if isinstance(element, Symbol):
                             val = get_option(
                                 evaluation.definitions.get_options(element.get_name()),
                                 name,

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1691,7 +1691,7 @@ class DispatchAtom(AtomBuiltin):
         #
         if isinstance(rules, Dispatch):
             return rules
-        if rules.is_symbol():
+        if isinstance(rules, Symbol):
             rules = rules.evaluate(evaluation)
 
         if rules.has_form("List", None):
@@ -1705,7 +1705,7 @@ class DispatchAtom(AtomBuiltin):
             return Expression(SymbolList, *leaves)
         flatten_list = []
         for rule in rules:
-            if rule.is_symbol():
+            if isinstance(rule, Symbol):
                 rule = rule.evaluate(evaluation)
             if rule.has_form("List", None):
                 flatten_list.extend(rule._elements)

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1618,7 +1618,7 @@ def item_is_free(item, form, evaluation):
     except _StopGeneratorBaseElementIsFree as exc:
         return exc.value
 
-    if item.is_atom():
+    if isinstance(item, Atom):
         return True
     else:
         return item_is_free(item.head, form, evaluation) and all(

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -11,6 +11,7 @@ from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.convert import sympy_symbol_prefix, from_sympy
 from mathics.core.attributes import constant
+from mathics.core.symbols import Atom
 
 
 class RSolve(Builtin):
@@ -68,7 +69,7 @@ class RSolve(Builtin):
                 return
 
         if (
-            (n.is_atom() and not n.is_symbol())
+            (isinstance(n, Atom) and not n.is_symbol())
             or n.get_head_name() in ("System`Plus", "System`Times", "System`Power")
             or constant & n.get_attributes(evaluation.definitions)
         ):
@@ -85,7 +86,7 @@ class RSolve(Builtin):
             func = Expression(a, n)
             function_form = Expression("List", n)
 
-        if func.is_atom() or len(func.leaves) != 1:
+        if isinstance(func, Atom) or len(func.leaves) != 1:
             evaluation.message("RSolve", "dsfun", a)
 
         if n not in func.leaves:

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -11,7 +11,7 @@ from mathics.builtin.base import Builtin
 from mathics.core.expression import Expression
 from mathics.core.convert import sympy_symbol_prefix, from_sympy
 from mathics.core.attributes import constant
-from mathics.core.symbols import Atom
+from mathics.core.symbols import Atom, Symbol
 
 
 class RSolve(Builtin):
@@ -69,7 +69,7 @@ class RSolve(Builtin):
                 return
 
         if (
-            (isinstance(n, Atom) and not n.is_symbol())
+            (isinstance(n, Atom) and not isinstance(n, Symbol))
             or n.get_head_name() in ("System`Plus", "System`Times", "System`Power")
             or constant & n.get_attributes(evaluation.definitions)
         ):

--- a/mathics/builtin/sparse.py
+++ b/mathics/builtin/sparse.py
@@ -11,7 +11,7 @@ from mathics.builtin.base import Builtin
 
 from mathics.core.expression import Expression
 from mathics.core.atoms import Integer, Integer0
-from mathics.core.symbols import Symbol
+from mathics.core.symbols import Atom, Symbol
 
 
 class SparseArray(Builtin):
@@ -148,7 +148,9 @@ class SparseArray(Builtin):
             evaluation.message("SparseArray", "list", rules)
             return
 
-        if not rules.leaves[0].is_atom() and rules.leaves[0].get_head_name() in (
+        if not isinstance(rules.leaves[0], Atom) and rules.leaves[
+            0
+        ].get_head_name() in (
             "System`Rule",
             "System`DelayedRule",
         ):

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -19,8 +19,9 @@ from mathics.core.atoms import (
     String,
 )
 from mathics.core.symbols import (
-    SymbolTrue,
+    Atom,
     SymbolFalse,
+    SymbolTrue,
 )
 from mathics.core.rules import Pattern
 
@@ -62,7 +63,7 @@ def get_default_distance(p):
 
 
 def get_dimensions(expr, head=None):
-    if expr.is_atom():
+    if isinstance(expr, Atom):
         return []
     else:
         if head is not None and not expr.head.sameQ(head):
@@ -419,7 +420,7 @@ class Outer(Builtin):
         lists = lists.get_sequence()
         head = None
         for list in lists:
-            if list.is_atom():
+            if isinstance(list, Atom):
                 evaluation.message("Outer", "normal")
                 return
             if head is None:
@@ -430,7 +431,7 @@ class Outer(Builtin):
 
         def rec(item, rest_lists, current):
             evaluation.check_stopped()
-            if item.is_atom() or not item.head.sameQ(head):
+            if isinstance(item, Atom) or not item.head.sameQ(head):
                 if rest_lists:
                     return rec(rest_lists[0], rest_lists[1:], current + [item])
                 else:

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -11,7 +11,12 @@ import bisect
 from collections import defaultdict
 
 import typing
-from mathics.core.symbols import fully_qualified_symbol_name, strip_context, Symbol
+from mathics.core.symbols import (
+    Atom,
+    Symbol,
+    fully_qualified_symbol_name,
+    strip_context,
+)
 from mathics.core.expression import Expression
 from mathics.core.atoms import String
 from mathics_scanner.tokeniser import full_names_pattern
@@ -743,7 +748,7 @@ class Definitions(object):
 def get_tag_position(pattern, name) -> typing.Optional[str]:
     if pattern.get_name() == name:
         return "own"
-    elif pattern.is_atom():
+    elif isinstance(pattern, Atom):
         return None
     else:
         head_name = pattern.get_head_name()

--- a/mathics/core/evaluators.py
+++ b/mathics/core/evaluators.py
@@ -12,7 +12,7 @@ algorithms.
 import sympy
 from typing import Optional
 from mathics.core.atoms import Number
-from mathics.core.symbols import BaseElement
+from mathics.core.symbols import Atom, BaseElement
 from mathics.core.systemsymbols import SymbolMachinePrecision, SymbolN
 from mathics.core.number import get_precision, PrecisionValueError
 from mathics.core.expression import Expression
@@ -104,7 +104,7 @@ def apply_nvalues(
     # If we are here, is because there are not NValues that matches
     # to the expression. In such a case, if we arrive to an atomic expression,
     # just return it.
-    if expr.is_atom():
+    if isinstance(expr, Atom):
         return expr
     else:
         # Otherwise, look at the attributes, determine over which leaves

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -501,7 +501,7 @@ class Expression(BaseElement, NumericOperators):
     def get_attributes(self, definitions):
         if self._head is SymbolFunction and len(self._elements) > 2:
             res = self._elements[2]
-            if res.is_symbol():
+            if isinstance(res, Symbol):
                 return (str(res),)
             elif res.has_form("List", None):
                 return set(str(a) for a in res._elements)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -754,6 +754,23 @@ class Expression(BaseElement, NumericOperators):
         s = structure(head, deps, evaluation, structure_cache=structure_cache)
         return s(list(leaves))
 
+    def round_to_float(self, evaluation=None, permit_complex=False) -> Optional[float]:
+        """
+        Round to a Python float. Return None if rounding is not possible.
+        This can happen if self or evaluation is NaN.
+        """
+
+        if evaluation is None:
+            value = self
+        elif isinstance(evaluation, sympy.core.numbers.NaN):
+            return None
+        else:
+            value = self.create_expression(SymbolN, self).evaluate(evaluation)
+        if hasattr(value, "round") and hasattr(value, "get_float_value"):
+            value = value.round()
+            return value.get_float_value(permit_complex=permit_complex)
+        return None
+
     def sequences(self):
         cache = self._cache
         if cache:

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -115,9 +115,6 @@ class Pattern:
     def get_name(self):
         return self.expr.get_name()
 
-    def is_atom(self):
-        return self.expr.is_atom()
-
     def get_head_name(self):
         return self.expr.get_head_name()
 
@@ -245,7 +242,7 @@ class ExpressionPattern(Pattern):
         attributes = self.head.get_attributes(evaluation.definitions)
         if not flat & attributes:
             fully = True
-        if not expression.is_atom():
+        if not isinstance(expression, Atom):
             # don't do this here, as self.get_pre_choices changes the
             # ordering of the leaves!
             # if self.leaves:

--- a/mathics/core/subexpression.py
+++ b/mathics/core/subexpression.py
@@ -3,7 +3,7 @@
 
 
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol
+from mathics.core.symbols import Atom, Symbol
 from mathics.core.atoms import Integer
 from mathics.builtin.base import MessageException
 
@@ -149,7 +149,7 @@ class ExpressionPointer(object):
                 return parent.head.copy()
         else:
             leaf = self.parent.leaves[p - 1]
-            if leaf.is_atom():
+            if isinstance(leaf, Atom):
                 return leaf
             else:
                 return leaf.copy()

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -310,7 +310,7 @@ class BaseElement(KeyComparable):
             # If expr is not an atom, looks for formats in its definition
             # and apply them.
             def format_expr(expr):
-                if not (expr.is_atom()) and not (expr.head.is_atom()):
+                if not (isinstance(expr, Atom)) and not (isinstance(expr.head, Atom)):
                     # expr is of the form f[...][...]
                     return None
                 name = expr.get_lookup_name()
@@ -338,7 +338,7 @@ class BaseElement(KeyComparable):
                 expr = expr.do_format(evaluation, form)
             elif (
                 head is not SymbolNumberForm
-                and not expr.is_atom()
+                and not isinstance(expr, Atom)
                 and head is not SymbolGraphics
                 and head is not SymbolGraphics3D
             ):
@@ -407,6 +407,10 @@ class BaseElement(KeyComparable):
     def get_head_name(self):
         raise NotImplementedError
 
+    # FIXME: this behavior of defining a specific default implementation
+    # that is basically saying it isn't implemented is wrong.
+    # However fixing this means not only removing but fixing up code
+    # in the callers.
     def get_float_value(self, permit_complex=False):
         return None
 
@@ -517,6 +521,7 @@ class BaseElement(KeyComparable):
     def get_string_value(self):
         return None
 
+    # FIXME: see above for comment about default "wrong" implementations
     def has_changed(self, definitions):
         return True
 
@@ -530,10 +535,6 @@ class BaseElement(KeyComparable):
 
     def is_machine_precision(self) -> bool:
         """Check if the number represents a floating point number"""
-        return False
-
-    def is_atom(self) -> bool:
-        """Better use isinstance(self, Atom)"""
         return False
 
     def is_true(self) -> bool:
@@ -787,9 +788,6 @@ class Atom(BaseElement):
 
     def has_symbol(self, symbol_name) -> bool:
         return False
-
-    def is_atom(self) -> bool:
-        return True
 
     def numerify(self, evaluation) -> "Atom":
         return self

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -529,10 +529,6 @@ class BaseElement(KeyComparable):
     def is_zero(self) -> bool:
         return False
 
-    def is_symbol(self) -> bool:
-        """Checks if self is a Symbol. Better use isinstance(self, Symbol)"""
-        return False
-
     def is_machine_precision(self) -> bool:
         """Check if the number represents a floating point number"""
         return False
@@ -907,9 +903,6 @@ class Symbol(Atom, NumericOperators):
 
     def get_name(self) -> str:
         return self.name
-
-    def is_symbol(self) -> bool:
-        return True
 
     def get_sort_key(self, pattern_sort=False):
         if pattern_sort:


### PR DESCRIPTION
* move round_to_float() into NumericOperations
* replace x.is_atom() with isinstance(x, Atom)
* replace x.is_symbol() with isinstance(x, Symbol)

As before, these mechanical changes touches lots of files.  (Not something I am fond of doing, gratuitously, were it not for the fact it was holding me up from more important things - see below).

Next up - splitting off BaseElement from mathics.core.symbols into a new module matthics.core.element

I had originally wanted to do this first, but because of the modularity violations in BaseElement I couldn't and had to do all of these others _first_. (I think the one that was crucial was the work to NumericOperations. But I couldn't have know that previously)