### PR TITLE
Adding summary text

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -15,6 +15,13 @@ from mathics.version import __version__  # noqa used in loading to check consist
 
 from typing import List
 
+# Set this to True to print all the builtins that do not have
+# a summary_text. In the future, we can set this to True
+# and raise an error if a new builtin is added without
+# this property or if do not fulfills some other conditions.
+CHECK_SUMMARY_TEXTS = False
+
+
 # Get a list of files in this directory. We'll exclude from the start
 # files with leading characters we don't want like __init__ with its leading underscore.
 __py_files__ = [
@@ -199,6 +206,13 @@ for module in modules:
                 # This set the default context for symbols in mathics.builtins
                 if not type(instance).context:
                     type(instance).context = "System`"
+                if CHECK_SUMMARY_TEXTS:
+                    if not hasattr(var, "summary_text"):
+                        print(
+                            "module.__name__",
+                            var.__name__,
+                            " does not have a summary_text.",
+                        )
                 _builtins.append((instance.get_name(), instance))
                 builtins_by_module[module.__name__].append(instance)
 

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -19,7 +19,7 @@ from typing import List
 # a summary_text. In the future, we can set this to True
 # and raise an error if a new builtin is added without
 # this property or if do not fulfills some other conditions.
-CHECK_SUMMARY_TEXTS = False
+RUN_SANITY_TEST = False
 
 
 # Get a list of files in this directory. We'll exclude from the start
@@ -35,6 +35,21 @@ from mathics.builtin.base import (
     Operator,
     PatternObject,
 )
+
+
+def sanity_check(cls, module):
+    if not RUN_SANITY_TEST:
+        return True
+
+    if not hasattr(cls, "summary_text"):
+        print(
+            "In ",
+            module.__name__,
+            var.__name__,
+            " does not have a summary_text.",
+        )
+        return False
+    return True
 
 
 def add_builtins(new_builtins):
@@ -206,13 +221,10 @@ for module in modules:
                 # This set the default context for symbols in mathics.builtins
                 if not type(instance).context:
                     type(instance).context = "System`"
-                if CHECK_SUMMARY_TEXTS:
-                    if not hasattr(var, "summary_text"):
-                        print(
-                            "module.__name__",
-                            var.__name__,
-                            " does not have a summary_text.",
-                        )
+                assert sanity_check(
+                    var, module
+                ), f"In {module.__name__} Builtin <<{var.__name__}>> did not pass the sanity check."
+
                 _builtins.append((instance.get_name(), instance))
                 builtins_by_module[module.__name__].append(instance)
 

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -83,6 +83,7 @@ class Compile(Builtin):
      =  CompiledFunction[{a, b}, a, -PythonizedCode-]
     """
 
+    summary_text = "Compile an expression."
     requires = ("llvmlite",)
 
     attributes = hold_all | protected
@@ -172,6 +173,7 @@ class Compile(Builtin):
 
 class CompiledCode(Atom):
     class_head_name = "System`CompiledCode"
+    summary_text = "An atom containing compiled code."
 
     def __init__(self, cfunc, args, **kwargs):
         super(CompiledCode, self).__init__(**kwargs)
@@ -237,6 +239,7 @@ class CompiledFunction(Builtin):
     """
 
     messages = {"argerr": "Invalid argument `1` should be Integer, Real or boolean."}
+    summary_text = "The result of compiling an expression."
 
     def apply(self, argnames, expr, code, args, evaluation):
         "CompiledFunction[argnames_, expr_, code_CompiledCode][args__]"

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -778,6 +778,7 @@ class Root(SympyFunction):
     }
 
     sympy_name = "CRootOf"
+    summary_text = "the i-esim root of a polinomial."
 
     def apply(self, f, i, evaluation):
         "Root[f_, i_]"
@@ -1525,6 +1526,7 @@ class FindMinimum(_BaseFinder):
     """
 
     methods = {}
+    summary_text = "Looks for a local minimum."
     try:
         from mathics.algorithm.optimizers import native_local_optimizer_methods
 
@@ -1567,7 +1569,7 @@ class FindMaximum(_BaseFinder):
     """
 
     methods = {}
