### PR TITLE
Reduce atom has changed

### DIFF
--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -84,13 +84,6 @@ class Number(Atom, NumericOperators):
     def __str__(self) -> str:
         return str(self.value)
 
-    def has_changed(self, definitions) -> bool:
-        """
-        Used in Expression.evaluate() to determine if we need to reevaluation
-        an expression. Numbers never change.
-        """
-        return False
-
     def is_numeric(self, evaluation=None) -> bool:
         return True
 
@@ -896,13 +889,6 @@ class String(Atom):
             return super().get_sort_key(True)
         else:
             return [0, 1, self.value, 0, 1]
-
-    def has_changed(self, definitions) -> bool:
-        """
-        Used in Expression.evaluate() to determine if we need to reevaluation
-        an expression.
-        """
-        return False
 
     def sameQ(self, other) -> bool:
         """Mathics SameQ"""

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -902,8 +902,7 @@ class String(Atom):
         Used in Expression.evaluate() to determine if we need to reevaluation
         an expression.
         """
-        # Should be false - investigate why we need to set this True.
-        return True
+        return False
 
     def sameQ(self, other) -> bool:
         """Mathics SameQ"""

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -100,6 +100,7 @@ class BaseElement(KeyComparable):
     def __init__(self, *args, **kwargs):
         self.options = None
         self.pattern_sequence = False
+        # FIXME: this should be removed
         self._cache = None
 
     def apply_rules(
@@ -123,6 +124,7 @@ class BaseElement(KeyComparable):
                 return result, True
         return self, False
 
+    # FIXME: this should be removed
     def clear_cache(self):
         self._cache = None
 

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -432,7 +432,7 @@ class BaseElement(KeyComparable):
 
     def has_changed(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluation
+        Used in Expression.evaluate() to determine if we need to reevaluate
         an expression. Each subclass should decide what is right here.
         """
         raise NotImplementedError

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -149,7 +149,7 @@ class ExpressionCache:
             if not hasattr(expr, "_cache") or expr.has_changed(definitions):
                 return None
 
-        # FIXME: this is workaround that some like String have a cache
+        # FIXME: this is workaround that some Atoms, like String, have a cache
         # even though they don't need it, by virtue of this getting set up
         # in BaseElement.__init__. Removing the self._cache in there the causes Boxing
         # to mess up. Untangle this mess.

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -149,10 +149,11 @@ class ExpressionCache:
             if not hasattr(expr, "_cache") or expr.has_changed(definitions):
                 return None
 
-        # FIXME: this is workaround that some Atoms, like String, have a cache
-        # even though they don't need it, by virtue of this getting set up
-        # in BaseElement.__init__. Removing the self._cache in there the causes Boxing
-        # to mess up. Untangle this mess.
+        # FIXME: this is workaround the current situtation that some
+        # Atoms, like String, have a cache even though they don't need
+        # it, by virtue of this getting set up in
+        # BaseElement.__init__. Removing the self._cache in there the
+        # causes Boxing to mess up. Untangle this mess.
         if expr._cache is None:
             return None
 
@@ -872,7 +873,7 @@ class Expression(BaseElement, NumericOperators):
 
     def has_changed(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluation
+        Used in Expression.evaluate() to determine if we need to reevaluate
         an expression.
         """
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -149,6 +149,13 @@ class ExpressionCache:
             if not hasattr(expr, "_cache") or expr.has_changed(definitions):
                 return None
 
+        # FIXME: this is workaround that some like String have a cache
+        # even though they don't need it, by virtue of this getting set up
+        # in BaseElement.__init__. Removing the self._cache in there the causes Boxing
+        # to mess up. Untangle this mess.
+        if expr._cache is None:
+            return None
+
         symbols = set.union(*[expr._cache.symbols for expr in expressions])
 
         return ExpressionCache(

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -291,11 +291,10 @@ class Atom(BaseElement):
     def has_changed(self, definitions) -> bool:
         """
         Used in Expression.evaluate() to determine if we need to reevaluation
-        an expression.
+        an expression. No Atoms need reevaluation. And  if this is wrong they
+        should override this method.
         """
-        # It would be nice to make the default "False" here and have Symbols
-        # and other special-cases override to True when needed.
-        return True
+        return False
 
     def has_form(self, heads, *element_counts) -> bool:
         if element_counts:
@@ -441,6 +440,11 @@ class Symbol(Atom, NumericOperators):
         Used in Expression.evaluate() to determine if we need to reevaluation
         an expression.
         """
+        # FIXME:
+        # The test:
+        #    InputForm[Context[]] == "Global`"
+        # is a test that fails when we return False.
+        # Understand what's up here.
         return True
 
     def has_symbol(self, symbol_name) -> bool:

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -290,9 +290,9 @@ class Atom(BaseElement):
 
     def has_changed(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluation
-        an expression. No Atoms need reevaluation. And  if this is wrong they
-        should override this method.
+        Used in Expression.evaluate() to determine if we need to reevaluate
+        an expression. No Atoms need reevaluation. And if this is wrong for a
+        subclass, the subclass should override this method.
         """
         return False
 
@@ -435,9 +435,9 @@ class Symbol(Atom, NumericOperators):
     def get_head_name(self):
         return "System`Symbol"
 
-    def has_changed(self, definitions):
+    def has_changed(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluation
+        Used in Expression.evaluate() to determine if we need to reevaluate
         an expression.
         """
         # FIXME:


### PR DESCRIPTION
Following up on @TiagoCavalcante ' s comment about (most) Atoms, especially Strings not being needing re-evaluation (or a complex cache) I have reduced this at the slight expense of an extra check in one of the caching routines.

That could be removed by fixing up BaseElement not to set up a cache in the first place (which I think is the right thing), but there is some other interaction with Boxing that is causing infinite recursion. Go figure. 

Until we get that problem fixed (and will that lead to some other unrelated place that needs to change as well?) in my opinion the best thing is just to make that extra lightweight test in the cache update routine. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/187"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

