### PR TITLE
Pre Rework BoxConstruct

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -115,7 +115,7 @@ class Builtin(object):
     ```
     expr_list = List(Integer(1), Integer(2), Integer(3))
     ```
-    is equivalent to write
+    is equivalent to:
     ```
     expr_list = Expression(SymbolList, Integer(1), Integer(2), Integer(3))
     ```

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -37,7 +37,7 @@ from mathics.core.symbols import (
     SymbolTrue,
 )
 
-from mathics.core.attributes import protected
+from mathics.core.attributes import protected, read_protected
 
 
 def get_option(options, name, evaluation, pop=False, evaluate=True):
@@ -68,6 +68,60 @@ mathics_to_python = {}
 
 
 class Builtin(object):
+    """
+    This class is the base class for Builtin symbol definitions.
+
+    A Builtin class is a structure that holds the information needed to generate
+    a Definition object for a built-in Symbol, like transformation rules, attributes, options,
+    etc.
+    Method with names of the form ``apply*`` are considered replacement rules, for expressions
+    that match the pattern described in their docstrings. For example
+
+    ```
+        def apply(x, evaluation):
+             '''F[x_Real]'''
+             return Expression("G", x*2)
+    ```
+    adds a ``BuilitinRule`` that implements ``F[x_]->G[x*2].
+    If the ``apply*`` method returns ``None``, the replacement fails, and the expression keeps its original form.
+    Notice that the argument names must coincide with the name of the corresponding pattern in the docstring.
+
+    For rules including ``OptionsPattern``
+    ```
+        def apply_with_options(x, evaluation, options):
+             '''F[x_Real, OptionsPattern[]]'''
+             ...
+    ```
+    the options are stored as a dictionary in the last parameter. For example, if the rule is applied to ``F[x, Method->Automatic]``
+    the expression is replaced by the output of ``apply_with_options(x, evaluation, {"System`Method": Symbol("Automatic")})
+
+    The method ``contribute`` stores the definition of the  ``Builtin`` ` `Symbol`` into a set of ``Definitions``. For example,
+
+    ```
+    definitions = Definitions(add_builtin=False)
+    List(expression=False).contribute(definitions)
+    ```
+    produces a ``Definitions`` object with just one definition, for the ``Symbol`` ``System`List``.
+
+    Notice that for creating a Bultinin, we must pass to the constructor the option ``expression=False``. Otherwise,
+    an Expression object is created, with the ``Symbol`` associated to the definition as the ``Head``.
+    For example,
+
+    ```
+    builtinlist = List(expression=False)
+    ```
+    creates the  ``Builtin``  ``List``, associated to the symbol ``System`List``, but
+
+    ```
+    expr_list = List(Integer(1), Integer(2), Integer(3))
+    ```
+    is equivalent to write
+    ```
+    expr_list = Expression(SymbolList, Integer(1), Integer(2), Integer(3))
+    ```
+
+    """
+
     name: typing.Optional[str] = None
     context: str = ""
     abstract: bool = False
@@ -80,6 +134,15 @@ class Builtin(object):
     defaults = {}
 
     def __new__(cls, *args, **kwargs):
+        # comment @mmatera:
+        # The goal of this method is to allow to build expressions
+        # like ``Expression(SymbolList,x,y,z)``
+        # in the handy way  ``List(x,y,z)``.
+        # This is handy, but can be confusing if this is not very
+        # well documented.
+        # Notice that this behavior was used extensively in
+        # mathics.builtin.inout
+
         if kwargs.get("expression", None) is not False:
             return Expression(cls.get_name(), *args)
         else:
@@ -589,14 +652,62 @@ class SympyFunction(SympyObject):
 
 
 class BoxConstruct(InstanceableBuiltin):
+    # This is the base class for the "Final form"
+    # of formatted expressions.
+    #
+    # The idea is that this class and their subclasses implement
+    # methods of the form ``boxes_to_*`` that now are in ``mathics.core.Expression``.
+    # Also, these objets should not be evaluated, so in the evaluation process should be
+    # considered "inert". However, it could happend that an Expression having them as an element
+    # be evaluable, and try to apply rules. For example,
+    # InputForm[ToBoxes[a+b]]
+    # should be evaluated to ``Expression("RowBox", '"a"', '"+"', '"b"')``.
+    #
+    # Changes to do, after the refactor of mathics.core:
+    #
+    # * Change the name of this class: It must be ``FormatExpression``,
+    #   ``BoxExpression`` or ``BoxElement`` or something like that.
+    # * Make this to be a subclass of ``BaseElement``.
+    # * Review the implementation
+
+    attributes = protected | read_protected
+
     def __new__(cls, *elements, **kwargs):
         instance = super().__new__(cls, *elements, **kwargs)
-        instance._elements = elements
+        # the __new__ method from InstanceableBuiltin
+        # calls self.init. It is expected that it set
+        # self._elements. However, if it didn't happens,
+        # we set it with a default value.
+        # There should be a better way to implement this
+        # behaviour...
+        if not hasattr(instance, "_elements"):
+            instance._elements = tuple(elements)
         return instance
+
+    def tex_block(self, tex, only_subsup=False):
+        if len(tex) == 1:
+            return tex
+        else:
+            if not only_subsup or "_" in tex or "^" in tex:
+                return "{%s}" % tex
+            else:
+                return tex
+
+    def to_expression(self):
+        expr = Expression(self.get_name(), self._elements)
+        return expr
+
+    def replace_vars(self, vars, options=None, in_scoping=True, in_function=True):
+        expr = self.to_expression()
+        result = expr.replace_vars(vars, options, in_scoping, in_function)
+        return result
 
     def evaluate(self, evaluation):
         # THINK about: Should we evaluate the elements here?
-        return
+        return self
+
+    def get_elements(self):
+        return self._elements
 
     def get_head_name(self):
         return self.get_name()
@@ -615,7 +726,9 @@ class BoxConstruct(InstanceableBuiltin):
         return self
 
     def format(self, evaluation, fmt):
-        return self
+        expr = Expression("HoldForm", self.to_expression())
+        fexpr = expr.format(evaluation, fmt)
+        return fexpr
 
     def get_head(self):
         return Symbol(self.get_name())
@@ -630,7 +743,7 @@ class BoxConstruct(InstanceableBuiltin):
 
     @property
     def leaves(self):
-        return self._elements
+        return self.get_elements()
 
     @leaves.setter
     def leaves(self, value):

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -364,7 +364,14 @@ class GraphicsBox(BoxConstruct):
     def __new__(cls, *leaves, **kwargs):
         instance = super().__new__(cls, *leaves, **kwargs)
         instance.evaluation = kwargs.get("evaluation", None)
+        instance._elements = leaves
         return instance
+
+    def to_expression(self):
+        return self
+
+    def get_elements(self):
+        return self._elements
 
     def _get_image_size(self, options, graphics_options, max_width):
         inside_row = options.pop("inside_row", False)

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -57,14 +57,14 @@ class _RoundBox(_GraphicsElement):
         self.edge_color, self.face_color = style.get_style(
             _Color, face_element=self.face_element
         )
-        self.c = Coords(graphics, item.leaves[0])
-        if len(item.leaves) == 1:
+        self.c = Coords(graphics, item.elements[0])
+        if len(item.elements) == 1:
             rx = ry = 1
-        elif len(item.leaves) == 2:
-            r = item.leaves[1]
+        elif len(item.elements) == 2:
+            r = item.elements[1]
             if r.has_form("List", 2):
-                rx = r.leaves[0].round_to_float()
-                ry = r.leaves[1].round_to_float()
+                rx = r.elements[0].round_to_float()
+                ry = r.elements[1].round_to_float()
             else:
                 rx = ry = r.round_to_float()
         self.r = self.c.add(rx, ry)
