### PR TITLE
Fix InputFileName

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -20,6 +20,7 @@ from itertools import chain
 
 from mathics_scanner import TranslateError
 from mathics.core.parser import MathicsFileLineFeeder, parse
+from mathics.core import read
 from mathics.core.read import (
     channel_to_stream,
     MathicsOpen,
@@ -61,7 +62,6 @@ INITIAL_DIR = os.getcwd()
 DIRECTORY_STACK = [INITIAL_DIR]
 
 INPUT_VAR = ""
-INPUTFILE_VAR = ""
 
 TMP_DIR = tempfile.gettempdir()
 SymbolPath = Symbol("$Path")
@@ -103,8 +103,7 @@ class InputFileName(Predefined):
     name = "$InputFileName"
 
     def evaluate(self, evaluation):
-        global INPUTFILE_VAR
-        return String(INPUTFILE_VAR)
+        return String(read.INPUTFILE_VAR)
 
 
 class EndOfFile(Builtin):

--- a/mathics/core/read.py
+++ b/mathics/core/read.py
@@ -12,6 +12,8 @@ from mathics.core.atoms import Integer, String
 from mathics.core.symbols import Symbol
 from mathics.core.streams import Stream, path_search, stream_manager
 
+INPUTFILE_VAR = ""
+
 SymbolEndOfFile = Symbol("EndOfFile")
 
 READ_TYPES = [


### PR DESCRIPTION
`InputFileName` was broken since 3e3802797677bdf075dfd92f3680c2c6a60055b3, because `INPUTFILE_VAR` is updated in another file.