### PR TITLE
removing flatten_x_sequence from Atoms and subclasses

### DIFF
--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -62,10 +62,11 @@ class BaseRule(KeyComparable):
             else:
                 result = new_expression
 
-            if isinstance(result, Expression) and result.elements_properties is None:
-                result._build_elements_properties()
-            # Flatten out sequences (important for Rule itself!)
-            result = result.flatten_pattern_sequence(evaluation)
+            if isinstance(result, Expression):
+                if result.elements_properties is None:
+                    result._build_elements_properties()
+                # Flatten out sequences (important for Rule itself!)
+                result = result.flatten_pattern_sequence(evaluation)
             if return_list:
                 result_list.append(result)
                 # count += 1

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -254,12 +254,6 @@ class Atom(BaseElement):
         """
         return self
 
-    def flatten_sequence(self, evaluation) -> "Atom":
-        return self
-
-    def flatten_pattern_sequence(self, evaluation) -> "Atom":
-        return self
-
     def flatten_with_respect_to_head(
         self, head, pattern_only=False, callback=None, level=None
     ) -> "Atom":


### PR DESCRIPTION
This PR removes two superfluous methods from the `Atom` interface and a superfluous call to them.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/321"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

