### PR TITLE
clear the cache of the definition for the symbol to be cleared

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,7 @@ Bugs
 *  ``Set*``: fixed issue #128.
 *  ``SameQ``: comparison with MachinePrecision only needs to be exact within the last bit Issue #148.
 * Fix a bug in `Simplify` that produced expressions of the form ``ConditionalExpression[_,{True}]``.
-
+* Fix bug in ``Clear``  and ``ClearAll`` (#194).
 
 4.0.1
 -----

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -117,6 +117,8 @@ class Clear(Builtin):
                 if not self.allow_locked and locked & attributes:
                     evaluation.message("Clear", "locked", Symbol(name))
                     continue
+                # remove the cache for the definition first.
+                evaluation.definitions.clear_cache(name)
                 definition = evaluation.definitions.get_user_definition(name)
                 self.do_clear(definition)
 

--- a/test/test_numericq.py
+++ b/test/test_numericq.py
@@ -117,7 +117,7 @@ def test_atomic_numericq(str_expr, str_expected):
 )
 def test_expression_numericq(str_expr, str_expected):
     check_evaluation(f"NumericQ[{str_expr}]", str_expected)
-    session.evaluate("ClearAll[a, F]")
+    session.evaluate("ClearAll[a];ClearAll[F]")
     session.evaluate("NumericQ[a]=False;NumericQ[b]=False; NumericQ[Pi]=True;")
 
 
@@ -170,4 +170,8 @@ def test_expression_numericq(str_expr, str_expected):
 def test_assign_numericq(str_expr, str_expected):
     check_evaluation(str_expr, str_expected)
     session.evaluate("ClearAll[a, F, g]")
+    print(session.evaluation.definitions.get_definition("Global`F"))
+    print(session.evaluation.definitions.get_definition("Global`a"))
+    print(session.evaluation.definitions.get_definition("System`F"))
+    print(session.evaluation.definitions.get_definition("System`a"))
     session.evaluate("NumericQ[a]=False;NumericQ[b]=False; NumericQ[Pi]=True;")

--- a/test/test_numericq.py
+++ b/test/test_numericq.py
@@ -117,7 +117,7 @@ def test_atomic_numericq(str_expr, str_expected):
 )
 def test_expression_numericq(str_expr, str_expected):
     check_evaluation(f"NumericQ[{str_expr}]", str_expected)
-    session.evaluate("ClearAll[a];ClearAll[F]")
+    session.evaluate("ClearAll[a, F]")
     session.evaluate("NumericQ[a]=False;NumericQ[b]=False; NumericQ[Pi]=True;")
 
 
@@ -170,8 +170,4 @@ def test_expression_numericq(str_expr, str_expected):
 def test_assign_numericq(str_expr, str_expected):
     check_evaluation(str_expr, str_expected)
     session.evaluate("ClearAll[a, F, g]")
-    print(session.evaluation.definitions.get_definition("Global`F"))
-    print(session.evaluation.definitions.get_definition("Global`a"))
-    print(session.evaluation.definitions.get_definition("System`F"))
-    print(session.evaluation.definitions.get_definition("System`a"))
     session.evaluate("NumericQ[a]=False;NumericQ[b]=False; NumericQ[Pi]=True;")


### PR DESCRIPTION
Fix #194 by cleaning the definitions cache for the corresponding symbol.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

