### PR TITLE
Remove more temporary files created in testing, make a pass over the I/O code

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -478,7 +478,7 @@ class _OpenAction(Builtin):
 
         path_string = path.get_string_value()
 
-        tmp = path_search(path_string)
+        tmp, is_temporary_file = path_search(path_string)
         if tmp is None:
             if mode in ["r", "rb"]:
                 evaluation.message("General", "noopen", path)
@@ -492,9 +492,12 @@ class _OpenAction(Builtin):
                 return
 
             opener = MathicsOpen(
-                path_string, mode=mode, encoding=encoding.get_string_value()
+                path_string,
+                mode=mode,
+                encoding=encoding.get_string_value(),
+                is_temporary_file=is_temporary_file,
             )
-            opener.__enter__()
+            opener.__enter__(is_temporary_file=is_temporary_file)
             n = opener.n
         except IOError:
             evaluation.message("General", "noopen", path)
@@ -503,7 +506,7 @@ class _OpenAction(Builtin):
             e.message(evaluation)
             return
 
-        return Expression(self.stream_type, path, Integer(n))
+        return Expression(Symbol(self.stream_type), path, Integer(n))
 
 
 class BinaryWrite(Builtin):
@@ -1187,7 +1190,7 @@ class Character(Builtin):
 class Close(Builtin):
     """
     <dl>
-    <dt>'Close[$stream$]'
+      <dt>'Close[$stream$]'
       <dd>closes an input or output stream.
     </dl>
 
@@ -1229,7 +1232,7 @@ class Close(Builtin):
             evaluation.message("General", "openx", channel)
             return
 
-        close_stream(stream, n)
+        close_stream(stream, n.value)
         return name
 
 
@@ -1302,7 +1305,7 @@ class FilePrint(Builtin):
         ):
             evaluation.message("FilePrint", "fstr", path)
             return
-        pypath = path_search(pypath[1:-1])
+        pypath, is_temporary_file = path_search(pypath[1:-1])
 
         # Options
         record_separators = options["System`RecordSeparators"].to_python()
@@ -1494,7 +1497,7 @@ class InputStream(Builtin):
 class OpenRead(_OpenAction):
     """
     <dl>
-    <dt>'OpenRead["file"]'
+      <dt>'OpenRead["file"]'
       <dd>opens a file and returns an InputStream.
     </dl>
 
@@ -1502,8 +1505,7 @@ class OpenRead(_OpenAction):
      = InputStream[...]
     #> Close[%];
 
-    S> OpenRead["https://raw.githubusercontent.com/Mathics3/mathics-core/master/README.rst"]
-     = ...
+    S> Close[OpenRead["https://raw.githubusercontent.com/Mathics3/mathics-core/master/README.rst"]];
 
     #> OpenRead[]
      : OpenRead called with 0 arguments; 1 argument is expected.

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -1621,36 +1621,41 @@ class WriteString(Builtin):
     >> stream = OpenWrite[];
     >> WriteString[stream, "This is a test 1"]
     >> WriteString[stream, "This is also a test 2"]
-    >> Close[stream];
+    >> pathname = Close[stream];
     >> FilePrint[%]
      | This is a test 1This is also a test 2
 
+    #> DeleteFile[pathname];
     >> stream = OpenWrite[];
     >> WriteString[stream, "This is a test 1", "This is also a test 2"]
-    >> Close[stream]
+    >> pathname = Close[stream]
      = ...
     >> FilePrint[%]
      | This is a test 1This is also a test 2
 
+    #> DeleteFile[pathname];
     #> stream = OpenWrite[];
     #> WriteString[stream, 100, 1 + x + y, Sin[x  + y]]
-    #> Close[stream]
+    #> pathname = Close[stream]
      = ...
     #> FilePrint[%]
      | 1001 + x + ySin[x + y]
 
+    #> DeleteFile[pathname];
     #> stream = OpenWrite[];
     #> WriteString[stream]
-    #> Close[stream]
+    #> pathame = Close[stream]
      = ...
     #> FilePrint[%]
 
     #> WriteString[%%, abc]
     #> Streams[%%%][[1]]
      = ...
-    #> Close[%];
+    #> pathname = Close[%];
     #> FilePrint[%]
      | abc
