### PR TITLE
By by is true

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,7 +59,8 @@ Internals
 * Improved support for ``Series`` Issue #46.
 * ``Cylinder`` rendering is implemented in Asymptote.
 * ``N[_,_,Method->method]`` was reworked (Issue #137).
-
+* the method ``Element.is_true()`` was removed in favor of `is SymbolTrue`
+  
 
 Package update
 ++++++++++++++

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1278,7 +1278,7 @@ class Assuming(Builtin):
     def apply_assuming(self, assumptions, expr, evaluation):
         "Assuming[assumptions_, expr_]"
         assumptions = assumptions.evaluate(evaluation)
-        if assumptions.is_true():
+        if assumptions is SymbolTrue:
             cond = []
         elif isinstance(assumptions, Symbol) or not assumptions.has_form("List", None):
             cond = [assumptions]
@@ -1344,7 +1344,7 @@ class ConditionalExpression(Builtin):
             cond = Expression("System`And", cond)
         if cond is None:
             return
-        if cond.is_true():
+        if cond is SymbolTrue:
             return expr
         if cond is SymbolFalse:
             return SymbolUndefined

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -41,7 +41,7 @@ from mathics.core.formatter import lookup_method
 from mathics.format.asy_fns import asy_color, asy_number
 
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol
+from mathics.core.symbols import Symbol, SymbolTrue
 from mathics.core.atoms import (
     Integer,
     Real,
@@ -809,10 +809,10 @@ clip(%s);
 
     def create_axes(self, elements, graphics_options, xmin, xmax, ymin, ymax):
         axes = graphics_options.get("System`Axes")
-        if axes.is_true():
+        if axes is SymbolTrue:
             axes = (True, True)
         elif axes.has_form("List", 2):
-            axes = (axes.elements[0].is_true(), axes.elements[1].is_true())
+            axes = (axes.elements[0] is SymbolTrue, axes.elements[1] is SymbolTrue)
         else:
             axes = (False, False)
         ticks_style = graphics_options.get("System`TicksStyle")

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -26,7 +26,7 @@ from mathics.builtin.drawing.graphics3d import (
 )
 
 from mathics.builtin.drawing.graphics_internals import get_class
-from mathics.core.expression import Symbol
+from mathics.core.symbols import Symbol, SymbolTrue
 from mathics.core.formatter import lookup_method
 from mathics.format.asy_fns import asy_create_pens, asy_number
 
@@ -615,10 +615,10 @@ currentlight=light(rgb(0.5,0.5,1), specular=red, (2,0,2), (2,2,2), (0,2,2));
         self, elements, graphics_options, xmin, xmax, ymin, ymax, zmin, zmax, boxscale
     ):
         axes = graphics_options.get("System`Axes")
-        if axes.is_true():
+        if axes is SymbolTrue:
             axes = (True, True, True)
         elif axes.has_form("List", 3):
-            axes = (leaf.is_true() for leaf in axes.leaves)
+            axes = (leaf is SymbolTrue for leaf in axes.leaves)
         else:
             axes = (False, False, False)
         ticks_style = graphics_options.get("System`TicksStyle")

--- a/mathics/builtin/distance/stringdata.py
+++ b/mathics/builtin/distance/stringdata.py
@@ -267,7 +267,7 @@ class HammingDistance(Builtin):
         ignore_case = self.get_option(options, "IgnoreCase", evaluation)
         py_u = u.get_string_value()
         py_v = v.get_string_value()
-        if ignore_case and ignore_case.is_true():
+        if ignore_case and ignore_case is SymbolTrue:
             py_u = py_u.lower()
             py_v = py_v.lower()
         return HammingDistance._compute(py_u, py_v, lambda x, y: x == y, evaluation)

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -18,7 +18,7 @@ from mathics.core.atoms import (
     from_python,
 )
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol, SymbolNull, SymbolList
+from mathics.core.symbols import Symbol, SymbolNull, SymbolList, SymbolTrue
 from mathics.core.systemsymbols import SymbolRule
 
 from mathics.builtin.colors.color_internals import (
@@ -1444,7 +1444,7 @@ class ColorCombine(_ImageBuiltin):
 
         numpy_channels = []
         for channel in channels.leaves:
-            if not Expression("MatrixQ", channel).evaluate(evaluation).is_true():
+            if not Expression("MatrixQ", channel).evaluate(evaluation) is SymbolTrue:
                 return
             numpy_channels.append(matrix_to_numpy(channel))
 
@@ -1518,7 +1518,7 @@ class Colorize(_ImageBuiltin):
             pixels = values.grayscale().pixels
             matrix = pixels_as_ubyte(pixels.reshape(pixels.shape[:2]))
         else:
-            if not Expression("MatrixQ", values).evaluate(evaluation).is_true():
+            if not Expression("MatrixQ", values).evaluate(evaluation) is SymbolTrue:
                 return
             matrix = matrix_to_numpy(values)
 

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -30,7 +30,7 @@ from mathics.core.atoms import (
 )
 from mathics.core.attributes import hold_all, protected
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol, SymbolList, SymbolN
+from mathics.core.symbols import Symbol, SymbolList, SymbolN, SymbolTrue
 from mathics.core.systemsymbols import SymbolRule
 
 
@@ -2547,7 +2547,7 @@ class DensityPlot(_Plot3D):
             color_function_min = color_function.leaves[2].leaves[0].round_to_float()
             color_function_max = color_function.leaves[2].leaves[1].round_to_float()
 
-        color_function_scaling = color_function_scaling.is_true()
+        color_function_scaling = color_function_scaling is SymbolTrue
         v_range = v_max - v_min
 
         if v_range == 0:

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -1740,7 +1740,7 @@ class _OpenAction(Builtin):
         # Options
         # BinaryFormat
         mode = self.mode
-        if options["System`BinaryFormat"].is_true():
+        if options["System`BinaryFormat"] is SymbolTrue:
             if not self.mode.endswith("b"):
                 mode += "b"
 

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -1710,7 +1710,7 @@ class Needs(Builtin):
             return
         test_loaded = Expression("MemberQ", Symbol("$Packages"), context)
         test_loaded = test_loaded.evaluate(evaluation)
-        if test_loaded.is_true():
+        if test_loaded is SymbolTrue:
             # Already loaded
             return SymbolNull
         result = Expression("Get", context).evaluate(evaluation)

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -10,7 +10,13 @@ from mathics.core.atoms import (
     from_python,
 )
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol, SymbolList, SymbolNull, strip_context
+from mathics.core.symbols import (
+    Symbol,
+    SymbolList,
+    SymbolNull,
+    SymbolTrue,
+    strip_context,
+)
 from mathics.core.systemsymbols import (
     SymbolRule,
     SymbolFailed,
@@ -1973,7 +1979,7 @@ class ExportString(Builtin):
             evaluation,
         )
 
-        is_binary = exporter_options["System`BinaryFormat"].is_true()
+        is_binary = exporter_options["System`BinaryFormat"] is SymbolTrue
         if function_channels is None:
             evaluation.message("ExportString", "emptyfch")
             evaluation.predetermined_out = current_predetermined_out

--- a/mathics/builtin/inference.py
+++ b/mathics/builtin/inference.py
@@ -108,7 +108,7 @@ def remove_nots_when_unnecesary(pred, evaluation):
     while cc:
         pred, cc = pred.apply_rules(remove_not_rules, evaluation)
         debug_logical_expr("->  ", pred, evaluation)
-        if pred.is_true() or pred is SymbolFalse:
+        if pred is SymbolTrue or pred is SymbolFalse:
             return pred
     return pred
 
@@ -149,7 +149,7 @@ def logical_expand_assumptions(assumptions_list, evaluation):
     changed = False
     for assumption in assumptions_list:
         if isinstance(assumption, Symbol):
-            if assumption.is_true():
+            if assumption is SymbolTrue:
                 changed = True
                 continue
             if assumption is SymbolFalse:
@@ -364,7 +364,7 @@ def evaluate_predicate(pred, evaluation):
     while cc:
         pred, cc = pred.apply_rules(logical_algebraic_rules, evaluation)
         debug_logical_expr("->  ", pred, evaluation)
-        if pred.is_true() or pred is SymbolFalse:
+        if pred is SymbolTrue or pred is SymbolFalse:
             return pred
 
     assumption_rules = get_assumption_rules_dispatch(evaluation)

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -32,7 +32,7 @@ from mathics.builtin.base import MessageException
 
 from mathics.core.expression import Expression
 from mathics.core.atoms import Integer, Integer0
-from mathics.core.symbols import Atom, Symbol, SymbolList, SymbolNull
+from mathics.core.symbols import Atom, Symbol, SymbolList, SymbolNull, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolFailed,
     SymbolMakeBoxes,
@@ -205,12 +205,12 @@ class Cases(Builtin):
 
         if ls.has_form("Rule", 2):
             if ls.leaves[0].get_name() == "System`Heads":
-                heads = ls.leaves[1].is_true()
+                heads = ls.leaves[1] is SymbolTrue
                 ls = Expression("List", 1)
             else:
                 return evaluation.message("Position", "level", ls)
         else:
-            heads = self.get_option(options, "Heads", evaluation).is_true()
+            heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
 
         try:
             start, stop = python_levelspec(ls)
@@ -1016,7 +1016,7 @@ class Pick(Builtin):
 
     def apply(self, items, sel, evaluation):
         "Pick[items_, sel_]"
-        return self._do(items, sel, lambda s: s.is_true(), evaluation)
+        return self._do(items, sel, lambda s: s is SymbolTrue, evaluation)
 
     def apply_pattern(self, items, sel, pattern, evaluation):
         "Pick[items_, sel_, pattern_]"
@@ -1301,7 +1301,7 @@ class Select(Builtin):
 
         def cond(leaf):
             test = Expression(expr, leaf)
-            return test.evaluate(evaluation).is_true()
+            return test.evaluate(evaluation) is SymbolTrue
 
         return items.filter(items.head, cond, evaluation)
 

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -22,7 +22,7 @@ from mathics.core.expression import (
     structure,
 )
 from mathics.core.atoms import Integer
-from mathics.core.symbols import Atom, Symbol, SymbolList
+from mathics.core.symbols import Atom, Symbol, SymbolList, SymbolTrue
 
 from mathics.core.attributes import flat, one_identity, protected
 
@@ -35,7 +35,7 @@ def _test_pair(test, a, b, evaluation, name):
         and (result.has_symbol("True") or result.has_symbol("False"))
     ):
         evaluation.message(name, "smtst", test_expr, result)
-    return result.is_true()
+    return result is SymbolTrue
 
 
 def _is_sameq(same_test):

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -225,7 +225,7 @@ class ContainsOnly(Builtin):
         def sameQ(a, b) -> bool:
             """Mathics SameQ"""
             result = Expression(same_test, a, b).evaluate(evaluation)
-            return result.is_true()
+            return result is SymbolTrue
 
         self.check_options(None, evaluation, options)
         for a in list1.leaves:
@@ -504,7 +504,7 @@ class Level(Builtin):
             result.append(level)
             return level
 
-        heads = self.get_option(options, "Heads", evaluation).is_true()
+        heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
         walk_levels(expr, start, stop, heads=heads, callback=callback)
         return Expression(SymbolList, *result)
 
@@ -702,7 +702,7 @@ class Split(Builtin):
         result = [[mlist.leaves[0]]]
         for leaf in mlist.leaves[1:]:
             applytest = Expression(test, result[-1][-1], leaf)
-            if applytest.evaluate(evaluation).is_true():
+            if applytest.evaluate(evaluation) is SymbolTrue:
                 result[-1].append(leaf)
             else:
                 result.append([leaf])
@@ -900,7 +900,7 @@ class Position(Builtin):
                 result.append(pos)
             return level
 
-        heads = self.get_option(options, "Heads", evaluation).is_true()
+        heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
         walk_levels(expr, start, stop, heads=heads, callback=callback, include_pos=True)
         return from_python(result)
 
@@ -1034,7 +1034,7 @@ class _IterationFunction(Builtin):
             cont = Expression(compare_type, index, imax).evaluate(evaluation)
             if cont is SymbolFalse:
                 break
-            if not cont.is_true():
+            if not cont is SymbolTrue:
                 if self.throw_iterb:
                     evaluation.message(self.get_name(), "iterb")
                 return
@@ -1445,9 +1445,8 @@ class _RankedTake(Builtin):
 
                     def exclude(item):
                         return (
-                            Expression("MatchQ", item, excluded)
-                            .evaluate(evaluation)
-                            .is_true()
+                            Expression("MatchQ", item, excluded).evaluate(evaluation)
+                            is SymbolTrue
                         )
 
                 filtered = [leaf for leaf in t.leaves if not exclude(leaf)]

--- a/mathics/builtin/logic.py
+++ b/mathics/builtin/logic.py
@@ -56,7 +56,7 @@ class Or(BinaryOperator):
         leaves = []
         for arg in args:
             result = arg.evaluate(evaluation)
-            if result.is_true():
+            if result is SymbolTrue:
                 return SymbolTrue
             elif result != SymbolFalse:
                 leaves.append(result)
@@ -107,7 +107,7 @@ class And(BinaryOperator):
             result = arg.evaluate(evaluation)
             if result is SymbolFalse:
                 return SymbolFalse
-            elif not result.is_true():
+            elif not result is SymbolTrue:
                 leaves.append(result)
         if leaves:
             if len(leaves) == 1:
@@ -214,7 +214,7 @@ class Implies(BinaryOperator):
         result0 = x.evaluate(evaluation)
         if result0 is SymbolFalse:
             return SymbolTrue
-        elif result0.is_true():
+        elif result0 is SymbolTrue:
             return y.evaluate(evaluation)
         else:
             return Expression("Implies", result0, y.evaluate(evaluation))
@@ -261,7 +261,7 @@ class Equivalent(BinaryOperator):
         flag = False
         for arg in args:
             result = arg.evaluate(evaluation)
-            if result is SymbolFalse or result.is_true():
+            if result is SymbolFalse or result is SymbolTrue:
                 flag = not flag
                 break
         if flag:
@@ -319,7 +319,7 @@ class Xor(BinaryOperator):
         flag = True
         for arg in args:
             result = arg.evaluate(evaluation)
-            if result.is_true():
+            if result is SymbolTrue:
                 flag = not flag
             elif result != SymbolFalse:
                 leaves.append(result)
@@ -390,7 +390,9 @@ class _ManyTrue(Builtin):
             return
 
         def callback(node):
-            self._short_circuit(Expression(test, node).evaluate(evaluation).is_true())
+            self._short_circuit(
+                Expression(test, node).evaluate(evaluation) is SymbolTrue
+            )
             return node
 
         try:

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -693,7 +693,7 @@ class Integrate(SympyFunction):
         if result.get_head_name() == "System`Piecewise":
             cases = result.elements[0].elements
             if len(result.elements) == 1:
-                if cases[-1].elements[1].is_true():
+                if cases[-1].elements[1] is SymbolTrue:
                     default = cases[-1].elements[0]
                     cases = result.elements[0].elements[:-1]
                 else:
@@ -711,7 +711,7 @@ class Integrate(SympyFunction):
                 # conditions...
                 cond = Expression("Simplify", case.elements[1]).evaluate(evaluation)
                 resif = Expression("Simplify", case.elements[0]).evaluate(evaluation)
-                if cond.is_true():
+                if cond is SymbolTrue:
                     if old_assumptions:
                         evaluation.definitions.set_ownvalue(
                             "System`$Assumptions", old_assumptions

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -245,7 +245,7 @@ class Replace(Builtin):
             if ret:
                 return rules
 
-            heads = self.get_option(options, "Heads", evaluation).is_true()
+            heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
 
             result, applied = expr.apply_rules(
                 rules,
@@ -672,7 +672,7 @@ class PatternTest(BinaryOperator, PatternObject):
                 else:
                     test_expr = Expression(self.test, item)
                     test_value = test_expr.evaluate(evaluation)
-                    if not test_value.is_true():
+                    if not test_value is SymbolTrue:
                         break
                         # raise StopGenerator
             else:
@@ -1526,7 +1526,7 @@ class Condition(BinaryOperator, PatternObject):
         def yield_match(new_vars, rest):
             test_expr = self.test.replace_vars(new_vars)
             test_result = test_expr.evaluate(evaluation)
-            if test_result.is_true():
+            if test_result is SymbolTrue:
                 yield_func(new_vars, rest)
 
         self.pattern.match(yield_match, expression, vars, evaluation)

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -127,7 +127,7 @@ class Catch(Builtin):
             # TODO: check that form match tag.
             # otherwise, re-raise the exception
             match = Expression("MatchQ", e.tag, form).evaluate(evaluation)
-            if match.is_true():
+            if match is SymbolTrue:
                 return Expression(f, e.value)
             else:
                 # A plain raise hide, this path and preserves the traceback
@@ -318,7 +318,7 @@ class For(Builtin):
 
     def apply(self, start, test, incr, body, evaluation):
         "For[start_, test_, incr_, body_]"
-        while test.evaluate(evaluation).is_true():
+        while test.evaluate(evaluation) is SymbolTrue:
             evaluation.check_stopped()
             try:
                 try:
@@ -454,7 +454,7 @@ class FixedPoint(Builtin):
             new_result = Expression(f, result).evaluate(evaluation)
             if sametest:
                 same = Expression(sametest, result, new_result).evaluate(evaluation)
-                same = same.is_true()
+                same = same is SymbolTrue
                 if same:
                     break
             else:
@@ -654,7 +654,7 @@ class NestWhile(Builtin):
                 test_elements = results[-m.value :]
             test_expr = Expression(test, *test_elements)
             test_result = test_expr.evaluate(evaluation)
-            if test_result.is_true():
+            if test_result is SymbolTrue:
                 next = Expression(f, results[-1])
                 results.append(next.evaluate(evaluation))
             else:
@@ -810,7 +810,7 @@ class Which(Builtin):
         while items:
             test, item = items[0], items[1]
             test_result = test.evaluate(evaluation)
-            if test_result.is_true():
+            if test_result is SymbolTrue:
                 return item.evaluate(evaluation)
             elif test_result != SymbolFalse:
                 if len(items) == nr_items:
@@ -849,7 +849,7 @@ class While(Builtin):
     def apply(self, test, body, evaluation):
         "While[test_, body_]"
 
-        while test.evaluate(evaluation).is_true():
+        while test.evaluate(evaluation) is SymbolTrue:
             try:
                 evaluation.check_stopped()
                 body.evaluate(evaluation)

--- a/mathics/builtin/structure.py
+++ b/mathics/builtin/structure.py
@@ -99,9 +99,8 @@ class Sort(Builtin):
 
                 def __gt__(self, other):
                     return (
-                        not Expression(p, self.leaf, other.leaf)
-                        .evaluate(evaluation)
-                        .is_true()
+                        not Expression(p, self.leaf, other.leaf).evaluate(evaluation)
+                        is SymbolTrue
                     )
 
             new_elements = sorted(list.leaves, key=Key)
@@ -468,7 +467,7 @@ class Apply(BinaryOperator):
             else:
                 return Expression(f, *level.leaves)
 
-        heads = self.get_option(options, "Heads", evaluation).is_true()
+        heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
         result, depth = walk_levels(expr, start, stop, heads=heads, callback=callback)
 
         return result
@@ -528,7 +527,7 @@ class Map(BinaryOperator):
         def callback(level):
             return Expression(f, level)
 
-        heads = self.get_option(options, "Heads", evaluation).is_true()
+        heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
         result, depth = walk_levels(expr, start, stop, heads=heads, callback=callback)
 
         return result
@@ -667,7 +666,7 @@ class Scan(Builtin):
             Expression(f, level).evaluate(evaluation)
             return level
 
-        heads = self.get_option(options, "Heads", evaluation).is_true()
+        heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
         result, depth = walk_levels(expr, start, stop, heads=heads, callback=callback)
 
         return SymbolNull
@@ -736,7 +735,7 @@ class MapIndexed(Builtin):
         def callback(level, pos):
             return Expression(f, level, Expression("List", *[Integer(p) for p in pos]))
 
-        heads = self.get_option(options, "Heads", evaluation).is_true()
+        heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
         result, depth = walk_levels(
             expr, start, stop, heads=heads, callback=callback, include_pos=True
         )

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -490,11 +490,6 @@ class BaseElement(KeyComparable):
         """
         return False
 
-    # Warning - this is going away
-    def is_true(self) -> bool:
-        """Better use self is SymbolTrue"""
-        return False
-
     @property
     def is_zero(self) -> bool:
         return False

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -38,6 +38,7 @@ from mathics.core.symbols import (
     Symbol,
     SymbolList,
     SymbolN,
+    SymbolTrue,
     system_symbols,
 )
 from mathics.core.systemsymbols import SymbolSequence
@@ -1576,7 +1577,7 @@ class Expression(BaseElement, NumericOperators):
                     name = rule._elements[0].get_name()
                     value = rule._elements[1]
                     if name == "System`ShowStringCharacters":
-                        value = value.is_true()
+                        value = value is SymbolTrue
                         options = options.copy()
                         options["show_string_characters"] = value
                     elif name == "System`ImageSizeMultipliers":

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -529,9 +529,6 @@ class Symbol(Atom, NumericOperators):
                 1,
             ]
 
-    def is_true(self) -> bool:
-        return self is SymbolTrue
-
     def user_hash(self, update) -> None:
         update(b"System`Symbol>" + self.name.encode("utf8"))
 

--- a/test/test_hash.py
+++ b/test/test_hash.py
@@ -12,7 +12,7 @@ from mathics.core.atoms import (
     Real,
     String,
 )
-from mathics.core.symbols import Symbol, SymbolFalse
+from mathics.core.symbols import Symbol, SymbolFalse, SymbolTrue
 
 from mathics.core.definitions import Definitions
 import sys
@@ -22,7 +22,7 @@ definitions = Definitions(add_builtin=True)
 
 
 def _symbol_truth_value(x):
-    if x.is_true():
+    if x is SymbolTrue:
         return True
     elif isinstance(x, Symbol) and x is SymbolFalse:
         return False


### PR DESCRIPTION
Following in the direction of looking a simpler and clearer interface for core.BaseElements, in this PR the use of `is_true()` was completely removed. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/294"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

