### PR TITLE
Revise Expression to use ElementsProperties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,7 @@ Internals
 * The methods  ``boxes_to_*`` were removed from ``Element`` and ``Expression``
   and kept just for ``Atoms`` and  ``BoxExpressions``.
 
-  
+
 Package update
 ++++++++++++++
 

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -19,7 +19,7 @@ from mathics.builtin.base import (
     SympyFunction,
 )
 
-from mathics.core.expression import Expression
+from mathics.core.expression import ElementsProperties, Expression, to_expression
 from mathics.core.atoms import (
     Complex,
     Integer,
@@ -126,6 +126,7 @@ class CubeRoot(Builtin):
                 SymbolDivide,
                 Integer1,
                 Integer3,
+                elements_properties=ElementsProperties(True, True, True),
             ),
         )
 
@@ -342,11 +343,11 @@ class Plus(BinaryOperator, SympyFunction):
             return False
 
         items = items.get_sequence()
-        values = [Expression(SymbolHoldForm, item) for item in items[:1]]
+        values = [to_expression(SymbolHoldForm, item) for item in items[:1]]
         ops = []
         for item in items[1:]:
             if (
-                item.has_form("Times", 1, None) and is_negative(item.leaves[0])
+                item.has_form("Times", 1, None) and is_negative(item.elements[0])
             ) or is_negative(item):
                 item = negate(item)
                 op = "-"

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -19,7 +19,9 @@ from mathics.builtin.lists import (
 from mathics.core.convert import from_sympy
 
 from mathics.core.expression import (
+    ElementsProperties,
     Expression,
+    to_expression,
     structure,
 )
 from mathics.core.atoms import Integer
@@ -110,7 +112,7 @@ class Array(Builtin):
                     level.append(rec(rest_dims[1:], current + [index]))
                 return Expression(head, *level)
             else:
-                return Expression(f, *current, element_conversion_fn=Integer)
+                return to_expression(f, *current, elements_conversion_fn=Integer)
 
         return rec(dims, [])
 
@@ -447,7 +449,9 @@ class Table(_IterationFunction):
 
     def get_result(self, items):
         return Expression(
-            SymbolList, *items, element_properties={"_elements_fully_evaluated": True}
+            SymbolList,
+            *items,
+            elements_properties=ElementsProperties(elements_fully_evaluated=True),
         )
 
 

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -11,7 +11,7 @@ from itertools import permutations
 
 from mathics.builtin.base import Builtin, Pattern
 
-from mathics.builtin.elemtns import ElementsProperties
+from mathics.core.element import ElementsProperties
 
 from mathics.builtin.lists import (
     _IterationFunction,

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -11,6 +11,8 @@ from itertools import permutations
 
 from mathics.builtin.base import Builtin, Pattern
 
+from mathics.builtin.elemtns import ElementsProperties
+
 from mathics.builtin.lists import (
     _IterationFunction,
     get_tuples,
@@ -19,7 +21,6 @@ from mathics.builtin.lists import (
 from mathics.core.convert import from_sympy
 
 from mathics.core.expression import (
-    ElementsProperties,
     Expression,
     to_expression,
     structure,

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -9,7 +9,7 @@ import sympy
 
 from mathics.core.evaluators import apply_N
 from mathics.builtin.base import Builtin, SympyFunction
-from mathics.core.expression import Expression
+from mathics.core.expression import Expression, to_expression
 from mathics.core.symbols import Symbol
 from mathics.core.atoms import (
     Integer,
@@ -99,8 +99,8 @@ class Divisors(Builtin):
         "Divisors[n_Integer]"
         if n == Integer0:
             return None
-        return Expression(
-            SymbolList, *sympy.divisors(n.to_sympy()), element_conversion_fn=from_sympy
+        return to_expression(
+            SymbolList, *sympy.divisors(n.to_sympy()), elements_conversion_fn=from_sympy
         )
 
 

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -100,7 +100,7 @@ class Divisors(Builtin):
         if n == Integer0:
             return None
         return to_expression(
-            SymbolList, *sympy.divisors(n.to_sympy()), elements_conversion_fn=from_sympy
+            SymbolList, *sympy.divisors(n.value), elements_conversion_fn=Integer
         )
 
 

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -6,6 +6,7 @@ Here we have the base class and related function for element inside an Expressio
 """
 
 from mathics.core.attributes import no_attributes
+from recordclass import RecordClass
 from typing import Any, Optional, Tuple
 
 
@@ -33,6 +34,41 @@ def fully_qualified_symbol_name(name) -> bool:
         and not name.endswith("`")
         and "``" not in name
     )
+
+
+# Note: Something in cythonization barfs if we put this in Expression and you try to call this
+# like ExpressionProperties(True, True, True). Cython reports:
+#   number of the arguments greater than the number of the items
+class ElementsProperties(RecordClass):
+    """Properties of Expression elements that are useful in evaluation.
+
+    In general, if you have some set of properties that you know should
+    be set a particular way, but don't know about the others, it is safe
+    to set the unknown properties to False.
+
+    When *all* of the properties are unknown, use a `None` value in
+    the Expression.properties field instead of creating an
+    ElementsProperties object with everything set False.
+    """
+
+    # True if none of the elements needs to be evaluated.
+    elements_fully_evaluated: bool = False
+
+    # is_flat: True if none of the elements is an Expression
+    # Some Mathics functions allow flattening of elements. Therefore
+    # it can be useful to know if the elements are already flat
+    is_flat: bool = False
+
+    # is_ordered: True if all of the elements are ordered. Of course this is true,
+    # if there are less than 2 elements. Ordered is an Attribute of a
+    # Mathics function.
+    #
+    # In rewrite_eval_apply() if a function is not marked as Ordered this attribute
+    # has no effect which means it doesn't matter how it is set. So
+    # when it doubt, it is always safe to set is_ordered to False since at worst
+    # it will cause an ordering operation on elements sometimes. On the other hand, setting
+    # this True elements are not sorted can cause evaluation differences.
+    is_ordered: bool = False
 
 
 class ImmutableValueMixin:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -44,11 +44,14 @@ class ElementsProperties(RecordClass):
 
     In general, if you have some set of properties that you know should
     be set a particular way, but don't know about the others, it is safe
-    to set the unknown properties to False.
+    to set the unknown properties to False. Omitting that property is the
+    same as setting a property to False.
 
-    When *all* of the properties are unknown, use a `None` value in
+    However, when *all* of the properties are unknown, use a `None` value in
     the Expression.properties field instead of creating an
     ElementsProperties object with everything set False.
+    By setting the field to None, the code will look over the elements before
+    evaluation and set the property values correctly.
     """
 
     # True if none of the elements needs to be evaluated.

--- a/mathics/core/evaluators.py
+++ b/mathics/core/evaluators.py
@@ -71,11 +71,14 @@ def apply_nvalues(
     # just apply `apply_nvalues` to each leaf and return the new list.
     if expr.get_head_name() in ("System`List", "System`Rule"):
         leaves = expr.leaves
+
+        # FIXME: incorporate these lines into Expression call
         result = Expression(expr.head)
         newleaves = [apply_nvalues(leaf, prec, evaluation) for leaf in expr.leaves]
         result.elements = tuple(
             newleaf if newleaf else leaf for leaf, newleaf in zip(leaves, newleaves)
         )
+        result._build_elements_properties()
         return result
 
     # Special case for the Root builtin
@@ -133,8 +136,10 @@ def apply_nvalues(
             if newleaf:
                 leaves[index] = newleaf
 
+        # FIXME: incorporate these 3 lines into Expression call
         result = Expression(head)
         result.elements = tuple(leaves)
+        result._build_elements_properties()
         return result
 
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -9,7 +9,6 @@ import typing
 from typing import Any, Callable, Iterable, Optional, Tuple, Union
 from itertools import chain
 from bisect import bisect_left
-from recordclass import RecordClass
 
 from mathics.core.atoms import from_python, Number, Integer
 
@@ -27,7 +26,7 @@ from mathics.core.attributes import (
     sequence_hold as SEQUENCE_HOLD,
 )
 from mathics.core.convert import sympy_symbol_prefix, SympyExpression
-from mathics.core.element import ensure_context
+from mathics.core.element import ensure_context, ElementsProperties
 from mathics.core.evaluation import Evaluation
 from mathics.core.interrupt import ReturnInterrupt
 from mathics.core.number import dps
@@ -87,38 +86,6 @@ class BoxError(Exception):
         super().__init__("Box %s cannot be formatted as %s" % (box, form))
         self.box = box
         self.form = form
-
-
-class ElementsProperties(RecordClass):
-    """Properties of Expression elements that are useful in evaluation.
-
-    In general, if you have some set of properties that you know should
-    be set a particular way, but don't know about the others, it is safe
-    to set the unknown properties to False.
-
-    When *all* of the properties are unknown, use a `None` value in
-    the Expression.properties field instead of creating an
-    ElementsProperties object with everything set False.
-    """
-
-    # True if none of the elements needs to be evaluated.
-    elements_fully_evaluated: bool = False
-
-    # is_flat: True if none of the elements is an Expression
-    # Some Mathics functions allow flattening of elements. Therefore
-    # it can be useful to know if the elements are already flat
-    is_flat: bool = False
-
-    # is_ordered: True if all of the elements are ordered. Of course this is true,
-    # if there are less than 2 elements. Ordered is an Attribute of a
-    # Mathics function.
-    #
-    # In rewrite_eval_apply() if a function is not marked as Ordered this attribute
-    # has no effect which means it doesn't matter how it is set. So
-    # when it doubt, it is always safe to set is_ordered to False since at worst
-    # it will cause an ordering operation on elements sometimes. On the other hand, setting
-    # this True elements are not sorted can cause evaluation differences.
-    is_ordered: bool = False
 
 
 # ExpressionCache keeps track of the following attributes for one Expression instance:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -181,7 +181,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
     positional Arguments:
         - head -- The head of the M-Expression
-        - *elements - optional: the remainin elements
+        - *elements - optional: the remaining elements
 
     Keyword Arguments:
         - element_properties -- properties of the collection of elements
@@ -716,6 +716,8 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             expr.options = self.options
         if expr.elements_properties is None:
             expr._build_elements_properties()
+        else:
+            expr.elements_properties.is_flat = True
         return expr
 
     def flatten_sequence(self, evaluation):
@@ -1618,8 +1620,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
         # update `self._elements` and self._cache with the possible permuted order.
         self.elements = elements
-        if self.elements_properties is None:
-            self._build_elements_properties()
+        self._build_elements_properties()
 
         if self._cache:
             self._cache = self._cache.reordered()

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -62,6 +62,8 @@ class BaseRule(KeyComparable):
             else:
                 result = new_expression
 
+            if isinstance(result, Expression) and result.elements_properties is None:
+                result._build_elements_properties()
             # Flatten out sequences (important for Rule itself!)
             result = result.flatten_pattern_sequence(evaluation)
             if return_list:

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ INSTALL_REQUIRES += [
     "pint",
     "python-dateutil",
     "llvmlite",
+    "recordclass",
     "requests",
 ]
 

--- a/test/core/test_elements_properties.py
+++ b/test/core/test_elements_properties.py
@@ -46,7 +46,10 @@ def test_elements_properties():
         # convert() creates the initial Expression. In that various properties should
         # be set.
         expr = convert(ast, session.definitions)
+        expr._build_elements_properties()
         # print("XXX", str_expression, expr)
-        assert expr._elements_fully_evaluated == full_eval, str_expression
-        assert expr._is_ordered == is_ordered, str_expression
-        assert expr._is_flat == is_flat, str_expression
+        assert (
+            expr.elements_properties.elements_fully_evaluated == full_eval
+        ), str_expression
+        assert expr.elements_properties.is_ordered == is_ordered, str_expression
+        assert expr.elements_properties.is_flat == is_flat, str_expression

--- a/test/core/test_expression_constructor.py
+++ b/test/core/test_expression_constructor.py
@@ -1,26 +1,32 @@
-from mathics.core.expression import Expression
+from mathics.core.expression import Expression, to_expression, ElementsProperties
 from mathics.core.systemsymbols import SymbolPlus
 from mathics.core.atoms import Integer, Integer1
 
 
 def test_expression_constructor():
     def attribute_check(e, varname: str):
-        assert e._elements_fully_evaluated == True, varname
-        assert e._is_flat == True, varname
-        assert e._is_ordered == True, varname
+        assert e.elements_properties.elements_fully_evaluated == True, varname
+        assert e.elements_properties.is_flat == True, varname
+        assert e.elements_properties.is_ordered == True, varname
 
     # The below will convert 1 Integer(1) multiple times
     # and discover that the arguments are flat, fully evaluated, and ordered.
     ones = [1] * 50
-    e1 = Expression(SymbolPlus, *ones)
+    e1 = to_expression(SymbolPlus, *ones)
     attribute_check(e1, "e1")
+
+    e1a = to_expression("Plus", *ones)
+    attribute_check(e1a, "e1a")
+
     integer_ones = [Integer1] * 50
     e2 = Expression(SymbolPlus, *integer_ones)
+    e2._build_elements_properties()
     attribute_check(e2, "e2")
     assert e1 == e2
     assert e1.elements == e2.elements, "Elements should get converted the same"
 
-    e3 = Expression(SymbolPlus, *ones, element_conversion_fn=Integer)
+    e3 = to_expression(SymbolPlus, *ones, elements_conversion_fn=Integer)
+    e3._build_elements_properties()
     attribute_check(e3, "e3")
     assert e1 == e3
     assert e1.elements == e3.elements, "Elements should get converted the same"
@@ -28,11 +34,7 @@ def test_expression_constructor():
     e4 = Expression(
         SymbolPlus,
         *integer_ones,
-        element_properties={
-            "_elements_fully_evaluated": True,
-            "_is_flat": True,
-            "_is_ordered": True,
-        },
+        elements_properties=ElementsProperties(True, True, True)
     )
     attribute_check(e4, "e4")
     assert e1 == e4


### PR DESCRIPTION
ElementsProperties is a mutable record.

Note that addition work is needed to categorize existing Expression() calls into `to_expression()` or
`Expression()`.

After that is done, we should see a big improvement in speed due to a
reduction of unneeded calls to convert elements.

Also, there should be improvements as we start setting the elements
properties in the calls to be more precise.

Until then, the performance here will be slightly worse with this
commit, since we have the worst of both worlds: we have to do conversion
on each Expression() call as well as conversion that may already be done in setup to calling
Expression which will be required (not optional) in the future.

A specialization of Expression, ListExpression() will be using this as the base code to work off of.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/305"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

