### PR TITLE
avoid Expression.element recalculation if possible

### DIFF
--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -87,7 +87,7 @@ class Array(Builtin):
                 return
             dims[index] = value
         if origins.has_form("List", None):
-            if len(origins.leaves) != len(dims):
+            if len(origins.elements) != len(dims):
                 evaluation.message("Array", "plen", dimsexpr, origins)
                 return
             origins = origins.get_mutable_elements()
@@ -151,7 +151,8 @@ class Normal(Builtin):
         if isinstance(expr, Atom):
             return
         return Expression(
-            expr.get_head(), *[Expression("Normal", leaf) for leaf in expr.leaves]
+            expr.get_head(),
+            *[Expression("Normal", element) for element in expr.elements],
         )
 
 
@@ -251,14 +252,14 @@ class Permutations(Builtin):
 
         rs = None
         if isinstance(n, Integer):
-            py_n = min(n.get_int_value(), len(li.leaves))
-        elif n.has_form("List", 1) and isinstance(n.leaves[0], Integer):
-            py_n = n.leaves[0].get_int_value()
+            py_n = min(n.get_int_value(), len(li.elements))
+        elif n.has_form("List", 1) and isinstance(n.elements[0], Integer):
+            py_n = n.elements[0].get_int_value()
             rs = (py_n,)
         elif (
-            n.has_form("DirectedInfinity", 1) and n.leaves[0].get_int_value() == 1
+            n.has_form("DirectedInfinity", 1) and n.elements[0].get_int_value() == 1
         ) or n.get_name() == "System`All":
-            py_n = len(li.leaves)
+            py_n = len(li.elements)
         else:
             py_n = None
 
@@ -274,7 +275,7 @@ class Permutations(Builtin):
         inner = structure("List", li, evaluation)
         outer = structure("List", inner, evaluation)
 
-        return outer([inner(p) for r in rs for p in permutations(li.leaves, r)])
+        return outer([inner(p) for r in rs for p in permutations(li.elements, r)])
 
 
 class Reap(Builtin):
@@ -479,7 +480,7 @@ class Tuples(Builtin):
         if n is None or n < 0:
             evaluation.message("Tuples", "intnn")
             return
-        items = expr.leaves
+        items = expr.elements
 
         def iterate(n_rest):
             evaluation.check_stopped()
@@ -491,7 +492,7 @@ class Tuples(Builtin):
                         yield [item] + rest
 
         return Expression(
-            SymbolList, *(Expression(expr.head, *leaves) for leaves in iterate(n))
+            SymbolList, *(Expression(expr.head, *elements) for elements in iterate(n))
         )
 
     def apply_lists(self, exprs, evaluation):
@@ -504,9 +505,9 @@ class Tuples(Builtin):
             if isinstance(expr, Atom):
                 evaluation.message("Tuples", "normal")
                 return
-            items.append(expr.leaves)
+            items.append(expr.elements)
 
         return Expression(
             SymbolList,
-            *(Expression(SymbolList, *leaves) for leaves in get_tuples(items)),
+            *(Expression(SymbolList, *elements) for elements in get_tuples(items)),
         )

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -66,23 +66,23 @@ class KeyComparable:
     def get_sort_key(self):
         raise NotImplementedError
 
-    def __lt__(self, other) -> bool:
-        return self.get_sort_key() < other.get_sort_key()
-
-    def __gt__(self, other) -> bool:
-        return self.get_sort_key() > other.get_sort_key()
-
-    def __le__(self, other) -> bool:
-        return self.get_sort_key() <= other.get_sort_key()
-
-    def __ge__(self, other) -> bool:
-        return self.get_sort_key() >= other.get_sort_key()
-
     def __eq__(self, other) -> bool:
         return (
             hasattr(other, "get_sort_key")
             and self.get_sort_key() == other.get_sort_key()
         )