@@ -86,11 +86,11 @@ class _RoundBox(_GraphicsElement):
 
 class _ArcBox(_RoundBox):
     def init(self, graphics, style, item):
-        if len(item.leaves) == 3:
-            arc_expr = item.leaves[2]
+        if len(item.elements) == 3:
+            arc_expr = item.elements[2]
             if arc_expr.get_head_name() != "System`List":
                 raise BoxConstructError
-            arc = arc_expr.leaves
+            arc = arc_expr.elements
             pi2 = 2 * pi
 
             start_angle = arc[0].round_to_float()
@@ -106,7 +106,7 @@ class _ArcBox(_RoundBox):
                 else:
                     self.arc = (start_angle, end_angle)
 
-            item = Expression(item.get_head_name(), *item.leaves[:2])
+            item = Expression(item.get_head_name(), *item.elements[:2])
         else:
             self.arc = None
         super(_ArcBox, self).init(graphics, style, item)
@@ -141,29 +141,29 @@ class ArrowBox(_Polyline):
 
         super(ArrowBox, self).init(graphics, item, style)
 
-        leaves = item.leaves
-        if len(leaves) == 2:
-            setback = self._setback_spec(leaves[1])
-        elif len(leaves) == 1:
+        elements = item.elements
+        if len(elements) == 2:
+            setback = self._setback_spec(elements[1])
+        elif len(elements) == 1:
             setback = (0, 0)
         else:
             raise BoxConstructError
 
-        curve = leaves[0]
+        curve = elements[0]
 
         curve_head_name = curve.get_head_name()
         if curve_head_name == "System`List":
             curve_points = curve
             self.curve = _Line()
         elif curve_head_name == "System`Line":
-            if len(curve.leaves) != 1:
+            if len(curve.elements) != 1:
                 raise BoxConstructError
-            curve_points = curve.leaves[0]
+            curve_points = curve.elements[0]
             self.curve = _Line()
         elif curve_head_name == "System`BezierCurve":
-            if len(curve.leaves) != 1:
+            if len(curve.elements) != 1:
                 raise BoxConstructError
-            curve_points = curve.leaves[0]
+            curve_points = curve.elements[0]
             self.curve = _BezierCurve()
         else:
             raise BoxConstructError
@@ -177,10 +177,10 @@ class ArrowBox(_Polyline):
     @staticmethod
     def _setback_spec(expr):
         if expr.get_head_name() == "System`List":
-            leaves = expr.leaves
-            if len(leaves) != 2:
+            elements = expr.elements
+            if len(elements) != 2:
                 raise BoxConstructError
-            return tuple(max(_to_float(l), 0.0) for l in leaves)
+            return tuple(max(_to_float(l), 0.0) for l in elements)
         else:
             s = max(_to_float(expr), 0.0)
             return s, s
@@ -329,10 +329,10 @@ class ArrowBox(_Polyline):
 class BezierCurveBox(_Polyline):
     def init(self, graphics, style, item, options):
         super(BezierCurveBox, self).init(graphics, item, style)
-        if len(item.leaves) != 1 or item.leaves[0].get_head_name() != "System`List":
+        if len(item.elements) != 1 or item.elements[0].get_head_name() != "System`List":
             raise BoxConstructError
         self.edge_color, _ = style.get_style(_Color, face_element=False)
-        points = item.leaves[0]
+        points = item.elements[0]
         self.do_init(graphics, points)
         spline_degree = options.get("System`SplineDegree")
         if not isinstance(spline_degree, Integer):
@@ -361,10 +361,10 @@ class GraphicsBox(BoxConstruct):
 
     attributes = hold_all | protected | read_protected
 
-    def __new__(cls, *leaves, **kwargs):
-        instance = super().__new__(cls, *leaves, **kwargs)
+    def __new__(cls, *elements, **kwargs):
+        instance = super().__new__(cls, *elements, **kwargs)
         instance.evaluation = kwargs.get("evaluation", None)
-        instance._elements = leaves
+        instance._elements = elements
         return instance
 
     def to_expression(self):
@@ -394,7 +394,7 @@ class GraphicsBox(BoxConstruct):
             base_height = None  # will be computed later in calc_dimensions
         elif image_size.has_form("System`List", 2):
             base_width, base_height = (
-                [x.round_to_float() for x in image_size.leaves] + [0, 0]
+                [x.round_to_float() for x in image_size.elements] + [0, 0]
             )[:2]
             if base_width is None or base_height is None:
                 raise BoxConstructError
@@ -422,10 +422,10 @@ class GraphicsBox(BoxConstruct):
 
         return base_width, base_height, multi, aspect
 
-    def _prepare_elements(self, leaves, options, neg_y=False, max_width=None):
-        if not leaves:
+    def _prepare_elements(self, elements, options, neg_y=False, max_width=None):
+        if not elements:
             raise BoxConstructError
