### PR TITLE
Summary numbers

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -172,7 +172,7 @@ class D(SympyFunction):
     >> D[2x, 2x]
      = 0
     """
-
+    summary_text = "partial derivatives of scalar or vector functions"
     sympy_name = "Derivative"
 
     messages = {
@@ -210,8 +210,6 @@ class D(SympyFunction):
             "Nest[Function[{t}, D[t, x]], expr, n]"
         ),
     }
-
-    summary_text = "partial derivatives of scalar or vector functions"
 
     def apply(self, f, x, evaluation):
         "D[f_, x_?NotListQ]"
@@ -395,6 +393,7 @@ class Derivative(PostfixOperator, SympyFunction):
      = Hold[Derivative[1][Derivative[x][4]]]
     """
 
+    summary_text = "symbolic and numerical derivative functions"
     operator = "'"
     precedence = 670
     attributes = n_hold_all
@@ -444,8 +443,6 @@ class Derivative(PostfixOperator, SympyFunction):
                 Function::slotn],
             Sequence @@ Table[{Slot[i], {n}[[i]]}, {i, 1, Length[{n}]}]]]&""",
     }
-
-    summary_text = "symbolic and numerical derivative functions"
 
     default_formats = False
 
@@ -932,6 +929,7 @@ class Solve(Builtin):
 
     """
 
+    summary_text = "find generic solutions for variables"
     messages = {
         "eqf": "`1` is not a well-formed equation.",
         "svars": 'Equations may not give solutions for all "solve" variables.',
@@ -946,8 +944,6 @@ class Solve(Builtin):
             "Cases[Solve[eqs, vars], {Rule[x_,y_Integer]}]"
         ),
     }
-
-    summary_text = "find generic solutions for variables"
 
     def apply(self, eqs, vars, evaluation):
         "Solve[eqs_, vars_]"
@@ -1171,7 +1167,7 @@ class Limit(Builtin):
      #> Limit[(1 + cos[x]) / x, x -> 0]
      = Limit[(1 + cos[x]) / x, x -> 0]
     """
-
+    summary_text = "directed and undirected limits"
     attributes = listable | protected
 
     options = {
@@ -1181,8 +1177,6 @@ class Limit(Builtin):
     messages = {
         "ldir": "Value of Direction -> `1` should be -1 or 1.",
     }
-
-    summary_text = "directed and undirected limits"
 
     def apply(self, expr, x, x0, evaluation, options={}):
         "Limit[expr_, x_->x0_, OptionsPattern[Limit]]"
@@ -1239,7 +1233,7 @@ class DiscreteLimit(Builtin):
     >> DiscreteLimit[(n/(n + 2)) E^(-m/(m + 1)), {m -> Infinity, n -> Infinity}]
      = 1 / E
     """
