### PR TITLE
fixing NIntegrate to make the internal integrators available.

### DIFF
--- a/mathics/algorithm/integrators.py
+++ b/mathics/algorithm/integrators.py
@@ -229,3 +229,5 @@ integrator_methods = {
 }
 integrator_methods["Simpson"] = integrator_methods["Internal"]
 integrator_methods["Automatic"] = integrator_methods["Internal"]
+
+integrator_messages = {}

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1285,18 +1285,9 @@ class _BaseFinder(Builtin):
     This class is the basis class for FindRoot, FindMinimum and FindMaximum.
     """
 
-    options = {
-        "MaxIterations": "100",
-        "Method": "Automatic",
-        "AccuracyGoal": "Automatic",
-        "PrecisionGoal": "Automatic",
-        "StepMonitor": "None",
-        "EvaluationMonitor": "None",
-        "Jacobian": "Automatic",
-    }
-
     attributes = hold_all | protected
-
+    requires = ["scipy"]
+    methods = {}
     messages = {
         "snum": "Value `1` is not a number.",
         "nnum": "The function value is not a number at `1` = `2`.",
@@ -1313,7 +1304,15 @@ class _BaseFinder(Builtin):
         ),
     }
 
-    methods = {}
+    options = {
+        "MaxIterations": "100",
+        "Method": "Automatic",
+        "AccuracyGoal": "Automatic",
+        "PrecisionGoal": "Automatic",
+        "StepMonitor": "None",
+        "EvaluationMonitor": "None",
+        "Jacobian": "Automatic",
+    }
 
     def apply(self, f, x, x0, evaluation, options):
         "%(name)s[f_, {x_, x0_}, OptionsPattern[]]"
@@ -2048,6 +2047,7 @@ class NIntegrate(Builtin):
 
     """
 
+    requires = ["scipy"]
     summary_text = "numerical integration in one or several variables"
     messages = {
         "bdmtd": "The Method option should be a built-in method name.",
@@ -2077,6 +2077,7 @@ class NIntegrate(Builtin):
         "Automatic": (None, False),
     }
     try:
+        # builtin integrators
         from mathics.algorithm.integrators import (
             integrator_methods,
             integrator_messages,
@@ -2088,6 +2089,7 @@ class NIntegrate(Builtin):
         pass
 
     try:
+        # scipy integrators
         from mathics.builtin.scipy_utils.integrators import (
             scipy_nintegrate_methods,
             scipy_nintegrate_messages,
@@ -2096,11 +2098,9 @@ class NIntegrate(Builtin):
         methods.update(scipy_nintegrate_methods)
         messages.update(scipy_nintegrate_messages)
     except Exception as e:
-        print(e)
-        print("scipy integrators was not loaded.")
         pass
 
-    methods.update(
+    messages.update(
         {
             "bdmtd": "The Method option should be a "
             + "built-in method name in {`"

--- a/mathics/builtin/optiondoc.py
+++ b/mathics/builtin/optiondoc.py
@@ -176,8 +176,10 @@ class MaxRecursion(Builtin):
       <dd>is an option for functions like NIntegrate and Plot that specifies how many recursive subdivisions can be made.
     </dl>
 
-    >> NIntegrate[Exp[-10^8 x^2], {x, -1, 1}, MaxRecursion -> 10]
-     =  1.97519×10^-207
+    >> NIntegrate[Exp[-10^8 x^2], {x, -1, 1}, Method->"Internal", MaxRecursion -> 3]
+     =  0.0777778
+    >> NIntegrate[Exp[-10^8 x^2], {x, -1, 1}, Method->"Internal", MaxRecursion -> 6]
+     =  0.00972222
     """
 
     summary_text = "maximum number of recursive subdivisions"


### PR DESCRIPTION
This PR fixes a few bugs I found in ``NIntegrate`` trying to make it works when scipy is not available. Also, I marked here ``NIntegrate``, and ``_BaseFinder`` daughter classes as builtin that requires scipy, to avoid running their doctests when scipy is not available (because the results are going to be slightly different).

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/363"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

