### PR TITLE
fix usage

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -288,6 +288,8 @@ class Builtin(object):
         for form, formatrules in formatvalues.items():
             formatrules.sort()
 
+        if hasattr(self, "summary_text"):
+            self.messages["usage"] = self.summary_text
         messages = [
             Rule(
                 Expression("MessageName", Symbol(name), String(msg)),


### PR DESCRIPTION
This PR fixes #225 by adding the usage message from the ``summary_text`` property of a ``Builtin`` sub-class during the call to the ``contribute`` method.