### PR TITLE
create_infix calls Expression() with Integer ..

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -39,7 +39,7 @@ from mathics.core.atoms import (
     from_python,
 )
 from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolList, SymbolTrue
-from mathics.core.systemsymbols import SymbolUndefined
+from mathics.core.systemsymbols import SymbolInfix, SymbolUndefined
 from mathics.core.number import min_prec, dps, SpecialValueError
 
 from mathics.core.convert import from_sympy, SympyExpression, sympy_symbol_prefix
@@ -205,10 +205,10 @@ def create_infix(items, operator, prec, grouping):
         return items[0]
     else:
         return Expression(
-            "Infix",
-            Expression("List", *items),
+            SymbolInfix,
+            Expression(SymbolList, *items),
             String(operator),
-            prec,
+            Integer(prec),
             Symbol(grouping),
         )
 

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -159,13 +159,13 @@ class BaseElement(KeyComparable):
         try:
             expr = self
             head = self.get_head()
-            leaves = self.get_elements()
+            elements = self.get_elements()
             include_form = False
             # If the expression is enclosed by a Format
             # takes the form from the expression and
             # removes the format from the expression.
-            if head in formats and len(leaves) == 1:
-                expr = leaves[0]
+            if head in formats and len(elements) == 1:
+                expr = elements[0]
                 if not (form is SymbolOutputForm and head is SymbolStandardForm):
                     form = head
                     include_form = True
@@ -177,12 +177,12 @@ class BaseElement(KeyComparable):
             # Repeated and RepeatedNull confuse the formatter,
             # so we need to hardlink their format rules:
             if head is SymbolRepeated:
-                if len(leaves) == 1:
+                if len(elements) == 1:
                     return self.create_expression(
                         SymbolHoldForm,
                         self.create_expression(
                             SymbolPostfix,
-                            self.create_expression(SymbolList, leaves[0]),
+                            self.create_expression(SymbolList, elements[0]),
                             "..",
                             170,
                         ),
@@ -190,12 +190,12 @@ class BaseElement(KeyComparable):
                 else:
                     return self.create_expression(SymbolHoldForm, expr)
             elif head is SymbolRepeatedNull:
-                if len(leaves) == 1:
+                if len(elements) == 1:
                     return self.create_expression(
                         SymbolHoldForm,
                         self.create_expression(
                             SymbolPostfix,
-                            self.create_expression(SymbolList, leaves[0]),
+                            self.create_expression(SymbolList, elements[0]),
                             "...",
                             170,
                         ),
@@ -227,7 +227,7 @@ class BaseElement(KeyComparable):
             # If the expression is still enclosed by a Format,
             # iterate.
             # If the expression is not atomic or of certain
-            # specific cases, iterate over the leaves.
+            # specific cases, iterate over the elements.
             head = expr.get_head()
             if head in formats:
                 expr = expr.do_format(evaluation, form)
@@ -239,7 +239,7 @@ class BaseElement(KeyComparable):
             ):
                 # print("Not inside graphics or numberform, and not is atom")
                 new_elements = [
-                    leaf.do_format(evaluation, form) for leaf in expr.leaves
+                    element.do_format(evaluation, form) for element in expr.elements
                 ]
                 expr = self.create_expression(
                     expr.head.do_format(evaluation, form), *new_elements
@@ -359,14 +359,14 @@ class BaseElement(KeyComparable):
         list_expr = self.flatten_with_respect_to_head(SymbolList)
         list = []
         if list_expr.has_form("List", None):
-            list.extend(list_expr.leaves)
+            list.extend(list_expr.elements)
         else:
             list.append(list_expr)
         rules = []
         for item in list:
             if not item.has_form(("Rule", "RuleDelayed"), 2):
                 return None
-            rule = Rule(item.leaves[0], item.leaves[1])
+            rule = Rule(item.elements[0], item.elements[1])
             rules.append(rule)
         return rules
 
@@ -375,7 +375,7 @@ class BaseElement(KeyComparable):
         from mathics.core.symbols import SymbolSequence
 
         if self.get_head() is SymbolSequence:
-            return self.leaves
+            return self.elements
         else:
             return [self]
 
@@ -414,7 +414,7 @@ class BaseElement(KeyComparable):
 
     def has_form(self, heads, *element_counts):
         """Check if the expression is of the form Head[l1,...,ln]
-        with Head.name in `heads` and a number of leaves according to the specification in
+        with Head.name in `heads` and a number of elements according to the specification in
         element_counts.
         """
         return False


### PR DESCRIPTION
not an int argument. This will be required in the future for
Expression() - otherwise use to_expression().

One more place leaves -> elements.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/296"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