-    summary_text = "Looks for a local maximum"
+    summary_text = "Looks for a local maximum."
     try:
         from mathics.algorithm.optimizers import native_local_optimizer_methods
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1109,6 +1109,8 @@ class Integers(Builtin):
      = {}
     """
 
+    summary_text = "The set of the Integer numbers"
+
 
 class Reals(Builtin):
     """
@@ -1122,6 +1124,8 @@ class Reals(Builtin):
      = {{x -> 1}}
     """
 
+    summary_text = "The set of the Real numbers"
+
 
 class Complexes(Builtin):
     """
@@ -1130,6 +1134,8 @@ class Complexes(Builtin):
         <dd>is the set of complex numbers.
     </dl>
     """
+
+    summary_text = "The set of the complex numbers"
 
 
 class Limit(Builtin):
@@ -1467,6 +1473,10 @@ class FindRoot(_BaseFinder):
     }
 
     methods = {}
+    summary_text = (
+        "Looks for a root of an equation or a zero of a numerical expression."
+    )
+
     try:
         from mathics.algorithm.optimizers import native_findroot_methods
 
@@ -1557,6 +1567,7 @@ class FindMaximum(_BaseFinder):
     """
 
     methods = {}
+    summary_text = "Looks for a local maximum"
     try:
         from mathics.algorithm.optimizers import native_local_optimizer_methods
 
@@ -2058,7 +2069,7 @@ class NIntegrate(Builtin):
     methods = {
         "Automatic": (None, False),
     }
-
+    summary_text = "Numerical integration"
     try:
         from mathics.algorithm.integrators import (
             integrator_methods,

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -213,6 +213,7 @@ class Catalan(_MPMathConstant, _SympyConstant):
     mpmath_name = "catalan"
     # numpy_name = "catalan"  ## This is not defined in numpy
     sympy_name = "Catalan"
+    summary_text = "The Catalan's constant"
 
 
 class ComplexInfinity(_SympyConstant):
@@ -238,6 +239,7 @@ class ComplexInfinity(_SympyConstant):
      = Indeterminate
     """
 
+    summary_text = "Infinite complex quantity of undertermined direction."
     sympy_name = "zoo"
 
     rules = {
@@ -271,6 +273,7 @@ class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 0.0174532925199432957692369076849
     """
 
+    summary_text = "Convertion constant between Radians and sexagesimal degrees."
     mpmath_name = "degree"
 
     def to_sympy(self, expr=None, **kwargs):
@@ -321,6 +324,7 @@ class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 13.5914
     """
 
+    summary_text = "The base of the natural logarithm."
     mpmath_name = "e"
     numpy_name = "e"
     sympy_name = "E"
@@ -344,6 +348,7 @@ class EulerGamma(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 0.5772156649015328606065120900824024310422
     """
 
+    summary_text = "The Euler`s constant."
     mpmath_name = "euler"
     numpy_name = "euler_gamma"
     sympy_name = "EulerGamma"
@@ -363,6 +368,7 @@ class Glaisher(_MPMathConstant):
      # 1.2824271291006219541941391071304678916931152343750
     """
 
+    summary_text = "The Glaiser`s constant."
     mpmath_name = "glaisher"
 
 
@@ -379,6 +385,7 @@ class GoldenRatio(_MPMathConstant, _SympyConstant):
      = 1.618033988749894848204586834365638117720
     """
 
+    summary_text = "The golden ration constant."
     sympy_name = "GoldenRatio"
     mpmath_name = "phi"
 
@@ -398,6 +405,7 @@ class Indeterminate(_SympyConstant):
      = Indeterminate
     """
 
+    summary_text = "An indeterminate value."
     sympy_name = "nan"
 
 
@@ -432,7 +440,7 @@ class Infinity(_SympyConstant):
     numpy_name = "Inf"
     mpmath_name = "inf"
     python_equivalent = math.inf
-
+    summary_text = "An infinite real quantity."
     rules = {
         "Infinity": "DirectedInfinity[1]",
         "MakeBoxes[Infinity, f:StandardForm|TraditionalForm]": ('"\\[Infinity]"'),
@@ -453,6 +461,7 @@ class Khinchin(_MPMathConstant):
      # = 2.6854520010653075701156922150403261184692382812500
     """
 
+    summary_text = "The Khinchin's constant"
     mpmath_name = "khinchin"
 
 
@@ -485,3 +494,4 @@ class Pi(_MPMathConstant, _SympyConstant):
     sympy_name = "pi"
     mpmath_name = "pi"
     numpy_name = "pi"
+    summary_text = "The Pi number."

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -104,6 +104,7 @@ class DSolve(Builtin):
         "symmua": "SymPy can't handle functions of multiple variables.",
         "sym11669": "Hit sympy bug #11669.",
     }
