### PR TITLE
Use python built-in functions to escape strings

### DIFF
--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -1744,7 +1744,7 @@ class Export(Builtin):
         "$OptionSyntax": "System`Ignore",
     }
 
-    def apply(self, filename, expr, evaluation, **options):
+    def apply(self, filename, expr, evaluation, options={}):
         "Export[filename_, expr_, OptionsPattern[Export]]"
 
         # Check filename

--- a/mathics/core/parser/convert.py
+++ b/mathics/core/parser/convert.py
@@ -29,12 +29,7 @@ class GenericConverter(object):
 
     @staticmethod
     def string_escape(s):
-        s = s.replace("\\\\", "\\").replace('\\"', '"')
-        s = s.replace("\\r\\n", "\r\n")
-        s = s.replace("\\r", "\r")
-        s = s.replace("\\n", "\n")
-        s = s.replace("\\t", "\t")
-        return s
+        return s.encode("raw_unicode_escape").decode("unicode_escape")
 
     def convert_Symbol(self, node: Symbol):
         if node.context is not None:

--- a/test/test_importexport.py
+++ b/test/test_importexport.py
@@ -6,6 +6,7 @@ import pytest
 import sys
 from .helper import check_evaluation, session
 
+from mathics.builtin.atomic.strings import to_python_encoding
 
 # def test_import():
 #     eaccent = "\xe9"
@@ -23,7 +24,7 @@ def run_export(temp_dirname: str, short_name: str, file_data: str, character_enc
     file_path = osp.join(temp_dirname, short_name)
     expr = fr'Export["{file_path}", {file_data}'
     expr += (
-        ', CharacterEncoding -> f"{character_encoding}"' if character_encoding else ""
+        fr', CharacterEncoding -> "{character_encoding}"' if character_encoding else ""
     )
     expr += "]"
     result = session.evaluate(expr)
@@ -43,7 +44,10 @@ def check_data(
     )
     if expected_data is None:
         expected_data = file_data
-    assert open(file_path, "r").read() == expected_data
+    assert (
+        open(file_path, "r", encoding=to_python_encoding(character_encoding)).read()
+        == expected_data
+    )
 
 
 # Github Action Windows CI servers have problems with releasing files using

--- a/test/test_parser/test_convert.py
+++ b/test/test_parser/test_convert.py
@@ -87,6 +87,7 @@ class ConvertTests(unittest.TestCase):
         self.incomplete_error(r'"abc')
         self.check(r'"abc(*def*)"', String("abc(*def*)"))
         self.check(r'"a\"b\\c"', String(r'a"b\c'))
+        self.check(r'"a\\nb"', String(r"a\nb"))
         self.incomplete_error(r'"\"')
         self.invalid_error(r'\""')
 


### PR DESCRIPTION
This PR fixes the following behaviour
```
In[1]:= StringForm["Text1\\n Text2"]
Out[1]= Text1
         Text2
```
### Expected behavior
```
In[1]:= StringForm["Text1\\n Text2"]
Out[1]= Text1\n Text2
```
### Further fixes
Some character encoding related bugs have been fixed. In particular `Export` did not honor the `CharacterEncoding` option.