### PR TITLE
Fix #200

### DIFF
--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -106,7 +106,7 @@ class _EqualityOperator(_InequalityOperator):
             return
         for l, r in zip(lhs._elements, rhs._elements):
             tst = self.equal2(l, r, max_extra_prec)
-            if not tst:
+            if tst is False or tst is None:
                 return tst
         return True
 
@@ -489,7 +489,10 @@ def do_cplx_equal(x, y) -> Optional[int]:
                 return False
             else:
                 return True
-    return do_cmp(x, y) == 0
+    c = do_cmp(x, y)
+    if c is None:
+        return None
+    return c == 0
 
 
 def do_cmp(x1, x2) -> Optional[int]:

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -106,8 +106,11 @@ class _EqualityOperator(_InequalityOperator):
             return
         for l, r in zip(lhs._elements, rhs._elements):
             tst = self.equal2(l, r, max_extra_prec)
-            if tst is False or tst is None:
-                return tst
+            # If the there are a pair of corresponding elements
+            # that are not equals, then we are not able to decide
+            # about the equality.
+            if not tst:
+                return None
         return True
 
     def infty_equal(self, lhs, rhs, max_extra_prec=None) -> Optional[bool]:
@@ -192,7 +195,6 @@ class _EqualityOperator(_InequalityOperator):
         # Still we didn't have a result. Try with the following
         # tests
         other_tests = (self.infty_equal, self.expr_equal, self.sympy_equal)
-
         for test in other_tests:
             c = test(lhs, rhs, max_extra_prec)
             if c is not None:

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -563,6 +563,8 @@ class Equal(_EqualityOperator, SympyComparison):
         For any expression $x$ and $y$, Equal[$x$, $y$] == Not[Unequal[$x$, $y$]].
 
         For any expression 'SameQ[$x$, $y$]' implies Equal[$x$, $y$].
+      <dt>'$x$ == $y$ == $z$ == $\ldots$'
+      <dd> express a chain of equalities.
     </dl>
 
 
@@ -633,6 +635,21 @@ class Equal(_EqualityOperator, SympyComparison):
      = True
     >> Pi == 3.14
      = False
+
+    For chains of equalities, the comparison is done amongs all the pairs. The evaluation is successful
+    only if the equality is satisfied over all the pairs:
+
+    >> g[1] == g[1] == g[1]
+     = True
+    >> g[1] == g[1] == g[r]
+     = g[1] == g[1] == g[r]
+
+    Equality can also be combined with other inequality expressions, like
+    >> g[1] == g[2] != g[3]
+     = g[1] == g[2] && g[2] != g[3]
+
+    >> g[1] == g[2] <= g[3]
+     = g[1] == g[2] && g[2] <= g[3]
 
     #> Pi ^ E == E ^ Pi
      = False

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -40,6 +40,23 @@ import pytest
         ("g[a]<g[b]", "g[a] < g[b]", "not comparable expressions"),
         ("g[a]<g[a]", "g[a] < g[a]", "not comparable expressions (like in WMA)"),
         ("g[1]<g[1]", "g[1] < g[1]", "not comparable expressions (like in WMA)"),
+        (
+            "g[1]==g[1]==g[2]",
+            "g[1] == g[1] == g[2]",
+            "WMA does not reduce these expressions.",
+        ),
+        (
+            "g[1]==g[2]==g[1]",
+            "g[1] == g[2] == g[1]",
+            "WMA does not reduce these expressions.",
+        ),
+        ("g[1]==g[1]==g[1]", "True", "Equal works over several elements"),
+        (
+            "g[1]==g[2]!=g[1]",
+            "g[1] == g[2] && g[2] != g[1]",
+            "Equal mixed with unequality splits",
+        ),
+        ("g[1]!=g[1]==g[2]", "False", "This evaluates first the inequality"),
     ],
 )
 def test_compare_many_members(str_expr: str, str_expected: str, fail_msg: str):

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -3,9 +3,51 @@ from .helper import check_evaluation, session
 import pytest
 
 
-def test_compare_many_members():
-    result = session.evaluate("ToString[g[2]==g[3]]").value
-    assert result == "g[2] == g[3]", "Issue #200"
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "fail_msg"),
+    [
+        #        (None, None, None,),
+        # Equality
+        (
+            "ClearAll[g,a,b];",
+            "Null",
+            None,
+        ),
+        ("g[2]==g[3]", "g[2] == g[3]", "not comparable expressions, Issue #200"),
+        ("g[a]==g[3]", "g[a] == g[3]", "not comparable expressions"),
+        ("g[2]==g[a]", "g[2] == g[a]", "not comparable expressions"),
+        ("g[a]==g[b]", "g[a] == g[b]", "not comparable expressions"),
+        ("g[a]==g[a]", "True", "identical expressions"),
+        ("g[1]==g[1]", "True", "identical expressions"),
+        # Inequalities
+        ("g[2]!=g[3]", "g[2] != g[3]", "not comparable expressions, Issue #200"),
+        ("g[a]!=g[3]", "g[a] != g[3]", "not comparable expressions"),
+        ("g[2]!=g[a]", "g[2] != g[a]", "not comparable expressions"),
+        ("g[a]!=g[b]", "g[a] != g[b]", "not comparable expressions"),
+        ("g[a]!=g[a]", "False", "identical expressions"),
+        ("g[1]!=g[1]", "False", "identical expressions"),
+        #
+        ("g[2]<=g[3]", "g[2] <= g[3]", "not comparable expressions, Issue #200"),
+        ("g[a]<=g[3]", "g[a] <= g[3]", "not comparable expressions"),
+        ("g[2]<=g[a]", "g[2] <= g[a]", "not comparable expressions"),
+        ("g[a]<=g[b]", "g[a] <= g[b]", "not comparable expressions"),
+        ("g[a]<=g[a]", "g[a] <= g[a]", "not comparable expressions (like in WMA)"),
+        ("g[1]<=g[1]", "g[1] <= g[1]", "not comparable expressions (like in WMA)"),
+        #
+        ("g[2]<g[3]", "g[2] < g[3]", "not comparable expressions, Issue #200"),
+        ("g[a]<g[3]", "g[a] < g[3]", "not comparable expressions"),
+        ("g[2]<g[a]", "g[2] < g[a]", "not comparable expressions"),
+        ("g[a]<g[b]", "g[a] < g[b]", "not comparable expressions"),
+        ("g[a]<g[a]", "g[a] < g[a]", "not comparable expressions (like in WMA)"),
+        ("g[1]<g[1]", "g[1] < g[1]", "not comparable expressions (like in WMA)"),
+    ],
+)
+def test_compare_many_members(str_expr: str, str_expected: str, fail_msg: str):
+    #    if str_expr is None:
+    #        reset_session()
+    result = session.evaluate(f"ToString[{str_expr}]").value
+    print("result:", result)
+    assert result == str_expected  # , fail_msg
 
 
 # SameQ test

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -3,6 +3,11 @@ from .helper import check_evaluation, session
 import pytest
 
 
+def test_compare_many_members():
+    result = session.evaluate("ToString[g[2]==g[3]]").value
+    assert result == "g[2] == g[3]", "Issue #200"
+
+
 # SameQ test
 @pytest.mark.parametrize(
     ("str_lhs", "str_rhs", "str_expected"),


### PR DESCRIPTION
This PR fix a bug in the implementation of ``Equal`` and  ``Unequal``, and adds several tests. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/204"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

