### PR TITLE
adding test for Unevaluated over symbols

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1079,6 +1079,8 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         # The idea is to mark which elements was marked as "Unevaluated"
         # Also, this consumes time for long lists, and is useful just for a very unfrequent
         # expressions, involving `Unevaluated` elements.
+        # Notice also that this behaviour is broken when the argument of "Unevaluated" is a symbol (see comment and tests in test/test_unevaluate.py)
+
         for element in elements:
             element.unevaluated = False
 

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -98,7 +98,9 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
         ),
     ],
 )
-@pytest.mark.skip
+@pytest.mark.skip(
+    reason="the right behaviour was broken since we start to use Symbol as singleton, to speedup comparisons."
+)
 def test_unevaluate(str_setup, str_expr, str_expected, message):
     if str_setup:
         evaluate(str_setup)

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -94,7 +94,7 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
             "a =.; F[a, x_Real, a] := List[x]^2;a=4.;",
             "F[Unevaluated[a], a, Unevaluated[a]]",
             "{16.}",
-            "Here, the second a is kept unevaluated because the bug.",
+            "Here, the second ``a`` is kept unevaluated because of a bug.",
         ),
     ],
 )

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -62,6 +62,53 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
 
 
 @pytest.mark.parametrize(
+    "str_setup,str_expr,str_expected,message",
+    [
+        (
+            "F[x___Real]:=List[x]^2; a=.4;",
+            "F[Unevaluated[a], a, Unevaluated[a]]",
+            "F[Unevaluated[a], 0.4, Unevaluated[a]]",
+            None,
+        ),
+        (
+            "F[x___Real]:=List[x]^2; a=.4;",
+            "F[Unevaluated[b], b, Unevaluated[b]]",
+            "F[Unevaluated[b], b, Unevaluated[b]]",
+            "the second argument shouldn't be ``Unevaluated[b]``",
+        ),
+        (
+            "G[x___Symbol]:=List[x]^2; a=.4;",
+            "G[Unevaluated[a], a, Unevaluated[a]]",
+            "F[Unevaluated[a], 0.4, Unevaluated[a]]",
+            None,
+        ),
+        (
+            "G[x___Symbol]:=List[x]^2; a=.4;",
+            "G[Unevaluated[b], b, Unevaluated[b]]",
+            "F[Unevaluated[b], b, Unevaluated[b]]",
+            "the second argument shouldn't be ``Unevaluated[b]``",
+        ),
+        (
+            "a =.; F[a, x_Real, a] := List[x]^2;a=4.;",
+            "F[Unevaluated[a], a, Unevaluated[a]]",
+            "{16.}",
+            "Here, se second a is kept unevaluated because the bug.",
+        ),
+    ],
+)
+@pytest.mark.xfail
+def test_unevaluate(str_setup, str_expr, str_expected, message):
+    if str_setup:
+        evaluate(str_setup)
+    result = evaluate(str_expr)
+    expected = evaluate(str_expected)
+    if message:
+        assert result == expected, message
+    else:
+        assert result == expected
+
+
+@pytest.mark.parametrize(
     "str_setup,str_expr,str_expected,msg",
     [
         (

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -94,7 +94,7 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
             "a =.; F[a, x_Real, a] := List[x]^2;a=4.;",
             "F[Unevaluated[a], a, Unevaluated[a]]",
             "{16.}",
-            "Here, se second a is kept unevaluated because the bug.",
+            "Here, the second a is kept unevaluated because the bug.",
         ),
     ],
 )

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -61,6 +61,8 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
         assert result == expected
 
 
+# We skip this test because this behaviour is currently
+# broken
 @pytest.mark.parametrize(
     "str_setup,str_expr,str_expected,message",
     [
@@ -96,7 +98,7 @@ def test_evaluation(str_expr: str, str_expected: str, message=""):
         ),
     ],
 )
-@pytest.mark.xfail
+@pytest.mark.skip
 def test_unevaluate(str_setup, str_expr, str_expected, message):
     if str_setup:
         evaluate(str_setup)


### PR DESCRIPTION
@rocky, this PRs adds the test case that shows the issue with ``Unevaluated``. I marked it as xfail. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/344"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

