### PR TITLE
Tolerate Unicode in parser testing

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -26,6 +26,8 @@ jobs:
         brew install llvm@11
         python -m pip install --upgrade pip
         LLVM_CONFIG=/usr/local/Cellar/llvm@11/11.1.0/bin/llvm-config pip install llvmlite
+        # Can remove after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install --upgrade pip
         LLVM_CONFIG=/usr/local/Cellar/llvm@11/11.1.0/bin/llvm-config pip install llvmlite
         # Can remove after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
         # Can remove after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full-cython

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -22,6 +22,8 @@ jobs:
       run: |
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
+        # Can remove after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full-cython

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,6 +24,8 @@ jobs:
       run: |
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
+        # Can remove after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
         # Can remove after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,8 @@ jobs:
         python -m pip install wheel
         choco install llvm
         set LLVM_DIR="C:\Program Files\LLVM"
+        # Can remove after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
     - name: Install Mathics
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
         choco install llvm
         set LLVM_DIR="C:\Program Files\LLVM"
         # Can remove after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
     - name: Install Mathics
       run: |

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 

--- a/test/test_parser/test_parser.py
+++ b/test/test_parser/test_parser.py
@@ -81,6 +81,11 @@ class AssocTests(ParserTests):
 
 
 class AtomTests(ParserTests):
+    def is_unicode(self) -> bool:
+        """Return True if the Mathics scanner is set up to
+        return standard Unicode symbols for various custom WL characters"""
+        return self.parse("\\[ExponentialE]") == "E"
+
     def check_number(self, s):
         self.assertEqual(self.parse(s), Number(s))
 
@@ -96,15 +101,15 @@ class AtomTests(ParserTests):
 
         # For now, the way we'll test for Unicode is simply to see
         # if E gets turned into a unicode symbol
-        if "\\[ExponentialE]" == "E":
-            self.check("\\[ExponentialE]", "E")
-            self.check("\\[ImaginaryJ]", "I")
-            self.check("\\[ImaginaryI]", "I")
-        else:
+        if self.is_unicode():
             # Unicode is bleeding through, so check the unicode symbols instead.
             self.check("\\[ExponentialE]", "\u2147")
             self.check("\\[ImaginaryJ]", "\u2149")
             self.check("\\[ImaginaryI]", "\u2148")
+        else:
+            self.check("\\[ExponentialE]", "E")
+            self.check("\\[ImaginaryJ]", "I")
+            self.check("\\[ImaginaryI]", "I")
         self.check("\\[Infinity]", "Infinity")
 
     def testNumber(self):

--- a/test/test_parser/test_parser.py
+++ b/test/test_parser/test_parser.py
@@ -93,9 +93,18 @@ class AtomTests(ParserTests):
     def testSpecialSymbol(self):
         self.check("\\[Pi]", "Pi")
         self.check("\\[Degree]", "Degree")
-        self.check("\\[ExponentialE]", "E")
-        self.check("\\[ImaginaryI]", "I")
-        self.check("\\[ImaginaryJ]", "I")
+
+        # For now, the way we'll test for Unicode is simply to see
+        # if E gets turned into a unicode symbol
+        if "\\[ExponentialE]" == "E":
+            self.check("\\[ExponentialE]", "E")
+            self.check("\\[ImaginaryJ]", "I")
+            self.check("\\[ImaginaryI]", "I")
+        else:
+            # Unicode is bleeding through, so check the unicode symbols instead.
+            self.check("\\[ExponentialE]", "\u2147")
+            self.check("\\[ImaginaryJ]", "\u2149")
+            self.check("\\[ImaginaryI]", "\u2148")
         self.check("\\[Infinity]", "Infinity")
 
     def testNumber(self):

--- a/test/test_parser/test_parser.py
+++ b/test/test_parser/test_parser.py
@@ -81,10 +81,10 @@ class AssocTests(ParserTests):
 
 
 class AtomTests(ParserTests):
-    def is_unicode(self) -> bool:
+    def has_unicode_setup_in_scanner(self) -> bool:
         """Return True if the Mathics scanner is set up to
         return standard Unicode symbols for various custom WL characters"""
-        return self.parse("\\[ExponentialE]") == "E"
+        return repr(self.parse("\\[ExponentialE]")) != "E"
 
     def check_number(self, s):
         self.assertEqual(self.parse(s), Number(s))
@@ -101,7 +101,7 @@ class AtomTests(ParserTests):
 
         # For now, the way we'll test for Unicode is simply to see
         # if E gets turned into a unicode symbol
-        if self.is_unicode():
+        if self.has_unicode_setup_in_scanner():
             # Unicode is bleeding through, so check the unicode symbols instead.
             self.check("\\[ExponentialE]", "\u2147")
             self.check("\\[ImaginaryJ]", "\u2149")


### PR DESCRIPTION
`test_parser.py` has been failing for me for a while. Apparently ever since in mathicsscript we added these alternate standard Unicode symbols for some custom Wolfram ones.

Here we adapt tests where unicode symbols have been bleeding cause failures in parser testing because it expect no unicode characters. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/220"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

