### PR TITLE
Tolerate not-implemented errors in graphics

### DIFF
--- a/mathics/format/asy.py
+++ b/mathics/format/asy.py
@@ -340,9 +340,18 @@ add_conversion_fn(FilledCurveBox, filled_curve_box)
 
 
 def graphics_elements(self, **options) -> str:
+    """
+    Asymptote formatting on a list of graphics elements.
+    """
     result = []
     for element in self.elements:
-        format_fn = lookup_method(element, "asy")
+        try:
+            format_fn = lookup_method(element, "asy")
+        except:
+            # Note error and continue
+            result.append(f"""unhandled {element}""")
+            continue
+
         if format_fn is None:
             result.append(element.to_asy(**options))
         else:
@@ -359,6 +368,7 @@ add_conversion_fn(Graphics3DElements)
 
 
 def insetbox(self, **options) -> str:
+    """Asymptote formatting for boxing an Inset in a graphic."""
     x, y = self.pos.pos()
     content = self.content.boxes_to_tex(evaluation=self.graphics.evaluation)
     pen = asy_create_pens(edge_color=self.color)

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -292,11 +292,17 @@ add_conversion_fn(GraphicsBox, graphics_box)
 
 def graphics_elements(self, **options) -> str:
     """
-    SVG Formatting for a list of graphics elements.
+    SVG formatting on a list of graphics elements.
     """
     result = ["<!--GraphicsElements-->"]
     for element in self.elements:
-        format_fn = lookup_method(element, "svg")
+        try:
+            format_fn = lookup_method(element, "svg")
+        except:
+            # Note error and continue
+            result.append(f"""unhandled {element}""")
+            continue
+
         if format_fn is None:
             result.append(element.to_svg(**options))
         else:
@@ -315,7 +321,7 @@ add_conversion_fn(Graphics3DElements)
 
 def inset_box(self, **options) -> str:
     """
-    SVG Formatting for boxing an Inset in a graphic.
+    SVG formatting for boxing an Inset in a graphic.
     """
     x, y = self.pos.pos()
     offset = options.get("offset", None)


### PR DESCRIPTION
Currently we give a traceback and error exit. A workaround for issue #224

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/226"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