-        self.graphics_options = self.get_option_values(leaves[1:], **options)
+        self.graphics_options = self.get_option_values(elements[1:], **options)
         background = self.graphics_options["System`Background"]
         if (
             isinstance(background, Symbol)
@@ -449,7 +449,7 @@ class GraphicsBox(BoxConstruct):
         evaluation = options.get("evaluation", None)
         if evaluation is None:
             evaluation = self.evaluation
-        elements = GraphicsElements(leaves[0], evaluation, neg_y)
+        elements = GraphicsElements(elements[0], evaluation, neg_y)
         axes = []  # to be filled further down
 
         def calc_dimensions(final_pass=True):
@@ -637,11 +637,11 @@ class GraphicsBox(BoxConstruct):
 
         return ticks, ticks_small, origin_x
 
-    def boxes_to_mathml(self, leaves=None, **options) -> str:
+    def boxes_to_mathml(self, elements=None, **options) -> str:
 
         # FIXME: SVG is the only thing we can convert MathML into.
         # Handle other graphics formats.
-        svg_body = self.boxes_to_svg(leaves, **options)
+        svg_body = self.boxes_to_svg(elements, **options)
 
         # mglyph, which is what we have been using, is bad because MathML standard changed.
         # metext does not work because the way in which we produce the svg images is also based on this outdated mglyph behaviour.
@@ -659,20 +659,22 @@ class GraphicsBox(BoxConstruct):
         # print("boxes_to_mathml", mathml)
         return mathml
 
-    def boxes_to_svg(self, leaves=None, **options) -> str:
+    def boxes_to_svg(self, elements=None, **options) -> str:
         """This is the top-level function that converts a Mathics Expression
         in to something suitable for SVG rendering.
         """
-        if not leaves:
-            leaves = self._elements
+        if not elements:
+            elements = self._elements
 
-        elements, calc_dimensions = self._prepare_elements(leaves, options, neg_y=True)
+        elements, calc_dimensions = self._prepare_elements(
+            elements, options, neg_y=True
+        )
         xmin, xmax, ymin, ymax, w, h, self.width, self.height = calc_dimensions()
         data = (elements, xmin, xmax, ymin, ymax, w, h, self.width, self.height)
         elements.view_width = w
 
         format_fn = lookup_method(self, "svg")
-        svg_body = format_fn(self, leaves, data=data, **options)
+        svg_body = format_fn(self, elements, data=data, **options)
         return svg_body
 
     def boxes_to_tex(self, elements=None, **options) -> str:
@@ -759,18 +761,18 @@ clip(%s);
         if axes.is_true():
             axes = (True, True)
         elif axes.has_form("List", 2):
-            axes = (axes.leaves[0].is_true(), axes.leaves[1].is_true())
+            axes = (axes.elements[0].is_true(), axes.elements[1].is_true())
         else:
             axes = (False, False)
         ticks_style = graphics_options.get("System`TicksStyle")
         axes_style = graphics_options.get("System`AxesStyle")
         label_style = graphics_options.get("System`LabelStyle")
         if ticks_style.has_form("List", 2):
-            ticks_style = ticks_style.leaves
+            ticks_style = ticks_style.elements
         else:
             ticks_style = [ticks_style] * 2
         if axes_style.has_form("List", 2):
-            axes_style = axes_style.leaves
+            axes_style = axes_style.elements
         else:
             axes_style = [axes_style] * 2
 
@@ -912,10 +914,14 @@ class FilledCurveBox(_GraphicsElement):
         super(FilledCurveBox, self).init(graphics, item, style)
         self.edge_color, self.face_color = style.get_style(_Color, face_element=True)
 
-        if item is not None and item.leaves and item.leaves[0].has_form("List", None):
-            if len(item.leaves) != 1:
+        if (
+            item is not None
+            and item.elements
+            and item.elements[0].has_form("List", None)
+        ):
+            if len(item.elements) != 1:
                 raise BoxConstructError
-            leaves = item.leaves[0].leaves
+            elements = item.elements[0].elements
 
             def parse_component(segments):
                 for segment in segments:
@@ -923,16 +929,16 @@ class FilledCurveBox(_GraphicsElement):
 
                     if head == "System`Line":
                         k = 1
-                        parts = segment.leaves
+                        parts = segment.elements
                     elif head == "System`BezierCurve":
-                        parts, options = _data_and_options(segment.leaves, {})
+                        parts, options = _data_and_options(segment.elements, {})
                         spline_degree = options.get("SplineDegree", Integer(3))
                         if not isinstance(spline_degree, Integer):
                             raise BoxConstructError
                         k = spline_degree.get_int_value()
                     elif head == "System`BSplineCurve":
                         raise NotImplementedError  # FIXME convert bspline to bezier here
-                        # parts = segment.leaves
+                        # parts = segment.elements
                     else:
                         raise BoxConstructError
 
@@ -942,15 +948,15 @@ class FilledCurveBox(_GraphicsElement):
                         if part.get_head_name() != "System`List":
                             raise BoxConstructError
                         coords.extend(
-                            [graphics.coords(graphics, xy) for xy in part.leaves]
+                            [graphics.coords(graphics, xy) for xy in part.elements]
                         )
 
                     yield k, coords
 
-            if all(x.get_head_name() == "System`List" for x in leaves):
-                self.components = [list(parse_component(x)) for x in leaves]
+            if all(x.get_head_name() == "System`List" for x in elements):
+                self.components = [list(parse_component(x)) for x in elements]
             else:
-                self.components = [list(parse_component(leaves))]
+                self.components = [list(parse_component(elements))]
         else:
             raise BoxConstructError
 
@@ -986,16 +992,16 @@ class InsetBox(_GraphicsElement):
         self.opacity = opacity
 
         if item is not None:
-            if len(item.leaves) not in (1, 2, 3):
+            if len(item.elements) not in (1, 2, 3):
                 raise BoxConstructError
-            content = item.leaves[0]
+            content = item.elements[0]
             self.content = content.format(graphics.evaluation, "TraditionalForm")
-            if len(item.leaves) > 1:
-                self.pos = Coords(graphics, item.leaves[1])
+            if len(item.elements) > 1:
+                self.pos = Coords(graphics, item.elements[1])
             else:
                 self.pos = Coords(graphics, pos=(0, 0))
-            if len(item.leaves) > 2:
-                self.opos = coords(item.leaves[2])
+            if len(item.elements) > 2:
+                self.opos = coords(item.elements[2])
             else:
                 self.opos = (0, 0)
         else:
@@ -1025,9 +1031,9 @@ class LineBox(_Polyline):
         super(LineBox, self).init(graphics, item, style)
         self.edge_color, _ = style.get_style(_Color, face_element=False)
         if item is not None:
-            if len(item.leaves) != 1:
+            if len(item.elements) != 1:
                 raise BoxConstructError
-            points = item.leaves[0]
+            points = item.elements[0]
             self.do_init(graphics, points)
         elif lines is not None:
             self.lines = lines
@@ -1059,11 +1065,11 @@ class PointBox(_Polyline):
         self.point_radius = image_width * point_size.value
 
         if item is not None:
-            if len(item.leaves) != 1:
+            if len(item.elements) != 1:
                 raise BoxConstructError
-            points = item.leaves[0]
-            if points.has_form("List", None) and len(points.leaves) != 0:
-                if all(not leaf.has_form("List", None) for leaf in points.leaves):
+            points = item.elements[0]
+            if points.has_form("List", None) and len(points.elements) != 0:
+                if all(not leaf.has_form("List", None) for leaf in points.elements):
                     points = Expression(SymbolList, points)
             self.do_init(graphics, points)
         else:
@@ -1087,16 +1093,16 @@ class PolygonBox(_Polyline):
         super(PolygonBox, self).init(graphics, item, style)
         self.edge_color, self.face_color = style.get_style(_Color, face_element=True)
         if item is not None:
-            if len(item.leaves) not in (1, 2):
+            if len(item.elements) not in (1, 2):
                 raise BoxConstructError
-            points = item.leaves[0]
+            points = item.elements[0]
             self.do_init(graphics, points)
             self.vertex_colors = None
-            for leaf in item.leaves[1:]:
+            for leaf in item.elements[1:]:
                 if not leaf.has_form("Rule", 2):
                     raise BoxConstructError
-                name = leaf.leaves[0].get_name()
-                self.process_option(name, leaf.leaves[1])
+                name = leaf.elements[0].get_name()
+                self.process_option(name, leaf.elements[1])
         else:
             raise BoxConstructError
 
@@ -1106,7 +1112,7 @@ class PolygonBox(_Polyline):
                 raise BoxConstructError
             black = RGBColor(components=[0, 0, 0, 1])
             self.vertex_colors = [[black] * len(line) for line in self.lines]
-            colors = value.leaves
+            colors = value.elements
             if not self.multi_parts:
                 colors = [Expression(SymbolList, *colors)]
             for line_index, line in enumerate(self.lines):
@@ -1115,7 +1121,7 @@ class PolygonBox(_Polyline):
                 line_colors = colors[line_index]
                 if not line_colors.has_form("List", None):
                     continue
-                for index, color in enumerate(line_colors.leaves):
+                for index, color in enumerate(line_colors.elements):
                     if index >= len(self.vertex_colors[line_index]):
                         break
                     try:
@@ -1129,14 +1135,14 @@ class PolygonBox(_Polyline):
 class RectangleBox(_GraphicsElement):
     def init(self, graphics, style, item):
         super(RectangleBox, self).init(graphics, item, style)
-        if len(item.leaves) not in (1, 2):
+        if len(item.elements) not in (1, 2):
             raise BoxConstructError
         self.edge_color, self.face_color = style.get_style(_Color, face_element=True)
-        self.p1 = Coords(graphics, item.leaves[0])
-        if len(item.leaves) == 1:
+        self.p1 = Coords(graphics, item.elements[0])
+        if len(item.elements) == 1:
             self.p2 = self.p1.add(1, 1)
-        elif len(item.leaves) == 2:
-            self.p2 = Coords(graphics, item.leaves[1])
+        elif len(item.elements) == 2:
+            self.p2 = Coords(graphics, item.elements[1])
 
     def extent(self):
         l = self.style.get_line_width(face_element=True) / 2
@@ -1151,30 +1157,30 @@ class RectangleBox(_GraphicsElement):
 
 class RegularPolygonBox(PolygonBox):
     def init(self, graphics, style, item):
-        if len(item.leaves) in (1, 2, 3) and isinstance(item.leaves[-1], Integer):
+        if len(item.elements) in (1, 2, 3) and isinstance(item.elements[-1], Integer):
             r = 1.0
             phi0 = None
 
-            if len(item.leaves) >= 2:
-                rspec = item.leaves[-2]
+            if len(item.elements) >= 2:
+                rspec = item.elements[-2]
                 if rspec.get_head_name() == "System`List":
-                    if len(rspec.leaves) != 2:
+                    if len(rspec.elements) != 2:
                         raise BoxConstructError
-                    r = rspec.leaves[0].round_to_float()
-                    phi0 = rspec.leaves[1].round_to_float()
+                    r = rspec.elements[0].round_to_float()
+                    phi0 = rspec.elements[1].round_to_float()
                 else:
                     r = rspec.round_to_float()
 
             x = 0.0
             y = 0.0
-            if len(item.leaves) == 3:
-                pos = item.leaves[0]
+            if len(item.elements) == 3:
+                pos = item.elements[0]
                 if not pos.has_form("List", 2):
                     raise BoxConstructError
-                x = pos.leaves[0].round_to_float()
-                y = pos.leaves[1].round_to_float()
+                x = pos.elements[0].round_to_float()
+                y = pos.elements[1].round_to_float()
 
-            n = item.leaves[-1].get_int_value()
+            n = item.elements[-1].get_int_value()
 
             if any(t is None for t in (x, y, r)) or n < 0:
                 raise BoxConstructError

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -761,7 +761,6 @@ class String(Atom):
 
     def boxes_to_text(self, show_string_characters=False, **options) -> str:
         value = self.value
-
         if (
             not show_string_characters
             and value.startswith('"')  # nopep8
@@ -775,6 +774,10 @@ class String(Atom):
         from mathics.core.parser import is_symbol_name
         from mathics.builtin import builtins_by_module
 
+        # comment @mmatera:  This piece of code loads all the operators
+        # in all the modules.
+        # Maybe it should be build and stored once in mathics.builtin object.
+        #
         operators = set()
         for modname, builtins in builtins_by_module.items():
             for builtin in builtins:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -100,7 +100,27 @@ class BaseElement(KeyComparable):
     def __init__(self, *args, **kwargs):
         self.options = None
         self.pattern_sequence = False
+        # This property would be useful for a BoxExpression
+        # (see comment in mathocs.core.expression.) However,
+        # WL has a way to handle the connection between
+        # an expression and a Box expression ``InterpretationBox``.
+        self.unformatted = self  # This may be a garbage-collection nightmare.
         self._cache = None
+
+    # comment @mmatera: The next method have a name that starts with ``apply``.
+    # This obstaculizes to define ``InstanceableBuiltin``
+    # with ``Element`` as an ancestor class. I would like to have this
+    # to reimplement  ``mathics.builtin.BoxConstruct`` in a way that do not
+    # require to redefine several of the methods of this class.
+    # I propose then to change the name to ``do_apply_rules``.
+    # This change implies to change just an small number of lines
+    # in the code of ``mathics.core`` and ``mathics.builtin``. In particular
+    # the afected files apart from this would be:
+    #
+    # mathics/core/expression.py
+    # mathics/builtin/inference.py
+    # mathics/builtin/patterns.py
+    # mathics/builtin/assignments/internals.py
 
     def apply_rules(
         self, rules, evaluation, level=0, options=None
@@ -154,7 +174,6 @@ class BaseElement(KeyComparable):
         if isinstance(form, str):
             form = Symbol(form)
         formats = format_symbols
-
         evaluation.inc_recursion_depth()
         try:
             expr = self
@@ -174,7 +193,6 @@ class BaseElement(KeyComparable):
                 if include_form:
                     expr = self.create_expression(form, expr)
                 return expr
-
             # Repeated and RepeatedNull confuse the formatter,
             # so we need to hardlink their format rules:
             if head is SymbolRepeated:
@@ -245,7 +263,6 @@ class BaseElement(KeyComparable):
                 expr = self.create_expression(
                     expr.head.do_format(evaluation, form), *new_elements
                 )
-
             if include_form:
                 expr = self.create_expression(form, expr)
             return expr

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -438,6 +438,8 @@ class Evaluation(object):
             raise ValueError
 
         try:
+            # With the new implementation, if result is not a ``BoxConstruct``
+            # then we should raise a BoxError here.
             boxes = result.boxes_to_text(evaluation=self)
         except BoxError:
             self.message(

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -172,6 +172,8 @@ class Expression(BaseElement, NumericOperators):
         self._head = head
         self._elements = tuple(from_python(element) for element in leaves)
         self._sequences = None
+        # comment @mmatera: this cache should be useful in BoxConstruct, but not
+        # here...
         self._format_cache = None
         return self
 
@@ -263,6 +265,15 @@ class Expression(BaseElement, NumericOperators):
 
     def _timestamp_cache(self, evaluation):
         self._cache = ExpressionCache(evaluation.definitions.now, copy=self._cache)
+
+    # comment @mmatera: I think that the methods ``boxes_to_`` does not belong
+    # here but to a specialized class for holding ``Box*`` expressions.
+    # Box expressions shouldn't be evaluated, because are a kind of Literal, describing
+    # a way in which certain expression should be shown.
+    # In this PR (#181) I propose a basic implementation of a ``BoxExpression`` class.
+    # ``BoxExpression``  shouldn't implement many of the methods related to ``evaluation``
+    # and rewritting. Also, BoxExpressions must be build just from other ``BoxExpression``,
+    # ``String`` and ``Lists``.
 
     def boxes_to_text(self, **options) -> str:
         """

--- a/test/test_custom_boxconstruct.py
+++ b/test/test_custom_boxconstruct.py
@@ -47,6 +47,17 @@ class CustomGraphicsBox(BoxConstruct):
     options = GRAPHICS_OPTIONS
     attributes = hold_all | protected | read_protected
 
+    def init(self, *elems, **options):
+        self._elements = elems
+        self.evaluation = options.pop("evaluation", None)
+        self.box_options = options.copy()
+
+    def to_expression(self):
+        return Expression("CustomGraphicsBox", *self._elements)
+
+    def get_elements(self):
+        return self._elements
+
     def apply_box(self, elems, evaluation, options):
         """System`MakeBoxes[System`Graphics[elems_, System`OptionsPattern[System`Graphics]],
         System`StandardForm|System`TraditionalForm|System`OutputForm]"""

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -9,108 +9,127 @@ session = MathicsSession()
 import pytest
 
 
-# MathML StandardForm
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        ('"4"', "<mtext>4</mtext>", None),
-        # The following seems wrong: they should be formatted as numbers
-        ("4", "<mn>4</mn>", None),
-        ('"4.32"', "<mtext>4.32</mtext>", None),
-        ('"4.32313213213`2"', "<mtext>4.32313213213`2</mtext>", None),
-        ('"Hola!"', "<mtext>Hola!</mtext>", None),
-        ("a", "<mi>a</mi>", None),
-        ("Pi", "<mi>Pi</mi>", None),
-        ("a^4", "<msup><mi>a</mi> <mn>4</mn></msup>", None),
-        ("Subscript[a, 4]", "<msub><mi>a</mi> <mn>4</mn></msub>", None),
-        (
-            "Subsuperscript[a, p, q]",
-            "<msubsup><mi>a</mi> <mi>p</mi> <mi>q</mi></msubsup>",
-            None,
-        ),
-        (
-            "Integrate[F[x],{x,a,g[b]}]",
-            '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">⁢</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">⁢</mo> <mrow><mtext></mtext> <mi>x</mi></mrow></mrow>',
-            None,
-        ),
-        # This seems to be wrong...
-        (
-            "a^(b/c)",
-            "<msup><mi>a</mi> <mfrac><mi>b</mi> <mi>c</mi></mfrac></msup>",
-            None,
-        ),
-        (
-            "1/(1+1/(1+1/a))",
-            "<mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow></mfrac>",
-            None,
-        ),
-        (
-            "Sqrt[1/(1+1/(1+1/a))]",
-            "<msqrt><mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow></mfrac></msqrt>",
-            None,
-        ),
-        (
-            "Graphics[{}]",
-            (
-                '<mglyph width="350px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMnB4IiBoZWlnaHQ9IjJweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9Ii0xLjAwMDAwMCAtMS4wMDAwMDAgMi4wMDAwMDAgMi4wMDAwMDAiPgogICAgICAgICAgICAgICAgPCEtLUdyYXBoaWNzRWxlbWVudHMtLT4KPC9zdmc+Cg=="/>'
-            ),
-            None,
-        ),
-        # These tests requires ``evaluation`` as a parameter.
-        (
-            "Grid[{{a,b},{c,d}}]",
-            (
-                '<mtable columnalign="center">\n'
-                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
-                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
-                "</mtable>"
-            ),
-            None,
-        ),
-        (
-            "TableForm[{{a,b},{c,d}}]",
-            (
-                '<mtable columnalign="center">\n'
-                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
-                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
-                "</mtable>"
-            ),
-            None,
-        ),
-        (
-            "MatrixForm[{{a,b},{c,d}}]",
-            (
-                '<mrow><mo>(</mo> <mtable columnalign="center">\n'
-                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
-                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
-                "</mtable> <mo>)</mo></mrow>"
-            ),
-            None,
-        ),
-        (
-            "Graphics[{Text[a^b,{0,0}]}]",
-            (
-                '<mglyph width="294px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjEzNi41MDAwMDAgMTYyLjUwMDAwMCAyMS4wMDAwMDAgMjUuMDAwMDAwIj4KICAgICAgICAgICAgICAgIDwhLS1HcmFwaGljc0VsZW1lbnRzLS0+Cjx0ZXh0IHg9IjE0Ny4wIiB5PSIxNzUuMCIgb3g9IjAiIG95PSIwIiBmb250LXNpemU9IjEwcHgiIHN0eWxlPSJ0ZXh0LWFuY2hvcjplbmQ7IGRvbWluYW50LWJhc2VsaW5lOmhhbmdpbmc7IHN0cm9rZTogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBzdHJva2Utb3BhY2l0eTogMTsgZmlsbDogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBmaWxsLW9wYWNpdHk6IDE7IGNvbG9yOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IG9wYWNpdHk6IDEuMCI+YV5iPC90ZXh0Pgo8L3N2Zz4K"/>'
-            ),
-            None,
-        ),
-        (
-            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
-            (
-                '<mtable columnalign="center">\n'
-                '<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n'
-                '<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n'
-                "</mtable>"
-            ),
-            None,
-        ),
+        ('"4.32313213213`2"', "\\text{4.32`2}", None),
     ],
 )
-def test_makeboxes_standardform_mathml(
+@pytest.mark.xfail
+def test_makeboxes_standardform_tex_failing(
     str_expr: str, str_expected: str, msg: str, message=""
 ):
     result = session.evaluate(str_expr)
     format_result = result.format(session.evaluation, "System`StandardForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        str_format = format_result.boxes_to_text(evaluation=session.evaluation)
+        assert str_format == str_expected
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4.32313213213`2"', "\\text{4.32`2}", None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_outputform_tex_failing(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`OutputForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        str_format = format_result.boxes_to_text(evaluation=session.evaluation)
+        assert str_format == str_expected
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4.32313213213`2"', "4.32`2", None),
+        # Boxerror
+        ("Subscript[a, 4]", "Subscript[a, 4]", None),
+        ("Subsuperscript[a, p, q]", "Subsuperscript[a, p, q]", None),
+        (
+            "Integrate[F[x],{x,a,g[b]}]",
+            "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
+            None,
+        ),
+        # This seems to be wrong...
+        ("a^(b/c)", "a^( ( b ) / ( c ) )", None),
+        # Boxerror
+        (
+            "Sqrt[1/(1+1/(1+1/a))]",
+            "Sqrt[ ( 1 ) / ( 1+ ( 1 ) / ( 1+ ( 1 ) / ( a )  )  ) ]",
+            None,
+        ),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_standardform_text_failing(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`StandardForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        str_format = format_result.boxes_to_text(evaluation=session.evaluation)
+        assert str_format == str_expected
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4.32313213213`2"', "4.32`2", None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_outputform_text_tofix(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`OutputForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4.32313213213`2"', "<mtext>4.32`2</mtext>", None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_outputform_mathml_failing(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`OutputForm")
     # Atoms are not still correctly processed as BoxConstruct
     #    assert isinstance(format_result,  BoxConstruct)
     if msg:
@@ -124,7 +143,7 @@ def test_makeboxes_standardform_mathml(
         assert str_format == str_expected
 
 
-# MathML OutputForm
+# MathML StandardForm
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
@@ -132,7 +151,6 @@ def test_makeboxes_standardform_mathml(
         # The following seems wrong: they should be formatted as numbers
         ("4", "<mn>4</mn>", None),
         ('"4.32"', "<mtext>4.32</mtext>", None),
-        ('"4.32313213213`2"', "<mtext>4.32313213213`2</mtext>", None),
         ('"Hola!"', "<mtext>Hola!</mtext>", None),
         ("a", "<mi>a</mi>", None),
         ("Pi", "<mi>Pi</mi>", None),
@@ -229,6 +247,7 @@ def test_makeboxes_standardform_mathml(
         ),
     ],
 )
+# @pytest.mark.xfail
 def test_makeboxes_outputform_mathml(
     str_expr: str, str_expected: str, msg: str, message=""
 ):
@@ -254,28 +273,11 @@ def test_makeboxes_outputform_mathml(
         ('"4"', "4", None),
         ("4", "4", None),
         ('"4.32"', "4.32", None),
-        ('"4.32313213213`2"', "4.32313213213`2", None),
         ('"Hola!"', "Hola!", None),
         ("a", "a", None),
         ("Pi", "Pi", None),
         ("a^4", "a^4", None),
-        # Boxerror
-        #        ("Subscript[a, 4]", "Subscript[a, 4]", None),
-        #        ("Subsuperscript[a, p, q]", "Subsuperscript[a, p, q]", None),
-        #        (
-        #            "Integrate[F[x],{x,a,g[b]}]",
-        #            "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
-        #            None,
-        #        ),
-        # This seems to be wrong...
-        ("a^(b/c)", "a^ ( b ) / ( c ) ", None),
         ("1/(1+1/(1+1/a))", " ( 1 ) / ( 1+ ( 1 ) / ( 1+ ( 1 ) / ( a )  )  ) ", None),
-        # Boxerror
-        #        (
-        #            "Sqrt[1/(1+1/(1+1/a))]",
-        #            "Sqrt[ ( 1 ) / ( 1+ ( 1 ) / ( 1+ ( 1 ) / ( a )  )  ) ]",
-        #            None,
-        #        ),
         ("Graphics[{}]", "-Graphics-", None),
         # These tests requires ``evaluation`` as a parameter.
         ("Grid[{{a,b},{c,d}}]", "a   b\n\nc   d\n", None),
@@ -289,6 +291,7 @@ def test_makeboxes_outputform_mathml(
         ),
     ],
 )
+# @pytest.mark.xfail
 def test_makeboxes_standardform_text(
     str_expr: str, str_expected: str, msg: str, message=""
 ):
@@ -312,7 +315,6 @@ def test_makeboxes_standardform_text(
         ('"4"', "4", None),
         ("4", "4", None),
         ('"4.32"', "4.32", None),
-        ('"4.32313213213`2"', "4.32313213213`2", None),
         ('"Hola!"', "Hola!", None),
         ("a", "a", None),
         ("Pi", "Pi", None),
@@ -336,6 +338,7 @@ def test_makeboxes_standardform_text(
         ),
     ],
 )
+# @pytest.mark.xfail
 def test_makeboxes_outputform_text(
     str_expr: str, str_expected: str, msg: str, message=""
 ):
@@ -360,8 +363,6 @@ def test_makeboxes_outputform_text(
         ('"4"', "\\text{4}", None),
         ("4", "4", None),
         ('"4.32"', "\\text{4.32}", None),
-        # This is wrong: it should return 4.32`2
-        ('"4.32313213213`2"', "\\text{4.32313213213`2}", None),
         ('"Hola!"', "\\text{Hola!}", None),
         ("Pi", "\\text{Pi}", None),
         ("a", "a", None),
@@ -423,6 +424,7 @@ def test_makeboxes_outputform_text(
         ),
     ],
 )
