### PR TITLE
Clarify function previously called "has_changed()"

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -259,7 +259,7 @@ class Definitions(object):
     def is_uncertain_final_value(self, last_evaluated_time: int, symbols: set) -> bool:
         """
         Used in Evaluate_do_format() to
-        determine if we should to (re)evaluate an expression.
+        determine if we should (re)evaluate an expression.
 
         Here, for a definitions object, we check if any symbol in the
         symbols has changed. `last_evaluated_time` indicates when the

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pickle
@@ -10,7 +9,7 @@ import bisect
 
 from collections import defaultdict
 
-import typing
+from typing import List, Optional
 
 from mathics.core.atoms import String
 from mathics.core.attributes import nothing
@@ -257,19 +256,30 @@ class Definitions(object):
         for k in self.proxy.pop(tail, []):
             definitions_cache.pop(k, None)
 
-    def has_changed(self, maximum, symbols):
-        # timestamp for the most recently changed part of a given expression.
+    def uncertain_final_value(self, last_evaluated_time: int, symbols: set) -> bool:
+        """
+        Used in Evaluate_do_format() to
+        determine if we should to (re)evaluate an expression.
+
+        Here, for a definitions object, we check if any symbol in the
+        symbols has changed. `last_evaluated_time` indicates when the
+        evaluation started. If a symbol has a time greater than
+        that, then things have changed since the evaluation started
+        and evaluation may lead to a different result.
+        """
         for name in symbols:
-            symb = self.get_definition(name, only_if_exists=True)
-            if symb is None:
-                # symbol doesn't exist so it was never changed
+            symbol = self.get_definition(name, only_if_exists=True)
+            if symbol is None:
+                # "symbol" doesn't exist, so it was never changed.
                 pass
             else:
-                changed = getattr(symb, "changed", None)
-                if changed is None:
-                    # must be system symbol
-                    symb.changed = 0
-                elif changed > maximum:
+                # Get timestamp for the most-recently changed part of the given expression.
+                symbol_change_time = getattr(symbol, "changed", None)
+                if symbol_change_time is None:
+                    # Must be a system symbol that never changes.
+                    # FIXME: couldn't this initially start out 0 so no test is needed?
+                    symbol.change_timestamp = 0
+                elif symbol_change_time > last_evaluated_time:
                     return True
 
         return False
@@ -318,7 +328,7 @@ class Definitions(object):
         accessible_ctxts.add(self.current_context)
         return accessible_ctxts
 
-    def get_matching_names(self, pattern) -> typing.List[str]:
+    def get_matching_names(self, pattern) -> List[str]:
         """
         Return a list of the symbol names matching a string pattern.
 
@@ -412,7 +422,7 @@ class Definitions(object):
                 return n
         return with_context
 
-    def get_package_names(self) -> typing.List[str]:
+    def get_package_names(self) -> List[str]:
         packages = self.get_ownvalue("System`$Packages")
         packages = packages.replace
         assert packages.has_form("System`List", None)
@@ -555,7 +565,7 @@ class Definitions(object):
             if result is not None:
                 return result
 
-    def get_user_definition(self, name, create=True) -> typing.Optional["Definition"]:
+    def get_user_definition(self, name, create=True) -> Optional["Definition"]:
         assert not isinstance(name, Symbol)
 
         existing = self.user.get(name)
@@ -746,7 +756,7 @@ class Definitions(object):
         return history_length
 
 
-def get_tag_position(pattern, name) -> typing.Optional[str]:
+def get_tag_position(pattern, name) -> Optional[str]:
     if pattern.get_name() == name:
         return "own"
     elif isinstance(pattern, Atom):

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -446,9 +446,9 @@ class BaseElement(KeyComparable):
     def get_string_value(self):
         return None
 