+    #> DeleteFile[pathname];
+    #> Clear[pathname];
 
     """
 

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -92,545 +92,7 @@ class Input_(Predefined):
         return String(INPUT_VAR)
 
 
-class InputFileName_(Predefined):
-    """
-    <dl>
-    <dt>'$InputFileName'
-      <dd>is the name of the file from which input is currently being read.
-    </dl>
-
-    While in interactive mode, '$InputFileName' is "".
-    X> $InputFileName
-    """
-
-    summary_text = (
-        "the full absolute path to the file from which input is currently being sought"
-    )
-    name = "$InputFileName"
-
-    def evaluate(self, evaluation):
-        return String(read.INPUTFILE_VAR)
-
-
-class EndOfFile(Builtin):
-    """
-    <dl>
-    <dt>'EndOfFile'
-      <dd>is returned by 'Read' when the end of an input stream is reached.
-    </dl>
-    """
-
-    summary_text = "end of the file"
-
-
 # TODO: Improve docs for these Read[] arguments.
-class Byte(Builtin):
-    """
-    <dl>
-    <dt>'Byte'
-      <dd>is a data type for 'Read'.
-    </dl>
-    """
-
-    summary_text = "single byte of data, returned as an integer"
-
-
-class Character(Builtin):
-    """
-    <dl>
-      <dt>'Character'
-      <dd>is a data type for 'Read'.
-    </dl>
-    """
-
-    summary_text = "single character, returned as a one‐character string"
-
-
-class Expression_(Builtin):
-    """
-    <dl>
-      <dt>'Expression'
-      <dd>is a data type for 'Read'.
-    </dl>
-
-    For information about underlying data structure Expression (a kind of M-expression) that is central in evaluation, see: <url>https://mathics-development-guide.readthedocs.io/en/latest/extending/code-overview/ast.html</url>
-    """
-
-    summary_text = "WL expression"
-    name = "Expression"
-
-
-class Number_(Builtin):
-    """
-    <dl>
-    <dt>'Number'
-      <dd>is a data type for 'Read'.
-    </dl>
-    """
-
-    summary_text = "exact or approximate number in Fortran‐like notation"
-    name = "Number"
-
-
-class Record(Builtin):
-    """
-    <dl>
-    <dt>'Record'
-      <dd>is a data type for 'Read'.
-    </dl>
-    """
-
-    summary_text = "sequence of characters delimited by record separators"
-
-
-class Word(Builtin):
-    """
-    <dl>
-    <dt>'Word'
-      <dd>is a data type for 'Read'.
-    </dl>
-    """
-
-    summary_text = "sequence of characters delimited by word separators"
-
-
-class Read(Builtin):
-    """
-    <dl>
-      <dt>'Read[$stream$]'
-      <dd>reads the input stream and returns one expression.
-
-      <dt>'Read[$stream$, $type$]'
-      <dd>reads the input stream and returns an object of the given type.
-
-      <dt>'Read[$stream$, $type$]'
-      <dd>reads the input stream and returns an object of the given type.
-
-      <dt>'Read[$stream$, Hold[Expression]]'
-      <dd>reads the input stream for an Expression and puts it inside 'Hold'.
-
-    </dl>
-    $type$ is one of:
-    <ul>
-      <li>Byte
-      <li>Character
-      <li>Expression
-      <li>HoldExpression
-      <li>Number
-      <li>Real
-      <li>Record
-      <li>String
-      <li>Word
-    </ul>
-
-    ## Malformed InputString
-    #> Read[InputStream[String], {Word, Number}]
-     = Read[InputStream[String], {Word, Number}]
-
-    ## Correctly formed InputString but not open
-    #> Read[InputStream[String, -1], {Word, Number}]
-     : InputStream[String, -1] is not open.
-     = Read[InputStream[String, -1], {Word, Number}]
-
-    ## Reading Strings
-    >> stream = StringToStream["abc123"];
-    >> Read[stream, String]
-     = abc123
-    #> Read[stream, String]
-     = EndOfFile
-    #> Close[stream];
-
-    ## Reading Words
-    >> stream = StringToStream["abc 123"];
-    >> Read[stream, Word]
-     = abc
-    >> Read[stream, Word]
-     = 123
-    #> Read[stream, Word]
-     = EndOfFile
-    #> Close[stream];
-    #> stream = StringToStream[""];
-    #> Read[stream, Word]
-     = EndOfFile
-    #> Read[stream, Word]
-     = EndOfFile
-    #> Close[stream];
-
-    ## Number
-    >> stream = StringToStream["123, 4"];
-    >> Read[stream, Number]
-     = 123
-    >> Read[stream, Number]
-     = 4
-    #> Read[stream, Number]
-     = EndOfFile
-    #> Close[stream];
-    #> stream = StringToStream["123xyz 321"];
-    #> Read[stream, Number]
-     = 123
-    #> Quiet[Read[stream, Number]]
-     = $Failed
-
-    ## Real
-    #> stream = StringToStream["123, 4abc"];
-    #> Read[stream, Real]
-     = 123.
-    #> Read[stream, Real]
-     = 4.
-    #> Quiet[Read[stream, Number]]
-     = $Failed
-
-    #> Close[stream];
-    #> stream = StringToStream["1.523E-19"]; Read[stream, Real]
-     = 1.523×10^-19
-    #> Close[stream];
-    #> stream = StringToStream["-1.523e19"]; Read[stream, Real]
-     = -1.523×10^19
-    #> Close[stream];
-    #> stream = StringToStream["3*^10"]; Read[stream, Real]
-     = 3.×10^10
-    #> Close[stream];
-    #> stream = StringToStream["3.*^10"]; Read[stream, Real]
-     = 3.×10^10
-    #> Close[stream];
-
-    ## Expression
-    #> stream = StringToStream["x + y Sin[z]"]; Read[stream, Expression]
-     = x + y Sin[z]
-    #> Close[stream];
-    ## #> stream = Quiet[StringToStream["Sin[1 123"]; Read[stream, Expression]]
-    ##  = $Failed
-
-    ## HoldExpression:
-    >> stream = StringToStream["2+2\\n2+3"];
-
-    'Read' with a 'Hold[Expression]' returns the expression it reads unevaluated so it can be later inspected and evaluated:
-
-    >> Read[stream, Hold[Expression]]
-     = Hold[2 + 2]
-
-    >> Read[stream, Expression]
-     = 5
-    >> Close[stream];
-
-    Reading a comment however will return the empy list:
-    >> stream = StringToStream["(* ::Package:: *)"];
-
-    >> Read[stream, Hold[Expression]]
-     = {}
-
-    >> Close[stream];
-
-    ## Multiple types
-    >> stream = StringToStream["123 abc"];
-    >> Read[stream, {Number, Word}]
-     = {123, abc}
-    #> Read[stream, {Number, Word}]
-     = EndOfFile
-    #> lose[stream];
-
-    #> stream = StringToStream["123 abc"];
-    #> Quiet[Read[stream, {Word, Number}]]
-     = $Failed
-    #> Close[stream];
-
-    #> stream = StringToStream["123 123"];  Read[stream, {Real, Number}]
-     = {123., 123}
-    #> Close[stream];
-
-    #> Quiet[Read[stream, {Real}]]
-     = Read[InputStream[String, ...], {Real}]
-
-    Multiple lines:
-    >> stream = StringToStream["\\"Tengo una\\nvaca lechera.\\""]; Read[stream]
-     = Tengo una
-     . vaca lechera.
-
-    """
-
-    summary_text = "read an object of the specified type from a stream"
-    messages = {
-        "openx": "`1` is not open.",
-        "readf": "`1` is not a valid format specification.",
-        "readn": "Invalid real number found when reading from `1`.",
-        "readt": "Invalid input found when reading `1` from `2`.",
-        "intnm": (
-            "Non-negative machine-sized integer expected at " "position 3 in `1`."
-        ),
-    }
-
-    rules = {
-        "Read[stream_]": "Read[stream, Expression]",
-    }
-
-    options = {
-        "NullRecords": "False",
-        "NullWords": "False",
-        "RecordSeparators": '{"\r\n", "\n", "\r"}',
-        "TokenWords": "{}",
-        "WordSeparators": '{" ", "\t"}',
-    }
-
-    def check_options(self, options):
-        # Options
-        # TODO Proper error messages
-
-        result = {}
-        keys = list(options.keys())
-
-        # AnchoredSearch
-        if "System`AnchoredSearch" in keys:
-            anchored_search = options["System`AnchoredSearch"].to_python()
-            assert anchored_search in [True, False]
-            result["AnchoredSearch"] = anchored_search
-
-        # IgnoreCase
-        if "System`IgnoreCase" in keys:
-            ignore_case = options["System`IgnoreCase"].to_python()
-            assert ignore_case in [True, False]
-            result["IgnoreCase"] = ignore_case
-
-        # WordSearch
-        if "System`WordSearch" in keys:
-            word_search = options["System`WordSearch"].to_python()
-            assert word_search in [True, False]
-            result["WordSearch"] = word_search
-
-        # RecordSeparators
-        if "System`RecordSeparators" in keys:
-            record_separators = options["System`RecordSeparators"].to_python()
-            assert isinstance(record_separators, list)
-            assert all(
-                isinstance(s, str) and s[0] == s[-1] == '"' for s in record_separators
-            )
-            record_separators = [s[1:-1] for s in record_separators]
-            result["RecordSeparators"] = record_separators
-
-        # WordSeparators
-        if "System`WordSeparators" in keys:
-            word_separators = options["System`WordSeparators"].to_python()
-            assert isinstance(word_separators, list)
-            assert all(
-                isinstance(s, str) and s[0] == s[-1] == '"' for s in word_separators
-            )
-            word_separators = [s[1:-1] for s in word_separators]
-            result["WordSeparators"] = word_separators
-
-        # NullRecords
-        if "System`NullRecords" in keys:
-            null_records = options["System`NullRecords"].to_python()
-            assert null_records in [True, False]
-            result["NullRecords"] = null_records
-
-        # NullWords
-        if "System`NullWords" in keys:
-            null_words = options["System`NullWords"].to_python()
-            assert null_words in [True, False]
-            result["NullWords"] = null_words
-
-        # TokenWords
-        if "System`TokenWords" in keys:
-            token_words = options["System`TokenWords"].to_python()
-            assert token_words == []
-            result["TokenWords"] = token_words
-
-        return result
-
-    def apply(self, channel, types, evaluation, options):
-        "Read[channel_, types_, OptionsPattern[Read]]"
-
-        name, n, stream = read_name_and_stream_from_channel(channel, evaluation)
-        if name is None:
-            return
-
-        # Wrap types in a list (if it isn't already one)
-        if types.has_form("List", None):
-            types = types.elements
-        else:
-            types = (types,)
-
-        # TODO: look for a better implementation handling "Hold[Expression]".
-        #
-        types = (
-            Symbol("HoldExpression")
-            if (
-                typ.get_head_name() == "System`Hold"
-                and typ.leaves[0].get_name() == "System`Expression"
-            )
-            else typ
-            for typ in types
-        )
-        types = Expression("List", *types)
-
-        for typ in types.leaves:
-            if typ not in READ_TYPES:
-                evaluation.message("Read", "readf", typ)
-                return SymbolFailed
-
-        record_separators, word_separators = read_get_separators(options)
-
-        name = name.to_python()
-
-        result = []
-
-        read_word = read_from_stream(stream, word_separators, evaluation.message)
-        read_record = read_from_stream(stream, record_separators, evaluation.message)
-        read_number = read_from_stream(
-            stream,
-            word_separators + record_separators,
-            evaluation.message,
-            ["+", "-", "."] + [str(i) for i in range(10)],
-        )
-        read_real = read_from_stream(
-            stream,
-            word_separators + record_separators,
-            evaluation.message,
-            ["+", "-", ".", "e", "E", "^", "*"] + [str(i) for i in range(10)],
-        )
-
-        from mathics.core.expression import BaseElement
-        from mathics_scanner.errors import IncompleteSyntaxError, InvalidSyntaxError
-        from mathics.core.parser import MathicsMultiLineFeeder, parse
-
-        for typ in types.leaves:
-            try:
-                if typ is Symbol("Byte"):
-                    tmp = stream.io.read(1)
-                    if tmp == "":
-                        raise EOFError
-                    result.append(ord(tmp))
-                elif typ is Symbol("Character"):
-                    tmp = stream.io.read(1)
-                    if tmp == "":
-                        raise EOFError
-                    result.append(tmp)
-                elif typ is Symbol("Expression") or typ is Symbol("HoldExpression"):
-                    tmp = next(read_record)
-                    while True:
-                        try:
-                            feeder = MathicsMultiLineFeeder(tmp)
-                            expr = parse(evaluation.definitions, feeder)
-                            break
-                        except (IncompleteSyntaxError, InvalidSyntaxError):
-                            try:
-                                nextline = next(read_record)
-                                tmp = tmp + "\n" + nextline
-                            except EOFError:
-                                expr = SymbolEndOfFile
-                                break
-                        except Exception as e:
-                            print(e)
-
-                    if expr is SymbolEndOfFile:
-                        evaluation.message(
-                            "Read", "readt", tmp, Expression("InputSteam", name, n)
-                        )
-                        return SymbolFailed
-                    elif isinstance(expr, BaseElement):
-                        if typ is Symbol("HoldExpression"):
-                            expr = Expression("Hold", expr)
-                        result.append(expr)
-                    # else:
-                    #  TODO: Supposedly we can't get here
-                    # what code should we put here?
-
-                elif typ is Symbol("Number"):
-                    tmp = next(read_number)
-                    try:
-                        tmp = int(tmp)
-                    except ValueError:
-                        try:
-                            tmp = float(tmp)
-                        except ValueError:
-                            evaluation.message(
-                                "Read", "readn", Expression("InputSteam", name, n)
-                            )
-                            return SymbolFailed
-                    result.append(tmp)
-
-                elif typ is Symbol("Real"):
-                    tmp = next(read_real)
-                    tmp = tmp.replace("*^", "E")
-                    try:
-                        tmp = float(tmp)
-                    except ValueError:
-                        evaluation.message(
-                            "Read", "readn", Expression("InputSteam", name, n)
-                        )
-                        return SymbolFailed
-                    result.append(tmp)
-                elif typ is Symbol("Record"):
-                    result.append(next(read_record))
-                elif typ is Symbol("String"):
-                    tmp = stream.io.readline()
-                    if len(tmp) == 0:
-                        raise EOFError
-                    result.append(tmp.rstrip("\n"))
-                elif typ is Symbol("Word"):
-                    result.append(next(read_word))
-
-            except EOFError:
-                return SymbolEndOfFile
-            except UnicodeDecodeError:
-                evaluation.message("General", "ucdec")
-
-        if isinstance(result, Symbol):
-            return result
-        if len(result) == 1:
-            return from_python(*result)
-
-        return from_python(result)
-
-    def apply_nostream(self, arg1, arg2, evaluation):
-        "Read[arg1_, arg2_]"
-        evaluation.message("General", "stream", arg1)
-        return
-
-
-class Write(Builtin):
-    """
-    <dl>
-    <dt>'Write[$channel$, $expr1$, $expr2$, ...]'
-      <dd>writes the expressions to the output channel followed by a newline.
-    </dl>
-
-    >> stream = OpenWrite[]
-     = ...
-    >> Write[stream, 10 x + 15 y ^ 2]
-    >> Write[stream, 3 Sin[z]]
-    >> Close[stream];
-    >> stream = OpenRead[%];
-    >> ReadList[stream]
-     = {10 x + 15 y ^ 2, 3 Sin[z]}
-    #> DeleteFile[Close[stream]];
-    """
-
-    summary_text = "write a sequence of expressions to a stream, ending the output with a newline (line feed)"
-
-    def apply(self, channel, expr, evaluation):
-        "Write[channel_, expr___]"
-
-        strm = channel_to_stream(channel)
-
-        if strm is None:
-            return
-
-        n = strm.leaves[1].get_int_value()
-        stream = stream_manager.lookup_stream(n)
-
-        if stream is None or stream.io is None or stream.io.closed:
-            evaluation.message("General", "openx", channel)
-            return SymbolNull
-
-        expr = expr.get_sequence()
-        expr = Expression("Row", Expression("List", *expr))
-
-        evaluation.format = "text"
-        text = evaluation.format_output(expr)
-        stream.io.write(str(text) + "\n")
-        return SymbolNull
-
-
 class _BinaryFormat(object):
     """
     Container for BinaryRead readers and BinaryWrite writers
