### PR TITLE
Contexts and message assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,9 @@ Enhancements
 * numeric overflows now do not affect the full evaluation, but just the element
   which produce it.
 * ``SameQ`` (``===``) handles chaining, e.g. ``a == b == c`` or ``SameQ[a, b, c]``
-* ``Simplify`` now has a semantics closer to the WMA, and handles properly expressions of the form
-  ``Simplify[0^a]`` (issue #167)
-
+* ``Simplify`` now has a semantics closer to the WMA, and handles properly expressions of the form ``Simplify[0^a]`` (issue #167)
+* The order of the context name resolution (and `$ContextPath`) follows now the standard in WMA, with ``"System`"`` coming before ``"Global`"`.
+* In assignment to messages associated to symbols, the attribute ``Protected`` is not having into account, folliwing the standard in WMA.
 
 Documentation
 .............

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -559,8 +559,9 @@ def process_assign_messagename(self, lhs, rhs, evaluation, tags, upset):
     lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
     rule = Rule(lhs, rhs)
     for tag in tags:
-        if rejected_because_protected(self, lhs, tag, evaluation):
-            continue
+        # Messages can be assigned even if the symbol is protected...
+        # if rejected_because_protected(self, lhs, tag, evaluation):
+        #    continue
         count += 1
         defs.add_message(tag, rule)
     return count > 0

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -503,13 +503,13 @@ class ContextPath(Predefined):
      = 1
     #> System`$ContextPath
      = {x`}
-    #> $ContextPath = {"Global`", "System`"};
+    #> $ContextPath = {"System`", "Global`"};
     """
 
     messages = {"cxlist": "`1` is not a list of valid context names ending in `."}
     name = "$ContextPath"
     rules = {
-        "$ContextPath": '{"Global`", "System`"}',
+        "$ContextPath": '{"System`", "Global`"}',
     }
     summary_text = "the current context search path"
 

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -100,8 +100,8 @@ class Definitions(object):
         self._packages = []
         self.current_context = "Global`"
         self.context_path = (
-            "Global`",
             "System`",
+            "Global`",
         )
         self.trace_evaluation = False
         self.timing_trace_evaluation = False

--- a/test/builtin/test_assignment.py
+++ b/test/builtin/test_assignment.py
@@ -209,13 +209,13 @@ def test_set_and_clear(str_expr, str_expected, msg):
         ),
         (
             "A=1; B=2; ClearAll[A, $ContextPath, B];{A,$ContextPath,B}",
-            "{A, {Global`, System`}, B}",
+            "{A, {System`, Global`}, B}",
             "This clears A and B, but not $ContextPath",
             ("Special symbol $ContextPath cannot be cleared.",),
         ),
         (
             "A=1; B=2; ClearAll[A, $ContextPath, B];{A,$ContextPath,B}",
-            "{A, {Global`, System`}, B}",
+            "{A, {System`, Global`}, B}",
             "This clears A and B, but not $ContextPath",
             ("Special symbol $ContextPath cannot be cleared.",),
         ),

--- a/test/helper.py
+++ b/test/helper.py
@@ -66,6 +66,8 @@ def check_evaluation(
     else:
         result = evaluate(str_expr)
 
+    outs = [out.text for out in session.evaluation.out]
+
     if to_string_expected:
         if hold_expected:
             expected = str_expected
@@ -82,8 +84,6 @@ def check_evaluation(
             expected = evaluate(str_expected)
             if to_python_expected:
                 expected = expected.to_python(string_quotes=False)
-
-    outs = [out.text for out in session.evaluation.out]
 
     print(time.asctime())
     if failure_message:

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -3,7 +3,7 @@ from .helper import check_evaluation
 from mathics_scanner.errors import IncompleteSyntaxError
 
 
-str_test_context = """
+str_test_context_1 = """
 BeginPackage["FeynCalc`"];
 
 AppendTo[$ContextPath, "FeynCalc`Package`"];
@@ -43,7 +43,7 @@ EndPackage[];
 
 def test_context1():
     expr = ""
-    for line in str_test_context.split("\n"):
+    for line in str_test_context_1.split("\n"):
         if line in ("", "\n"):
             continue
         expr = expr + line
@@ -58,3 +58,133 @@ def test_context1():
             continue
     check_evaluation("foo[42]", "42", to_string_expr=False, to_string_expected=False)
     check_evaluation("bar[]", "42", to_string_expr=False, to_string_expected=False)
+
+
+def test_context2():
+    nomessage = tuple([])
+    for expr, expected, lst_messages, msg in [
+        (
+            """BeginPackage["apackage`"];""",
+            None,
+            nomessage,
+            "Start a context. Add it to the context path",
+        ),
+        (
+            """Minus::usage=" usage string setted in the package for Minus";""",
+            None,
+            nomessage,
+            "set the usage string for a protected symbol ->no error",
+        ),
+        (
+            """Minus::mymessage=" custom message string for Minus";""",
+            None,
+            nomessage,
+            "set a custom message for a protected symbol ->no error",
+        ),
+        (
+            """Minus = pq;""",
+            None,
+            tuple(
+                [
+                    "Symbol Minus is Protected.",
+                ]
+            ),
+            "try to set a value for a protected symbol ->error",
+        ),
+        (
+            """X::usage = "package variable";""",
+            None,
+            nomessage,
+            "set the usage string for a package variable",
+        ),
+        ("""B = 6;""", None, nomessage, "Set a symbol value in the package context"),
+        (
+            """Begin["`implementation`"];""",
+            None,
+            nomessage,
+            "Start a context. Do not add it to the context path",
+        ),
+        (
+            """Plus = PP;""",
+            None,
+            tuple(
+                [
+                    "Symbol Plus is Protected.",
+                ]
+            ),
+            "try to set a value for a protected symbol ->error",
+        ),
+        (
+            """Plus::usage=" usage string setted in the package for Plus";""",
+            None,
+            nomessage,
+            "set the usage string for a protected symbol ->no error",
+        ),
+        (
+            """Plus::mymessage=" custom message string for Plus";""",
+            None,
+            nomessage,
+            "set a custom message for a protected symbol ->no error",
+        ),
+        ("""A = 7;""", None, nomessage, "Set a symbol value in the context"),
+        ("""X = 9;""", None, nomessage, "set the value of the package variable"),
+        ("""End[];""", None, nomessage, "go back to the previous context"),
+        (
+            """EndPackage[];""",
+            None,
+            nomessage,
+            "go back to the previous context. Keep the context in the contextpath",
+        ),
+        ("""A""", "A", nomessage, "A is not in any context of the context path. "),
+        ("""B""", "6", nomessage, "B is in a context of the context path"),
+        ("""X""", "9", nomessage, "X is in a context of the context path"),
+        (
+            """X::usage""",
+            '"package variable"',
+            nomessage,
+            "X is in a context of the context path",
+        ),
+        (
+            """apackage`implementation`A""",
+            "7",
+            nomessage,
+            "get A using its fully qualified name",
+        ),
+        ("""apackage`B""", "6", nomessage, "get B using its fully qualified name"),
+        (
+            """Plus::usage""",
+            ' " usage string setted in the package for Plus" ',
+            nomessage,
+            "custom usage for Plus",
+        ),
+        (
+            """Minus::usage""",
+            '" usage string setted in the package for Minus"',
+            nomessage,
+            "custom usage for Minus",
+        ),
+        (
+            """Plus::mymessage""",
+            '" custom message string for Plus"',
+            nomessage,
+            "custom message for Plus",
+        ),
+        (
+            """Minus::mymessage""",
+            '" custom message string for Minus"',
+            nomessage,
+            "custom message for Minus",
+        ),
+    ]:
+
+        if expected is None:
+            expected = "System`Null"
+        check_evaluation(
+            expr,
+            expected,
+            failure_message=msg,
+            to_string_expr=False,
+            to_string_expected=False,
+            expected_messages=lst_messages,
+            hold_expected=True,
+        )

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .helper import check_evaluation
+from .helper import check_evaluation, reset_session
 from mathics_scanner.errors import IncompleteSyntaxError
 
 
@@ -64,6 +64,18 @@ def test_context2():
     nomessage = tuple([])
     for expr, expected, lst_messages, msg in [
         (
+            """globalvarY = 37;""",
+            None,
+            nomessage,
+            "set the value of a global symbol",
+        ),
+        (
+            """globalvarZ = 37;""",
+            None,
+            nomessage,
+            "set the value of a global symbol",
+        ),
+        (
             """BeginPackage["apackage`"];""",
             None,
             nomessage,
@@ -97,12 +109,42 @@ def test_context2():
             nomessage,
             "set the usage string for a package variable",
         ),
+        (
+            """globalvarZ::usage = "a global variable";""",
+            None,
+            nomessage,
+            "set the usage string for a global symbol",
+        ),
+        (
+            """globalvarZ = 57;""",
+            None,
+            nomessage,
+            "reset the value of a global symbol",
+        ),
         ("""B = 6;""", None, nomessage, "Set a symbol value in the package context"),
         (
             """Begin["`implementation`"];""",
             None,
             nomessage,
             "Start a context. Do not add it to the context path",
+        ),
+        (
+            """{Context[A], Context[B], Context[X], Context[globalvarY], Context[globalvarZ]}""",
+            """{"apackage`implementation`", "apackage`", "apackage`", "apackage`implementation`", "apackage`"}""",
+            nomessage,
+            None,  # "context of the variables"
+        ),
+        (
+            """globalvarY::usage = "a global variable";""",
+            None,
+            nomessage,
+            "set the usage string for a global symbol",
+        ),
+        (
+            """globalvarY = 97;""",
+            None,
+            nomessage,
+            "reset the value of a global symbol",
         ),
         (
             """Plus = PP;""",
@@ -130,13 +172,53 @@ def test_context2():
         ("""X = 9;""", None, nomessage, "set the value of the package variable"),
         ("""End[];""", None, nomessage, "go back to the previous context"),
         (
+            """{Context[A], Context[B], Context[X], Context[globalvarY], Context[globalvarZ]}""",
+            """{"apackage`", "apackage`", "apackage`", "apackage`", "apackage`"}""",
+            nomessage,
+            None,  # "context of the variables in the package"
+        ),
+        (
             """EndPackage[];""",
             None,
             nomessage,
             "go back to the previous context. Keep the context in the contextpath",
         ),
+        (
+            """{Context[A], Context[B], Context[X], Context[globalvarY], Context[globalvarZ]}""",
+            """{"apackage`", "apackage`", "apackage`", "apackage`", "apackage`"}""",
+            nomessage,
+            None,  # "context of the variables at global level"
+        ),
         ("""A""", "A", nomessage, "A is not in any context of the context path. "),
         ("""B""", "6", nomessage, "B is in a context of the context path"),
+        ("""Global`globalvarY""", "37", nomessage, ""),
+        (
+            """Global`globalvarY::usage""",
+            "Global`globalvarY::usage",
+            nomessage,
+            "In WMA, the value would be set in the package",
+        ),
+        ("""Global`globalvarZ""", "37", nomessage, "the value set inside the package"),
+        (
+            """Global`globalvarZ::usage""",
+            "Global`globalvarZ::usage",
+            nomessage,
+            "not affected by the package",
+        ),
+        ("""globalvarY""", "apackage`globalvarY", nomessage, ""),
+        (
+            """globalvarY::usage""",
+            "apackage`globalvarY::usage",
+            nomessage,
+            "In WMA, the value would be set in the package",
+        ),
+        ("""globalvarZ""", "57", nomessage, "the value set inside the package"),
+        (
+            """globalvarZ::usage""",
+            '"a global variable"',
+            nomessage,
+            "not affected by the package",
+        ),
         ("""X""", "9", nomessage, "X is in a context of the context path"),
         (
             """X::usage""",
@@ -188,3 +270,4 @@ def test_context2():
             expected_messages=lst_messages,
             hold_expected=True,
         )
+    reset_session()

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -375,7 +375,7 @@ def test_makeboxes_outputform_text(
         ("Subsuperscript[a, p, q]", "a_p^q", None),
         (
             "Integrate[F[x],{x,a,g[b]}]",
-            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \uf74cx",
+            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \\, dx",
             None,
         ),
         ("a^(b/c)", "a^{\\frac{b}{c}}", None),

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -375,7 +375,7 @@ def test_makeboxes_outputform_text(
         ("Subsuperscript[a, p, q]", "a_p^q", None),
         (
             "Integrate[F[x],{x,a,g[b]}]",
-            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \\, dx",
+            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \uf74cx",
             None,
         ),
         ("a^(b/c)", "a^{\\frac{b}{c}}", None),


### PR DESCRIPTION
This PR fixes the behavior of assignments to Message in protected symbols. Also, pytests in ``pytest_context.py`` where improved to check the compatibility with the WMA behavior.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/283"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

