### PR TITLE
Handle expressions not representable by SymPy

### DIFF
--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -510,6 +510,10 @@ def do_cmp(x1, x2) -> Optional[int]:
     s1 = x1.to_sympy()
     s2 = x2.to_sympy()
 
+    # return None if expression cannot be handled by SymPy
+    if s1 is None or s2 is None:
+        return None
+
     # Use internal comparisons only for Real which is uses
     # WL's interpretation of equal (which allows for slop
     # in the least significant digit of precision), and use

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -418,8 +418,9 @@ class Apart(Builtin):
 
         expr_sympy = expr.to_sympy()
         var_sympy = var.to_sympy()
+        # If the expression cannot be handled by Sympy, just return it.
         if expr_sympy is None or var_sympy is None:
-            return None
+            return expr
 
         try:
             result = sympy.apart(expr_sympy, var_sympy)
@@ -1392,8 +1393,9 @@ class Factor(Builtin):
         "Factor[expr_]"
 
         expr_sympy = expr.to_sympy()
+        # If the expression cannot be handled by Sympy, just return it.
         if expr_sympy is None:
-            return None
+            return expr
 
         try:
             return from_sympy(sympy_factor(expr_sympy))


### PR DESCRIPTION
This deals with some cases where it is safe to return the expression, when it cannot be handled by SymPy.