+
+    def __gt__(self, other) -> bool:
+        return self.get_sort_key() > other.get_sort_key()
+
+    def __ge__(self, other) -> bool:
+        return self.get_sort_key() >= other.get_sort_key()
+
+    def __le__(self, other) -> bool:
+        return self.get_sort_key() <= other.get_sort_key()
+
+    def __lt__(self, other) -> bool:
+        return self.get_sort_key() < other.get_sort_key()
 
     def __ne__(self, other) -> bool:
         return (

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -78,6 +78,10 @@ symbols_arithmetic_operations = system_symbols(
 )
 
 
+def identity_fn(arg: Any) -> Any:
+    return arg
+
+
 class BoxError(Exception):
     def __init__(self, box, form) -> None:
         super().__init__("Box %s cannot be formatted as %s" % (box, form))
@@ -1236,7 +1240,7 @@ class Expression(BaseElement, NumericOperators):
         for element in elements:
             element.unevaluated = False
 
-        # If HoldAllComplete is not an attribute,
+        # If HoldAllComplete Attribute (flag ``HOLD_ALL_COMPLETE``) is not set,
         # and the expression has elements of the form  `Unevaluated[element]`
         # change them to `element` and set a flag `unevaluated=True`
         # If the evaluation fails, use this flag to restore back the initial form
@@ -1263,8 +1267,9 @@ class Expression(BaseElement, NumericOperators):
                 new.elements = dirty_elements
                 elements = dirty_elements
 
-        # If the attribute FLAT is set, calls flatten with a callback
-        # that set elements as unevaluated too.
+        # If the Attribute ``Flat`` (flag ``FLAT``) is set, calls
+        # flatten with a callback that set elements as unevaluated
+        # too.
         def flatten_callback(new_elements, old):
             for element in new_elements:
                 element.unevaluated = old.unevaluated
@@ -1285,8 +1290,9 @@ class Expression(BaseElement, NumericOperators):
 
         # Step 5: Must we need to thread-rewrite the expression?
         #
-        # Threading is needed when head has the ``LISTABLE``
-        # Attribute.  ``Expression.thread`` rewrites the expression:
+        # Threading is needed when head has the ``Listable``
+        # Attribute (or flag ``LISTABLE``).
+        # ``Expression.thread`` rewrites the expression:
         #  ``F[{a,b,c,...}]`` as:
         #  ``{F[a], F[b], F[c], ...}``.
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1208,7 +1208,7 @@ class Expression(BaseElement, NumericOperators):
                     "_elements_fully_evaluated": self._elements_fully_evaluated,
                 }
             )
-            elements = self.elements
+            elements = new.elements
         else:
             elements = self.get_mutable_elements()
             eval_elements()

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -603,8 +603,8 @@ class Expression(BaseElement, NumericOperators):
         return self._elements
 
     @elements.setter
