### PR TITLE
Check requires list revision and a pass over image test routines

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,6 @@ jobs:
         python setup.py install
     - name: Test Mathics
       run: |
-        pip install -e .[dev,full]
+        pip install -e .[dev]
         set PYTEST_WORKERS="-n3"
         make check

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Enhancements
 * Improving the compatibility of ``TeXForm`` and ``MathMLForm`` outputs with WMA. MatML tags around numbers appear as "<mn>" tags instead of "<mtext>", except in the case of ``InputForm`` expressions. In TeXForm some quotes around strings have been removed to conform to WMA. It is not clear whether this is the correct behavior.
 * Allow scipy and skimage to be optional. In particular:
    - Revise ``Nintegrate[]`` use ``Method="Internal"`` when scipy isn't available
-
+* Pyston up to versions from 2.2 to 2.3.4 are supported as are PyPy versions from 3.7-7.3.9.0 up 3.9-7.3.9. However those Python interpreters may have limitations and limitations on packages that they support.
 
 Documentation
 .............

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,8 @@ Enhancements
 * In assignment to messages associated with symbols, the attribute ``Protected`` is not having into account, following the standard in WMA. With this and the above change, Combinatorical 2.0 works as written.
 * ``Share[]`` performs an explicit call to the Python garbage collection and returns the amount of memory free.
 * Improving the compatibility of ``TeXForm`` and ``MathMLForm`` outputs with WMA. MatML tags around numbers appear as "<mn>" tags instead of "<mtext>", except in the case of ``InputForm`` expressions. In TeXForm some quotes around strings have been removed to conform to WMA. It is not clear whether this is the correct behavior.
-* Revise ``Nintegrate[]`` to allow scipy to be optional.
-
+* Allow scipy and skimage to be optional. In particular:
+   - Revise ``Nintegrate[]`` use ``Method="Internal"`` when scipy isn't available
 
 
 Documentation
@@ -47,19 +47,16 @@ Internals
 * ``Definition`` has a new property ``is_numeric``.
 * ``Symbol.is_numeric`` and  ``Expression.is_numeric`` now uses the attribute ``Definition.is_numeric`` to determine the returned value.
 * ``NIntegrate`` internal algorithms and interfaces to ``scipy`` were moved to ``mathics.algorithm.integrators`` and ``mathics.builtin.scipy_utils.integrators`` respectively.
-* To speed up attributes read, and RAM usage, attributes are now stored in a bitset instead of a tuple of strings.
 * Definitions for symbols ``CurrentContext`` and ``ContextPath[]`` are mirrored in the ``mathics.core.definitions.Definitions`` object for faster access.
-* To speed up the lookup of symbols names, ``Definitions`` object now have two properties: ``current_context`` and ``context_path``. These properties stores the values of the corresponding symbols in the `builtin` definitions.
+
 * ``FullForm[List[...]]`` now is shown as ``{...}`` according to the WL standard.
 * ``Expression.is_numeric()`` accepts an ``Evaluation`` object as a parameter;  the definitions attribute of that is used.
-* ``apply_N`` was introduced in module ``mathics.builtin.numeric`` to speed up the critical built-in function``N``. Its use instead of the idiom ``Expression(SymbolN, expr, prec).evaluate(evaluation)`` makes the evaluation faster.
 * A failure in the order in which ``mathics.core.definitions`` stores the rules was fixed.
 * ``any`` /``all`` calls were unrolled as loops in Cythonized modules: this avoids the overhead of a function call replacing it by a (C) for loop, which is faster.
 * ``BaseExpression.get_head``  now avoids building a symbol and then look for its name. It saves two function calls.
 * ``SameQ`` first checks type, then ``id``s, and then names in symbols.
 * In ``mathics.builtin.patterns.PatternTest``, if the condition is one of the most used tests (``NumberQ``, ``NumericQ``, ``StringQ``, etc) the ``match`` method is overwritten to specialized versions that avoid function calls.
 * in the same aim, ``mathics.core.patterns.AtomPattern`` now specializes the comparison depending of the ``Atom`` type.
-* To speed up the Mathics ``Expression`` manipulation code, `Symbol`s objects are now a singleton class. This avoids a lot of unnecesary string comparisons, and calls to ``ensure_context``.
 * To speed up development, you can set ``NO_CYTHON`` to skip Cythonizing Python modules
 * A bug was fixed relating to the order in which ``mathics.core.definitions`` stores the rules
 * Improved support for ``Series`` Issue #46.
