### PR TITLE
fix format pytest for integrate in tex

### DIFF
--- a/test/test_format.py
+++ b/test/test_format.py
@@ -375,7 +375,7 @@ def test_makeboxes_outputform_text(
         ("Subsuperscript[a, p, q]", "a_p^q", None),
         (
             "Integrate[F[x],{x,a,g[b]}]",
-            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \uf74cx",
+            "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \\, dx",
             None,
         ),
         ("a^(b/c)", "a^{\\frac{b}{c}}", None),


### PR DESCRIPTION
As I mentioned before, a recent modification of the code, fixed the behavior of `boxes_to_tex`.  
 Here I fixed the pytest accordingly.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/284"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