+# @pytest.mark.xfail
 def test_makeboxes_standard_tex(str_expr: str, str_expected: str, msg: str, message=""):
     result = session.evaluate(str_expr)
     format_result = result.format(session.evaluation, "System`StandardForm")
@@ -444,7 +446,6 @@ def test_makeboxes_standard_tex(str_expr: str, str_expected: str, msg: str, mess
         ('"4"', "\\text{4}", None),
         ("4", "4", None),
         ('"4.32"', "\\text{4.32}", None),
-        ('"4.32313213213`2"', "\\text{4.32313213213`2}", None),
         ('"Hola!"', "\\text{Hola!}", None),
         ("Pi", "\\text{Pi}", None),
         ("a", "a", None),
@@ -514,6 +515,7 @@ def test_makeboxes_standard_tex(str_expr: str, str_expected: str, msg: str, mess
         ),
     ],
 )
+# @pytest.mark.xfail
 def test_makeboxes_output_tex(str_expr: str, str_expected: str, msg: str, message=""):
     result = session.evaluate(str_expr)
     format_result = result.format(session.evaluation, "System`OutputForm")

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -1,0 +1,528 @@
+# from .helper import session
+from mathics.session import MathicsSession
+
+session = MathicsSession()
+
+# from mathics.builtin.base import BoxConstruct, Predefined
+
+
+import pytest
+
+
+# MathML StandardForm
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4"', "<mtext>4</mtext>", None),
+        # The following seems wrong: they should be formatted as numbers
+        ("4", "<mn>4</mn>", None),
+        ('"4.32"', "<mtext>4.32</mtext>", None),
+        ('"4.32313213213`2"', "<mtext>4.32313213213`2</mtext>", None),
+        ('"Hola!"', "<mtext>Hola!</mtext>", None),
+        ("a", "<mi>a</mi>", None),
+        ("Pi", "<mi>Pi</mi>", None),
+        ("a^4", "<msup><mi>a</mi> <mn>4</mn></msup>", None),
+        ("Subscript[a, 4]", "<msub><mi>a</mi> <mn>4</mn></msub>", None),
+        (
+            "Subsuperscript[a, p, q]",
+            "<msubsup><mi>a</mi> <mi>p</mi> <mi>q</mi></msubsup>",
+            None,
+        ),
+        (
+            "Integrate[F[x],{x,a,g[b]}]",
+            '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">⁢</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">⁢</mo> <mrow><mtext></mtext> <mi>x</mi></mrow></mrow>',
+            None,
+        ),
+        # This seems to be wrong...
+        (
+            "a^(b/c)",
+            "<msup><mi>a</mi> <mfrac><mi>b</mi> <mi>c</mi></mfrac></msup>",
+            None,
+        ),
+        (
+            "1/(1+1/(1+1/a))",
+            "<mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow></mfrac>",
+            None,
+        ),
+        (
+            "Sqrt[1/(1+1/(1+1/a))]",
+            "<msqrt><mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow></mfrac></msqrt>",
+            None,
+        ),
+        (
+            "Graphics[{}]",
+            (
+                '<mglyph width="350px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMnB4IiBoZWlnaHQ9IjJweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9Ii0xLjAwMDAwMCAtMS4wMDAwMDAgMi4wMDAwMDAgMi4wMDAwMDAiPgogICAgICAgICAgICAgICAgPCEtLUdyYXBoaWNzRWxlbWVudHMtLT4KPC9zdmc+Cg=="/>'
+            ),
+            None,
+        ),
+        # These tests requires ``evaluation`` as a parameter.
+        (
+            "Grid[{{a,b},{c,d}}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+        (
+            "TableForm[{{a,b},{c,d}}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+        (
+            "MatrixForm[{{a,b},{c,d}}]",
+            (
+                '<mrow><mo>(</mo> <mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
+                "</mtable> <mo>)</mo></mrow>"
+            ),
+            None,
+        ),
+        (
+            "Graphics[{Text[a^b,{0,0}]}]",
+            (
+                '<mglyph width="294px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjEzNi41MDAwMDAgMTYyLjUwMDAwMCAyMS4wMDAwMDAgMjUuMDAwMDAwIj4KICAgICAgICAgICAgICAgIDwhLS1HcmFwaGljc0VsZW1lbnRzLS0+Cjx0ZXh0IHg9IjE0Ny4wIiB5PSIxNzUuMCIgb3g9IjAiIG95PSIwIiBmb250LXNpemU9IjEwcHgiIHN0eWxlPSJ0ZXh0LWFuY2hvcjplbmQ7IGRvbWluYW50LWJhc2VsaW5lOmhhbmdpbmc7IHN0cm9rZTogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBzdHJva2Utb3BhY2l0eTogMTsgZmlsbDogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBmaWxsLW9wYWNpdHk6IDE7IGNvbG9yOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IG9wYWNpdHk6IDEuMCI+YV5iPC90ZXh0Pgo8L3N2Zz4K"/>'
+            ),
+            None,
+        ),
+        (
+            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+    ],
+)
+def test_makeboxes_standardform_mathml(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`StandardForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_mathml(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        str_format = format_result.boxes_to_mathml(evaluation=session.evaluation)
+        print(f"<<{str_format}>>")
+        print(f"<<{str_expected}>>")
+        assert str_format == str_expected
+
+
+# MathML OutputForm
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4"', "<mtext>4</mtext>", None),
+        # The following seems wrong: they should be formatted as numbers
+        ("4", "<mn>4</mn>", None),
+        ('"4.32"', "<mtext>4.32</mtext>", None),
+        ('"4.32313213213`2"', "<mtext>4.32313213213`2</mtext>", None),
+        ('"Hola!"', "<mtext>Hola!</mtext>", None),
+        ("a", "<mi>a</mi>", None),
+        ("Pi", "<mi>Pi</mi>", None),
+        (
+            "a^4",
+            "<mrow><mi>a</mi> <mtext>&nbsp;^&nbsp;</mtext> <mn>4</mn></mrow>",
+            None,
+        ),
+        (
+            "Subscript[a, 4]",
+            "<mrow><mi>Subscript</mi> <mo>[</mo> <mrow><mi>a</mi> <mtext>,&nbsp;</mtext> <mn>4</mn></mrow> <mo>]</mo></mrow>",
+            None,
+        ),
+        (
+            "Subsuperscript[a, p, q]",
+            "<mrow><mi>Subsuperscript</mi> <mo>[</mo> <mrow><mi>a</mi> <mtext>,&nbsp;</mtext> <mi>p</mi> <mtext>,&nbsp;</mtext> <mi>q</mi></mrow> <mo>]</mo></mrow>",
+            None,
+        ),
+        (
+            "Integrate[F[x],{x,a,g[b]}]",
+            "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
+            None,
+        ),
+        # This seems to be wrong...
+        (
+            "a^(b/c)",
+            "<mrow><mi>a</mi> <mtext>&nbsp;^&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mi>b</mi> <mtext>&nbsp;/&nbsp;</mtext> <mi>c</mi></mrow> <mo>)</mo></mrow></mrow>",
+            None,
+        ),
+        (
+            "1/(1+1/(1+1/a))",
+            "<mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mi>a</mi></mrow></mrow> <mo>)</mo></mrow></mrow></mrow> <mo>)</mo></mrow></mrow>",
+            None,
+        ),
+        (
+            "Sqrt[1/(1+1/(1+1/a))]",
+            "<mrow><mi>Sqrt</mi> <mo>[</mo> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mi>a</mi></mrow></mrow> <mo>)</mo></mrow></mrow></mrow> <mo>)</mo></mrow></mrow> <mo>]</mo></mrow>",
+            None,
+        ),
+        (
+            "Graphics[{}]",
+            (
+                '<mglyph width="350px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMnB4IiBoZWlnaHQ9IjJweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9Ii0xLjAwMDAwMCAtMS4wMDAwMDAgMi4wMDAwMDAgMi4wMDAwMDAiPgogICAgICAgICAgICAgICAgPCEtLUdyYXBoaWNzRWxlbWVudHMtLT4KPC9zdmc+Cg=="/>'
+            ),
+            None,
+        ),
+        # These tests requires ``evaluation`` as a parameter.
+        (
+            "Grid[{{a,b},{c,d}}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+        (
+            "TableForm[{{a,b},{c,d}}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+        (
+            "MatrixForm[{{a,b},{c,d}}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mi>a</mi></mtd><mtd columnalign="center"><mi>b</mi></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mi>c</mi></mtd><mtd columnalign="center"><mi>d</mi></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+        (
+            "Graphics[{Text[a^b,{0,0}]}]",
+            (
+                '<mglyph width="294px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjEzNi41MDAwMDAgMTYyLjUwMDAwMCAyMS4wMDAwMDAgMjUuMDAwMDAwIj4KICAgICAgICAgICAgICAgIDwhLS1HcmFwaGljc0VsZW1lbnRzLS0+Cjx0ZXh0IHg9IjE0Ny4wIiB5PSIxNzUuMCIgb3g9IjAiIG95PSIwIiBmb250LXNpemU9IjEwcHgiIHN0eWxlPSJ0ZXh0LWFuY2hvcjplbmQ7IGRvbWluYW50LWJhc2VsaW5lOmhhbmdpbmc7IHN0cm9rZTogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBzdHJva2Utb3BhY2l0eTogMTsgZmlsbDogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBmaWxsLW9wYWNpdHk6IDE7IGNvbG9yOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IG9wYWNpdHk6IDEuMCI+YV5iPC90ZXh0Pgo8L3N2Zz4K"/>'
+            ),
+            None,
+        ),
+        (
+            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
+            (
+                '<mtable columnalign="center">\n'
+                '<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n'
+                '<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n'
+                "</mtable>"
+            ),
+            None,
+        ),
+    ],
+)
+def test_makeboxes_outputform_mathml(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`OutputForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_mathml(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        str_format = format_result.boxes_to_mathml(evaluation=session.evaluation)
+        print(f"<<{str_format}>>")
+        print(f"<<{str_expected}>>")
+        assert str_format == str_expected
+
+
+# Text StandardForm
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4"', "4", None),
+        ("4", "4", None),
+        ('"4.32"', "4.32", None),
+        ('"4.32313213213`2"', "4.32313213213`2", None),
+        ('"Hola!"', "Hola!", None),
+        ("a", "a", None),
+        ("Pi", "Pi", None),
+        ("a^4", "a^4", None),
+        # Boxerror
+        #        ("Subscript[a, 4]", "Subscript[a, 4]", None),
+        #        ("Subsuperscript[a, p, q]", "Subsuperscript[a, p, q]", None),
+        #        (
+        #            "Integrate[F[x],{x,a,g[b]}]",
+        #            "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
+        #            None,
+        #        ),
+        # This seems to be wrong...
+        ("a^(b/c)", "a^ ( b ) / ( c ) ", None),
+        ("1/(1+1/(1+1/a))", " ( 1 ) / ( 1+ ( 1 ) / ( 1+ ( 1 ) / ( a )  )  ) ", None),
+        # Boxerror
+        #        (
+        #            "Sqrt[1/(1+1/(1+1/a))]",
+        #            "Sqrt[ ( 1 ) / ( 1+ ( 1 ) / ( 1+ ( 1 ) / ( a )  )  ) ]",
+        #            None,
+        #        ),
+        ("Graphics[{}]", "-Graphics-", None),
+        # These tests requires ``evaluation`` as a parameter.
+        ("Grid[{{a,b},{c,d}}]", "a   b\n\nc   d\n", None),
+        ("TableForm[{{a,b},{c,d}}]", "a   b\n\nc   d\n", None),
+        ("MatrixForm[{{a,b},{c,d}}]", "(a   b\n\nc   d\n)", None),
+        ("Graphics[{Text[a^b,{0,0}]}]", "-Graphics-", None),
+        (
+            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
+            ("-Graphics-\n\n-Graphics-\n"),
+            None,
+        ),
+    ],
+)
+def test_makeboxes_standardform_text(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`StandardForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        str_format = format_result.boxes_to_text(evaluation=session.evaluation)
+        assert str_format == str_expected
+
+
+# Text OutputForm
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4"', "4", None),
+        ("4", "4", None),
+        ('"4.32"', "4.32", None),
+        ('"4.32313213213`2"', "4.32313213213`2", None),
+        ('"Hola!"', "Hola!", None),
+        ("a", "a", None),
+        ("Pi", "Pi", None),
+        ("a^4", "a ^ 4", None),
+        ("Subscript[a, 4]", "Subscript[a, 4]", None),
+        ("Subsuperscript[a, p, q]", "Subsuperscript[a, p, q]", None),
+        ("Integrate[F[x],{x,a,g[b]}]", "Integrate[F[x], {x, a, g[b]}]", None),
+        ("a^(b/c)", "a ^ (b / c)", None),
+        ("1/(1+1/(1+1/a))", "1 / (1 + 1 / (1 + 1 / a))", None),
+        ("Sqrt[1/(1+1/(1+1/a))]", "Sqrt[1 / (1 + 1 / (1 + 1 / a))]", None),
+        ("Graphics[{}]", "-Graphics-", None),
+        # These tests requires ``evaluation`` as a parameter.
+        ("Grid[{{a,b},{c,d}}]", "a   b\n\nc   d\n", None),
+        ("TableForm[{{a,b},{c,d}}]", "a   b\n\nc   d\n", None),
+        ("MatrixForm[{{a,b},{c,d}}]", "a   b\n\nc   d\n", None),
+        ("Graphics[{Text[a^b,{0,0}]}]", "-Graphics-", None),
+        (
+            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
+            ("-Graphics-\n\n-Graphics-\n"),
+            None,
+        ),
+    ],
+)
+def test_makeboxes_outputform_text(
+    str_expr: str, str_expected: str, msg: str, message=""
+):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`OutputForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    #    assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        assert (
+            format_result.boxes_to_text(evaluation=session.evaluation) == str_expected
+        )
+
+
+# TeX StandardForm
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4"', "\\text{4}", None),
+        ("4", "4", None),
+        ('"4.32"', "\\text{4.32}", None),
+        # This is wrong: it should return 4.32`2
+        ('"4.32313213213`2"', "\\text{4.32313213213`2}", None),
+        ('"Hola!"', "\\text{Hola!}", None),
+        ("Pi", "\\text{Pi}", None),
+        ("a", "a", None),
+        ("a^4", "a^4", None),
+        ("Subscript[a, 4]", "a_4", None),
+        ("Subsuperscript[a, p, q]", "a_p^q", None),
+        (
+            "Integrate[F[x],{x,a,g[b]}]",
+            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \uf74cx",
+            None,
+        ),
+        ("a^(b/c)", "a^{\\frac{b}{c}}", None),
+        ("1/(1+1/(1+1/a))", "\\frac{1}{1+\\frac{1}{1+\\frac{1}{a}}}", None),
+        (
+            "Sqrt[1/(1+1/(1+1/a))]",
+            "\\sqrt{\\frac{1}{1+\\frac{1}{1+\\frac{1}{a}}}}",
+            None,
+        ),
+        (
+            "Graphics[{}]",
+            (
+                """\n\\begin{asy}\nusepackage("amsmath");"""
+                """\nsize(5.8333cm, 5.8333cm);\n\n\n"""
+                """clip(box((-1,-1), (1,1)));\n\n\\end{asy}\n"""
+            ),
+            None,
+        ),
+        # These tests requires ``evaluation`` as a parameter.
+        ("Grid[{{a,b},{c,d}}]", "\\begin{array}{cc} a & b\\\\ c & d\\end{array}", None),
+        (
+            "TableForm[{{a,b},{c,d}}]",
+            "\\begin{array}{cc} a & b\\\\ c & d\\end{array}",
+            None,
+        ),
+        (
+            "MatrixForm[{{a,b},{c,d}}]",
+            "\\left(\\begin{array}{cc} a & b\\\\ c & d\\end{array}\\right)",
+            None,
+        ),
+        (
+            "Graphics[{Text[a^b,{0,0}]}]",
+            (
+                '\n\\begin{asy}\nusepackage("amsmath");\nsize(4.9cm, 5.8333cm);\n\n'
+                '// InsetBox\nlabel("$a^b$", (147.0,175.0), (0,0), rgb(0, 0, 0));\n\n'
+                "clip(box((136.5,162.5), (157.5,187.5)));\n\n\\end{asy}\n"
+            ),
+            None,
+        ),
+        (
+            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
+            (
+                '\\begin{array}{c} \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n'
+                '// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0));\n\nclip(box((63,75), (84,100)));\n\n'
+                '\\end{asy}\n\\\\ \n\\begin{asy}\nusepackage("amsmath");\n'
+                'size(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0));\n\n'
+                "clip(box((63,75), (84,100)));\n\n\\end{asy}\n\\end{array}"
+            ),
+            None,
+        ),
+    ],
+)
+def test_makeboxes_standard_tex(str_expr: str, str_expected: str, msg: str, message=""):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`StandardForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    # assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_tex(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        strresult = format_result.boxes_to_tex(evaluation=session.evaluation)
+        assert strresult == str_expected
+
+
+# TeX OutputForm
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ('"4"', "\\text{4}", None),
+        ("4", "4", None),
+        ('"4.32"', "\\text{4.32}", None),
+        ('"4.32313213213`2"', "\\text{4.32313213213`2}", None),
+        ('"Hola!"', "\\text{Hola!}", None),
+        ("Pi", "\\text{Pi}", None),
+        ("a", "a", None),
+        ("a^4", "a\\text{ ${}^{\\wedge}$ }4", None),
+        ("Subscript[a, 4]", "\\text{Subscript}\\left[a, 4\\right]", None),
+        (
+            "Subsuperscript[a, p, q]",
+            "\\text{Subsuperscript}\\left[a, p, q\\right]",
+            None,
+        ),
+        (
+            "Integrate[F[x],{x,a,g[b]}]",
+            "\\text{Integrate}\\left[F\\left[x\\right], \\left\\{x, a, g\\left[b\\right]\\right\\}\\right]",
+            None,
+        ),
+        ("a^(b/c)", "a\\text{ ${}^{\\wedge}$ }\\left(b\\text{ / }c\\right)", None),
+        (
+            "1/(1+1/(1+1/a))",
+            "1\\text{ / }\\left(1\\text{ + }1\\text{ / }\\left(1\\text{ + }1\\text{ / }a\\right)\\right)",
+            None,
+        ),
+        (
+            "Sqrt[1/(1+1/(1+1/a))]",
+            "\\text{Sqrt}\\left[1\\text{ / }\\left(1\\text{ + }1\\text{ / }\\left(1\\text{ + }1\\text{ / }a\\right)\\right)\\right]",
+            None,
+        ),
+        (
+            "Graphics[{}]",
+            (
+                """\n\\begin{asy}\nusepackage("amsmath");"""
+                """\nsize(5.8333cm, 5.8333cm);\n\n\n"""
+                """clip(box((-1,-1), (1,1)));\n\n\\end{asy}\n"""
+            ),
+            None,
+        ),
+        # These tests requires ``evaluation`` as a parameter.
+        ("Grid[{{a,b},{c,d}}]", "\\begin{array}{cc} a & b\\\\ c & d\\end{array}", None),
+        (
+            "TableForm[{{a,b},{c,d}}]",
+            "\\begin{array}{cc} a & b\\\\ c & d\\end{array}",
+            None,
+        ),
+        (
+            "MatrixForm[{{a,b},{c,d}}]",
+            "\\begin{array}{cc} a & b\\\\ c & d\\end{array}",
+            None,
+        ),
+        (
+            "Graphics[{Text[a^b,{0,0}]}]",
+            (
+                '\n\\begin{asy}\nusepackage("amsmath");\nsize(4.9cm, 5.8333cm);\n\n'
+                '// InsetBox\nlabel("$a^b$", (147.0,175.0), (0,0), rgb(0, 0, 0));\n\n'
+                "clip(box((136.5,162.5), (157.5,187.5)));\n\n\\end{asy}\n"
+            ),
+            None,
+        ),
+        (
+            "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]",
+            (
+                '\\begin{array}{c} \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n'
+                '// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0));\n\nclip(box((63,75), (84,100)));\n\n'
+                '\\end{asy}\n\\\\ \n\\begin{asy}\nusepackage("amsmath");\n'
+                'size(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0));\n\n'
+                "clip(box((63,75), (84,100)));\n\n\\end{asy}\n\\end{array}"
+            ),
+            None,
+        ),
+    ],
+)
+def test_makeboxes_output_tex(str_expr: str, str_expected: str, msg: str, message=""):
+    result = session.evaluate(str_expr)
+    format_result = result.format(session.evaluation, "System`OutputForm")
+    # Atoms are not still correctly processed as BoxConstruct
+    # assert isinstance(format_result,  BoxConstruct)
+    if msg:
+        assert (
+            format_result.boxes_to_tex(evaluation=session.evaluation) == str_expected
+        ), msg
+    else:
+        strresult = format_result.boxes_to_tex(evaluation=session.evaluation)
+        assert strresult == str_expected

--- a/test/test_formatter/test_svg.py
+++ b/test/test_formatter/test_svg.py
@@ -39,7 +39,7 @@ def get_svg(expression):
 
     # Would be nice to DRY this boilerplate from boxes_to_mathml
 
-    leaves = boxes._elements
+    leaves = boxes.get_elements()
     elements, calc_dimensions = boxes._prepare_elements(
         leaves, options=options, neg_y=True
     )


### PR DESCRIPTION
This PR follows #184: includes several comments on ``mathics.core`` and basic changes in  ``mathics.builtin.__init__`` and ``mathics.builtin.base`` to clarify and improve the implementation of ``BoxConstruct``. 


<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/185"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