@@ -70,6 +67,15 @@ Internals
 * ``N[_,_,Method->method]`` was reworked. Issue #137.
 * The methods  ``boxes_to_*`` were moved to ``BoxExpression``.
 * remove ``flatten_*`` from the ``Atom`` interface.
+*
+
+Speed improvements:
+..................
+
+* In ``Expression`` manipulation code, `Symbol`s objects are now a singleton class. This avoids a lot of unnecesary string comparisons, and calls to ``ensure_context``.
+* Attributes are now stored in a bitset instead of a tuple of strings.
+* To speed up the lookup of symbols names, ``Definitions`` object now have two properties: ``current_context`` and ``context_path``. These properties stores the values of the corresponding symbols in the ``builtin`` definitions.
+* ``apply_N`` was add to speed up the then often-used built-in function ``N``.
 
 
 Package update

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -34,6 +34,7 @@ from mathics.builtin.base import (
     SympyObject,
     Operator,
     PatternObject,
+    check_requires_list,
 )
 
 

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -475,6 +475,11 @@ class Builtin:
                 "General",
                 "pyimport",  # see inout.py
                 strip_context(self.get_name()),
+                # WARNING: package isn't defined here, but mysteriously is
+                # defined in the place gets apply (or rather "eval"'d).
+                # Without it we there are a number of doctests we won't run
+                # even though they are should be.
+                package,  # noqa
             )
 
         requires = getattr(self, "requires", [])

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -7,7 +7,7 @@ from functools import total_ordering
 import importlib
 from itertools import chain
 import typing