@@ -959,20 +421,110 @@ class _BinaryFormat(object):
         s.write(struct.pack("QQ", a, b))
 
 
+class _OpenAction(Builtin):
+
+    # BinaryFormat: 'False',
+    # CharacterEncoding :> Automatic,
+    # DOSTextFormat :> True,
+    # FormatType -> InputForm,
+    # NumberMarks :> $NumberMarks,
+    # PageHeight -> 22, PageWidth -> 78,
+    # TotalHeight -> Infinity,
+    # TotalWidth -> Infinity
+
+    options = {
+        "BinaryFormat": "False",
+        "CharacterEncoding": "$CharacterEncoding",
+    }
+
+    messages = {
+        "argx": "OpenRead called with 0 arguments; 1 argument is expected.",
+        "fstr": (
+            "File specification `1` is not a string of " "one or more characters."
+        ),
+    }
+
+    def apply_empty(self, evaluation, options):
+        "%(name)s[OptionsPattern[]]"
+
+        if isinstance(self, (OpenWrite, OpenAppend)):
+            # We use delete=False because we write to the name *after*
+            # tfms.close() is done. In other words we are using
+            # NamedTempararyFile to get a unique name and ensure that
+            # no one else uses it.
+            # In Close[] we will explicitly remove the name from the
+            # filesystem.
+            tmpf = tempfile.NamedTemporaryFile(dir=TMP_DIR, delete=False)
+            path = String(tmpf.name)
+            tmpf.close()
+            return self.apply_path(path, evaluation, options)
+        else:
+            evaluation.message("OpenRead", "argx")
+            return
+
+    def apply_path(self, path, evaluation, options):
+        "%(name)s[path_?NotOptionQ, OptionsPattern[]]"
+
+        # Options
+        # BinaryFormat
+        mode = self.mode
+        if options["System`BinaryFormat"] is SymbolTrue:
+            if not self.mode.endswith("b"):
+                mode += "b"
+
+        if not (isinstance(path, String) and len(path.to_python()) > 2):
+            evaluation.message(self.__class__.__name__, "fstr", path)
+            return
+
+        path_string = path.get_string_value()
+
+        tmp = path_search(path_string)
+        if tmp is None:
+            if mode in ["r", "rb"]:
+                evaluation.message("General", "noopen", path)
+                return
+        else:
+            path_string = tmp
+
+        try:
+            encoding = self.get_option(options, "CharacterEncoding", evaluation)
+            if not isinstance(encoding, String):
+                return
+
+            opener = MathicsOpen(
+                path_string, mode=mode, encoding=encoding.get_string_value()
+            )
+            opener.__enter__()
+            n = opener.n
+        except IOError:
+            evaluation.message("General", "noopen", path)
+            return
+        except MessageException as e:
+            e.message(evaluation)
+            return
+
+        return Expression(self.stream_type, path, Integer(n))
+
+
 class BinaryWrite(Builtin):
     """
     <dl>
-    <dt>'BinaryWrite[$channel$, $b$]'
+      <dt>'BinaryWrite[$channel$, $b$]'
       <dd>writes a single byte given as an integer from 0 to 255.
-    <dt>'BinaryWrite[$channel$, {b1, b2, ...}]'
+
+      <dt>'BinaryWrite[$channel$, {b1, b2, ...}]'
       <dd>writes a sequence of byte.
-    <dt>'BinaryWrite[$channel$, "string"]'
+
+      <dt>'BinaryWrite[$channel$, "string"]'
       <dd>writes the raw characters in a string.
-    <dt>'BinaryWrite[$channel$, $x$, $type$]'
+
+      <dt>'BinaryWrite[$channel$, $x$, $type$]'
       <dd>writes $x$ as the specified type.
-    <dt>'BinaryWrite[$channel$, {$x1$, $x2$, ...}, $type$]'
+
+      <dt>'BinaryWrite[$channel$, {$x1$, $x2$, ...}, $type$]'
       <dd>writes a sequence of objects as the specified type.
-    <dt>'BinaryWrite[$channel$, {$x1$, $x2$, ...}, {$type1$, $type2$, ...}]'
+
+      <dt>'BinaryWrite[$channel$, {$x1$, $x2$, ...}, {$type1$, $type2$, ...}]'
       <dd>writes a sequence of objects using a sequence of specified types.
     </dl>
 
@@ -980,8 +532,7 @@ class BinaryWrite(Builtin):
      = OutputStream[...]
     >> BinaryWrite[strm, {39, 4, 122}]
      = OutputStream[...]
-    >> Close[strm]
-     = ...
+    >> Close[strm];
     >> strm = OpenRead[%, BinaryFormat -> True]
      = InputStream[...]
     >> BinaryRead[strm]
@@ -997,7 +548,7 @@ class BinaryWrite(Builtin):
      = OutputStream[...]
     >> BinaryWrite[strm, "abc123"]
      = OutputStream[...]
-    >> Close[%]
+    >> pathname = Close[%]
      = ...
 
     Read as Bytes
@@ -1005,7 +556,7 @@ class BinaryWrite(Builtin):
      = InputStream[...]
     >> BinaryRead[strm, {"Character8", "Character8", "Character8", "Character8", "Character8", "Character8", "Character8"}]
      = {a, b, c, 1, 2, 3, EndOfFile}
-    >> Close[strm]
+    >> pathname = Close[strm]
      = ...
 
     Read as Characters
@@ -1025,7 +576,7 @@ class BinaryWrite(Builtin):
     >> DeleteFile[Close[%]];
 
     ## Write then Read as Bytes
-    #> WRb[bytes_, form_] := Module[{stream, res={}, byte}, stream = OpenWrite[BinaryFormat -> True]; BinaryWrite[stream, bytes, form]; stream = OpenRead[Close[stream], BinaryFormat -> True]; While[Not[SameQ[byte = BinaryRead[stream], EndOfFile]], res = Join[res, {byte}];]; Close[stream]; res]
+    #> WRb[bytes_, form_] := Module[{stream, res={}, byte}, stream = OpenWrite[BinaryFormat -> True]; BinaryWrite[stream, bytes, form]; stream = OpenRead[Close[stream], BinaryFormat -> True]; While[Not[SameQ[byte = BinaryRead[stream], EndOfFile]], res = Join[res, {byte}];]; DeleteFile[Close[stream]]; res]
 
     ## Byte
     #> WRb[{149, 2, 177, 132}, {"Byte", "Byte", "Byte", "Byte"}]
@@ -1611,170 +1162,166 @@ class BinaryRead(Builtin):
                 return result[0]
 
 
-class WriteString(Builtin):
+class Byte(Builtin):
     """
     <dl>
-    <dt>'WriteString[$stream$, $str1, $str2$, ... ]'
-      <dd>writes the strings to the output stream.
+    <dt>'Byte'
+      <dd>is a data type for 'Read'.
     </dl>
