### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/mathics/builtin/pymimesniffer/magic.py
+++ b/mathics/builtin/pymimesniffer/magic.py
@@ -191,9 +191,7 @@ class TestDetector(unittest.TestCase):
             self.detector = MagicDetector(loader.mimetypes)
 
     def testMagicNumber(self):
-        self.assertEqual(
-            ["application/zip"], self.detector.match("test.zip", "PKtest")
-        )
+        self.assertEqual(["application/zip"], self.detector.match("test.zip", "PKtest"))
         self.assertEqual([], self.detector.match("test.zip", "_PKtest"))
         self.assertEqual([], self.detector.match("test.zip1", "PKtest"))
 

--- a/mathics/builtin/pymimesniffer/magic.py
+++ b/mathics/builtin/pymimesniffer/magic.py
@@ -191,29 +191,29 @@ class TestDetector(unittest.TestCase):
             self.detector = MagicDetector(loader.mimetypes)
 
     def testMagicNumber(self):
-        self.assertEquals(
+        self.assertEqual(
             ["application/zip"], self.detector.match("test.zip", "PKtest")
         )
-        self.assertEquals([], self.detector.match("test.zip", "_PKtest"))
-        self.assertEquals([], self.detector.match("test.zip1", "PKtest"))
+        self.assertEqual([], self.detector.match("test.zip", "_PKtest"))
+        self.assertEqual([], self.detector.match("test.zip1", "PKtest"))
 
-        self.assertEquals(
+        self.assertEqual(
             ["application/gzip"], self.detector.match("test.gz", "\x1f\x8b\x08test")
         )
-        self.assertEquals(
+        self.assertEqual(
             ["application/gzip"], self.detector.match("test.tgz", "\x1f\x8b\x08test")
         )
-        self.assertEquals([], self.detector.match("test.gz1", "\x1f\x8b\x08test"))
-        self.assertEquals([], self.detector.match("test.gz", "\x1f \x8b\x08test"))
+        self.assertEqual([], self.detector.match("test.gz1", "\x1f\x8b\x08test"))
+        self.assertEqual([], self.detector.match("test.gz", "\x1f \x8b\x08test"))
 
         padding = "".join([" " for _ in range(257)])
 
-        self.assertEquals(
+        self.assertEqual(
             ["application/x-tar"],
             self.detector.match("test.tar", padding + "ustartest"),
         )
-        self.assertEquals([], self.detector.match("test.tar1", padding + "ustartest"))
-        self.assertEquals([], self.detector.match("test.tar", padding + "ust artest"))
+        self.assertEqual([], self.detector.match("test.tar1", padding + "ustartest"))
+        self.assertEqual([], self.detector.match("test.tar", padding + "ust artest"))
 
 
 class TestLoader(unittest.TestCase):


### PR DESCRIPTION
Deprecated aliases have been removed in python/cpython#28268