+    summary_text = "Differential equation analytical solver."
 
     def apply(self, eqn, y, x, evaluation):
         "DSolve[eqn_, y_, x_]"
@@ -215,3 +216,7 @@ class C(Builtin):
         differential equation.
     </dl>
     """
+
+    summary_text = (
+        "n-th intertermined constant in the solution of a differential equation."
+    )

--- a/mathics/builtin/physchemdata.py
+++ b/mathics/builtin/physchemdata.py
@@ -101,6 +101,8 @@ class ElementData(Builtin):
         'ElementData["Properties"]': 'ElementData[All, "Properties"]',
     }
 
+    summary_text = "Data about chemical elements"
+
     messages = {
         "noent": (
             "`1` is not a known entity, class, or tag for ElementData. "

--- a/mathics/builtin/quantities.py
+++ b/mathics/builtin/quantities.py
@@ -35,6 +35,8 @@ class KnownUnitQ(Test):
      = False
     """
 
+    summary_text = "Checks if its argument is a canonical unit."
+
     def test(self, expr):
         def validate(unit):
             try:
@@ -82,6 +84,7 @@ class UnitConvert(Builtin):
     messages = {
         "argrx": "UnitConvert called with `1` arguments; 2 arguments are expected"
     }
+    summary_text = "Conversion between units."
 
     def apply(self, expr, toUnit, evaluation):
         "UnitConvert[expr_, toUnit_]"
@@ -185,6 +188,7 @@ class Quantity(Builtin):
     messages = {
         "unkunit": "Unable to interpret unit specification `1`.",
     }
+    summary_text = "Quantity with units."
 
     def validate(self, unit, evaluation):
         if KnownUnitQ(unit).evaluate(evaluation) is Symbol("False"):
@@ -251,6 +255,8 @@ class QuantityQ(Test):
      = False
     """
 
+    summary_text = "Checks if the argument is a quantity."
+
     def test(self, expr):
         def validate_unit(unit):
             try:
@@ -300,6 +306,8 @@ class QuantityUnit(Builtin):
      : Unable to interpret unit specification aaa.
      = QuantityUnit[Quantity[10,aaa]]
     """
+
+    summary_text = "The unit associated to a quantity."
 
     def apply(self, expr, evaluation):
         "QuantityUnit[expr_]"
@@ -358,6 +366,8 @@ class QuantityMagnitude(Builtin):
      : Unable to interpret unit specification mater.
      = QuantityMagnitude[Quantity[3,mater]]
     """
+
+    summary_text = "The magnitude associated to a quantity."
 
     def apply(self, expr, evaluation):
         "QuantityMagnitude[expr_]"

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -52,6 +52,7 @@ class RSolve(Builtin):
         "dsfun": "`1` cannot be used as a function.",
         "dsvar": "`1` cannot be used as a variable.",
     }
+    summary_text = "Recurrence equations solver."
 
     def apply(self, eqns, a, n, evaluation):
         "RSolve[eqns_, a_, n_]"

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -74,6 +74,7 @@ class Gamma(_MPMathMultiFunction):
         1: "gamma",  # one argument
         2: "uppergamma",
     }
+    summary_text = "The gamma and gamma incomplete functions."
 
     rules = {
         "Gamma[z_, x0_, x1_]": "Gamma[z, x0] - Gamma[z, x1]",
@@ -111,7 +112,7 @@ class Pochhammer(SympyFunction):
     attributes = listable | numeric_function | protected
 
     sympy_name = "RisingFactorial"
-
+    summary_text = "The Pochhammer symbol."
     rules = {
         "Pochhammer[a_, n_]": "Gamma[a + n] / Gamma[a]",
         "Derivative[1,0][Pochhammer]": "(Pochhammer[#1, #2]*(-PolyGamma[0, #1] + PolyGamma[0, #1 + #2]))&",
@@ -136,7 +137,6 @@ class PolyGamma(_MPMathMultiFunction):
     >> PolyGamma[3, 5]
      = -22369 / 3456 + Pi ^ 4 / 15
     """