-    def elements(self, values: Iterable, **kwargs: Optional[dict]):
-        self._elements = self._build_elements(values, **kwargs)
+    def elements(self, values: Iterable):
+        self._elements = self._build_elements(values)
 
     def equal2(self, rhs: Any) -> Optional[bool]:
         """Mathics two-argument Equal (==)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -603,7 +603,7 @@ class Expression(BaseElement, NumericOperators):
         return self._elements
 
     @elements.setter
-    def elements(self, values: list, **kwargs: Optional[dict]):
+    def elements(self, values: Iterable, **kwargs: Optional[dict]):
         self._elements = self._build_elements(values, **kwargs)
 
     def equal2(self, rhs: Any) -> Optional[bool]:
@@ -1948,7 +1948,7 @@ class UnlinkedStructure(Structure):
 
     def __call__(self, elements):
         expr = Expression(self._head)
-        expr._elements = tuple(elements)
+        expr.elements = elements
         return expr
 
     def filter(self, expr, cond):
@@ -1989,7 +1989,7 @@ class LinkedStructure(Structure):
             raise ValueError("Structure.slice only supports slice steps of 1")
 
         new = Expression(self._head)
-        new.elements = tuple(elements[lower:upper])
+        new.elements = elements[lower:upper]
         if expr._cache:
             new._cache = expr._cache.sliced(lower, upper)
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -85,7 +85,7 @@ class BaseRule(KeyComparable):
             if hasattr(expr, "_elements_fully_evaluated"):
                 expr._elements_fully_evaluated = False
                 expr._is_flat = False  # I think this is fully updated
-                expr._is_sorted = False
+                expr._is_ordered = False
             return expr
 
         if return_list:

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -40,14 +40,14 @@ class NumericOperators:
     def __abs__(self) -> BaseElement:
         return self.create_expression("Abs", self)
 
+    def __add__(self, other) -> BaseElement:
+        return self.create_expression("Plus", self, other)
+
     def __pos__(self):
         return self
 
     def __neg__(self):
         return self.create_expression("Times", self, -1)
-
-    def __add__(self, other) -> BaseElement:
-        return self.create_expression("Plus", self, other)
 
     def __sub__(self, other) -> BaseElement:
         return self.create_expression(
@@ -124,24 +124,6 @@ class Monomial(object):
     def __init__(self, exps_dict):
         self.exps = exps_dict
 
-    def __lt__(self, other) -> bool:
-        return self.__cmp(other) < 0
-
-    def __gt__(self, other) -> bool:
-        return self.__cmp(other) > 0
-
-    def __le__(self, other) -> bool:
-        return self.__cmp(other) <= 0
-
-    def __ge__(self, other) -> bool:
-        return self.__cmp(other) >= 0
-
-    def __eq__(self, other) -> bool:
-        return self.__cmp(other) == 0
-
-    def __ne__(self, other) -> bool:
-        return self.__cmp(other) != 0
-
     def __cmp(self, other) -> int:
         self_exps = self.exps.copy()
         other_exps = other.exps.copy()
@@ -192,6 +174,24 @@ class Monomial(object):
                         return -1
             index += 1
         return 0
+
+    def __eq__(self, other) -> bool:
+        return self.__cmp(other) == 0
+
+    def __le__(self, other) -> bool:
+        return self.__cmp(other) <= 0
+
+    def __lt__(self, other) -> bool:
+        return self.__cmp(other) < 0
+
+    def __ge__(self, other) -> bool:
+        return self.__cmp(other) >= 0
+
+    def __gt__(self, other) -> bool:
+        return self.__cmp(other) > 0
+
+    def __ne__(self, other) -> bool:
+        return self.__cmp(other) != 0
 
 
 class Atom(BaseElement):

--- a/test/core/test_elements_properties.py
+++ b/test/core/test_elements_properties.py
@@ -15,7 +15,7 @@ def test_elements_properties():
     coming out of initial conversion are set accurately.
     """
 
