### PR TITLE
summary_text in mathics.builtin.numeric.constants

### DIFF
--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -213,7 +213,7 @@ class Catalan(_MPMathConstant, _SympyConstant):
     mpmath_name = "catalan"
     # numpy_name = "catalan"  ## This is not defined in numpy
     sympy_name = "Catalan"
-    summary_text = "Catalan's constant $C\approx 0.916$"
+    summary_text = "Catalan's constant C≃ 0.916"
 
 
 class ComplexInfinity(_SympyConstant):
@@ -324,7 +324,7 @@ class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 13.5914
     """
 
-    summary_text = "exponential constant E ≃ 2.718"
+    summary_text = "exponential constant E ≃ 2.7182"
     mpmath_name = "e"
     numpy_name = "e"
     sympy_name = "E"
@@ -348,7 +348,7 @@ class EulerGamma(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 0.5772156649015328606065120900824024310422
     """
 
-    summary_text = "Euler's constant γ ≃ 0.577"
+    summary_text = "Euler's constant γ ≃ 0.5772"
     mpmath_name = "euler"
     numpy_name = "euler_gamma"
     sympy_name = "EulerGamma"
@@ -385,7 +385,7 @@ class GoldenRatio(_MPMathConstant, _SympyConstant):
      = 1.618033988749894848204586834365638117720
     """
 
-    summary_text = "golden ratio φ ≃ 1.618"
+    summary_text = "golden ratio φ ≃ 1.6180"
     sympy_name = "GoldenRatio"
     mpmath_name = "phi"
 
@@ -461,7 +461,7 @@ class Khinchin(_MPMathConstant):
      # = 2.6854520010653075701156922150403261184692382812500
     """
 
-    summary_text = "Khinchin's constant K ≃ 2.685"
+    summary_text = "Khinchin's constant K ≃ 2.6854"
     mpmath_name = "khinchin"
 
 

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -239,7 +239,7 @@ class ComplexInfinity(_SympyConstant):
      = Indeterminate
     """
 
-    summary_text = "represents an infinite complex quantity of undetermined direction"
+    summary_text = "infinite complex quantity of undetermined direction"
     sympy_name = "zoo"
 
     rules = {
@@ -385,7 +385,7 @@ class GoldenRatio(_MPMathConstant, _SympyConstant):
      = 1.618033988749894848204586834365638117720
     """
 
-    summary_text = "golden ration φ ≃ 1.618"
+    summary_text = "golden ratio φ ≃ 1.618"
     sympy_name = "GoldenRatio"
     mpmath_name = "phi"
 
@@ -440,7 +440,7 @@ class Infinity(_SympyConstant):
     numpy_name = "Inf"
     mpmath_name = "inf"
     python_equivalent = math.inf
-    summary_text = "represents an infinite real quantity"
+    summary_text = "infinite real quantity"
     rules = {
         "Infinity": "DirectedInfinity[1]",
         "MakeBoxes[Infinity, f:StandardForm|TraditionalForm]": ('"\\[Infinity]"'),

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -213,7 +213,7 @@ class Catalan(_MPMathConstant, _SympyConstant):
     mpmath_name = "catalan"
     # numpy_name = "catalan"  ## This is not defined in numpy
     sympy_name = "Catalan"
-    summary_text = "Catalan's constant"
+    summary_text = "Catalan's constant $C\approx 0.916$"
 
 
 class ComplexInfinity(_SympyConstant):
@@ -239,7 +239,7 @@ class ComplexInfinity(_SympyConstant):
      = Indeterminate
     """
 
-    summary_text = "infinite complex quantity of undertermined direction"
+    summary_text = "represents an infinite complex quantity of undetermined direction"
     sympy_name = "zoo"
 
     rules = {
@@ -273,7 +273,7 @@ class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 0.0174532925199432957692369076849
     """
 
-    summary_text = "conversion factor from radians to sexagesimal degrees"
+    summary_text = "conversion factor from radians to degrees"
     mpmath_name = "degree"
 
     def to_sympy(self, expr=None, **kwargs):
@@ -324,7 +324,7 @@ class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 13.5914
     """
 
-    summary_text = "the base of the natural logarithm"
+    summary_text = "exponential constant E ≃ 2.718"
     mpmath_name = "e"
     numpy_name = "e"
     sympy_name = "E"
@@ -348,7 +348,7 @@ class EulerGamma(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 0.5772156649015328606065120900824024310422
     """
 
-    summary_text = "Euler`s constant"
+    summary_text = "Euler's constant γ ≃ 0.577"
     mpmath_name = "euler"
     numpy_name = "euler_gamma"
     sympy_name = "EulerGamma"
@@ -368,7 +368,7 @@ class Glaisher(_MPMathConstant):
      # 1.2824271291006219541941391071304678916931152343750
     """
 
-    summary_text = "Glaiser`s constant"
+    summary_text = "Glaiser's constant A ≃ 1.282"
     mpmath_name = "glaisher"
 
 
@@ -385,7 +385,7 @@ class GoldenRatio(_MPMathConstant, _SympyConstant):
      = 1.618033988749894848204586834365638117720
     """
 
-    summary_text = "golden ration constant"
+    summary_text = "golden ration φ ≃ 1.618"
     sympy_name = "GoldenRatio"
     mpmath_name = "phi"
 
@@ -405,7 +405,7 @@ class Indeterminate(_SympyConstant):
      = Indeterminate
     """
 
-    summary_text = "an indeterminate value"
+    summary_text = "indeterminate value"
     sympy_name = "nan"
 
 
@@ -440,7 +440,7 @@ class Infinity(_SympyConstant):
     numpy_name = "Inf"
     mpmath_name = "inf"
     python_equivalent = math.inf
-    summary_text = "an infinite real quantity"
+    summary_text = "represents an infinite real quantity"
     rules = {
         "Infinity": "DirectedInfinity[1]",
         "MakeBoxes[Infinity, f:StandardForm|TraditionalForm]": ('"\\[Infinity]"'),
@@ -461,7 +461,7 @@ class Khinchin(_MPMathConstant):
      # = 2.6854520010653075701156922150403261184692382812500
     """
 
-    summary_text = "Khinchin's constant"
+    summary_text = "Khinchin's constant K ≃ 2.685"
     mpmath_name = "khinchin"
 
 
@@ -494,4 +494,4 @@ class Pi(_MPMathConstant, _SympyConstant):
     sympy_name = "pi"
     mpmath_name = "pi"
     numpy_name = "pi"
-    summary_text = "the constant \u03c0"
+    summary_text = "pi \u03c0 ≃ 3.1416"

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -213,7 +213,7 @@ class Catalan(_MPMathConstant, _SympyConstant):
     mpmath_name = "catalan"
     # numpy_name = "catalan"  ## This is not defined in numpy
     sympy_name = "Catalan"
-    summary_text = "Catalan's constant C≃ 0.916"
+    summary_text = "Catalan's constant C ≃ 0.916"
 
 
 class ComplexInfinity(_SympyConstant):


### PR DESCRIPTION
This is just the part of #237 associated with mathematical constants

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/239"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