-
-    >> stream = OpenWrite[];
-    >> WriteString[stream, "This is a test 1"]
-    >> WriteString[stream, "This is also a test 2"]
-    >> pathname = Close[stream];
-    >> FilePrint[%]
-     | This is a test 1This is also a test 2
-
-    #> DeleteFile[pathname];
-    >> stream = OpenWrite[];
-    >> WriteString[stream, "This is a test 1", "This is also a test 2"]
-    >> pathname = Close[stream]
-     = ...
-    >> FilePrint[%]
-     | This is a test 1This is also a test 2
-
-    #> DeleteFile[pathname];
-    #> stream = OpenWrite[];
-    #> WriteString[stream, 100, 1 + x + y, Sin[x  + y]]
-    #> pathname = Close[stream]
-     = ...
-    #> FilePrint[%]
-     | 1001 + x + ySin[x + y]
-
-    #> DeleteFile[pathname];
-    #> stream = OpenWrite[];
-    #> WriteString[stream]
-    #> pathame = Close[stream]
-     = ...
-    #> FilePrint[%]
-
-    #> WriteString[%%, abc]
-    #> Streams[%%%][[1]]
-     = ...
-    #> pathname = Close[%];
-    #> FilePrint[%]
-     | abc
-    #> DeleteFile[pathname];
-    #> Clear[pathname];
-
     """
 
-    summary_text = "write a sequence of strings to a stream, with no extra newlines"
+    summary_text = "single byte of data, returned as an integer"
+
+
+class Character(Builtin):
+    """
+    <dl>
+      <dt>'Character'
+      <dd>is a data type for 'Read'.
+    </dl>
+    """
+
+    summary_text = "single character, returned as a one‐character string"
+
+
+class Close(Builtin):
+    """
+    <dl>
+    <dt>'Close[$stream$]'
+      <dd>closes an input or output stream.
+    </dl>
+
+    >> Close[StringToStream["123abc"]]
+     = String
+
+    >> Close[OpenWrite[]]
+     = ...
+
+    #> Streams[] == (Close[OpenWrite[]]; Streams[])
+     = True
+
+    #> Close["abc"]
+     : abc is not open.
+     = Close[abc]
+
+    #> strm = OpenWrite[];
+    #> Close[strm];
+    #> Quiet[Close[strm]]
+     = Close[OutputStream[...]]
+    """
+
+    summary_text = "close a stream"
     messages = {
-        "strml": ("`1` is not a string, stream, " "or list of strings and streams."),
-        "writex": "`1`.",
+        "closex": "`1`.",
     }
 
-    def apply(self, channel, expr, evaluation):
-        "WriteString[channel_, expr___]"
-        strm = channel_to_stream(channel, "w")
+    def apply(self, channel, evaluation):
+        "Close[channel_]"
 
-        if strm is None:
-            return
-
-        stream = stream_manager.lookup_stream(strm.leaves[1].get_int_value())
+        if channel.has_form(("InputStream", "OutputStream"), 2):
+            [name, n] = channel.get_elements()
+            py_n = n.get_int_value()
+            stream = stream_manager.lookup_stream(py_n)
+        else:
+            stream = None
 
         if stream is None or stream.io is None or stream.io.closed:
-            return None
+            evaluation.message("General", "openx", channel)
+            return
 
-        exprs = []
-        for expri in expr.get_sequence():
-            result = expri.format(evaluation, "System`OutputForm")
-            try:
-                result = result.boxes_to_text(evaluation=evaluation)
-            except BoxError:
-                return evaluation.message(
-                    "General",
-                    "notboxes",
-                    Expression("FullForm", result).evaluate(evaluation),
-                )
-            exprs.append(result)
-        line = "".join(exprs)
-        if type(stream) is BytesIO:
-            line = line.encode("utf8")
-        stream.io.write(line)
-        try:
-            stream.io.flush()
-        except IOError as err:
-            evaluation.message("WriteString", "writex", err.strerror)
-        return SymbolNull
+        close_stream(stream, n)
+        return name
 
 
-class _OpenAction(Builtin):
+class EndOfFile(Builtin):
+    """
+    <dl>
+    <dt>'EndOfFile'
+      <dd>is returned by 'Read' when the end of an input stream is reached.
+    </dl>
+    """
 
-    # BinaryFormat: 'False',
-    # CharacterEncoding :> Automatic,
-    # DOSTextFormat :> True,
-    # FormatType -> InputForm,
-    # NumberMarks :> $NumberMarks,
-    # PageHeight -> 22, PageWidth -> 78,
-    # TotalHeight -> Infinity,
-    # TotalWidth -> Infinity
+    summary_text = "end of the file"
 
-    options = {
-        "BinaryFormat": "False",
-        "CharacterEncoding": "$CharacterEncoding",
-    }
 
+class Expression_(Builtin):
+    """
+    <dl>
+      <dt>'Expression'
+      <dd>is a data type for 'Read'.
+    </dl>
+
+    For information about underlying data structure Expression (a kind of M-expression) that is central in evaluation, see: <url>https://mathics-development-guide.readthedocs.io/en/latest/extending/code-overview/ast.html</url>
+    """
+
+    summary_text = "WL expression"
+    name = "Expression"
+
+
+class FilePrint(Builtin):
+    """
+    <dl>
+    <dt>'FilePrint[$file$]'
+      <dd>prints the raw contents of $file$.
+    </dl>
+
+    #> exp = Sin[1];
+    #> FilePrint[exp]
+     : File specification Sin[1] is not a string of one or more characters.
+     = FilePrint[Sin[1]]
+
+    #> FilePrint["somenonexistantpath_h47sdmk^&h4"]
+     : Cannot open somenonexistantpath_h47sdmk^&h4.
+     = FilePrint[somenonexistantpath_h47sdmk^&h4]
+
+    #> FilePrint[""]
+     : File specification  is not a string of one or more characters.
+     = FilePrint[]
+    """
+
+    summary_text = "display the contents of a file"
     messages = {
-        "argx": "OpenRead called with 0 arguments; 1 argument is expected.",
         "fstr": (
             "File specification `1` is not a string of " "one or more characters."
         ),
     }
 
-    def apply_empty(self, evaluation, options):
-        "%(name)s[OptionsPattern[]]"
+    options = {
+        "CharacterEncoding": "$CharacterEncoding",
+        "RecordSeparators": '{"\r\n", "\n", "\r"}',
+        "WordSeparators": '{" ", "\t"}',
+    }
 
-        if isinstance(self, (OpenWrite, OpenAppend)):
-            # We use delete=False because we write to the name *after*
-            # tfms.close() is done. In other words we are using
-            # NamedTempararyFile to get a unique name and ensure that
-            # no one else uses it.
-            # In Close[] we will explicitly remove the name from the
-            # filesystem.
-            tmpf = tempfile.NamedTemporaryFile(dir=TMP_DIR, delete=False)
-            path = String(tmpf.name)
-            tmpf.close()
-            return self.apply_path(path, evaluation, options)
-        else:
-            evaluation.message("OpenRead", "argx")
+    def apply(self, path, evaluation, options):
+        "FilePrint[path_ OptionsPattern[FilePrint]]"
+        pypath = path.to_python()
+        if not (
+            isinstance(pypath, str)
+            and pypath[0] == pypath[-1] == '"'
+            and len(pypath) > 2
+        ):
+            evaluation.message("FilePrint", "fstr", path)
             return
-
-    def apply_path(self, path, evaluation, options):
-        "%(name)s[path_?NotOptionQ, OptionsPattern[]]"
+        pypath = path_search(pypath[1:-1])
 
         # Options
-        # BinaryFormat
-        mode = self.mode
-        if options["System`BinaryFormat"] is SymbolTrue:
-            if not self.mode.endswith("b"):
-                mode += "b"
+        record_separators = options["System`RecordSeparators"].to_python()
+        assert isinstance(record_separators, list)
+        assert all(
+            isinstance(s, str) and s[0] == s[-1] == '"' for s in record_separators
+        )
+        record_separators = [s[1:-1] for s in record_separators]
 
-        if not (isinstance(path, String) and len(path.to_python()) > 2):
-            evaluation.message(self.__class__.__name__, "fstr", path)
+        if pypath is None:
+            evaluation.message("General", "noopen", path)
             return
 
-        path_string = path.get_string_value()
-
-        tmp = path_search(path_string)
-        if tmp is None:
-            if mode in ["r", "rb"]:
-                evaluation.message("General", "noopen", path)
-                return
-        else:
-            path_string = tmp
+        if not osp.isfile(pypath):
+            return SymbolFailed
 
         try:
-            encoding = self.get_option(options, "CharacterEncoding", evaluation)
-            if not isinstance(encoding, String):
-                return
-
-            opener = MathicsOpen(
-                path_string, mode=mode, encoding=encoding.get_string_value()
-            )
-            opener.__enter__()
-            n = opener.n
+            with MathicsOpen(pypath, "r") as f:
+                result = f.read()
         except IOError:
             evaluation.message("General", "noopen", path)
             return
@@ -1782,97 +1329,29 @@ class _OpenAction(Builtin):
             e.message(evaluation)
             return
 
-        return Expression(self.stream_type, path, Integer(n))
+        result = [result]
+        for sep in record_separators:
+            result = [item for res in result for item in res.split(sep)]
+
+        if result[-1] == "":
+            result = result[:-1]
+
+        for res in result:
+            evaluation.print_out(String(res))
+
+        return SymbolNull
 
 
-class OpenRead(_OpenAction):
+class Number_(Builtin):
     """
     <dl>
-    <dt>'OpenRead["file"]'
-      <dd>opens a file and returns an InputStream.
+    <dt>'Number'
+      <dd>is a data type for 'Read'.
     </dl>
