### PR TITLE
Speed up tests by reducing numbers...

### DIFF
--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -507,13 +507,13 @@ class RealDigits(Builtin):
     >> RealDigits[19 / 7]
      = {{2, {7, 1, 4, 2, 8, 5}}, 1}
 
-    The 10000th digit of  is an 8:
-    >> RealDigits[Pi, 10, 1, -10000]
-    = {{8}, -9999}
+    The 500th digit of Pi is 2:
+    >> RealDigits[Pi, 10, 1, -500]
+    = {{2}, -499}
 
-    20 digits starting with the coefficient of 10^-5:
-    >> RealDigits[Pi, 10, 20, -5]
-     = {{9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4, 6, 2, 6, 4, 3}, -4}
+    11 digits starting with the coefficient of 10^-3:
+    >> RealDigits[Pi, 10, 11, -3]
+     = {{1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7}, -2}
 
     RealDigits gives Indeterminate if more digits than the precision are requested:
     >> RealDigits[123.45, 10, 18]

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1524,9 +1524,9 @@ class FindMinimum(_BaseFinder):
      = {-0.5, {x -> 1.00001}}
     >> Clear[phi];
     For a not so well behaving function, the result can be less accurate:
-    >> FindMinimum[Exp[-1/x^2]+1., {x,1.2}, MaxIterations->300]
+    >> FindMinimum[Exp[-1/x^2]+1., {x,1.2}, MaxIterations->10]
      : The maximum number of iterations was exceeded. The result might be inaccurate.
-     =  FindMinimum[Exp[-1 / x ^ 2] + 1., {x, 1.2}, MaxIterations -> 300]
+     =  FindMinimum[Exp[-1 / x ^ 2] + 1., {x, 1.2}, MaxIterations -> 10]
     """
 
     methods = {}
@@ -1567,9 +1567,9 @@ class FindMaximum(_BaseFinder):
      = {0.5, {x -> 1.00001}}
     >> Clear[phi];
     For a not so well behaving function, the result can be less accurate:
-    >> FindMaximum[-Exp[-1/x^2]+1., {x,1.2}, MaxIterations->300]
+    >> FindMaximum[-Exp[-1/x^2]+1., {x,1.2}, MaxIterations->10]
      : The maximum number of iterations was exceeded. The result might be inaccurate.
-     = FindMaximum[-Exp[-1 / x ^ 2] + 1., {x, 1.2}, MaxIterations -> 300]
+     = FindMaximum[-Exp[-1 / x ^ 2] + 1., {x, 1.2}, MaxIterations -> 10]
     """
 
     methods = {}

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -594,7 +594,7 @@ class NestList(Builtin):
     ## TODO: improve this example when RandomChoice, PointSize, Axes->False are implemented
     Chaos game rendition of the Sierpinski triangle:
     >> vertices = {{0,0}, {1,0}, {.5, .5 Sqrt[3]}};
-    >> points = NestList[.5(vertices[[ RandomInteger[{1,3}] ]] + #) &, {0.,0.}, 2000];
+    >> points = NestList[.5(vertices[[ RandomInteger[{1,3}] ]] + #) &, {0.,0.}, 500];
     >> Graphics[Point[points], ImageSize->Small]
      = -Graphics-
     """


### PR DESCRIPTION
Here there are a number of tests where having large numbers really is
showning much benefit. For example whether we wan the 500 digit versus
the 1000000 digit is kind of pointless and just takes time.

Or how about a maximum number of iterations. In the end we get this same
result: too many iterations.

For plotting and image processing though, I suppose there is benefit in
taking the time since in the end you see a prettier plot. In the case of
images, well, we use reasonable size images.

(The time for plotting eventually I expect to see drop.)

The same things should be done for the pytests. However the combinatorica tests like plotting tests need to stay as the are. Those tests are exactly those from a published book. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/360"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

