### PR TITLE
Another cleanup round

### DIFF
--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -28,7 +28,7 @@ from mathics.core.atoms import (
     Integer1,
     Number,
 )
-from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolTrue
+from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolList, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolDirectedInfinity,
     SymbolInfinity,
@@ -938,7 +938,7 @@ class _MinMax(Builtin):
     def apply(self, items, evaluation):
         "%(name)s[items___]"
 
-        items = items.flatten(Symbol("List")).get_sequence()
+        items = items.flatten_with_respect_to_head(SymbolList).get_sequence()
         results = []
         best = None
 

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -394,7 +394,7 @@ class _Plot(Builtin):
                     for rule in rules:
                         f = rule.apply(f, evaluation, fully=True)
                 functions_param[index] = f
-            functions = functions.flatten(Symbol("List"))
+            functions = functions.flatten_with_respect_to_head(SymbolList)
 
         expr_limits = Expression(SymbolList, x, start, stop)
         expr = Expression(

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1130,17 +1130,17 @@ class Style(object):
         return edge_style.get_thickness()
 
 
-def _flatten(leaves):
-    for leaf in leaves:
-        if leaf.get_head() is SymbolList:
-            flattened = leaf.flatten(SymbolList)
+def _flatten(elements):
+    for element in elements:
+        if element.get_head() is SymbolList:
+            flattened = element.flatten_with_respect_to_head(SymbolList)
             if flattened.get_head() is SymbolList:
-                for x in flattened.leaves:
+                for x in flattened.elements:
                     yield x
             else:
                 yield flattened
         else:
-            yield leaf
+            yield element
 
 
 class _GraphicsElements(object):

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -447,7 +447,9 @@ class Simplify(Builtin):
             if assumptions_list.get_head() is not SymbolList:
                 assumptions_list = Expression(SymbolList, assumptions_list)
             assum = Expression(SymbolList, assum, assumptions_list)
-        assumptions = assum.evaluate(evaluation).flatten(SymbolList)
+        assumptions = assum.evaluate(evaluation).flatten_with_respect_to_head(
+            SymbolList
+        )
         # Now, reevaluate the expression with all the assumptions.
         simplify_expr = Expression(self.get_name(), expr)
         return dynamic_scoping(
@@ -456,7 +458,7 @@ class Simplify(Builtin):
             evaluation,
         )
 
-    def apply_power_of_zero(self, b, evaluation):
+    def apply_power_of_zero(self, b, evaluation, options):
         "%(name)s[0^b_]"
         if self.apply(Expression("Less", 0, b), evaluation, options) is SymbolTrue:
             return Integer0

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -8,6 +8,7 @@ Options and Default Arguments
 from mathics.builtin.base import Builtin, Test, get_option
 from mathics.core.symbols import (
     Symbol,
+    SymbolList,
     ensure_context,
     strip_context,
 )
@@ -308,7 +309,7 @@ class OptionQ(Test):
     """
 
     def test(self, expr):
-        expr = expr.flatten(Symbol("List"))
+        expr = expr.flatten_with_respect_to_head(SymbolList)
         if not expr.has_form("List", None):
             expr = [expr]
         else:
@@ -338,7 +339,7 @@ class NotOptionQ(Test):
     """
 
     def test(self, expr):
-        expr = expr.flatten(Symbol("List"))
+        expr = expr.flatten_with_respect_to_head(SymbolList)
         if not expr.has_form("List", None):
             expr = [expr]
         else:

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -449,7 +449,7 @@ class StringJoin(BinaryOperator):
         "StringJoin[items___]"
 
         result = ""
-        items = items.flatten(SymbolList)
+        items = items.flatten_with_respect_to_head(SymbolList)
         if items.get_head_name() == "System`List":
             items = items.leaves
         else:

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -1085,14 +1085,16 @@ class Flatten(Builtin):
         "Flatten[expr_, n_, h_]"
 
         if n == Expression("DirectedInfinity", 1):
-            n = None
+            n = -1  # a negative number indicates an unbounded level
         else:
             n_int = n.get_int_value()
+            # Here we test for negative since in Mathics Flatten[] as opposed to flatten_with_respect_to_head()
+            # negative numbers (and None) are not allowed.
             if n_int is None or n_int < 0:
                 return evaluation.message("Flatten", "flpi", n)
             n = n_int
 
-        return expr.flatten(h, level=n)
+        return expr.flatten_with_respect_to_head(h, level=n)
 
 
 class Null(Predefined):

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -97,7 +97,7 @@ class BaseElement(KeyComparable):
     # this variable holds a function defined in mathics.core.expression that creates an expression
     create_expression: Any
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *arg):
         self.options = None
         self.pattern_sequence = False
         # This property would be useful for a BoxExpression
@@ -453,16 +453,8 @@ class BaseElement(KeyComparable):
         """
         raise NotImplementedError
 
-    @property
-    def is_zero(self) -> bool:
-        return False
-
     def is_machine_precision(self) -> bool:
         """Check if the number represents a floating point number"""
-        return False
-
-    def is_true(self) -> bool:
-        """Better use self is SymbolTrue"""
         return False
 
     def is_numeric(self, evaluation=None) -> bool:
@@ -477,6 +469,15 @@ class BaseElement(KeyComparable):
         with Head.name in `heads` and a number of leaves according to the specification in
         element_counts.
         """
