### PR TITLE
Removing Expression "cache" from BaseElement.

### DIFF
--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -273,7 +273,8 @@ def walk_parts(list_of_list, indices, evaluation, assign_rhs=None):
         except MessageException as e:
             e.message(evaluation)
             return False
-        result.clear_cache()
+        if isinstance(result, Expression):
+            result.clear_cache()
         return result
     else:
         try:

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -845,7 +845,7 @@ class Times(BinaryOperator, SympyFunction):
     def apply(self, items, evaluation):
         "Times[items___]"
         items = items.numerify(evaluation).get_sequence()
-        leaves = []
+        elements = []
         numbers = []
         infinity_factor = False
 
@@ -856,51 +856,51 @@ class Times(BinaryOperator, SympyFunction):
         for item in items:
             if isinstance(item, Number):
                 numbers.append(item)
-            elif leaves and item == leaves[-1]:
-                leaves[-1] = Expression(SymbolPower, leaves[-1], Integer(2))
+            elif elements and item == elements[-1]:
+                elements[-1] = Expression(SymbolPower, elements[-1], Integer(2))
             elif (
-                leaves
+                elements
                 and item.has_form("Power", 2)
-                and leaves[-1].has_form("Power", 2)
-                and item.leaves[0].sameQ(leaves[-1].leaves[0])
+                and elements[-1].has_form("Power", 2)
+                and item.elements[0].sameQ(elements[-1].elements[0])
             ):
-                leaves[-1] = Expression(
+                elements[-1] = Expression(
                     SymbolPower,
-                    leaves[-1].leaves[0],
-                    Expression(SymbolPlus, item.leaves[1], leaves[-1].leaves[1]),
+                    elements[-1].elements[0],
+                    Expression(SymbolPlus, item.elements[1], elements[-1].elements[1]),
                 )
             elif (
-                leaves
+                elements
                 and item.has_form("Power", 2)
-                and item.leaves[0].sameQ(leaves[-1])
+                and item.elements[0].sameQ(elements[-1])
             ):
-                leaves[-1] = Expression(
+                elements[-1] = Expression(
                     SymbolPower,
-                    leaves[-1],
-                    Expression(SymbolPlus, item.leaves[1], Integer1),
+                    elements[-1],
+                    Expression(SymbolPlus, item.elements[1], Integer1),
                 )
             elif (
-                leaves
-                and leaves[-1].has_form("Power", 2)
-                and leaves[-1].leaves[0].sameQ(item)
+                elements
+                and elements[-1].has_form("Power", 2)
+                and elements[-1].elements[0].sameQ(item)
             ):
-                leaves[-1] = Expression(
+                elements[-1] = Expression(
                     SymbolPower,
                     item,
-                    Expression(SymbolPlus, Integer1, leaves[-1].leaves[1]),
+                    Expression(SymbolPlus, Integer1, elements[-1].elements[1]),
                 )
             elif item.get_head().sameQ(SymbolDirectedInfinity):
                 infinity_factor = True
-                if len(item.leaves) > 1:
-                    direction = item.leaves[0]
+                if len(item.elements) > 1:
+                    direction = item.elements[0]
                     if isinstance(direction, Number):
                         numbers.append(direction)
                     else:
-                        leaves.append(direction)
+                        elements.append(direction)
             elif item.sameQ(SymbolInfinity) or item.sameQ(SymbolComplexInfinity):
                 infinity_factor = True
             else:
-                leaves.append(item)
+                elements.append(item)
 
         if numbers:
             if prec is not None:
@@ -925,31 +925,32 @@ class Times(BinaryOperator, SympyFunction):
             if infinity_factor:
                 return SymbolIndeterminate
             return number
-        elif number.sameQ(Integer(-1)) and leaves and leaves[0].has_form("Plus", None):
-            leaves[0] = Expression(
-                leaves[0].get_head(),
+        elif (
+            number.sameQ(Integer(-1))
+            and elements
+            and elements[0].has_form("Plus", None)
+        ):
+            elements[0] = Expression(
+                elements[0].get_head(),
                 *[
-                    Expression(SymbolTimes, Integer(-1), leaf)
-                    for leaf in leaves[0].leaves
+                    Expression(SymbolTimes, Integer(-1), element)
+                    for element in elements[0].elements
                 ],
             )
             number = None
 
-        for leaf in leaves:
-            leaf.clear_cache()
-
         if number is not None:
-            leaves.insert(0, number)
+            elements.insert(0, number)
 
-        if not leaves:
+        if not elements:
             if infinity_factor:
                 return SymbolComplexInfinity
             return Integer1
 
-        if len(leaves) == 1:
-            ret = leaves[0]
+        if len(elements) == 1:
+            ret = elements[0]
         else:
-            ret = Expression(SymbolTimes, *leaves)
+            ret = Expression(SymbolTimes, *elements)
         if infinity_factor:
             return Expression(SymbolDirectedInfinity, ret)
         else:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -107,8 +107,7 @@ class BaseElement(KeyComparable):
         # (see comment in mathocs.core.expression.) However,
         # WL has a way to handle the connection between
         # an expression and a Box expression ``InterpretationBox``.
-        self.unformatted = self  # This may be a garbage-collection nightmare.
-        self._cache = None
+        # self.unformatted = self  # This may be a garbage-collection nightmare.
 
     # comment @mmatera: The next method have a name that starts with ``apply``.
     # This obstaculizes to define ``InstanceableBuiltin``
@@ -145,10 +144,6 @@ class BaseElement(KeyComparable):
             if result is not None:
                 return result, True
         return self, False
-
-    # FIXME: this should be removed
-    def clear_cache(self):
-        self._cache = None
 
     # FIXME the fact that we have to import all of these symbols means
     # modularity is broken somehwere.

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -183,7 +183,7 @@ class Expression(BaseElement, NumericOperators):
         self._head = head
         self._elements = tuple(from_python(element) for element in elts)
         self._sequences = None
-
+        self._cache = None
         # comment @mmatera: this cache should be useful in BoxConstruct, but not
         # here...
         self._format_cache = None


### PR DESCRIPTION
Remove _cache property from Element and clear_cache method from ``BaseElement``, and move them to the class ``Expression``. These properties do not make sense for Elements that do not have sub-elements. Also, I added a couple of *ifs* 
to check that calls to ``clear_cache`` in builtins are performed just over expressions.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/218"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