-
     attributes = listable | numeric_function | protected
 
     mpmath_names = {

--- a/mathics/builtin/specialfns/othogonal.py
+++ b/mathics/builtin/specialfns/othogonal.py
@@ -24,6 +24,7 @@ class ChebyshevT(_MPMathFunction):
     nargs = 2
     sympy_name = "chebyshevt"
     mpmath_name = "chebyt"
+    summary_text = "Chebyshev polynomials of the first kind."
 
 
 class ChebyshevU(_MPMathFunction):
@@ -43,6 +44,7 @@ class ChebyshevU(_MPMathFunction):
     nargs = 2
     sympy_name = "chebyshevu"
     mpmath_name = "chebyu"
+    summary_text = "Chebyshev polynomials of the second kind."
 
 
 class GegenbauerC(_MPMathFunction):
@@ -64,6 +66,7 @@ class GegenbauerC(_MPMathFunction):
     nargs = 3
     sympy_name = "gegenbauer"
     mpmath_name = "gegenbauer"
+    summary_text = "Gegenbauer polynomials."
 
 
 class HermiteH(_MPMathFunction):
@@ -86,6 +89,7 @@ class HermiteH(_MPMathFunction):
     nargs = 2
     sympy_name = "hermite"
     mpmath_name = "hermite"
+    summary_text = "Hermite polynomials."
 
 
 class JacobiP(_MPMathFunction):
@@ -105,6 +109,7 @@ class JacobiP(_MPMathFunction):
     nargs = 4
     sympy_name = "jacobi"
     mpmath_name = "jacobi"
+    summary_text = "Jacoby polynomials."
 
 
 class LaguerreL(_MPMathFunction):
@@ -133,6 +138,7 @@ class LaguerreL(_MPMathFunction):
     nargs = 3
     sympy_name = "laguerre_poly"
     mpmath_name = "laguerre"
+    summary_text = "Laguerre polynomials"
 
     def prepare_sympy(self, leaves):
         if len(leaves) == 3:
@@ -181,6 +187,7 @@ class LegendreP(_MPMathFunction):
     nargs = 3
     sympy_name = "legendre"
     mpmath_name = "legenp"
+    summary_text = "Legendre polynomials of first kind."
 
     def prepare_sympy(self, leaves):
         if leaves[1] == Integer0:
@@ -223,6 +230,7 @@ class LegendreQ(_MPMathFunction):
     nargs = 3
     sympy_name = ""
     mpmath_name = "legenq"
+    summary_text = "Legendre polynomials of second kind."
 
     def prepare_sympy(self, leaves):
         if leaves[1] == Integer0:
@@ -251,6 +259,8 @@ class SphericalHarmonicY(_MPMathFunction):
     nargs = 4
     sympy_name = "Ynm"
     mpmath_name = "spherharm"
+    summary_text = "3D Spherical Harmonic."
+
     rules = {
         "Derivative[0,0,1,0][SphericalHarmonicY]": "(Cot[#3]*#2*SphericalHarmonicY[#1, #2, #3, #4] + (Sqrt[Gamma[1 + #1 - #2]]*Sqrt[Gamma[2 + #1 + #2]]*SphericalHarmonicY[#1, 1 + #2, #3, #4])/(E^(I*#4)*Sqrt[Gamma[#1 - #2]]*Sqrt[Gamma[1 + #1 + #2]]))&",
         "Derivative[0,0,0,1][SphericalHarmonicY]": "(I*#2*SphericalHarmonicY[#1, #2, #3, #4])&",

--- a/mathics/builtin/string/regexp.py
+++ b/mathics/builtin/string/regexp.py
@@ -29,3 +29,4 @@ class RegularExpression(Builtin):
      : Element RegularExpression[2] is not a valid string or pattern element in RegularExpression[2].
      = StringSplit[ab23c, RegularExpression[2]]
     """
+    summary_text = "string to regular expression."


### PR DESCRIPTION
This PR starts fixing the lack of summary_text  on many of the builtins symbols. I also included a few lines that allow activating a sanity check verifying that this attribute is set on all the built-in classes.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/222"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