-
-    >> OpenRead["ExampleData/EinsteinSzilLetter.txt"]
-     = InputStream[...]
-    #> Close[%];
-
-    S> OpenRead["https://raw.githubusercontent.com/Mathics3/mathics-core/master/README.rst"]
-     = InputStream[...]
-    S> Close[%];
-
-    #> OpenRead[]
-     : OpenRead called with 0 arguments; 1 argument is expected.
-     = OpenRead[]
-
-    #> OpenRead[y]
-     : File specification y is not a string of one or more characters.
-     = OpenRead[y]
-
-    #> OpenRead[""]
-     : File specification  is not a string of one or more characters.
-     = OpenRead[]
-
-    #> OpenRead["MathicsNonExampleFile"]
-     : Cannot open MathicsNonExampleFile.
-     = OpenRead[MathicsNonExampleFile]
-
-    #> OpenRead["ExampleData/EinsteinSzilLetter.txt", BinaryFormat -> True]
-     = InputStream[...]
-    #> Close[%];
     """
 
-    summary_text = "open a file for reading"
-    mode = "r"
-    stream_type = "InputStream"
-
-
-class OpenWrite(_OpenAction):
-    """
-    <dl>
-    <dt>'OpenWrite["file"]'
-      <dd>opens a file and returns an OutputStream.
-    </dl>
-
-    >> OpenWrite[]
-     = OutputStream[...]
-    #> DeleteFile[Close[%]];
-
-    #> OpenWrite[BinaryFormat -> True]
-     = OutputStream[...]
-    #> DeleteFile[Close[%]];
-    """
-
-    summary_text = (
-        "send an output stream to a file, wiping out the previous contents of the file"
-    )
-    mode = "w"
-    stream_type = "OutputStream"
-
-
-class OpenAppend(_OpenAction):
-    """
-    <dl>
-    <dt>'OpenAppend["file"]'
-      <dd>opens a file and returns an OutputStream to which writes are appended.
-    </dl>
-
-    >> OpenAppend[]
-     = OutputStream[...]
-    #> DeleteFile[Close[%]];
-
-    #> appendFile = OpenAppend["MathicsNonExampleFile"]
-     = OutputStream[MathicsNonExampleFile, ...]
-
-    #> Close[appendFile]
-     = MathicsNonExampleFile
-    #> DeleteFile["MathicsNonExampleFile"]
-    """
-
-    summary_text = (
-        "open an output stream to a file, appending to what was already in the file"
-    )
-    mode = "a"
-    stream_type = "OutputStream"
+    summary_text = "exact or approximate number in Fortran‐like notation"
+    name = "Number"
 
 
 class Get(PrefixOperator):
@@ -1974,6 +1453,131 @@ class Get(PrefixOperator):
         expr = Expression("Get", filename)
         evaluation.message("General", "stream", filename)
         return expr
+
+
+class InputFileName_(Predefined):
+    """
+    <dl>
+    <dt>'$InputFileName'
+      <dd>is the name of the file from which input is currently being read.
+    </dl>
+
+    While in interactive mode, '$InputFileName' is "".
+    X> $InputFileName
+    """
+
+    summary_text = (
+        "the full absolute path to the file from which input is currently being sought"
+    )
+    name = "$InputFileName"
+
+    def evaluate(self, evaluation):
+        return String(read.INPUTFILE_VAR)
+
+
+class InputStream(Builtin):
+    """
+    <dl>
+    <dt>'InputStream[$name$, $n$]'
+      <dd>represents an input stream.
+    </dl>
+
+    >> stream = StringToStream["Mathics is cool!"]
+     = ...
+    >> Close[stream]
+     = String
+    """
+
+    summary_text = "an input stream"
+
+
+class OpenRead(_OpenAction):
+    """
+    <dl>
+    <dt>'OpenRead["file"]'
+      <dd>opens a file and returns an InputStream.
+    </dl>
+
+    >> OpenRead["ExampleData/EinsteinSzilLetter.txt"]
+     = InputStream[...]
+    #> Close[%];
+
+    S> OpenRead["https://raw.githubusercontent.com/Mathics3/mathics-core/master/README.rst"]
+     = ...
+
+    #> OpenRead[]
+     : OpenRead called with 0 arguments; 1 argument is expected.
+     = OpenRead[]
+
+    #> OpenRead[y]
+     : File specification y is not a string of one or more characters.
+     = OpenRead[y]
+
+    #> OpenRead[""]
+     : File specification  is not a string of one or more characters.
+     = OpenRead[]
+
+    #> OpenRead["MathicsNonExampleFile"]
+     : Cannot open MathicsNonExampleFile.
+     = OpenRead[MathicsNonExampleFile]
+
+    #> OpenRead["ExampleData/EinsteinSzilLetter.txt", BinaryFormat -> True]
+     = InputStream[...]
+    #> Close[%];
+    """
+
+    summary_text = "open a file for reading"
+    mode = "r"
+    stream_type = "InputStream"
+
+
+class OpenWrite(_OpenAction):
+    """
+    <dl>
+    <dt>'OpenWrite["file"]'
+      <dd>opens a file and returns an OutputStream.
+    </dl>
+
+    >> OpenWrite[]
+     = OutputStream[...]
+    #> DeleteFile[Close[%]];
+
+    #> OpenWrite[BinaryFormat -> True]
+     = OutputStream[...]
+    #> DeleteFile[Close[%]];
+    """
+
+    summary_text = (
+        "send an output stream to a file, wiping out the previous contents of the file"
+    )
+    mode = "w"
+    stream_type = "OutputStream"
+
+
+class OpenAppend(_OpenAction):
+    """
+    <dl>
+    <dt>'OpenAppend["file"]'
+      <dd>opens a file and returns an OutputStream to which writes are appended.
+    </dl>
+
+    >> OpenAppend[]
+     = OutputStream[...]
+    #> DeleteFile[Close[%]];
+
+    #> appendFile = OpenAppend["MathicsNonExampleFile"]
+     = OutputStream[MathicsNonExampleFile, ...]
+
+    #> Close[appendFile]
+     = MathicsNonExampleFile
+    #> DeleteFile["MathicsNonExampleFile"]
+    """
+
+    summary_text = (
+        "open an output stream to a file, appending to what was already in the file"
+    )
+    mode = "a"
+    stream_type = "OutputStream"
 
 
 class Put(BinaryOperator):
@@ -2161,6 +1765,399 @@ class PutAppend(BinaryOperator):
         return expr
 
 
+class Read(Builtin):
+    """
+    <dl>
+      <dt>'Read[$stream$]'
+      <dd>reads the input stream and returns one expression.
+
+      <dt>'Read[$stream$, $type$]'
+      <dd>reads the input stream and returns an object of the given type.
+
+      <dt>'Read[$stream$, $type$]'
+      <dd>reads the input stream and returns an object of the given type.
+
+      <dt>'Read[$stream$, Hold[Expression]]'
+      <dd>reads the input stream for an Expression and puts it inside 'Hold'.
+
+    </dl>
+    $type$ is one of:
+    <ul>
+      <li>Byte
+      <li>Character
+      <li>Expression
+      <li>HoldExpression
+      <li>Number
+      <li>Real
+      <li>Record
+      <li>String
+      <li>Word
+    </ul>
+
+    ## Malformed InputString
+    #> Read[InputStream[String], {Word, Number}]
+     = Read[InputStream[String], {Word, Number}]
+
+    ## Correctly formed InputString but not open
+    #> Read[InputStream[String, -1], {Word, Number}]
+     : InputStream[String, -1] is not open.
+     = Read[InputStream[String, -1], {Word, Number}]
+
+    ## Reading Strings
+    >> stream = StringToStream["abc123"];
+    >> Read[stream, String]
+     = abc123
+    #> Read[stream, String]
+     = EndOfFile
+    #> Close[stream];
+
+    ## Reading Words
+    >> stream = StringToStream["abc 123"];
+    >> Read[stream, Word]
+     = abc
+    >> Read[stream, Word]
+     = 123
+    #> Read[stream, Word]
+     = EndOfFile
+    #> Close[stream];
+    #> stream = StringToStream[""];
+    #> Read[stream, Word]
+     = EndOfFile
+    #> Read[stream, Word]
+     = EndOfFile
+    #> Close[stream];
+
+    ## Number
+    >> stream = StringToStream["123, 4"];
+    >> Read[stream, Number]
+     = 123
+    >> Read[stream, Number]
+     = 4
+    #> Read[stream, Number]
+     = EndOfFile
+    #> Close[stream];
+    #> stream = StringToStream["123xyz 321"];
+    #> Read[stream, Number]
+     = 123
+    #> Quiet[Read[stream, Number]]
+     = $Failed
+
+    ## Real
+    #> stream = StringToStream["123, 4abc"];
+    #> Read[stream, Real]
+     = 123.
+    #> Read[stream, Real]
+     = 4.
+    #> Quiet[Read[stream, Number]]
+     = $Failed
+
+    #> Close[stream];
+    #> stream = StringToStream["1.523E-19"]; Read[stream, Real]
+     = 1.523×10^-19
+    #> Close[stream];
+    #> stream = StringToStream["-1.523e19"]; Read[stream, Real]
+     = -1.523×10^19
+    #> Close[stream];
+    #> stream = StringToStream["3*^10"]; Read[stream, Real]
+     = 3.×10^10
+    #> Close[stream];
+    #> stream = StringToStream["3.*^10"]; Read[stream, Real]
+     = 3.×10^10
+    #> Close[stream];
+
+    ## Expression
+    #> stream = StringToStream["x + y Sin[z]"]; Read[stream, Expression]
+     = x + y Sin[z]
+    #> Close[stream];
+    ## #> stream = Quiet[StringToStream["Sin[1 123"]; Read[stream, Expression]]
+    ##  = $Failed
+
+    ## HoldExpression:
+    >> stream = StringToStream["2+2\\n2+3"];
+
+    'Read' with a 'Hold[Expression]' returns the expression it reads unevaluated so it can be later inspected and evaluated:
+
+    >> Read[stream, Hold[Expression]]
+     = Hold[2 + 2]
+
+    >> Read[stream, Expression]
+     = 5
+    >> Close[stream];
+
+    Reading a comment however will return the empy list:
+    >> stream = StringToStream["(* ::Package:: *)"];
+
+    >> Read[stream, Hold[Expression]]
+     = {}
+
+    >> Close[stream];
+
+    ## Multiple types
+    >> stream = StringToStream["123 abc"];
+    >> Read[stream, {Number, Word}]
+     = {123, abc}
+    #> Read[stream, {Number, Word}]
+     = EndOfFile
+    #> lose[stream];
+
+    #> stream = StringToStream["123 abc"];
+    #> Quiet[Read[stream, {Word, Number}]]
+     = $Failed
+    #> Close[stream];
+
+    #> stream = StringToStream["123 123"];  Read[stream, {Real, Number}]
+     = {123., 123}
+    #> Close[stream];
+
+    #> Quiet[Read[stream, {Real}]]
+     = Read[InputStream[String, ...], {Real}]
+
+    Multiple lines:
+    >> stream = StringToStream["\\"Tengo una\\nvaca lechera.\\""]; Read[stream]
+     = Tengo una
+     . vaca lechera.
+
+    """
+
+    summary_text = "read an object of the specified type from a stream"
+    messages = {
+        "openx": "`1` is not open.",
+        "readf": "`1` is not a valid format specification.",
+        "readn": "Invalid real number found when reading from `1`.",
+        "readt": "Invalid input found when reading `1` from `2`.",
+        "intnm": (
+            "Non-negative machine-sized integer expected at " "position 3 in `1`."
+        ),
+    }
+
+    rules = {
+        "Read[stream_]": "Read[stream, Expression]",
+    }
+
+    options = {
+        "NullRecords": "False",
+        "NullWords": "False",
+        "RecordSeparators": '{"\r\n", "\n", "\r"}',
+        "TokenWords": "{}",
+        "WordSeparators": '{" ", "\t"}',
+    }
+
+    def check_options(self, options):
+        # Options
+        # TODO Proper error messages
+
+        result = {}
+        keys = list(options.keys())
+
+        # AnchoredSearch
+        if "System`AnchoredSearch" in keys:
+            anchored_search = options["System`AnchoredSearch"].to_python()
+            assert anchored_search in [True, False]
+            result["AnchoredSearch"] = anchored_search
+
+        # IgnoreCase
+        if "System`IgnoreCase" in keys:
+            ignore_case = options["System`IgnoreCase"].to_python()
+            assert ignore_case in [True, False]
+            result["IgnoreCase"] = ignore_case
+
+        # WordSearch
+        if "System`WordSearch" in keys:
+            word_search = options["System`WordSearch"].to_python()
+            assert word_search in [True, False]
+            result["WordSearch"] = word_search
+
+        # RecordSeparators
+        if "System`RecordSeparators" in keys:
+            record_separators = options["System`RecordSeparators"].to_python()
+            assert isinstance(record_separators, list)
+            assert all(
+                isinstance(s, str) and s[0] == s[-1] == '"' for s in record_separators
+            )
+            record_separators = [s[1:-1] for s in record_separators]
+            result["RecordSeparators"] = record_separators
+
+        # WordSeparators
+        if "System`WordSeparators" in keys:
+            word_separators = options["System`WordSeparators"].to_python()
+            assert isinstance(word_separators, list)
+            assert all(
+                isinstance(s, str) and s[0] == s[-1] == '"' for s in word_separators
+            )
+            word_separators = [s[1:-1] for s in word_separators]
+            result["WordSeparators"] = word_separators
+
+        # NullRecords
+        if "System`NullRecords" in keys:
+            null_records = options["System`NullRecords"].to_python()
+            assert null_records in [True, False]
+            result["NullRecords"] = null_records
+
+        # NullWords
+        if "System`NullWords" in keys:
+            null_words = options["System`NullWords"].to_python()
+            assert null_words in [True, False]
+            result["NullWords"] = null_words
+
+        # TokenWords
+        if "System`TokenWords" in keys:
+            token_words = options["System`TokenWords"].to_python()
+            assert token_words == []
+            result["TokenWords"] = token_words
+
+        return result
+
+    def apply(self, channel, types, evaluation, options):
+        "Read[channel_, types_, OptionsPattern[Read]]"
+
+        name, n, stream = read_name_and_stream_from_channel(channel, evaluation)
+        if name is None:
+            return
+
+        # Wrap types in a list (if it isn't already one)
+        if types.has_form("List", None):
+            types = types.elements
+        else:
+            types = (types,)
+
+        # TODO: look for a better implementation handling "Hold[Expression]".
+        #
+        types = (
+            Symbol("HoldExpression")
+            if (
+                typ.get_head_name() == "System`Hold"
+                and typ.leaves[0].get_name() == "System`Expression"
+            )
+            else typ
+            for typ in types
+        )
+        types = Expression("List", *types)
+
+        for typ in types.leaves:
+            if typ not in READ_TYPES:
+                evaluation.message("Read", "readf", typ)
+                return SymbolFailed
+
+        record_separators, word_separators = read_get_separators(options)
+
+        name = name.to_python()
+
+        result = []
+
+        read_word = read_from_stream(stream, word_separators, evaluation.message)
+        read_record = read_from_stream(stream, record_separators, evaluation.message)
+        read_number = read_from_stream(
+            stream,
+            word_separators + record_separators,
+            evaluation.message,
+            ["+", "-", "."] + [str(i) for i in range(10)],
+        )
+        read_real = read_from_stream(
+            stream,
+            word_separators + record_separators,
+            evaluation.message,
+            ["+", "-", ".", "e", "E", "^", "*"] + [str(i) for i in range(10)],
+        )
+
+        from mathics.core.expression import BaseElement
+        from mathics_scanner.errors import IncompleteSyntaxError, InvalidSyntaxError
+        from mathics.core.parser import MathicsMultiLineFeeder, parse
+
+        for typ in types.leaves:
+            try:
+                if typ is Symbol("Byte"):
+                    tmp = stream.io.read(1)
+                    if tmp == "":
+                        raise EOFError
+                    result.append(ord(tmp))
+                elif typ is Symbol("Character"):
+                    tmp = stream.io.read(1)
+                    if tmp == "":
+                        raise EOFError
+                    result.append(tmp)
+                elif typ is Symbol("Expression") or typ is Symbol("HoldExpression"):
+                    tmp = next(read_record)
+                    while True:
+                        try:
+                            feeder = MathicsMultiLineFeeder(tmp)
+                            expr = parse(evaluation.definitions, feeder)
+                            break
+                        except (IncompleteSyntaxError, InvalidSyntaxError):
+                            try:
+                                nextline = next(read_record)
+                                tmp = tmp + "\n" + nextline
+                            except EOFError:
+                                expr = SymbolEndOfFile
+                                break
+                        except Exception as e:
+                            print(e)
+
+                    if expr is SymbolEndOfFile:
+                        evaluation.message(
+                            "Read", "readt", tmp, Expression("InputSteam", name, n)
+                        )
+                        return SymbolFailed
+                    elif isinstance(expr, BaseElement):
+                        if typ is Symbol("HoldExpression"):
+                            expr = Expression("Hold", expr)
+                        result.append(expr)
+                    # else:
+                    #  TODO: Supposedly we can't get here
+                    # what code should we put here?
+
+                elif typ is Symbol("Number"):
+                    tmp = next(read_number)
+                    try:
+                        tmp = int(tmp)
+                    except ValueError:
+                        try:
+                            tmp = float(tmp)
+                        except ValueError:
+                            evaluation.message(
+                                "Read", "readn", Expression("InputSteam", name, n)
+                            )
+                            return SymbolFailed
+                    result.append(tmp)
+
+                elif typ is Symbol("Real"):
+                    tmp = next(read_real)
+                    tmp = tmp.replace("*^", "E")
+                    try:
+                        tmp = float(tmp)
+                    except ValueError:
+                        evaluation.message(
+                            "Read", "readn", Expression("InputSteam", name, n)
+                        )
+                        return SymbolFailed
+                    result.append(tmp)
+                elif typ is Symbol("Record"):
+                    result.append(next(read_record))
+                elif typ is Symbol("String"):
+                    tmp = stream.io.readline()
+                    if len(tmp) == 0:
+                        raise EOFError
+                    result.append(tmp.rstrip("\n"))
+                elif typ is Symbol("Word"):
+                    result.append(next(read_word))
+
+            except EOFError:
+                return SymbolEndOfFile
+            except UnicodeDecodeError:
+                evaluation.message("General", "ucdec")
+
+        if isinstance(result, Symbol):
+            return result
+        if len(result) == 1:
+            return from_python(*result)
+
+        return from_python(result)
+
+    def apply_nostream(self, arg1, arg2, evaluation):
+        "Read[arg1_, arg2_]"
+        evaluation.message("General", "stream", arg1)
+        return
+
+
 class ReadList(Read):
     """
     <dl>
