### PR TITLE
Faster Range[] most of the time...

### DIFF
--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -185,6 +185,14 @@ class Range(Builtin):
     def apply(self, imin, imax, di, evaluation):
         "Range[imin_?RealNumberQ, imax_?RealNumberQ, di_?RealNumberQ]"
 
+        if (
+            isinstance(imin, Integer)
+            and isinstance(imax, Integer)
+            and isinstance(di, Integer)
+        ):
+            result = [Integer(i) for i in range(imin.value, imax.value + 1, di.value)]
+            return Expression(SymbolList, *result)
+
         imin = imin.to_sympy()
         imax = imax.to_sympy()
         di = di.to_sympy()


### PR DESCRIPTION
Using Python range(). Previous attempt was simply off by one by one.
We get a 5x speed improvement with Python range().

[This time, for sure!](https://youtu.be/yIBdVkJ9L-k?t=66)