### PR TITLE
Use get_elements() (not _elements) ...

### DIFF
--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -177,7 +177,7 @@ def unroll_conditions(lhs):
     if isinstance(lhs, Symbol):
         return lhs, None
     else:
-        name, lhs_elements = lhs.get_head_name(), lhs._elements
+        name, lhs_elements = lhs.get_head_name(), lhs.get_elements()
     condition = []
     # This handle the case of many sucesive conditions:
     # f[x_]/; cond1 /; cond2 ... ->  f[x_]/; And[cond1, cond2, ...]

--- a/test/builtin/test_assignment.py
+++ b/test/builtin/test_assignment.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
-from .helper import check_evaluation, reset_session, session
+from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
 
@@ -231,4 +231,10 @@ def test_set_and_clear_messages(str_expr, str_expected, message, out_msgs):
         hold_expected=True,
         failure_message=message,
         expected_messages=out_msgs,
+    )
+
+
+def test_predecrement():
+    check_evaluation(
+        "--5", "4", failure_message="Set::setraw: Cannot assign to raw object 5."
     )

--- a/test/helper.py
+++ b/test/helper.py
@@ -95,7 +95,9 @@ def check_evaluation(
 
     if expected_messages is not None:
         msgs = list(expected_messages)
-        assert len(msgs) == len(outs), "outs are not the same"
+        expected_len = len(msgs)
+        got_len = len(outs)
+        assert expected_len == got_len, f"expected {expected_len}; got {got_len}"
         for (out, msg) in zip(outs, msgs):
             if out != msg:
                 print(f"out:<<{out}>>")


### PR DESCRIPTION
`get_elements()` is what element access uses.
`_elements` is a private structure on Expression.

Small tweaks to test_helper and move `test/test_assignment.py` into `test/builtin/test_assignment.py`

Fixes #267