-    def has_changed(self, definitions) -> bool:
+    def uncertain_final_definitions(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluate
+        Used in Expression.do_format() to determine if we should to (re)evaluate
         an expression. Each subclass should decide what is right here.
         """
         raise NotImplementedError

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -448,7 +448,7 @@ class BaseElement(KeyComparable):
 
     def is_uncertain_final_definitions(self, definitions) -> bool:
         """
-        Used in Expression.do_format() to determine if we should to (re)evaluate
+        Used in Expression.do_format() to determine if we should (re)evaluate
         an expression. Each subclass should decide what is right here.
         """
         raise NotImplementedError

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -146,7 +146,9 @@ class ExpressionCache:
         definitions = evaluation.definitions
 
         for expr in expressions:
-            if not hasattr(expr, "_cache") or expr.has_changed(definitions):
+            if not hasattr(expr, "_cache") or expr.uncertain_final_definitions(
+                definitions
+            ):
                 return None
 
         # FIXME: this is workaround the current situtation that some
@@ -484,12 +486,12 @@ class Expression(BaseElement, NumericOperators):
             raise Exception("Expression.do_format\n", form, " should be a Symbol")
             form = Symbol(form)
 
-        last_evaluated, expr = self._format_cache.get(form, (None, None))
-        if last_evaluated is not None and expr is not None:
+        last_evaluated_time, expr = self._format_cache.get(form, (None, None))
+        if last_evaluated_time is not None and expr is not None:
             symbolname = expr.get_name()
             if symbolname != "":
-                if not evaluation.definitions.has_changed(
-                    last_evaluated, (symbolname,)
+                if not evaluation.definitions.uncertain_final_value(
+                    last_evaluated_time, (symbolname,)
                 ):
                     return expr
         expr = super().do_format(evaluation, form)
@@ -568,7 +570,7 @@ class Expression(BaseElement, NumericOperators):
                 # changed before last evaluated?
                 # This prevents to reevaluate expressions that
                 # have been already evaluated. This uses Expression._cache
-                if not expr.has_changed(definitions):
+                if not expr.uncertain_final_definitions(definitions):
                     break
 
                 # Here the names of the lookupname of the expression
@@ -882,7 +884,7 @@ class Expression(BaseElement, NumericOperators):
             else:
                 return [1 if self.is_numeric() else 2, 3, head, self._elements, 1]
 
-    def has_changed(self, definitions) -> bool:
+    def uncertain_final_definitions(self, definitions) -> bool:
         """
         Used in Expression.evaluate() to determine if we need to reevaluate
         an expression.
@@ -906,7 +908,7 @@ class Expression(BaseElement, NumericOperators):
         if cache.symbols is None:
             cache = self._rebuild_cache()
 
-        return definitions.has_changed(time, cache.symbols)
+        return definitions.uncertain_final_value(time, cache.symbols)
 
     def has_form(self, heads, *element_counts):
         """

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -491,7 +491,7 @@ class Expression(BaseElement, NumericOperators):
             symbolname = expr.get_name()
             if symbolname != "":
                 if not evaluation.definitions.uncertain_final_value(
-                    last_evaluated_time, (symbolname,)
+                    last_evaluated_time, set((symbolname,))
                 ):
                     return expr
         expr = super().do_format(evaluation, form)

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -288,11 +288,16 @@ class Atom(BaseElement):
         else:
             raise NotImplementedError
 
-    def has_changed(self, definitions) -> bool:
+    def uncertain_final_definitions(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluate
-        an expression. No Atoms need reevaluation. And if this is wrong for a
-        subclass, the subclass should override this method.
+        Used in Expression.do_format() to determine if we may need to
+        (re)evaluate an expression.
+
+        Most Atoms, e.g. Numbers and Strings, need do not need
+        evaluation or reevaluation. However some kinds of Atoms like
+        Symbols sometimes do. The Symbol class or any other class like
+        this then needs to override this method.
+
         """
         return False
 
@@ -435,16 +440,24 @@ class Symbol(Atom, NumericOperators):
     def get_head_name(self):
         return "System`Symbol"
 
-    def has_changed(self, definitions) -> bool:
+    def uncertain_final_definitions(self, definitions) -> bool:
         """
-        Used in Expression.evaluate() to determine if we need to reevaluate
-        an expression.
+        Used in Expression.do_format to determine if we need to
+        (re)evaluate an expression.
+
+        Here, we have to be pessimistic and return True.
+
+           InputForm[Context[]] == "Global`"
+
+        is an example where we need to evaluate "Global`" and it doesn't start out as a
+        final value.
         """
-        # FIXME:
-        # The test:
-        #    InputForm[Context[]] == "Global`"
-        # is a test that fails when we return False.
-        # Understand what's up here.
+
+        # FIXME: can we arrange things so that a string like "Global`"
+        # starts out as an evaluated symbol?
+
+        # FIXME: revise Class structure for *constant* Symbols like True, False, and Null.
+        # They would have an uncertain_final_value() class that returns False.
         return True
 
     def has_symbol(self, symbol_name) -> bool:

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -305,11 +305,11 @@ class Atom(BaseElement):
         Used in Expression.do_format() to determine if we may need to
         (re)evaluate an expression.
 
-        Most Atoms, e.g. Numbers and Strings, do not need
-        evaluation or reevaluation. However some kinds of Atoms like
-        Symbols sometimes do. The Symbol class or any other class like
-        this then needs to override this method.
-
+        Most Atoms, like Numbers and Strings, do not need evaluation
+        or reevaluation. However some kinds of Atoms like Symbols
+        sometimes do. The Symbol class or any other class like this
+        that is subclassed from Atom then needs to override this
+        method.
         """
         return False
 
@@ -442,22 +442,6 @@ class Symbol(Atom, NumericOperators):
 
     def has_symbol(self, symbol_name) -> bool:
         return self.name == ensure_context(symbol_name)
-
-    def is_uncertain_final_definitions(self, definitions) -> bool:
-        """
-        Used in Expression.do_format() to determine if we need to
-        (re)evaluate an expression.
-
-        Here, we have to be pessimistic and return True. For example,
-        in:
-
-           Context[]
-
-        this routine will get called where "self" is $System`Context. We
-        can't stop here, but must continue evaluation to get the function's value,
-        such as "Global`".
-        """
-        return True
 
     def is_numeric(self, evaluation=None) -> bool:
         """


### PR DESCRIPTION
has_changed() is now either uncertain_final_value(), called in do_format()
or uncertain_final_definitions(), called in evaluate().

Document what these do, and motivate why specific constant values are
returned in specific classes.

Having the same name for two slightly different things was confusing.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