-from typing import Any, Iterable, cast
+from typing import Any, Callable, Iterable, List, Optional, cast
 
 
 from mathics.builtin.exceptions import (
@@ -463,7 +463,7 @@ class Builtin:
     def get_option(options, name, evaluation, pop=False):
         return get_option(options, name, evaluation, pop)
 
-    def _get_unavailable_function(self) -> "Optional[function]":
+    def _get_unavailable_function(self) -> Optional[Callable]:
         """
         If some of the required libraries for a symbol are not available,
         returns a default function that override the ``apply_`` methods
@@ -475,7 +475,6 @@ class Builtin:
                 "General",
                 "pyimport",  # see inout.py
                 strip_context(self.get_name()),
-                package,
             )
 
         requires = getattr(self, "requires", [])
@@ -565,7 +564,7 @@ class Operator(Builtin):
 
 
 class Predefined(Builtin):
-    def get_functions(self, prefix="apply", is_pymodule=False):
+    def get_functions(self, prefix="apply", is_pymodule=False) -> List[Callable]:
         functions = list(super().get_functions(prefix))
         if prefix == "apply" and hasattr(self, "evaluate"):
             functions.append((Symbol(self.get_name()), self.evaluate))

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -51,9 +51,8 @@ SymbolImage = Symbol("Image")
 SymbolMatrixQ = Symbol("MatrixQ")
 SymbolThreshold = Symbol("Threshold")
 
-
+# Note a list of packages that are needed for image Builtins.
 _image_requires = ("numpy", "PIL")
-
 _skimage_requires = _image_requires + ("skimage", "scipy", "matplotlib", "networkx")
 
 try:
@@ -73,12 +72,20 @@ except ImportError:
 
 from io import BytesIO
 
+# The following classes are used to allow inclusion of
+# Buultin Functions only when certain Python packages
+# are available. They do this by setting the `requires` class variable.
+
 
 class _ImageBuiltin(Builtin):
     requires = _image_requires
 
 
 class _ImageTest(Test):
+    """
+    Testing Image Builtins -- those function names ending with "Q" -- that require scikit-image.
+    """
+
     requires = _image_requires
 
 
@@ -90,7 +97,7 @@ class _SkimageBuiltin(_ImageBuiltin):
     requires = _skimage_requires
 
 
-# import and export
+# Code related to Mathics Functions that import and export.
 
 
 class _Exif:
@@ -136,8 +143,8 @@ class _Exif:
 class ImageImport(_ImageBuiltin):
     """
     <dl>
-    <dt> 'ImageImport["path"]'
-    <dd> import an image from the file "path".
+      <dt> 'ImageImport["path"]'
+      <dd> import an image from the file "path".
     </dl>
 
     ## Image
@@ -176,13 +183,13 @@ class ImageImport(_ImageBuiltin):
 class ImageExport(_ImageBuiltin):
     """
     <dl>
-    <dt> 'ImageExport["path", $image$]'
-    <dd> export $image$ as file in "path".
+      <dt> 'ImageExport["path", $image$]'
+      <dd> export $image$ as file in "path".
     </dl>
     """
 
-    summary_text = "export an image to a file"
     messages = {"noimage": "only an Image[] can be exported into an image file"}
+    summary_text = "export an image to a file"
 
     def apply(self, path, expr, opts, evaluation):
         """ImageExport[path_String, expr_, opts___]"""
@@ -303,7 +310,7 @@ class ImageSubtract(_ImageArithmetic):
 class ImageMultiply(_ImageArithmetic):
     """
     <dl>
-    <dt>'ImageMultiply[$image$, $expr_1$, $expr_2$, ...]'
+      <dt>'ImageMultiply[$image$, $expr_1$, $expr_2$, ...]'
       <dd>multiplies all $expr_i$ with $image$ where each $expr_i$ must be an image or a real number.
     </dl>
 
@@ -358,20 +365,19 @@ class RandomImage(_ImageBuiltin):
      = -Image-
     """
 
-    summary_text = "build an image with random pixels"
     options = {"ColorSpace": "Automatic"}
 
+    messages = {
+        "bddim": "The specified dimension `1` should be a pair of positive integers.",
+        "imgcstype": "`1` is an invalid color space specification.",
+    }
     rules = {
         "RandomImage[]": "RandomImage[{0, 1}, {150, 150}]",
         "RandomImage[max_?RealNumberQ]": "RandomImage[{0, max}, {150, 150}]",
         "RandomImage[{minval_?RealNumberQ, maxval_?RealNumberQ}]": "RandomImage[{minval, maxval}, {150, 150}]",
         "RandomImage[max_?RealNumberQ, {w_Integer, h_Integer}]": "RandomImage[{0, max}, {w, h}]",
     }
-
-    messages = {
-        "bddim": "The specified dimension `1` should be a pair of positive integers.",
-        "imgcstype": "`1` is an invalid color space specification.",
-    }
+    summary_text = "build an image with random pixels"
 
     def apply(self, minval, maxval, w, h, evaluation, options):
         "RandomImage[{minval_?RealNumberQ, maxval_?RealNumberQ}, {w_Integer, h_Integer}, OptionsPattern[RandomImage]]"
@@ -874,9 +880,10 @@ class Blur(_ImageBuiltin):
 class Sharpen(_ImageBuiltin):
     """
     <dl>
-    <dt>'Sharpen[$image$]'
+      <dt>'Sharpen[$image$]'
       <dd>gives a sharpened version of $image$.
-    <dt>'Sharpen[$image$, $r$]'
+
+      <dt>'Sharpen[$image$, $r$]'
       <dd>sharpens $image$ with a kernel of size $r$.
     </dl>
 

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__doc__ = """
+"""
 Image[] and image related functions
 
 Note that you (currently) need scikit-image installed in order for this module to work.
@@ -83,6 +83,10 @@ class _ImageTest(Test):
 
 
 class _SkimageBuiltin(_ImageBuiltin):
+    """
+    Image Builtins that require scikit-image.
+    """
+
     requires = _skimage_requires
 
 
@@ -237,7 +241,7 @@ class _ImageArithmetic(_ImageBuiltin):
 class ImageAdd(_ImageArithmetic):
     """
     <dl>
-    <dt>'ImageAdd[$image$, $expr_1$, $expr_2$, ...]'
+      <dt>'ImageAdd[$image$, $expr_1$, $expr_2$, ...]'
       <dd>adds all $expr_i$ to $image$ where each $expr_i$ must be an image or a real number.
     </dl>
 
@@ -273,7 +277,7 @@ class ImageAdd(_ImageArithmetic):
 class ImageSubtract(_ImageArithmetic):
     """
     <dl>
-    <dt>'ImageSubtract[$image$, $expr_1$, $expr_2$, ...]'
+      <dt>'ImageSubtract[$image$, $expr_1$, $expr_2$, ...]'
       <dd>subtracts all $expr_i$ from $image$ where each $expr_i$ must be an image or a real number.
     </dl>
 
@@ -318,9 +322,9 @@ class ImageMultiply(_ImageArithmetic):
      : Expecting a number, image, or graphics instead of x.
      = ImageMultiply[-Image-, x]
 
-    >> ein = Import["ExampleData/Einstein.jpg"];
-    >> noise = RandomImage[{0.7, 1.3}, ImageDimensions[ein]];
-    >> ImageMultiply[noise, ein]
+    S> ein = Import["ExampleData/Einstein.jpg"];
+    S> noise = RandomImage[{0.7, 1.3}, ImageDimensions[ein]];
+    S> ImageMultiply[noise, ein]
      = -Image-
     """
 
@@ -404,58 +408,46 @@ class RandomImage(_ImageBuiltin):
 class ImageResize(_ImageBuiltin):
     """
     <dl>
-    <dt>'ImageResize[$image$, $width$]'
+      <dt>'ImageResize[$image$, $width$]'
       <dd>
-    <dt>'ImageResize[$image$, {$width$, $height$}]'
+
+      <dt>'ImageResize[$image$, {$width$, $height$}]'
       <dd>
     </dl>
 
-    >> ein = Import["ExampleData/Einstein.jpg"];
-    >> ImageDimensions[ein]
-     = {615, 768}
-    >> ImageResize[ein, {400, 600}]
+    S> ein = Import["ExampleData/Einstein.jpg"]
      = -Image-
-    #> ImageDimensions[%]
+
+    S> ImageDimensions[ein]
+     = {615, 768}
+    S> ImageResize[ein, {400, 600}]
+     = -Image-
+    S> ImageDimensions[%]
      = {400, 600}
 
-    >> ImageResize[ein, 256]
+    S> ImageResize[ein, {256}]
      = -Image-
-    >> ImageDimensions[%]
-     = {256, 320}
 
-    The default sampling method is Bicubic
-    >> ImageResize[ein, 256, Resampling -> "Bicubic"]
-     = -Image-
-    #> ImageDimensions[%]
-     = {256, 320}
-    >> ImageResize[ein, 256, Resampling -> "Nearest"]
-     = -Image-
-    #> ImageDimensions[%]
-     = {256, 320}
-    >> ImageResize[ein, 256, Resampling -> "Gaussian"]
-     = -Image-
-    #> ImageDimensions[%]
-     = {256, 320}
-    #> ImageResize[ein, {256, 256}, Resampling -> "Gaussian"]
-     : Gaussian resampling needs to maintain aspect ratio.
-     = ImageResize[-Image-, {256, 256}, Resampling -> Gaussian]
-    #> ImageResize[ein, 256, Resampling -> "Invalid"]
-     : Invalid resampling method Invalid.
-     = ImageResize[-Image-, 256, Resampling -> Invalid]
-
-    #> ImageDimensions[ImageResize[ein, {256}]]
+    S> ImageDimensions[%]
      = {256, 256}
 
-    #> ImageResize[ein, {x}]
-     : The size {x} is not a valid image size specification.
-     = ImageResize[-Image-, {x}]
-    #> ImageResize[ein, x]
-     : The size x is not a valid image size specification.
-     = ImageResize[-Image-, x]
-    """
+    The Resampling option can be used to specify how to resample the image. Options are:
+    <ul>
+      <li>Automatic
+      <li>Bicubic
+      <li>Gaussian
+      <li>Nearest
+    </ul>
 
-    summary_text = "resize an image"
-    options = {"Resampling": "Automatic"}
+    The default sampling method is Bicubic.
+
+    S> ImageResize[ein, 256, Resampling -> "Bicubic"]
+     = -Image-
+
+    S> ImageResize[ein, 256, Resampling -> "Gaussian"]
+     = ...
+     : ...
+    """
 
     messages = {
         "imgrssz": "The size `1` is not a valid image size specification.",
@@ -463,6 +455,9 @@ class ImageResize(_ImageBuiltin):
         "gaussaspect": "Gaussian resampling needs to maintain aspect ratio.",
         "skimage": "Please install scikit-image to use Resampling -> Gaussian.",
     }
+
+    options = {"Resampling": "Automatic"}
+    summary_text = "resize an image"
 
     def _get_image_size_spec(self, old_size, new_size) -> Optional[float]:
         predefined_sizes = {
@@ -904,7 +899,7 @@ class Sharpen(_ImageBuiltin):
 class GaussianFilter(_ImageBuiltin):
     """
     <dl>
-    <dt>'GaussianFilter[$image$, $r$]'
+      <dt>'GaussianFilter[$image$, $r$]'
       <dd>blurs $image$ using a Gaussian blur filter of radius $r$.
     </dl>
 
@@ -1329,7 +1324,7 @@ class ColorQuantize(_ImageBuiltin):
 class Threshold(_SkimageBuiltin):
     """
     <dl>
-    <dt>'Threshold[$image$]'
+      <dt>'Threshold[$image$]'
       <dd>gives a value suitable for binarizing $image$.
     </dl>
 
@@ -1338,11 +1333,11 @@ class Threshold(_SkimageBuiltin):
     >> img = Import["ExampleData/lena.tif"];
     >> Threshold[img]
      = 0.456739
-    >> Binarize[img, %]
+    X> Binarize[img, %]
      = -Image-
-    >> Threshold[img, Method -> "Mean"]
+    X> Threshold[img, Method -> "Mean"]
      = 0.486458
-    >> Threshold[img, Method -> "Median"]
+    X> Threshold[img, Method -> "Median"]
      = 0.504726
     """
 
@@ -1381,20 +1376,22 @@ class Threshold(_SkimageBuiltin):
 class Binarize(_SkimageBuiltin):
     """
     <dl>
-    <dt>'Binarize[$image$]'
+      <dt>'Binarize[$image$]'
       <dd>gives a binarized version of $image$, in which each pixel is either 0 or 1.
-    <dt>'Binarize[$image$, $t$]'
+
+      <dt>'Binarize[$image$, $t$]'
       <dd>map values $x$ > $t$ to 1, and values $x$ <= $t$ to 0.
-    <dt>'Binarize[$image$, {$t1$, $t2$}]'
+
+      <dt>'Binarize[$image$, {$t1$, $t2$}]'
       <dd>map $t1$ < $x$ < $t2$ to 1, and all other values to 0.
     </dl>
 
     >> img = Import["ExampleData/lena.tif"];
-    >> Binarize[img]
+    X> Binarize[img]
      = -Image-
-    >> Binarize[img, 0.7]
+    X> Binarize[img, 0.7]
      = -Image-
-    >> Binarize[img, {0.2, 0.6}]
+    X> Binarize[img, {0.2, 0.6}]
      = -Image-
     """
 
@@ -1855,7 +1852,7 @@ class ImageType(_ImageBuiltin):
     >> ImageType[Image[{{0, 1}, {1, 0}}]]
      = Real
 
-    >> ImageType[Binarize[img]]
+    X> ImageType[Binarize[img]]
      = Bit
 
     """
@@ -1870,19 +1867,20 @@ class ImageType(_ImageBuiltin):
 class BinaryImageQ(_ImageTest):
     """
     <dl>
-    <dt>'BinaryImageQ[$image]'
+      <dt>'BinaryImageQ[$image]'
       <dd>returns True if the pixels of $image are binary bit values, and False otherwise.
     </dl>
 
-    >> img = Import["ExampleData/lena.tif"];
+    S> img = Import["ExampleData/lena.tif"];
     S> BinaryImageQ[img]
      = False
 
     S> BinaryImageQ[Binarize[img]]
-     = True
+     = ...
+     : ...
     """
 
-    summary_text = "test whether pixels in an image ar binary bit values"
+    summary_text = "test whether pixels in an image are binary bit values"
 
     def test(self, expr):
         return isinstance(expr, Image) and expr.storage_type() == "Bit"
@@ -1906,7 +1904,7 @@ def _image_pixels(matrix):
 class ImageQ(_ImageTest):
     """
     <dl>
-    <dt>'ImageQ[Image[$pixels]]'
+      <dt>'ImageQ[Image[$pixels]]'
       <dd>returns True if $pixels has dimensions from which an Image can be constructed, and False otherwise.
     </dl>
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -2033,7 +2033,7 @@ class NIntegrate(Builtin):
     >> NIntegrate[Exp[x],{x,-Infinity, 0},Tolerance->1*^-6, Method->"Internal"]
      = 1.
     >> NIntegrate[Exp[-x^2/2.],{x,-Infinity, Infinity},Tolerance->1*^-6, Method->"Internal"]
-     = 2.50664
+     = 2.5066...
 
     """
 

--- a/mathics/builtin/scipy_utils/integrators.py
+++ b/mathics/builtin/scipy_utils/integrators.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import sys
+from mathics.builtin import check_requires_list
 
 IS_PYPY = "__pypy__" in sys.builtin_module_names
-if IS_PYPY:
+if IS_PYPY or not check_requires_list(["scipy", "numpy"]):
     raise ImportError
 
 import numpy as np

--- a/mathics/builtin/scipy_utils/integrators.py
+++ b/mathics/builtin/scipy_utils/integrators.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 from mathics.builtin import check_requires_list
+from mathics.core.utils import IS_PYPY
 
-IS_PYPY = "__pypy__" in sys.builtin_module_names
 if IS_PYPY or not check_requires_list(["scipy", "numpy"]):
     raise ImportError
 

--- a/mathics/builtin/scipy_utils/optimizers.py
+++ b/mathics/builtin/scipy_utils/optimizers.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 
+from mathics.builtin import check_requires_list
+
 from mathics.core.expression import Expression
 from mathics.core.evaluation import Evaluation
 from mathics.core.atoms import Number, Real
@@ -12,8 +14,9 @@ from mathics.core.evaluators import apply_N
 SymbolCompile = Symbol("Compile")
 
 IS_PYPY = "__pypy__" in sys.builtin_module_names
-if IS_PYPY:
+if IS_PYPY or not check_requires_list(["scipy", "numpy"]):
     raise ImportError
+
 
 from scipy.optimize import (
     minimize_scalar,

--- a/mathics/builtin/scipy_utils/optimizers.py
+++ b/mathics/builtin/scipy_utils/optimizers.py
@@ -3,13 +3,14 @@ import sys
 
 from mathics.builtin import check_requires_list
 
+from mathics.core.atoms import Number, Real
 from mathics.core.expression import Expression
 from mathics.core.evaluation import Evaluation
-from mathics.core.atoms import Number, Real
+from mathics.core.evaluators import apply_N
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolAutomatic, SymbolInfinity, SymbolFailed
-from mathics.core.evaluators import apply_N
+from mathics.core.utils import IS_PYPY
 
 SymbolCompile = Symbol("Compile")
 

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -15,6 +15,7 @@ from mathics.builtin.base import Builtin, Predefined
 from mathics.core.atoms import (
     Integer,
     Integer0,
+    IntegerM1,
     Real,
     String,
 )
@@ -510,7 +511,7 @@ else:
         name = "$SystemMemory"
 
         def evaluate(self, evaluation) -> Integer:
-            return Integer(-1)
+            return IntegerM1
 
     class MemoryAvailable(Builtin):
         """
@@ -535,7 +536,7 @@ class MemoryInUse(Builtin):
     """
     <dl>
       <dt>'MemoryInUse[]'
-      <dd>Returns the amount of memory used by the definitions object.
+      <dd>Returns the amount of memory used by the definitions object. If we can't determine this we return -1.
     </dl>
 
     >> MemoryInUse[]
@@ -552,7 +553,11 @@ class MemoryInUse(Builtin):
 
         definitions = evaluation.definitions
         seen = set()
-        default_size = getsizeof(0)
+        try:
+            default_size = getsizeof(0)
+        except TypeError:
+            return IntegerM1
+
         handlers = {
             tuple: iter,
             list: iter,

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -10,6 +10,8 @@ FORMAT_RE = re.compile(r"\`(\d*)\`")
 
 import time
 
+IS_PYPY = "__pypy__" in sys.builtin_module_names
+
 # A small, simple timing tool
 MIN_ELAPSE_REPORT = int(os.environ.get("MIN_ELAPSE_REPORT", "0"))
 

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -39,6 +39,7 @@ from mathics import builtin
 from mathics import settings
 from mathics.builtin import get_module_doc, check_requires_list
 from mathics.core.evaluation import Message, Print
+from mathics.core.util import IS_PYPY
 from mathics.doc.utils import slugify
 
 # These regular expressions pull out information from docstring or text in a file.
@@ -836,6 +837,11 @@ class MathicsMainDocumentation(Documentation):
                         # user manual
                         if submodule.__doc__ is None:
                             continue
+                        elif IS_PYPY and submodule.__name__ == "builtins":
+                            # PyPy seems to add this module on its own,
+                            # but it is not something htat can be importable
+                            continue
+
                         if submodule in modules_seen:
                             continue
 
@@ -850,7 +856,6 @@ class MathicsMainDocumentation(Documentation):
                         modules_seen.add(submodule)
                         guide_section.subsections.append(section)
 
-                        builtins = builtins_by_module[submodule.__name__]
                         subsections = [
                             builtin
                             for builtin in builtins

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -37,7 +37,7 @@ from typing import Callable
 
 from mathics import builtin
 from mathics import settings
-from mathics.builtin import get_module_doc
+from mathics.builtin import get_module_doc, check_requires_list
 from mathics.core.evaluation import Message, Print
 from mathics.doc.utils import slugify
 
@@ -665,6 +665,8 @@ class Documentation(object):
                                     # iterated below. Probably some other code is faulty and
                                     # when fixed the below loop and collection into doctest_list[]
                                     # will be removed.
+                                    if not docsubsection.installed:
+                                        continue
                                     doctest_list = []
                                     index = 1
                                     for doctests in docsubsection.items:
@@ -906,13 +908,8 @@ class MathicsMainDocumentation(Documentation):
         object to the chapter, a DocChapter object.
         "section_object" is either a Python module or a Class object instance.
         """
-        installed = True
-        for package in getattr(section_object, "requires", []):
-            try:
-                importlib.import_module(package)
-            except ImportError:
-                installed = False
-                break
+        installed = check_requires_list(getattr(section_object, "requires", []))
+
         # FIXME add an additional mechanism in the module
         # to allow a docstring and indicate it is not to go in the
         # user manual
@@ -949,17 +946,12 @@ class MathicsMainDocumentation(Documentation):
         operator=None,
         in_guide=False,
     ):