-
+    summary_text = "limits of sequences including recurrence and number theory"
     attributes = listable | protected
 
     options = {
@@ -1249,8 +1243,6 @@ class DiscreteLimit(Builtin):
     messages = {
         "dltrials": "The value of Trials should be a positive integer",
     }
-
-    summary_text = "limits of sequences including recurrence and number theory"
 
     def apply(self, f, n, n0, evaluation, options={}):
         "DiscreteLimit[f_, n_->n0_, OptionsPattern[DiscreteLimit]]"
@@ -2044,6 +2036,7 @@ class NIntegrate(Builtin):
 
     """
 
+    summary_text = "numerical integration in one or several variables"
     messages = {
         "bdmtd": "The Method option should be a built-in method name.",
         "inumr": (
@@ -2071,7 +2064,6 @@ class NIntegrate(Builtin):
     methods = {
         "Automatic": (None, False),
     }
-    summary_text = "numerical integration"
     try:
         from mathics.algorithm.integrators import (
             integrator_methods,

--- a/mathics/builtin/numbers/exptrig.py
+++ b/mathics/builtin/numbers/exptrig.py
@@ -363,6 +363,7 @@ class ArcCos(_MPMathFunction):
      = Pi
     """
 
+    summary_text = "inverse cosine function"
     sympy_name = "acos"
     mpmath_name = "acos"
 
@@ -391,6 +392,7 @@ class ArcCosh(_MPMathFunction):
      = 0.867015
     """
 
+    summary_text = "inverse hyperbolic cosine function"
     sympy_name = "acosh"
     mpmath_name = "acosh"
 
@@ -412,6 +414,7 @@ class ArcCot(_MPMathFunction):
      = Pi / 4
     """
 
+    summary_text = "inverse cotangent function"
     sympy_name = "acot"
     mpmath_name = "acot"
 
@@ -442,6 +445,7 @@ class ArcCoth(_MPMathFunction):
      = 1.57079632679489661923132169163975144210 I
     """
 
+    summary_text = "inverse hyperbolic cotangent function"
     sympy_name = "acoth"
     mpmath_name = "acoth"
 
@@ -464,6 +468,7 @@ class ArcCsc(_MPMathFunction):
      = -Pi / 2
     """
 
+    summary_text = "inverse cosecant function"
     sympy_name = ""
     mpmath_name = "acsc"
 
@@ -493,6 +498,7 @@ class ArcCsch(_MPMathFunction):
      = 0.881374
     """
 
+    summary_text = "inverse hyperbolic cosecant function"
     sympy_name = ""
     mpmath_name = "acsch"
 
@@ -522,6 +528,7 @@ class ArcSec(_MPMathFunction):
      = Pi
     """
 
+    summary_text = "inverse secant function"
     sympy_name = ""
     mpmath_name = "asec"
 
@@ -553,6 +560,7 @@ class ArcSech(_MPMathFunction):
      = 1.31696
     """
 
+    summary_text = "inverse hyperbolic secant function"
     sympy_name = ""
     mpmath_name = "asech"
 
@@ -582,6 +590,7 @@ class ArcSin(_MPMathFunction):
      = Pi / 2
     """
 
+    summary_text = "inverse sine function"
     sympy_name = "asin"
     mpmath_name = "asin"
 
@@ -607,6 +616,7 @@ class ArcSinh(_MPMathFunction):
      = 0.881374
     """
 
+    summary_text = "inverse hyperbolic sine function"
     sympy_name = "asinh"
     mpmath_name = "asinh"
 
@@ -648,6 +658,7 @@ class ArcTan(_MPMathFunction):
      = -Pi / 2
     """
 
+    summary_text = "inverse tangent function"
     sympy_name = "atan"
     mpmath_name = "atan"
 
@@ -679,6 +690,7 @@ class ArcTanh(_MPMathFunction):
      = ArcTanh[2 + I]
     """
 
+    summary_text = "inverse hyperbolic tangent function"
     sympy_name = "atanh"
     mpmath_name = "atanh"
     numpy_name = "arctanh"
@@ -702,6 +714,7 @@ class Cos(_MPMathFunction):
      = -1.83697*^-16
     """
 
+    summary_text = "cosine function"
     mpmath_name = "cos"
 
     rules = {
@@ -724,6 +737,7 @@ class Cosh(_MPMathFunction):
      = 1
     """
 
+    summary_text = "hyperbolic cosine function"
     mpmath_name = "cosh"
 
     rules = {
@@ -744,6 +758,7 @@ class Cot(_MPMathFunction):
      = 0.642093
     """
 
+    summary_text = "cotangent function"
     mpmath_name = "cot"
 
     rules = {
@@ -763,6 +778,7 @@ class Coth(_MPMathFunction):
      = ComplexInfinity
     """
 
+    summary_text = "hyperbolic cotangent function"
     mpmath_name = "coth"
 
     rules = {
@@ -787,6 +803,7 @@ class Csc(_MPMathFunction):
      = 1.1884
     """
 
+    summary_text = "cosecant function"
     mpmath_name = "csc"
 
     rules = {
@@ -812,6 +829,7 @@ class Csch(_MPMathFunction):
      = ComplexInfinity
     """
 
+    summary_text = "hyperbolic cosecant function"
     sympy_name = ""
     mpmath_name = "csch"
 
@@ -849,6 +867,7 @@ class Exp(_MPMathFunction):
      = Overflow[]
     """
 
+    summary_text = "exponential function"
     rules = {
         "Exp[x_]": "E ^ x",
         "Derivative[1][Exp]": "Exp",
@@ -872,6 +891,7 @@ class Haversine(_MPMathFunction):
      = -1.15082 + 0.869405 I
     """
 
+    summary_text = "haversine function"
     rules = {"Haversine[z_]": "Power[Sin[z/2], 2]"}
 
 
@@ -893,6 +913,7 @@ class InverseHaversine(_MPMathFunction):
      = 1.76459 + 2.33097 I
     """
 
+    summary_text = "inverse haversine function"
     rules = {"InverseHaversine[z_]": "2 * ArcSin[Sqrt[z]]"}
 
 
@@ -926,6 +947,7 @@ class Log(_MPMathFunction):
      = 2.30258509299404568401799145468
     """
 
+    summary_text = "logarithm function"
     nargs = 2
     mpmath_name = "log"
     sympy_name = "log"
@@ -964,6 +986,7 @@ class Log2(Builtin):
      = 2 / Log[2]
     """
 
+    summary_text = "base-2 logarithm function"
     attributes = listable | numeric_function | protected
 
     rules = {
@@ -986,6 +1009,7 @@ class Log10(Builtin):
      = 3 / Log[10]
     """
 
+    summary_text = "base-10 logarithm function"
     attributes = listable | numeric_function | protected
 
     rules = {
@@ -1013,42 +1037,10 @@ class LogisticSigmoid(Builtin):
      = LogisticSigmoid[I Pi]
     """
 
+    summary_text = "logistic function"
     attributes = listable | numeric_function | protected
 
     rules = {"LogisticSigmoid[z_?NumberQ]": "1 / (1 + Exp[-z])"}
-
-
-# Look over and add
-# class PolyGamma(_MPMathFunction):
-#     """
-#     <dl>
-#       <dt>'Polygama[$z$]'
-#       <dd>returns the digamma function .
-
-#       <dt>'Polygama[$n$, $z$]'
-#       <dd>gives the n^(th) derivative of the digamma function .
-#     </dl>
-
-#     >> PolyGamma[5]
-
-#     >> PolyGamma[3, 5]
-#     """
-
-#     sympy_name = "polygamma"
-#     mpmath_name = "polygamma"
-
-#     def apply_N(self, precision, evaluation):
-#         "N[PolyGamma, precision_]"
-
-#         try:
-#             d = get_precision(precision, evaluation)
-#         except PrecisionValueError:
-#             return
-
-#         if d is None:
-#             return MachineReal(mpmath.polygamma)
-#         else:
-#             return PrecisionReal(sympy.polygamma.n(d))
 
 
 class Sec(_MPMathFunction):
@@ -1066,6 +1058,7 @@ class Sec(_MPMathFunction):
      = 1.85082
     """
 
+    summary_text = "secant function"
     mpmath_name = "sec"
 
     rules = {
@@ -1091,6 +1084,7 @@ class Sech(_MPMathFunction):
      = 1
     """
 
+    summary_text = "hyperbolic secant function"
     sympy_name = ""
     mpmath_name = "sech"
 
@@ -1128,6 +1122,7 @@ class Sin(_MPMathFunction):
      = 0.8414709848078965066525023216302989996226
     """
 
+    summary_text = "sine function"
     mpmath_name = "sin"
 
     rules = {
@@ -1150,6 +1145,7 @@ class Sinh(_MPMathFunction):
      = 0
     """
 
+    summary_text = "hyperbolic sine function"
     mpmath_name = "sinh"
 
     rules = {
@@ -1173,6 +1169,7 @@ class Tan(_MPMathFunction):
      = 1.63312*^16
     """
 
+    summary_text = "tangent function"
     mpmath_name = "tan"
 
     rules = {
@@ -1193,6 +1190,7 @@ class Tanh(_MPMathFunction):
      = 0
     """
 
+    summary_text = "hyperbolic tangent function"
     mpmath_name = "tanh"
 
     rules = {

--- a/mathics/builtin/numbers/integer.py
+++ b/mathics/builtin/numbers/integer.py
@@ -21,10 +21,10 @@ class Floor(SympyFunction):
     """
     <dl>
       <dt>'Floor[$x$]'
-      <dd>gives the smallest integer less than or equal to $x$.
+      <dd>gives the greatest integer less than or equal to $x$.
 
       <dt>'Floor[$x$, $a$]'
-      <dd>gives the smallest multiple of $a$ less than or equal to $x$.
+      <dd>gives the greatest multiple of $a$ less than or equal to $x$.
     </dl>
 
     >> Floor[10.4]
@@ -52,6 +52,7 @@ class Floor(SympyFunction):
      = -10
     """
 
+    summary_text = "closest smaller integer"
     attributes = listable | numeric_function | protected
 
     sympy_name = "floor"
@@ -68,7 +69,7 @@ class Ceiling(SympyFunction):
     """
     <dl>
        <dt>'Ceiling[$x$]'
-       <dd>gives the first integer greater than $x$.
+       <dd>gives the smallest integer greater than or equal to $x$.
     </dl>
 
     >> Ceiling[1.2]
@@ -81,6 +82,7 @@ class Ceiling(SympyFunction):
      = 2 + I
     """
 
+    summary_text = "closest larger integer"
     attributes = listable | numeric_function | protected
 
     rules = {"Ceiling[x_, a_]": "Ceiling[x / a] * a"}
@@ -110,6 +112,7 @@ class BitLength(Builtin):
      = 0
     """
 
+    summary_text = "length of the binary representation"
     attributes = listable | protected
 
     def apply(self, n, evaluation):
@@ -175,6 +178,7 @@ class IntegerString(Builtin):
      = c6i5
     """
 
+    summary_text = "decimal representation of a number as a string"
     attributes = listable | protected
 
     rules = {
@@ -262,6 +266,7 @@ class IntegerDigits(_IntBaseBuiltin):
      = {12, 6, 18, 5}
     """
 
+    summary_text = "list of digits of a number"
     rules = {
         "IntegerDigits[n_Integer]": "IntegerDigits[n, 10]",
     }
@@ -326,6 +331,9 @@ class DigitCount(_IntBaseBuiltin):
      = 9
     """
 
+    summary_text = (
+        "number of occurrences of a digit in the base-b representation of a number"
+    )
     rules = {
         "DigitCount[n_Integer]": "DigitCount[n, 10]",
     }
@@ -373,6 +381,7 @@ class IntegerReverse(_IntBaseBuiltin):
      = 321
     """
 
+    summary_text = "number with digits in the inverse order"
     rules = {
         "IntegerReverse[n_Integer]": "IntegerReverse[n, 10]",
     }
@@ -427,6 +436,7 @@ class FromDigits(Builtin):
      = FromDigits[x, 10]
     """
 
+    summary_text = "integer from a list of digits"
     rules = {"FromDigits[l_]": "FromDigits[l, 10]"}
 
     messages = {"nlst": "The input must be a string of digits or a list."}

--- a/mathics/builtin/numbers/linalg.py
+++ b/mathics/builtin/numbers/linalg.py
@@ -76,6 +76,8 @@ class Tr(Builtin):
      = a + e + i
     """
 
+    summary_text = "trace of a matrix"
+
     messages = {"matsq": "The matrix `1` is not square."}
 
     # TODO: generalize to vectors and higher-rank tensors, and allow function arguments for application
@@ -105,6 +107,8 @@ class Det(Builtin):
      = a e i - a f h - b d i + b f g + c d h - c e g
     """
 
+    summary_text = "determinant of a matrix"
+
     def apply(self, m, evaluation):
         "Det[m_]"
 
@@ -133,6 +137,7 @@ class Cross(Builtin):
      = Cross[{1, 2}, {3, 4, 5}]
     """
 
+    summary_text = "vector cross product"
     rules = {"Cross[{x_, y_}]": "{-y, x}"}
 
     messages = {
@@ -178,6 +183,7 @@ class VectorAngle(Builtin):
      = 0
     """
 
+    summary_text = "angle between vectors"
     rules = {"VectorAngle[u_, v_]": "ArcCos[u.v / (Norm[u] Norm[v])]"}
 
 
@@ -196,6 +202,7 @@ class Inverse(Builtin):
 
     """
 
+    summary_text = "inverse matrix"
     messages = {
         "sing": "The matrix `1` is singular.",
         "matsq": "Argument `1` at position 1 is not " "a non-empty square matrix.",
@@ -255,7 +262,7 @@ class SingularValueDecomposition(Builtin):
     >> SingularValueDecomposition[{{1, 2, 0}, {2, 3, 0}, {3, 4, 1}}]
      = {{-3, 2, 0}, {2, -1, 0}, {1, -2, 1}}
     """
-
+    summary_text = "singular value decomposition"
     messages = {
         "nosymb": "Symbolic SVD is not implemented, performing numerically.",
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix.",
@@ -295,6 +302,7 @@ class QRDecomposition(Builtin):
      = QRDecomposition[{1, {2}}]
     """
 
+    summary_text = "qr decomposition"
     messages = {
         "sympy": "Sympy is unable to perform the QR decomposition.",
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix.",
@@ -336,6 +344,7 @@ class PseudoInverse(Builtin):
     = PseudoInverse[{1, {2}}]
     """
 
+    summary_text = "Moore-Penrose pseudoinverse"
     messages = {
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix."
     }
@@ -381,6 +390,7 @@ class LeastSquares(Builtin):
      = LeastSquares[{{1, 2}, {3, 4}}, {1, {2}}]
     """
 
+    summary_text = "least square solver for linear problems"
     messages = {
         "underdetermined": "Solving for underdetermined system not implemented.",
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix.",
@@ -434,6 +444,7 @@ class LinearSolve(Builtin):
      = LinearSolve[{{1, 2}, {3, 4}}, {1, {2}}]
     """
 
+    summary_text = "solves linear systems in matrix form"
     messages = {
         "lslc": (
             "Coefficient matrix and target vector(s) or matrix "
@@ -478,6 +489,14 @@ class LinearSolve(Builtin):
 
 
 class FittedModel(Builtin):
+    """
+    <dl>
+    <dd>'FittedModel[...]'
+    <dt> Result of a linear fit
+    </dl>
+    """
+
+    summary_text = "fitted model"
     rules = {
         "FittedModel[x_List][s_String]": "s /. x",
         "FittedModel[x_List][y_]": '("Function" /. x)[y]',
@@ -493,7 +512,7 @@ class DesignMatrix(Builtin):
     """
     <dl>
     <dt>'DesignMatrix[$m$, $f$, $x$]'
-        <dd>returns the design matrix.
+        <dd>returns the design matrix for a linear model $f$ in the variables $x$.
     </dl>
 
     >> DesignMatrix[{{2, 1}, {3, 4}, {5, 3}, {7, 6}}, x, x]
@@ -503,6 +522,7 @@ class DesignMatrix(Builtin):
      = {{1, f[2]}, {1, f[3]}, {1, f[5]}, {1, f[7]}}
     """
 
+    summary_text = "design matrix for a linear model"
     rules = {
         "DesignMatrix[m_, f_List, x_?AtomQ]": "DesignMatrix[m, {f}, ConstantArray[x, Length[f]]]",
         "DesignMatrix[m_, f_, x_?AtomQ]": "DesignMatrix[m, {f}, {x}]",
@@ -514,7 +534,7 @@ class LinearModelFit(Builtin):
     """
     <dl>
     <dt>'LinearModelFit[$m$, $f$, $x$]'
-        <dd>returns the design matrix.
+        <dd>fits a linear model $f$ in the variables $x$ to the dataset $m$.
     </dl>
 
     >> m = LinearModelFit[{{2, 1}, {3, 4}, {5, 3}, {7, 6}}, x, x];
@@ -554,6 +574,7 @@ class LinearModelFit(Builtin):
      = {-0.142857, 0.214286, -0.0714286}
     """
 
+    summary_text = "fit a linear model to a dataset"
     # see the paper "Regression by linear combination of basis functions" by Risi Kondor for a good
     # summary of the math behind this
 
@@ -609,6 +630,7 @@ class NullSpace(Builtin):
      = NullSpace[{1, {2}}]
     """
 
+    summary_text = "generators for the null space of a matrix"
     messages = {
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix."
     }
@@ -648,6 +670,7 @@ class RowReduce(Builtin):
      = RowReduce[{{1, 0}, {0}}]
     """
 
+    summary_text = "matrix reduced row-echelon form"
     messages = {
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix."
     }
@@ -681,6 +704,7 @@ class MatrixRank(Builtin):
      = MatrixRank[{{1, 0}, {0}}]
     """
 
+    summary_text = "rank of a matrix"
     messages = {
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix."
     }
@@ -724,6 +748,7 @@ class Eigenvalues(Builtin):
      = Eigenvalues[{{1, 0}, {0}}]
     """
 
+    summary_text = "eigenvalues of a matrix"
     sympy_name = "eigenvalues"
     mpmath_name = "eig"
 
@@ -801,6 +826,7 @@ class Eigensystem(Builtin):
      = {{2, -1, 1}, {{1, 1, 1}, {1, -2, 1}, {-1, 0, 1}}}
     """
 
+    summary_text = "eigenvalues and corresponding eigenvectors of a matrix"
     rules = {"Eigensystem[m_]": "{Eigenvalues[m], Eigenvectors[m]}"}
 
 
@@ -825,6 +851,7 @@ class MatrixPower(Builtin):
      = MatrixPower[{{1, 0}, {0}}, 2]
     """
 
+    summary_text = "power of a matrix"
     messages = {
         "matrixpowernotimplemented": "Matrix power not implemented for matrix `1`.",
         "matrix": "Argument `1` at position `2` is not a non-empty rectangular matrix.",
@@ -877,6 +904,7 @@ class MatrixExp(Builtin):
     }
 
     # TODO fix precision
+    summary_text = "matrix exponentiation"
 
     def apply(self, m, evaluation):
         "MatrixExp[m_]"
@@ -940,6 +968,7 @@ class Norm(Builtin):
      = 0
     """
 
+    summary_text = "norm of a vector or matrix"
     rules = {
         "Norm[m_?NumberQ]": "Abs[m]",
         "Norm[m_?VectorQ, DirectedInfinity[1]]": "Max[Abs[m]]",
@@ -1012,6 +1041,7 @@ class Normalize(Builtin):
      = {}
     """
 
+    summary_text = "normalizes a vector"
     rules = {"Normalize[v_]": "Module[{norm = Norm[v]}, If[norm == 0, v, v / norm, v]]"}
 
 
@@ -1040,6 +1070,7 @@ class Eigenvectors(Builtin):
      = {{1, 7, 3}, {1, 1, 0}, {0, 0, 0}}
     """
 
+    summary_text = "list of matrix eigenvectors"
     messages = {
         "eigenvecnotimplemented": (
             "Eigenvectors is not yet implemented for the matrix `1`."
@@ -1089,6 +1120,9 @@ class Eigenvectors(Builtin):
         return Expression("List", *result)
 
 
+# These distance functions deserves a different module
+
+
 def _norm_calc(head, u, v, evaluation):
     expr = Expression(head, u, v)
     old_quiet_all = evaluation.quiet_all
@@ -1121,6 +1155,8 @@ class EuclideanDistance(Builtin):
      = Sqrt[Abs[a - c] ^ 2 + Abs[b - d] ^ 2]
     """
 
+    summary_text = "euclidean distance"
+
     def apply(self, u, v, evaluation):
         "EuclideanDistance[u_, v_]"
         t = _norm_calc("Subtract", u, v, evaluation)
@@ -1141,6 +1177,8 @@ class SquaredEuclideanDistance(Builtin):
     >> SquaredEuclideanDistance[{-1, -1}, {1, 1}]
      = 8
     """
+
+    summary_text = "square of the euclidean distance"
 
     def apply(self, u, v, evaluation):
         "SquaredEuclideanDistance[u_, v_]"
@@ -1164,6 +1202,8 @@ class ManhattanDistance(Builtin):
      = 4
     """
 
+    summary_text = "Manhattan distance"
+
     def apply(self, u, v, evaluation):
         "ManhattanDistance[u_, v_]"
         t = _norm_calc("Subtract", u, v, evaluation)
@@ -1185,6 +1225,8 @@ class ChessboardDistance(Builtin):
     >> ChessboardDistance[{-1, -1}, {1, 1}]
      = 2
     """
+
+    summary_text = "chessboard distance"
 
     def apply(self, u, v, evaluation):
         "ChessboardDistance[u_, v_]"
@@ -1208,6 +1250,8 @@ class CanberraDistance(Builtin):
      = 2
     """
 
+    summary_text = "Canberra distance"
+
     def apply(self, u, v, evaluation):
         "CanberraDistance[u_, v_]"
         t = _norm_calc("Subtract", u, v, evaluation)
@@ -1226,15 +1270,17 @@ class BrayCurtisDistance(Builtin):
     """
     <dl>
     <dt>'BrayCurtisDistance[$u$, $v$]'
-        <dd>returns the Bray Curtis distance between $u$ and $v$.
+        <dd>returns the Bray-Curtis distance between $u$ and $v$.
     </dl>
-
+    The Bray-Curtis distance is equivalent to Total[Abs[u-v]]/Total[Abs[u+v]].
     >> BrayCurtisDistance[-7, 5]
      = 6
 
     >> BrayCurtisDistance[{-1, -1}, {10, 10}]
      = 11 / 9
     """
+
+    summary_text = "Bray-Curtis distance"
 
     def apply(self, u, v, evaluation):
         "BrayCurtisDistance[u_, v_]"
@@ -1253,6 +1299,8 @@ class CosineDistance(Builtin):
     <dt>'CosineDistance[$u$, $v$]'
       <dd>returns the cosine distance between $u$ and $v$.
     </dl>
+    The cosine distance is given by $1 - u\cdot v/(Norm[u] Norm[v])=2\sin(\phi/2)^2$ with $\phi$
+    the angle between both vectors.
 
     >> N[CosineDistance[{7, 9}, {71, 89}]]
      = 0.0000759646
@@ -1260,6 +1308,8 @@ class CosineDistance(Builtin):
     >> CosineDistance[{a, b}, {c, d}]
      = 1 + (-a c - b d) / (Sqrt[Abs[a] ^ 2 + Abs[b] ^ 2] Sqrt[Abs[c] ^ 2 + Abs[d] ^ 2])
     """
+
+    summary_text = "cosine distance"
 
     def apply(self, u, v, evaluation):
         "CosineDistance[u_, v_]"

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -48,6 +48,7 @@ class ContinuedFraction(SympyFunction):
      = {8, {2, 1, 2, 1, 2, 16}}
     """
 
+    summary_text = "continued fraction expansion"
     sympy_name = "continued_fraction"
 
     attributes = listable | numeric_function | protected
@@ -89,7 +90,7 @@ class Divisors(Builtin):
 
     # TODO: support GaussianIntegers
     # e.g. Divisors[2, GaussianIntegers -> True]
-
+    summary_text = "integer divisors"
     attributes = listable | protected
 
     def apply(self, n, evaluation):
@@ -157,6 +158,7 @@ class FactorInteger(Builtin):
      = {{2, 1}, {3, 1}, {5, 1}, {67, 1}, {2011, -1}}
     """
 
+    summary_text = "list of prime factors and exponents"
     attributes = listable | protected
 
     # TODO: GausianIntegers option
@@ -234,6 +236,7 @@ class FractionalPart(Builtin):
      = -8769956796 + Pi ^ 20
     """
 
+    summary_text = "fractional part of a number"
     attributes = listable | numeric_function | read_protected | protected
 
     def apply(self, n, evaluation):
@@ -270,6 +273,7 @@ class FromContinuedFraction(SympyFunction):
      = 225 / 157
     """
 
+    summary_text = "reconstructs a number from its continued fraction representation"
     sympy_name = "continued_fraction_reduce"
 
     attributes = numeric_function | protected
@@ -344,6 +348,7 @@ class MantissaExponent(Builtin):
      = {0, 0}
     """
 
+    summary_text = "decomposes numbers as mantissa and exponent"
     attributes = listable | protected
 
     rules = {
@@ -438,6 +443,7 @@ class NextPrime(Builtin):
      = NextPrime[5, 10.5]
     """
 
+    summary_text = "closest, smallest prime number"
     rules = {
         "NextPrime[n_]": "NextPrime[n, 1]",
     }
@@ -473,6 +479,7 @@ class PartitionsP(SympyFunction):
      = {0, 0, 1, 1, 2, 3, 5, 7, 11, 15, 22, 30, 42, 56, 77}
     """
 
+    summary_text = "number of unrestricted partitions"
     attributes = listable | numeric_function | orderless | protected
     sympy_name = "npartitions"
 
@@ -510,6 +517,7 @@ class Prime(SympyFunction):
      = {Prime[0], 2, Prime[1.2], 5}
     """
 
+    summary_text = "n-esim prime number"
     attributes = listable | numeric_function | protected
 
     def apply(self, n, evaluation):
@@ -545,6 +553,7 @@ class PrimePi(SympyFunction):
      = 1
     """
 
+    summary_text = "amount of prime numbers less than or equal"
     sympy_name = "ntheory.primepi"
     mpmath_name = "primepi"
 
@@ -584,7 +593,7 @@ class PrimePowerQ(Builtin):
     rules = {
         "PrimePowerQ[1]": "False",
     }
-
+    summary_text = "test if a number is a power of a prime number"
     attributes = listable | protected | read_protected
 
     # TODO: GaussianIntegers option
@@ -649,6 +658,7 @@ class RandomPrime(Builtin):
      = {{2, 2}, {2, 2}, {2, 2}}
     """
 
+    summary_text = "picks a random prime in an interval"
     messages = {
         "posdim": (
             "The dimensions parameter `1` is expected to be a positive "


### PR DESCRIPTION
This PR adds ``summary_text`` to all the ``Builtin`` in the module, except ``mathics.builtin.numbers.algebra`` that goes in a different PR. I tried to follow the WR style.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/248"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