@@ -2281,139 +2278,6 @@ class ReadList(Read):
                 break
             result.append(tmp)
         return from_python(result)
-
-
-class FilePrint(Builtin):
-    """
-    <dl>
-    <dt>'FilePrint[$file$]'
-      <dd>prints the raw contents of $file$.
-    </dl>
-
-    #> exp = Sin[1];
-    #> FilePrint[exp]
-     : File specification Sin[1] is not a string of one or more characters.
-     = FilePrint[Sin[1]]
-
-    #> FilePrint["somenonexistantpath_h47sdmk^&h4"]
-     : Cannot open somenonexistantpath_h47sdmk^&h4.
-     = FilePrint[somenonexistantpath_h47sdmk^&h4]
-
-    #> FilePrint[""]
-     : File specification  is not a string of one or more characters.
-     = FilePrint[]
-    """
-
-    summary_text = "display the contents of a file"
-    messages = {
-        "fstr": (
-            "File specification `1` is not a string of " "one or more characters."
-        ),
-    }
-
-    options = {
-        "CharacterEncoding": "$CharacterEncoding",
-        "RecordSeparators": '{"\r\n", "\n", "\r"}',
-        "WordSeparators": '{" ", "\t"}',
-    }
-
-    def apply(self, path, evaluation, options):
-        "FilePrint[path_ OptionsPattern[FilePrint]]"
-        pypath = path.to_python()
-        if not (
-            isinstance(pypath, str)
-            and pypath[0] == pypath[-1] == '"'
-            and len(pypath) > 2
-        ):
-            evaluation.message("FilePrint", "fstr", path)
-            return
-        pypath = path_search(pypath[1:-1])
-
-        # Options
-        record_separators = options["System`RecordSeparators"].to_python()
-        assert isinstance(record_separators, list)
-        assert all(
-            isinstance(s, str) and s[0] == s[-1] == '"' for s in record_separators
-        )
-        record_separators = [s[1:-1] for s in record_separators]
-
-        if pypath is None:
-            evaluation.message("General", "noopen", path)
-            return
-
-        if not osp.isfile(pypath):
-            return SymbolFailed
-
-        try:
-            with MathicsOpen(pypath, "r") as f:
-                result = f.read()
-        except IOError:
-            evaluation.message("General", "noopen", path)
-            return
-        except MessageException as e:
-            e.message(evaluation)
-            return
-
-        result = [result]
-        for sep in record_separators:
-            result = [item for res in result for item in res.split(sep)]
-
-        if result[-1] == "":
-            result = result[:-1]
-
-        for res in result:
-            evaluation.print_out(String(res))
-
-        return SymbolNull
-
-
-class Close(Builtin):
-    """
-    <dl>
-    <dt>'Close[$stream$]'
-      <dd>closes an input or output stream.
-    </dl>
-
-    >> Close[StringToStream["123abc"]]
-     = String
-
-    >> Close[OpenWrite[]]
-     = ...
-
-    #> Streams[] == (Close[OpenWrite[]]; Streams[])
-     = True
-
-    #> Close["abc"]
-     : abc is not open.
-     = Close[abc]
-
-    #> strm = OpenWrite[];
-    #> Close[strm];
-    #> Quiet[Close[strm]]
-     = Close[OutputStream[...]]
-    """
-
-    summary_text = "close a stream"
-    messages = {
-        "closex": "`1`.",
-    }
-
-    def apply(self, channel, evaluation):
-        "Close[channel_]"
-
-        if channel.has_form(("InputStream", "OutputStream"), 2):
-            [name, n] = channel.get_elements()
-            py_n = n.get_int_value()
-            stream = stream_manager.lookup_stream(py_n)
-        else:
-            stream = None
-
-        if stream is None or stream.io is None or stream.io.closed:
-            evaluation.message("General", "openx", channel)
-            return
-
-        close_stream(stream, n)
-        return name
 
 
 class StreamPosition(Builtin):
