### PR TITLE
improving Share[] 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,9 @@ Enhancements
 * ``Simplify`` now has a semantics closer to the WMA, and handles properly expressions of the form ``Simplify[0^a]`` (issue #167)
 * The order of the context name resolution (and `$ContextPath`) follows now the standard in WMA, with ``"System`"`` coming before ``"Global`"`.
 * In assignment to messages associated to symbols, the attribute ``Protected`` is not having into account, folliwing the standard in WMA.
+* ``Share[]`` now performs an explicit call to the Python garbage collection.
 
+  
 Documentation
 .............
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,16 +4,15 @@ CHANGES
 Enhancements
 ============
 
-* ``D`` can now act over ``Integrate`` and  ``NIntegrate`` (fix issue #130).
-* numeric overflows now do not affect the full evaluation, but just the element
-  which produce it.
+* ``D`` acts over ``Integrate`` and  ``NIntegrate``. Issue #130
+* numeric overflows now do not affect the full evaluation, but instead just the element which produce it.
 * ``SameQ`` (``===``) handles chaining, e.g. ``a == b == c`` or ``SameQ[a, b, c]``
-* ``Simplify`` now has a semantics closer to the WMA, and handles properly expressions of the form ``Simplify[0^a]`` (issue #167)
-* The order of the context name resolution (and `$ContextPath`) follows now the standard in WMA, with ``"System`"`` coming before ``"Global`"`.
-* In assignment to messages associated to symbols, the attribute ``Protected`` is not having into account, folliwing the standard in WMA.
-* ``Share[]`` now performs an explicit call to the Python garbage collection.
+* ``Simplify`` handles properly expressions of the form ``Simplify[0^a]`` (issue #167)
+* The order of the context name resolution (and ``$ContextPath``) switched putting ``"System`"`` before ``"Global`"`.
+* In assignment to messages associated with symbols, the attribute ``Protected`` is not having into account, folliwing the standard in WMA. With this and the above change, Combinatorical 2.0 works as written.
+* ``Share[]`` performs an explicit call to the Python garbage collection and returns the amount of memory free.
 
-  
+
 Documentation
 .............
 
@@ -23,15 +22,15 @@ Documentation
 New Builtins
 ============
 * Euler's ``Beta`` function.
-* ``Diagonal`` (Issue #115)
+* ``Diagonal``. Issue #115
 * ``EulerPhi``
-* ``$Echo`` (Issue #42).
-* ``FindRoot`` was improved for supporting numerical derivatives (issue 67), as well as the use of scipy libraries when are available.
+* ``$Echo``. Issue #42.
+* ``FindRoot`` was improved for supporting numerical derivatives Issue #67, as well as the use of scipy libraries when are available.
 * ``FindRoot`` (for the ``newton`` method) partially supports ``EvaluationMonitor`` and ``StepMonitor`` options.
 * ``FindMinimum`` and ``FindMaximum`` now have a minimal implementation for 1D problems and the use of scipy libraries when are available.
 * ``LogGamma`` function.
 * ``NumericFunction``
-* Partial support for ``Opacity``.
+* Partial support for Graphics option ``Opacity``.
 * ``SeriesData`` operations was improved.
 * ``TraceEvaluation[]`` shows expression name calls and return values of it argument.
    -  Pass option ``ShowTimeBySteps``, to show accumulated time before each setp
@@ -60,7 +59,7 @@ Internals
 * A bug was fixed relating to the order in which ``mathics.core.definitions`` stores the rules
 * Improved support for ``Series`` Issue #46.
 * ``Cylinder`` rendering is implemented in Asymptote.
-* ``N[_,_,Method->method]`` was reworked (Issue #137).
+* ``N[_,_,Method->method]`` was reworked. Issue #137
 
 
 Package update
@@ -85,6 +84,9 @@ Bugs
 *  ``SameQ``: comparison with MachinePrecision only needs to be exact within the last bit Issue #148.
 * Fix a bug in `Simplify` that produced expressions of the form ``ConditionalExpression[_,{True}]``.
 * Fix bug in ``Clear``  and ``ClearAll`` (#194).
+* Fix base 10 formatting for infix ``Times`` Issue #266
+* Partial fix of ``FillSimplify``
+
 
 4.0.1
 -----

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -582,11 +581,9 @@ class Share(Builtin):
     """
     <dl>
       <dt>'Share[]'
-      <dd>Tries to reduce the amount of memory required to store definitions, by reducing duplicated definitions.
-          By now, it just tries to release memory forcing Python to do garbage collection.
-          If psutil is available, returns the amount of released memory. Otherwise always returns $0$.
+      <dd>release memory forcing Python to do garbage collection. If Python package is 'psutil' installed is the amount of released memoryis returned. Otherwise returns $0$. This function differs from WMA which tries to reduce the amount of memory required to store definitions, by reducing duplicated definitions.
       <dt>'Share[Symbol]'
-      <dd>Tries to reduce the amount of memory required to store definitions associated to $Symbol$.
+      <dd>Does the same thing as 'Share[]'; Note: this function differs from WMA which tries to reduce the amount of memory required to store definitions associated to $Symbol$.
 
     </dl>
 
@@ -594,9 +591,9 @@ class Share(Builtin):
      = ...
     """
 
-    summary_text = "share common subexpressions throughout memory"
+    summary_text = "force Python garbage collection"
 
-    def apply_0(self, evaluation) -> Integer:
+    def apply(self, evaluation) -> Integer:
         """Share[]"""
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
@@ -610,7 +607,7 @@ class Share(Builtin):
             gc.collect()
             return Integer0
 
-    def apply_1(self, symbol, evaluation) -> Integer:
+    def apply_with_symbol(self, symbol, evaluation) -> Integer:
         """Share[symbol_Symbol]"""
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -583,9 +583,11 @@ class Share(Builtin):
     <dl>
       <dt>'Share[]'
       <dd>Tries to reduce the amount of memory required to store definitions, by reducing duplicated definitions.
-          Now it just do nothing.
+          By now, it just tries to release memory forcing Python to do garbage collection.
+          If psutil is available, returns the amount of released memory. Otherwise always returns $0$.
       <dt>'Share[Symbol]'
       <dd>Tries to reduce the amount of memory required to store definitions associated to $Symbol$.
+
     </dl>
 
     >> Share[]
@@ -596,20 +598,28 @@ class Share(Builtin):
 
     def apply_0(self, evaluation) -> Integer:
         """Share[]"""
-        totalmem = psutil.virtual_memory().available
-        gc.collect()
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
         # remplace them by references.
         # Return the amount of memory recovered.
-        return Integer(totalmem - psutil.virtual_memory().available)
+        if have_psutil:
+            totalmem = psutil.virtual_memory().available
+            gc.collect()
+            return Integer(totalmem - psutil.virtual_memory().available)
+        else:
+            gc.collect()
+            return Integer0
 
     def apply_1(self, symbol, evaluation) -> Integer:
         """Share[symbol_Symbol]"""
-        totalmem = psutil.virtual_memory().available
-        gc.collect()
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
         # remplace them by references.
         # Return the amount of memory recovered.
-        return Integer(totalmem - psutil.virtual_memory().available)
+        if have_psutil:
+            totalmem = psutil.virtual_memory().available
+            gc.collect()
+            return Integer(totalmem - psutil.virtual_memory().available)
+        else:
+            gc.collect()
+            return Integer0

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -596,6 +596,9 @@ class Share(Builtin):
 
     def apply_0(self, evaluation) -> Integer:
         """Share[]"""
+        import gc
+
+        gc.collect()
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
         # remplace them by references.
@@ -604,6 +607,9 @@ class Share(Builtin):
 
     def apply_1(self, symbol, evaluation) -> Integer:
         """Share[symbol_Symbol]"""
+        import gc
+
+        gc.collect()
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
         # remplace them by references.

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -5,7 +5,7 @@
 Global System Information
 """
 
-
+import gc
 import os
 import platform
 import sys
@@ -596,22 +596,20 @@ class Share(Builtin):
 
     def apply_0(self, evaluation) -> Integer:
         """Share[]"""
-        import gc
-
+        totalmem = psutil.virtual_memory().available
         gc.collect()
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
         # remplace them by references.
         # Return the amount of memory recovered.
-        return Integer0
+        return Integer(totalmem - psutil.virtual_memory().available)
 
     def apply_1(self, symbol, evaluation) -> Integer:
         """Share[symbol_Symbol]"""
-        import gc
-
+        totalmem = psutil.virtual_memory().available
         gc.collect()
         # TODO: implement a routine that swap all the definitions,
         # collecting repeated symbols and expressions, and then
         # remplace them by references.
         # Return the amount of memory recovered.
-        return Integer0
+        return Integer(totalmem - psutil.virtual_memory().available)


### PR DESCRIPTION
In WMA, the command  ``Share[]`` tries to recover memory by replacing repeated expressions by references to a single instance of the expression. For example, if we have two definitions
```
In[1]:= table=Table[i^2,{i,1000}];                                              
In[2]:= a=F[table,2];                                                           
In[3]:= b=F[table,3];                                                           
In[4]:= MemoryAvailable[]                                                       
Out[4]= 9147990016
In[5]:= Share[]                                                                 
Out[5]= 17104
``` 
in a way that 17104 bytes are recovered by replacing (internally) the three lists in the definitions of `table`,`a` and `b`  by a single list expression, that is referenced in the three places.

In Mathics, ``Share[]`` is doing nothing, and returns always `0`. This PR tries to improve this by calling explicitly the garbage collector.  

reduces the amount of used memory 


<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/291"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