-    for str_expression, full_eval, is_flat, is_sorted in [
+    for str_expression, full_eval, is_flat, is_ordered in [
         # fmt: off
         # expr          fully evaluated?  flat?  sorted?
         ("Plus[1, 1, 1]",          True,  True,  True),
@@ -47,5 +47,5 @@ def test_elements_properties():
         expr = convert(ast, session.definitions)
         # print("XXX", str_expression, expr)
         assert expr._elements_fully_evaluated == full_eval, str_expression
-        assert expr._is_sorted == is_sorted, str_expression
+        assert expr._is_ordered == is_ordered, str_expression
         assert expr._is_flat == is_flat, str_expression

--- a/test/core/test_elements_properties.py
+++ b/test/core/test_elements_properties.py
@@ -17,25 +17,26 @@ def test_elements_properties():
 
     for str_expression, full_eval, is_flat, is_ordered in [
         # fmt: off
-        # expr          fully evaluated?  flat?  sorted?
+        # expr          fully evaluated?  flat?  ordered?
         ("Plus[1, 1, 1]",          True,  True,  True),
         ("List[]",                 True,  True,  True),
-        ('List["a", "a", "a"]',    True,  True,  True),
+        ('List["a", "a", "b"]',    True,  True,  True),
+        ('List["b", "a", "a"]',    True,  True,  False),
 
         ('List["a", 2, 3]',        True,  True,  False),
-        ("Plus[1, 2, 3]",          True,  True,  False),
+        ("Plus[1, 2, 3]",          True,  True,  True),
         ("Plus[x]",                False, True,  True),
-        ("Plus[Plus[x]]",          False, False,  True),
-        ("Plus[x, y]",             False, True,  False),
+        ("Plus[Plus[x]]",          False, False, True),
+        ("Plus[x, y]",             False, True,  True),
 
-        # Note: sorted could start out True here, but
-        # we would need a more sophisticated convert routine.
-        ("Plus[Plus[x], Plus[x]]", False, False, False),
+        ("Plus[Plus[x], Plus[x]]", False, False, True),
+
+        ("Plus[Plus[y], Plus[x]]", False, False, False),
 
         # Is sorted is true here since we have the same symbol repeated
         ('List[a, a, a]',          False,  True,  True),
 
-        ('Plus["x", Plus["x"]]',   False, False, False),
+        ('Plus["x", Plus["x"]]',   False, False, True),
     ]:
         # fmt: on
         session.evaluation.out.clear()

--- a/test/core/test_expression_constructor.py
+++ b/test/core/test_expression_constructor.py
@@ -1,0 +1,39 @@
+from mathics.core.expression import Expression
+from mathics.core.systemsymbols import SymbolPlus
+from mathics.core.atoms import Integer, Integer1
+
+
+def test_expression_constructor():
+    def attribute_check(e, varname: str):
+        assert e._elements_fully_evaluated == True, varname
+        assert e._is_flat == True, varname
+        assert e._is_ordered == True, varname
+
+    # The below will convert 1 Integer(1) multiple times
+    # and discover that the arguments are flat, fully evaluated, and ordered.
+    ones = [1] * 50
+    e1 = Expression(SymbolPlus, *ones)
+    attribute_check(e1, "e1")
+    integer_ones = [Integer1] * 50
+    e2 = Expression(SymbolPlus, *integer_ones)
+    attribute_check(e2, "e2")
+    assert e1 == e2
+    assert e1.elements == e2.elements, "Elements should get converted the same"
+
+    e3 = Expression(SymbolPlus, *ones, element_conversion_fn=Integer)
+    attribute_check(e3, "e3")
+    assert e1 == e3
+    assert e1.elements == e3.elements, "Elements should get converted the same"
+
+    e4 = Expression(
+        SymbolPlus,
+        *integer_ones,
+        element_properties={
+            "_elements_fully_evaluated": True,
+            "_is_flat": True,
+            "_is_ordered": True,
+        },
+    )
+    attribute_check(e4, "e4")
+    assert e1 == e4
+    assert e1.elements == e4.elements, "Elements should get converted the same"

--- a/test/format/test_svg.py
+++ b/test/format/test_svg.py
@@ -39,15 +39,15 @@ def get_svg(expression):
 
     # Would be nice to DRY this boilerplate from boxes_to_mathml
 
-    leaves = boxes.get_elements()
+    elements = boxes._elements
     elements, calc_dimensions = boxes._prepare_elements(
-        leaves, options=options, neg_y=True
+        elements, options=options, neg_y=True
     )
     xmin, xmax, ymin, ymax, w, h, width, height = calc_dimensions()
     data = (elements, xmin, xmax, ymin, ymax, w, h, width, height)
 
     format_fn = lookup_method(boxes, "svg")
-    return format_fn(boxes, leaves, data=data, options=options)
+    return format_fn(boxes, elements, data=data, options=options)
 
 
 def test_svg_circle():


### PR DESCRIPTION
@mmatera In #277 the property recalculation of elements properties and avoidance of calling `to_python()` was removing by virtue of called the setters property. Also, we weren't making use the flat property that was fixed as a result of #277. 

This preserves those properties and allows Expression creation to give (some of) these properties. To be added could be  add a way to indicate that `to_python()` on elements isn't needed. 

What could be done is to go over all calls to `Expression` to see if we can specify whether we can avoid calling `to_python` and if we determine element properties and set them up front.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/281"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>