@@ -2684,22 +2548,6 @@ class Find(Read):
                     return from_python(py_tmp)
 
 
-class InputStream(Builtin):
-    """
-    <dl>
-    <dt>'InputStream[$name$, $n$]'
-      <dd>represents an input stream.
-    </dl>
-
-    >> stream = StringToStream["Mathics is cool!"]
-     = ...
-    >> Close[stream]
-     = String
-    """
-
-    summary_text = "an input stream"
-
-
 class OutputStream(Builtin):
     """
     <dl>
@@ -2798,3 +2646,158 @@ class Streams(Builtin):
             if name is None or _name == name:
                 result.append(expr)
         return Expression("List", *result)
+
+
+class Record(Builtin):
+    """
+    <dl>
+    <dt>'Record'
+      <dd>is a data type for 'Read'.
+    </dl>
+    """
+
+    summary_text = "sequence of characters delimited by record separators"
+
+
+class Word(Builtin):
+    """
+    <dl>
+    <dt>'Word'
+      <dd>is a data type for 'Read'.
+    </dl>
+    """
+
+    summary_text = "sequence of characters delimited by word separators"
+
+
+class Write(Builtin):
+    """
+    <dl>
+    <dt>'Write[$channel$, $expr1$, $expr2$, ...]'
+      <dd>writes the expressions to the output channel followed by a newline.
+    </dl>
+
+    >> stream = OpenWrite[]
+     = ...
+    >> Write[stream, 10 x + 15 y ^ 2]
+    >> Write[stream, 3 Sin[z]]
+    >> Close[stream];
+    >> stream = OpenRead[%];
+    >> ReadList[stream]
+     = {10 x + 15 y ^ 2, 3 Sin[z]}
+    #> DeleteFile[Close[stream]];
+    """
+
+    summary_text = "write a sequence of expressions to a stream, ending the output with a newline (line feed)"
+
+    def apply(self, channel, expr, evaluation):
+        "Write[channel_, expr___]"
+
+        strm = channel_to_stream(channel)
+
+        if strm is None:
+            return
+
+        n = strm.leaves[1].get_int_value()
+        stream = stream_manager.lookup_stream(n)
+
+        if stream is None or stream.io is None or stream.io.closed:
+            evaluation.message("General", "openx", channel)
+            return SymbolNull
+
+        expr = expr.get_sequence()
+        expr = Expression("Row", Expression("List", *expr))
+
+        evaluation.format = "text"
+        text = evaluation.format_output(expr)
+        stream.io.write(str(text) + "\n")
+        return SymbolNull
+
+
+class WriteString(Builtin):
+    """
+    <dl>
+    <dt>'WriteString[$stream$, $str1, $str2$, ... ]'
+      <dd>writes the strings to the output stream.
+    </dl>
+
+    >> stream = OpenWrite[];
+    >> WriteString[stream, "This is a test 1"]
+    >> WriteString[stream, "This is also a test 2"]
+    >> pathname = Close[stream];
+    >> FilePrint[%]
+     | This is a test 1This is also a test 2
+
+    #> DeleteFile[pathname];
+    >> stream = OpenWrite[];
+    >> WriteString[stream, "This is a test 1", "This is also a test 2"]
+    >> pathname = Close[stream]
+     = ...
+    >> FilePrint[%]
+     | This is a test 1This is also a test 2
+
+    #> DeleteFile[pathname];
+    #> stream = OpenWrite[];
+    #> WriteString[stream, 100, 1 + x + y, Sin[x  + y]]
+    #> pathname = Close[stream]
+     = ...
+    #> FilePrint[%]
+     | 1001 + x + ySin[x + y]
+
+    #> DeleteFile[pathname];
+    #> stream = OpenWrite[];
+    #> WriteString[stream]
+    #> pathame = Close[stream]
+     = ...
+    #> FilePrint[%]
+
+    #> WriteString[%%, abc]
+    #> Streams[%%%][[1]]
+     = ...
+    #> pathname = Close[%];
+    #> FilePrint[%]
+     | abc
+    #> DeleteFile[pathname];
+    #> Clear[pathname];
+
+    """
+
+    summary_text = "write a sequence of strings to a stream, with no extra newlines"
+    messages = {
+        "strml": ("`1` is not a string, stream, " "or list of strings and streams."),
+        "writex": "`1`.",
+    }
+
+    def apply(self, channel, expr, evaluation):
+        "WriteString[channel_, expr___]"
+        strm = channel_to_stream(channel, "w")
+
+        if strm is None:
+            return
+
+        stream = stream_manager.lookup_stream(strm.leaves[1].get_int_value())
+
+        if stream is None or stream.io is None or stream.io.closed:
+            return None
+
+        exprs = []
+        for expri in expr.get_sequence():
+            result = expri.format(evaluation, "System`OutputForm")
+            try:
+                result = result.boxes_to_text(evaluation=evaluation)
+            except BoxError:
+                return evaluation.message(
+                    "General",
+                    "notboxes",
+                    Expression("FullForm", result).evaluate(evaluation),
+                )
+            exprs.append(result)
+        line = "".join(exprs)
+        if type(stream) is BytesIO:
+            line = line.encode("utf8")
+        stream.io.write(line)
+        try:
+            stream.io.flush()
+        except IOError as err:
+            evaluation.message("WriteString", "writex", err.strerror)
+        return SymbolNull

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -79,7 +79,7 @@ class AbsoluteFileName(Builtin):
             return
         py_name = py_name[1:-1]
 
-        result = path_search(py_name)
+        result, is_temporary_file = path_search(py_name)
 
         if result is None:
             evaluation.message(
@@ -196,7 +196,7 @@ class CopyFile(Builtin):
         py_source = py_source[1:-1]
         py_dest = py_dest[1:-1]
 
-        py_source = path_search(py_source)
+        py_source, is_temporary_file = path_search(py_source)
 
         if py_source is None:
             evaluation.message("CopyFile", "filex", source)
@@ -439,7 +439,7 @@ class DeleteFile(Builtin):
                 return
 
             path = path[1:-1]
-            path = path_search(path)
+            path, is_temporary_file = path_search(path)
 
             if path is None:
                 evaluation.message(
@@ -602,7 +602,7 @@ class DirectoryQ(Builtin):
             return
         path = path[1:-1]
 
-        path = path_search(path)
+        path, is_temporary_file = path_search(path)
 
         if path is not None and osp.isdir(path):
             return SymbolTrue
@@ -784,7 +784,7 @@ class FileDate(Builtin):
 
     def apply(self, path, timetype, evaluation):
         "FileDate[path_, timetype_]"
-        py_path = path_search(path.to_python()[1:-1])
+        py_path, is_temparary_file = path_search(path.to_python()[1:-1])
 
         if py_path is None:
             if timetype is None:
@@ -857,7 +857,7 @@ class FileExistsQ(Builtin):
             return
         path = path[1:-1]
 
-        path = path_search(path)
+        path, is_temporary_file = path_search(path)
 
         if path is None:
             return SymbolFalse
@@ -1122,7 +1122,7 @@ class FileType(Builtin):
             return
         path = filename.to_python()[1:-1]
 
-        path = path_search(path)
+        path, is_temporary_file = path_search(path)
 
         if path is None:
             return Symbol("None")
@@ -1170,7 +1170,7 @@ class FindFile(Builtin):
             return
         py_name = py_name[1:-1]
 
-        result = path_search(py_name)
+        result, is_temporary_file = path_search(py_name)
 
         if result is None:
             return SymbolFailed
@@ -1910,7 +1910,7 @@ class RenameFile(Builtin):
         py_source = py_source[1:-1]
         py_dest = py_dest[1:-1]
 
-        py_source = path_search(py_source)
+        py_source, is_temporary_file = path_search(py_source)
 
         if py_source is None:
             evaluation.message("RenameFile", "filex", source)
@@ -2104,7 +2104,7 @@ class SetFileDate(Builtin):
         ):
             evaluation.message("SetFileDate", "fstr", filename)
             return
-        py_filename = path_search(py_filename[1:-1])
+        py_filename, is_temporary_file = path_search(py_filename[1:-1])
 
         if py_filename is None:
             evaluation.message("SetFileDate", "nffil", expr)

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -5,6 +5,7 @@ Importing and Exporting
 """
 
 import os