-        installed = True
-        for package in getattr(instance, "requires", []):
-            try:
-                importlib.import_module(package)
-            except ImportError:
-                installed = False
-                break
+        installed = check_requires_list(getattr(instance, "requires", []))
 
         # FIXME add an additional mechanism in the module
         # to allow a docstring and indicate it is not to go in the
         # user manual
+
         if not instance.__doc__:
             return
         subsection = DocSubsection(
@@ -1058,6 +1050,8 @@ class PyMathicsDocumentation(Documentation):
                 and var.__module__[: len(self.pymathicsmodule.__name__)]
                 == self.pymathicsmodule.__name__
             ):  # nopep8
+                if not check_requires_list(var):
+                    continue
                 instance = var(expression=False)
                 if isinstance(instance, Builtin):
                     self.symbols[instance.get_name()] = instance
@@ -1105,13 +1099,7 @@ class PyMathicsDocumentation(Documentation):
         chapter = DocChapter(builtin_part, title, XMLDoc(text))
         for name in self.symbols:
             instance = self.symbols[name]
-            installed = True
-            for package in getattr(instance, "requires", []):
-                try:
-                    importlib.import_module(package)
-                except ImportError:
-                    installed = False
-                    break
+            installed = check_requires_list(getattr(instance, "requires", []))
             section = DocSection(
                 chapter,
                 strip_system_prefix(name),
@@ -1329,8 +1317,12 @@ class DocGuideSection(DocSection):
         # A guide section's subsection are Sections without the Guide.
         # it is *their* subsections where we generally find tests.
         for section in self.subsections:
+            if not section.installed:
+                continue
             for subsection in section.subsections:
                 # FIXME we are omitting the section title here...
+                if not subsection.installed:
+                    continue
                 for doctests in subsection.items:
                     yield doctests.get_tests()
 

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -1653,7 +1653,7 @@ class DocTest(object):
         self.private = testcase[0] == "#"
 
         # Ignored test cases are NOT executed, but shown as part of the docs
-        # Sandboxed test cases are NOT executed if environtment SANDBOX is set
+        # Sandboxed test cases are NOT executed if environment SANDBOX is set
         if testcase[0] == "X" or (testcase[0] == "S" and getenv("SANDBOX", False)):
             self.ignore = True
             # substitute '>' again so we get the correct formatting

--- a/test/builtin/image/test_image.py
+++ b/test/builtin/image/test_image.py
@@ -9,14 +9,16 @@ import os
 import pytest
 
 from test.helper import evaluate
+from mathics.core.symbols import SymbolNull
 
 # From How to check if a Python module exists without importing it:
 # https://stackoverflow.com/a/14050282/546218
 skimage_module = importlib.util.find_spec("skimage")
 
-image_tests = [('img = Import["ExampleData/lena.tif"]; BinaryImageQ[img]', "False", "")]
+image_tests = [('img = Import["ExampleData/lena.tif"];', None, "")]
 if skimage_module is not None:
     image_tests += [
+        ("BinaryImageQ[img]", "False", ""),
         ("BinaryImageQ[Binarize[img]]", "True", ""),
         (
             """ein = Import["ExampleData/Einstein.jpg"]; ImageDimensions[ein]""",
@@ -49,8 +51,9 @@ if skimage_module is not None:
 @pytest.mark.parametrize(("str_expr, str_expected, msg"), image_tests)
 def test_image(str_expr: str, str_expected: str, msg: str, message=""):
     result = evaluate(str_expr)
-    expected = evaluate(str_expected)
-    if msg:
-        assert result == expected, msg
-    else:
-        assert result == expected
+    if result is not SymbolNull or str_expected is not None:
+        expected = evaluate(str_expected)
+        if msg:
+            assert result == expected, msg
+        else:
+            assert result == expected

--- a/test/builtin/image/test_image.py
+++ b/test/builtin/image/test_image.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for mathics.core.drawing.image:
+
+Image[] and image related functions.
+"""
+import importlib
+import os
+import pytest
+
+from test.helper import evaluate
+
+# From How to check if a Python module exists without importing it:
+# https://stackoverflow.com/a/14050282/546218
+skimage_module = importlib.util.find_spec("skimage")
+
+image_tests = [('img = Import["ExampleData/lena.tif"]; BinaryImageQ[img]', "False", "")]
+if skimage_module is not None:
+    image_tests += [
+        ("BinaryImageQ[Binarize[img]]", "True", ""),
+        (
+            """ein = Import["ExampleData/Einstein.jpg"]; ImageDimensions[ein]""",
+            "{615, 768}",
+            "",
+        ),
+        # FIXME: I wonder if the testing framework is broken here.
+        # ('ImageResize[img], {400, 600}]', "-Image-", ""),
+        # ("ImageDimensions[%]", "{400, 600}", ""),
+        # ("ImageResize[ein, 256]", "-Image-", ""),
+        # ("ImageDimensions[%]", "{256, 320}", ""),
+        # ('ImageResize[ein, 256, Resampling -> "Bicubic"]', "-Image-", ""),
+        # ('ImageResize[ein, {256, 256}, Resampling -> "Gaussian"]', "",
+        #  "Gaussian resampling needs to maintain aspect ratio.")
+        # ('ImageResize[ein, 256, Resampling -> "Invalid"]', "", "Invalid resampling method Invalid."),
+        # ('ImageResize[ein, 256, Resampling -> Invalid]', "", "Invalid resampling method Invalid."),
+        # ('ImageResize[ein, {x}]', "", "The size {x} is not a valid image size specification."),
+        # ('ImageResize[ein, x]', "", "The size x is not a valid image size specification."),
+        # ("ImageType[Binarize[img]]", "Bit", ""),
+        # ("Binarize[img, 0.7]", "-Image-", ""),
+        # ("Binarize[img, {0.2, 0.6}", "-Image-", "")
+        # Are there others?
+    ]
+
+
+@pytest.mark.skipif(
+    os.getenv("SANDBOX", False),
+    reason="Test doesn't work in a sandboxed environment with access to local files",
+)
+@pytest.mark.parametrize(("str_expr, str_expected, msg"), image_tests)
+def test_image(str_expr: str, str_expected: str, msg: str, message=""):
+    result = evaluate(str_expr)
+    expected = evaluate(str_expected)
+    if msg:
+        assert result == expected, msg
+    else:
+        assert result == expected

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -9,7 +9,9 @@ from test.helper import evaluate
 
 # From How to check if a Python module exists without importing it:
 # https://stackoverflow.com/a/14050282/546218
-scipy_integrate_module = importlib.util.find_spec("scipy.integrate")
+scipy_integrate_module = None
+if importlib.util.find_spec("scipy") is not None:
+    scipy_integrate_module = importlib.util.find_spec("scipy.integrate")
 
 if scipy_integrate_module is not None:
     methods = ["Automatic", "Romberg", "Internal", "NQuadrature"]

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -2,7 +2,6 @@
 """
 NIntegrate[] tests
 
-This also
 """
 import importlib
 import pytest
@@ -10,9 +9,9 @@ from test.helper import evaluate
 
 # From How to check if a Python module exists without importing it:
 # https://stackoverflow.com/a/14050282/546218
-scipy_integrate = importlib.util.find_spec("scipy.integrate")
+scipy_integrate_module = importlib.util.find_spec("scipy.integrate")
 
-if scipy_integrate is not None:
+if scipy_integrate_module is not None:
     methods = ["Automatic", "Romberg", "Internal", "NQuadrature"]
 
     generic_tests_for_nintegrate = [


### PR DESCRIPTION
This was the part where we have more control over tests and doctests and adapting builtins when Python packages aren't available. 

It doesn't require forging ahead with new CI in order to test this, simply remove one module like scikit from an _existing_ CI. 

I spent way too much time going over this when _what I wanted to do was finish the existing stuff I am working on_.  

In my opinion too often we forge ahead with new shiny stuff when the foundation is weak and should be fixed up before doing work that requires building upon that. Here it is adding new CI when we don't have install optional packages working properly. And removing the flakiness in doctests around not supporting optional packages and removing the unit tests that shouldn't  have been added to doctests. All of this lays the foundation for any new CI that doesn't support optional packages. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/376"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