+        return False
+
+    # Warning - this is going away
+    def is_true(self) -> bool:
+        """Better use self is SymbolTrue"""
+        return False
+
+    @property
+    def is_zero(self) -> bool:
         return False
 
     def __hash__(self):

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -97,7 +97,10 @@ class BaseElement(KeyComparable):
     # this variable holds a function defined in mathics.core.expression that creates an expression
     create_expression: Any
 
-    def __init__(self, *arg):
+    # FIXME: kwargs seems to be is needed because Real.__new_() takes a parameter
+    # and magically that gets turned into kwargs here.
+    # Figure out how to address this.
+    def __init__(self, *args, **kwargs):
         self.options = None
         self.pattern_sequence = False
         # This property would be useful for a BoxExpression

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -368,7 +368,7 @@ class BaseElement(KeyComparable):
 
         options = self
         if options.has_form("List", None):
-            options = options.flatten(SymbolList)
+            options = options.flatten_with_respect_to_head(SymbolList)
             values = options.leaves
         else:
             values = [options]
@@ -420,7 +420,7 @@ class BaseElement(KeyComparable):
         # have at most a trivial implementation here, and specialize it
         # in the `Expression` class.
 
-        list_expr = self.flatten(SymbolList)
+        list_expr = self.flatten_with_respect_to_head(SymbolList)
         list = []
         if list_expr.has_form("List", None):
             list.extend(list_expr.leaves)

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -253,13 +253,21 @@ class Atom(BaseElement):
         """
         return self
 
-    def flatten(self, head, pattern_only=False, callback=None) -> "Atom":
-        return self
-
     def flatten_sequence(self, evaluation) -> "Atom":
         return self
 
     def flatten_pattern_sequence(self, evaluation) -> "Atom":
+        return self
+
+    def flatten_with_respect_to_head(
+        self, head, pattern_only=False, callback=None, level=None
+    ) -> "Atom":
+        """
+        Flatten elements in self which have `head` in them.
+
+        Atoms don't have elements, so an Atom is already "flattened". So just return
+        the Atom.
+        """
         return self
 
     def get_atom_name(self) -> str:

--- a/test/test_elements/test_flatten_head.py
+++ b/test/test_elements/test_flatten_head.py
@@ -1,0 +1,51 @@
+from mathics.core.expression import Expression
+from mathics.core.symbols import Symbol
+
+
+def test_flatten_with_respect_to_head():
+    """
+    Tests expr.flatten_with_respect_to_head(head_element)
+    """
+
+    Plus = Symbol("Plus")
+    plus_expr = Expression(Plus, 1, Expression(Plus, 2, Expression(Plus, 3, 4)), 5)
+    assert (
+        len(plus_expr.elements) == 3
+    ), "Unflattened Plus elements should be 1, Plus(...), 5"
+
+    flattened_plus_expr = plus_expr.flatten_with_respect_to_head(Plus)
+    assert (
+        len(flattened_plus_expr.elements) == 5
+    ), "Flattened Plus elements should be 1, 2, 3, 4, 5"
+
+    # Now test setting the level parameter
+    flattened_plus_expr = plus_expr.flatten_with_respect_to_head(Plus, level=1)
+    assert (
+        len(flattened_plus_expr.elements) == 4
+    ), "Flattened Plus elements with level should be 1, 2, Plus(...), 5"
+
+    flattened_plus_expr = plus_expr.flatten_with_respect_to_head(Plus, level=0)
+    assert flattened_plus_expr == plus_expr, "No flattening with level=0"
+
+    for level in (-1, 10, 100):
+        flattened_plus_expr = plus_expr.flatten_with_respect_to_head(Plus, level=level)
+        assert (
+            len(flattened_plus_expr.elements) == 5
+        ), f"Flattened Plus elements limit {level} should be 1, 2, 3, 4, 5"
+
+    f = Symbol("f")
+    a = Symbol("a")
+    b = Symbol("b")
+    expr = Expression(f, a, Expression(f, b, Expression(f, a, b)))
+    assert len(expr.elements) == 2
+    flattened_expr = expr.flatten_with_respect_to_head(f)
+    assert len(flattened_expr.elements) == 4, "should have flattened to: a, b, a, b"
+
+    flattened_expr = expr.flatten_with_respect_to_head(a)
+    assert (
+        flattened_expr == expr
+    ), "Non-matching head - nothing should have been flattened"
+
+
+if __name__ == "__main__":
+    test_flatten_with_respect_to_head()


### PR DESCRIPTION
Remove **kwargs in init/new methods when they aren't used. At the lowest level if `**kwargs` isn't used, it should not be tolerated (as opposed to tolerated and ignored). Instead, callers should need to know what is accepted in construction and not have arbitrary stuff accepted and ignored.
   
More leaf/leaves to element/elements conversions.

Go over `flatten_with_respect_to_head()`:  

*  `flatten` -> `flatten_with_respect_to_head()` when that's what it means. Other `flatten()` methods which work slightly differently haven't been touched.
 * a small unit test started for flatten_with_respect_to_head was started.  Expect more unit tests of elements in the future
    
Some minor bugs encountered were fixed.





<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/196"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