+import sys
 
 from mathics.core.atoms import (
     ByteArrayAtom,
@@ -2016,7 +2017,12 @@ class ExportString(Builtin):
                         tmpstream = open(filename.value, "r")
                     res = tmpstream.read()
                     tmpstream.close()
-                    os.unlink(tmpstream.name)
+                    if sys.platform not in ("win32",):
+                        # On Windows unlink make the second NamedTemporaryFIle
+                        # fail giving something like:
+                        #   [WinError 32] The process cannot access the file because it is being used by another process: ...
+                        #    \\AppData\\Local\\Temp\\Mathics3-ExportString35eo_rih.svg'
+                        os.unlink(tmpstream.name)
                 except Exception as e:
                     print("something went wrong")
                     print(e)

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -4,6 +4,7 @@
 Importing and Exporting
 """
 
+import os
 
 from mathics.core.atoms import (
     ByteArrayAtom,
@@ -1888,9 +1889,10 @@ class Export(Builtin):
 class ExportString(Builtin):
     """
     <dl>
-    <dt>'ExportString[$expr$, $form$]'
+      <dt>'ExportString[$expr$, $form$]'
       <dd>exports $expr$ to a string, in the format $form$.
-    <dt>'Export["$file$", $exprs$, $elems$]'
+
+      <dt>'Export["$file$", $exprs$, $elems$]'
       <dd>exports $exprs$ to a string as elements specified by $elems$.
     </dl>
 
@@ -2014,6 +2016,7 @@ class ExportString(Builtin):
                         tmpstream = open(filename.value, "r")
                     res = tmpstream.read()
                     tmpstream.close()
+                    os.unlink(tmpstream.name)
                 except Exception as e:
                     print("something went wrong")
                     print(e)

--- a/mathics/core/read.py
+++ b/mathics/core/read.py
@@ -5,7 +5,6 @@ Functions to support Read[]
 import io
 import os
 import os.path as osp
-from typing import Optional
 
 from mathics.builtin.base import MessageException
 from mathics.builtin.atomic.strings import to_python_encoding
@@ -39,7 +38,7 @@ READ_TYPES = [
 
 
 class MathicsOpen(Stream):
-    def __init__(self, name, mode="r", encoding=None):
+    def __init__(self, name, mode="r", encoding=None, is_temporary_file=False):
         if encoding is not None:
             encoding = to_python_encoding(encoding)
             if "b" in mode:
@@ -50,10 +49,11 @@ class MathicsOpen(Stream):
         self.encoding = encoding
         super().__init__(name, mode, self.encoding)
         self.old_inputfile_var = None  # Set in __enter__ and __exit__
+        self.is_temporary_file = is_temporary_file
 
-    def __enter__(self):
+    def __enter__(self, is_temporary_file=False):
         # find path
-        path = path_search(self.name)
+        path, _ = path_search(self.name)
         if path is None and self.mode in ["w", "a", "wb", "ab"]:
             path = self.name
         if path is None:
@@ -70,6 +70,7 @@ class MathicsOpen(Stream):
             encoding=self.encoding,
             io=fp,
             num=stream_manager.next,
+            is_temporary_file=is_temporary_file,
         )
         return fp
 
@@ -100,13 +101,13 @@ def channel_to_stream(channel, mode="r"):
         return None
 
 
-def close_stream(stream, stream_number: int, delete_name: Optional[String] = None):
+def close_stream(stream: Stream, stream_number: int):
+    """
+    Close stream: `stream` and delete it from the list of streams we manage.
+    If the stream was to a temporary file, remove the temporary file.
+    """
     stream.io.close()
     stream_manager.delete(stream_number)
-    # We need an explicit unlink because we've written
-    # to a name outside of the scope that NamedTemporaryFile sees.
-    if delete_name is not None:
-        os.unlink(delete_name.value)
 
 
 def read_name_and_stream_from_channel(channel, evaluation):

--- a/mathics/core/read.py
+++ b/mathics/core/read.py
@@ -3,7 +3,9 @@ Functions to support Read[]
 """
 
 import io
+import os
 import os.path as osp
+from typing import Optional
 
 from mathics.builtin.base import MessageException
 from mathics.builtin.atomic.strings import to_python_encoding
@@ -96,6 +98,15 @@ def channel_to_stream(channel, mode="r"):
         return channel
     else:
         return None
+
+
+def close_stream(stream, stream_number: int, delete_name: Optional[String] = None):
+    stream.io.close()
+    stream_manager.delete(stream_number)
+    # We need an explicit unlink because we've written
+    # to a name outside of the scope that NamedTemporaryFile sees.
+    if delete_name is not None:
+        os.unlink(delete_name.value)
 
 
 def read_name_and_stream_from_channel(channel, evaluation):

--- a/mathics/core/streams.py
+++ b/mathics/core/streams.py
@@ -127,7 +127,7 @@ class StreamsManager(object):
             return True
         return False
 
-    def lookup_stream(self, n=None) -> Optional["Stream"]:
+    def lookup_stream(self, n: Optional[int] = None) -> Optional["Stream"]:
         if n is None:
             return None
         return self.STREAMS.get(n, None)

--- a/test/builtin/colors/test_colors.py
+++ b/test/builtin/colors/test_colors.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Unit tests from builtins ... colors.py
+Unit tests from builtins/colors/colors.py
 """
 
 

--- a/test/builtin/files_io/test_files.py
+++ b/test/builtin/files_io/test_files.py
@@ -36,6 +36,9 @@ def test_get_and_put():
     check_evaluation(f"DeleteFile[{temp_filename}]", "Null")
 
 
+@pytest.mark.skipif(
+    sys.platform in ("win32",), reason="$Path does not work on Windows?"
+)
 def test_get_path_search():
     # Check that AppendTo[$Path] works in conjunction with Get[]
     dirname = osp.join(osp.dirname(osp.abspath(__file__)), "..", "..", "data")
@@ -44,6 +47,9 @@ def test_get_path_search():
     check_evaluation('Get["fortytwo.m"]', "42")
 
 
+@pytest.mark.skipif(
+    sys.platform in ("win32",), reason="$Path does not work on Windows?"
+)
 def test_temptream():
     temp_filename = evaluate("Close[OpenWrite[BinaryFormat -> True]]").value
     assert osp.exists(


### PR DESCRIPTION
Add a number of `DeleteFile[]`'s into the doc tests. 

Isolate and separate stream close. 

Move test_files.py to its proper place in the test hierarchy

Fixes #309

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/310"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

