### PR TITLE
Remove unformatted property from BaseElement

### DIFF
--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -1002,7 +1002,7 @@ class TableForm(Builtin):
         f:StandardForm|TraditionalForm|OutputForm]"""
 
         dims = len(get_dimensions(table, head=SymbolList))
-        depth = self.get_option(options, "TableDepth", evaluation).unformatted
+        depth = self.get_option(options, "TableDepth", evaluation)
         depth = expr_min((Integer(dims), depth))
         depth = depth.get_int_value()
         if depth is None:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -97,18 +97,10 @@ class BaseElement(KeyComparable):
     # this variable holds a function defined in mathics.core.expression that creates an expression
     create_expression: Any
 
-    # __new__ seems to be used because this object references itself.
-    # In particular:
-    #    self.unformatted = self
-    #
-    # See if there's a way to get rid of this, or ensure that this isn't causing
-    # a garbage collection problem.
-    def __new__(cls, *args, **kwargs):
-        self = object.__new__(cls)
+    def __init__(self, *args, **kwargs):
         self.options = None
         self.pattern_sequence = False
         self._cache = None
-        return self
 
     def apply_rules(
         self, rules, evaluation, level=0, options=None

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -107,7 +107,6 @@ class BaseElement(KeyComparable):
         self = object.__new__(cls)
         self.options = None
         self.pattern_sequence = False
-        self.unformatted = self  # This may be a garbage-collection nightmare.
         self._cache = None
         return self
 
@@ -178,12 +177,10 @@ class BaseElement(KeyComparable):
                 if not (form is SymbolOutputForm and head is SymbolStandardForm):
                     form = head
                     include_form = True
-            unformatted = expr
             # If form is Fullform, return it without changes
             if form is SymbolFullForm:
                 if include_form:
                     expr = self.create_expression(form, expr)
-                    expr.unformatted = unformatted
                 return expr
 
             # Repeated and RepeatedNull confuse the formatter,
@@ -234,7 +231,6 @@ class BaseElement(KeyComparable):
                 result = formatted.do_format(evaluation, form)
                 if include_form:
                     result = self.create_expression(form, result)
-                result.unformatted = unformatted
                 return result
 
             # If the expression is still enclosed by a Format,
@@ -260,7 +256,6 @@ class BaseElement(KeyComparable):
 
             if include_form:
                 expr = self.create_expression(form, expr)
-            expr.unformatted = unformatted
             return expr
         finally:
             evaluation.dec_recursion_depth()

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1186,8 +1186,6 @@ class Expression(BaseElement, NumericOperators):
             new = Expression(head)
             new._elements = tuple(dirty_elements)
 
-        # copy the "unformatted" form of the original expression,
-        new.unformatted = self.unformatted
         # Step 8:updates the cache and returns the new form, with the reevaluate flag to false.
         new._timestamp_cache(evaluation)
         return new, False


### PR DESCRIPTION
unformatted was used only in 1 place, and seems it works without it there.

I think that now the `__new__` method can be converted to a `__init__`, fixing the garbage collection problem.