### PR TITLE
Handle unexpected SymPy exceptions in `Simplify[]`

### DIFF
--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -501,7 +501,13 @@ class Simplify(Builtin):
         if sympy_expr is None:
             return expr
         # Now, try to simplify using sympy
-        sympy_result = sympy.simplify(sympy_expr)
+        try:
+            sympy_result = sympy.simplify(sympy_expr)
+        except Exception:
+            # This handles the exception reported in 214.
+            # However, it seems that the crash is due to a
+            # problem in the implentation of the class SympyExpression
+            return expr
         # and bring it back
         result = from_sympy(sympy_result).evaluate(evaluation)
         return result

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -504,9 +504,6 @@ class Simplify(Builtin):
         try:
             sympy_result = sympy.simplify(sympy_expr)
         except Exception:
-            # This handles the exception reported in 214.
-            # However, it seems that the crash is due to a
-            # problem in the implentation of the class SympyExpression
             return expr
         # and bring it back
         result = from_sympy(sympy_result).evaluate(evaluation)

--- a/test/test_algebra.py
+++ b/test/test_algebra.py
@@ -284,3 +284,14 @@ def test_simplify():
         ),
     ):
         check_evaluation(str_expr, str_expected)
+
+
+def test_fullsimplify():
+    for str_expr, str_expected, failure_message in (
+        (
+            " a[x] + e f / (2 d) + c[x] // FullSimplify",
+            "e f / (2 d) + a[x] + c[x]",
+            "issue #214",
+        ),
+    ):
+        check_evaluation(str_expr, str_expected, failure_message)


### PR DESCRIPTION
This PR fixes issue #214, by catching the exception. In the future, we can prevent the exception for this particular case, but still would appear in other cases.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/238"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

