### PR TITLE
Add builtin Diagonal

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -160,6 +160,7 @@ for subdir in (
     "files_io",
     "intfns",
     "list",
+    "matrices",
     "moments",
     "numbers",
     "specialfns",

--- a/mathics/builtin/matrices/__init__.py
+++ b/mathics/builtin/matrices/__init__.py
@@ -1,0 +1,7 @@
+"""
+Matrices and Linear Algebra
+
+Construction and manipulation of Matrices.
+"""
+
+from mathics.version import __version__  # noqa used in loading to check consistency.

--- a/mathics/builtin/matrices/partmatrix.py
+++ b/mathics/builtin/matrices/partmatrix.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+"""
+Parts of Matrices
+
+Set of methods for manipulating Matrices.
+"""
+
+
+from mathics.builtin.base import Builtin
+from mathics.core.expression import Expression
+from mathics.core.symbols import SymbolList
+
+
+class Diagonal(Builtin):
+    """
+    <dl>
+        <dt>'Diagonal[$m$]'
+        <dd>gives a list with the values in the diagonal of the matrix $m$.
+        <dt>'Diagonal[$m$, $k$]'
+        <dd>gives a list with the values in the $k$ diagonal of the matrix $m$.
+    </dl>
+
+    >> Diagonal[{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}]
+     = {1, 5, 9}
+    >> Diagonal[{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, 1]
+     = {2, 6}
+    """
+
+    rules = {
+        "Diagonal[expr_]": "Diagonal[expr, 0]",
+    }
+
+    summary_text = "Return a list with the diagonal elements of a given matrix"
+
+    def apply(self, expr, diag, evaluation):
+        "Diagonal[expr_List, diag_Integer]"
+
+        result = []
+
+        for count, value in enumerate(expr.elements, start=diag.value):
+            if not hasattr(value, "elements") or len(value.elements) <= count:
+                break
+            if count < 0:
+                continue
+            result.append(value.elements[count])
+        return Expression(SymbolList, *result)
+
+
+class MatrixQ(Builtin):
+    """
+    <dl>
+    <dt>'MatrixQ[$m$]'
+        <dd>returns 'True' if $m$ is a list of equal-length lists.
+    <dt>'MatrixQ[$m$, $f$]'
+        <dd>only returns 'True' if '$f$[$x$]' returns 'True' for each
+        element $x$ of the matrix $m$.
+    </dl>
+
+    >> MatrixQ[{{1, 3}, {4.0, 3/2}}, NumberQ]
+     = True
+    """
+
+    rules = {
+        "MatrixQ[expr_]": "ArrayQ[expr, 2]",
+        "MatrixQ[expr_, test_]": "ArrayQ[expr, 2, test]",
+    }
+
+    summary_text = (
+        "Return 'True' if the given argument is a list of equal-length lists."
+    )

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -445,26 +445,6 @@ class Outer(Builtin):
         return rec(lists[0], lists[1:], [])
 
 
-class MatrixQ(Builtin):
-    """
-    <dl>
-    <dt>'MatrixQ[$m$]'
-        <dd>returns 'True' if $m$ is a list of equal-length lists.
-    <dt>'MatrixQ[$m$, $f$]'
-        <dd>only returns 'True' if '$f$[$x$]' returns 'True' for each
-        element $x$ of the matrix $m$.
-    </dl>
-
-    >> MatrixQ[{{1, 3}, {4.0, 3/2}}, NumberQ]
-     = True
-    """
-
-    rules = {
-        "MatrixQ[expr_]": "ArrayQ[expr, 2]",
-        "MatrixQ[expr_, test_]": "ArrayQ[expr, 2, test]",
-    }
-
-
 class RotationTransform(Builtin):
     """
     <dl>

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ setup(
         "mathics.builtin.fileformats",
         "mathics.builtin.files_io",
         "mathics.builtin.intfns",
+        "mathics.builtin.matrices",
         "mathics.builtin.moments",
         "mathics.builtin.numbers",
         "mathics.builtin.numpy_utils",


### PR DESCRIPTION
I tried to implement Diagonal and it seems working.
In https://github.com/Mathics3/mathics-core/issues/115 is proposed to use native Wolfram Language, but I hope this it will be sufficient, at least for the moment.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/215"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

