### PR TITLE
Reorganize builtins

### DIFF
--- a/mathics/builtin/matrices/constrmatrix.py
+++ b/mathics/builtin/matrices/constrmatrix.py
@@ -20,9 +20,6 @@ class DiagonalMatrix(Builtin):
      . 0   2   0
      .
      . 0   0   3
-
-    #> DiagonalMatrix[a + b]
-     = DiagonalMatrix[a + b]
     """
 
     summary_text = "gives a diagonal matrix with the elements of a given list"
@@ -42,8 +39,8 @@ class DiagonalMatrix(Builtin):
 class IdentityMatrix(Builtin):
     """
     <dl>
-    <dt>'IdentityMatrix[$n$]'
-        <dd>gives the identity matrix with $n$ rows and columns.
+      <dt>'IdentityMatrix[$n$]'
+      <dd>gives the identity matrix with $n$ rows and columns.
     </dl>
 
     >> IdentityMatrix[3]

--- a/mathics/builtin/matrices/constrmatrix.py
+++ b/mathics/builtin/matrices/constrmatrix.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from mathics.builtin.base import Builtin
+from mathics.core.expression import Expression
+from mathics.core.atoms import Integer0
+
+
+class DiagonalMatrix(Builtin):
+    """
+    <dl>
+      <dt>'DiagonalMatrix[$list$]'
+      <dd>gives a matrix with the values in $list$ on its diagonal and zeroes elsewhere.
+    </dl>
+
+    >> DiagonalMatrix[{1, 2, 3}]
+     = {{1, 0, 0}, {0, 2, 0}, {0, 0, 3}}
+    >> MatrixForm[%]
+     = 1   0   0
+     .
+     . 0   2   0
+     .
+     . 0   0   3
+
+    #> DiagonalMatrix[a + b]
+     = DiagonalMatrix[a + b]
+    """
+
+    summary_text = "gives a diagonal matrix with the elements of a given list"
+
+    def apply(self, list, evaluation):
+        "DiagonalMatrix[list_List]"
+
+        result = []
+        n = len(list.leaves)
+        for index, item in enumerate(list.leaves):
+            row = [Integer0] * n
+            row[index] = item
+            result.append(Expression("List", *row))
+        return Expression("List", *result)
+
+
+class IdentityMatrix(Builtin):
+    """
+    <dl>
+    <dt>'IdentityMatrix[$n$]'
+        <dd>gives the identity matrix with $n$ rows and columns.
+    </dl>
+
+    >> IdentityMatrix[3]
+     = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+    """
+
+    rules = {
+        "IdentityMatrix[n_Integer]": "DiagonalMatrix[Table[1, {n}]]",
+    }
+
+    summary_text = "gives the identity matrix with a given dimension"

--- a/mathics/builtin/matrices/partmatrix.py
+++ b/mathics/builtin/matrices/partmatrix.py
@@ -31,7 +31,7 @@ class Diagonal(Builtin):
         "Diagonal[expr_]": "Diagonal[expr, 0]",
     }
 
-    summary_text = "Return a list with the diagonal elements of a given matrix"
+    summary_text = "gives a list with the diagonal elements of a given matrix"
 
     def apply(self, expr, diag, evaluation):
         "Diagonal[expr_List, diag_Integer]"
@@ -66,6 +66,4 @@ class MatrixQ(Builtin):
         "MatrixQ[expr_, test_]": "ArrayQ[expr, 2, test]",
     }
 
-    summary_text = (
-        "Return 'True' if the given argument is a list of equal-length lists."
-    )
+    summary_text = "gives 'True' if the given argument is a list of equal-length lists."

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -15,7 +15,6 @@ from mathics.builtin.base import Builtin, BinaryOperator
 from mathics.core.expression import Expression
 from mathics.core.atoms import (
     Integer,
-    Integer0,
     String,
 )
 from mathics.core.symbols import (
@@ -169,38 +168,6 @@ class ArrayQ(Builtin):
         return SymbolTrue
 
 
-class DiagonalMatrix(Builtin):
-    """
-    <dl>
-      <dt>'DiagonalMatrix[$list$]'
-      <dd>gives a matrix with the values in $list$ on its diagonal and zeroes elsewhere.
-    </dl>
-
-    >> DiagonalMatrix[{1, 2, 3}]
-     = {{1, 0, 0}, {0, 2, 0}, {0, 0, 3}}
-    >> MatrixForm[%]
-     = 1   0   0
-     .
-     . 0   2   0
-     .
-     . 0   0   3
-
-    #> DiagonalMatrix[a + b]
-     = DiagonalMatrix[a + b]
-    """
-
-    def apply(self, list, evaluation):
-        "DiagonalMatrix[list_List]"
-
-        result = []
-        n = len(list.leaves)
-        for index, item in enumerate(list.leaves):
-            row = [Integer0] * n
-            row[index] = item
-            result.append(Expression("List", *row))
-        return Expression("List", *result)
-
-
 class Dimensions(Builtin):
     """
     <dl>
@@ -268,22 +235,6 @@ class Dot(BinaryOperator):
     }
 
     summary_text = "dot product"
-
-
-class IdentityMatrix(Builtin):
-    """
-    <dl>
-    <dt>'IdentityMatrix[$n$]'
-        <dd>gives the identity matrix with $n$ rows and columns.
-    </dl>
-
-    >> IdentityMatrix[3]
-     = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
-    """
-
-    rules = {
-        "IdentityMatrix[n_Integer]": "DiagonalMatrix[Table[1, {n}]]",
-    }
 
 
 class Inner(Builtin):

--- a/test/test_constrmatrix.py
+++ b/test/test_constrmatrix.py
@@ -1,4 +1,4 @@
-from .helper import check_evaluation, session
+from .helper import session
 import pytest
 
 
@@ -8,7 +8,7 @@ import pytest
         (
             "DiagonalMatrix[a + b]",
             "DiagonalMatrix[a + b]",
-            "Leaves unchanged? Adapted from #> code that was in tensor.py",
+            "argument needs to be a list",
         ),
     ],
 )

--- a/test/test_constrmatrix.py
+++ b/test/test_constrmatrix.py
@@ -1,0 +1,18 @@
+from .helper import check_evaluation, session
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "fail_msg"),
+    [
+        (
+            "DiagonalMatrix[a + b]",
+            "DiagonalMatrix[a + b]",
+            "Leaves unchanged? Adapted from #> code that was in tensor.py",
+        ),
+    ],
+)
+def test_diagonal_matrix(str_expr: str, str_expected: str, fail_msg: str):
+    result = session.evaluate(f"ToString[{str_expr}]").value
+    print("result:", result)
+    assert result == str_expected, fail_msg


### PR DESCRIPTION
Move a `#>` test into a unit test and Moved DiagonalMatrix and IdentityMatrix to group Matrices and Linear Algebra from @adamantian

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/229"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

