### PR TITLE
Changes to allow PyPy to build and mostly run ...

### DIFF
--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -1393,12 +1393,12 @@ class Binarize(_SkimageBuiltin):
       <dd>map $t1$ < $x$ < $t2$ to 1, and all other values to 0.
     </dl>
 
-    >> img = Import["ExampleData/lena.tif"];
-    X> Binarize[img]
+    S> img = Import["ExampleData/lena.tif"];
+    S> Binarize[img]
      = -Image-
-    X> Binarize[img, 0.7]
+    S> Binarize[img, 0.7]
      = -Image-
-    X> Binarize[img, {0.2, 0.6}]
+    S> Binarize[img, {0.2, 0.6}]
      = -Image-
     """
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -2033,7 +2033,7 @@ class NIntegrate(Builtin):
     >> NIntegrate[Exp[x],{x,-Infinity, 0},Tolerance->1*^-6, Method->"Internal"]
      = 1.
     >> NIntegrate[Exp[-x^2/2.],{x,-Infinity, Infinity},Tolerance->1*^-6, Method->"Internal"]
-     = 2.50664
+     = 2.5066...
 
     """
 

--- a/mathics/builtin/scipy_utils/integrators.py
+++ b/mathics/builtin/scipy_utils/integrators.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import sys
+from mathics.builtin import check_requires_list
+from mathics.core.utils import IS_PYPY
 
-IS_PYPY = "__pypy__" in sys.builtin_module_names
-if IS_PYPY:
+if IS_PYPY or not check_requires_list(["scipy", "numpy"]):
     raise ImportError
 
 import numpy as np

--- a/mathics/builtin/scipy_utils/optimizers.py
+++ b/mathics/builtin/scipy_utils/optimizers.py
@@ -1,19 +1,22 @@
 # -*- coding: utf-8 -*-
 import sys
 
+from mathics.builtin import check_requires_list
+
+from mathics.core.atoms import Number, Real
 from mathics.core.expression import Expression
 from mathics.core.evaluation import Evaluation
-from mathics.core.atoms import Number, Real
+from mathics.core.evaluators import apply_N
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolAutomatic, SymbolInfinity, SymbolFailed
-from mathics.core.evaluators import apply_N
+from mathics.core.utils import IS_PYPY
 
 SymbolCompile = Symbol("Compile")
 
-IS_PYPY = "__pypy__" in sys.builtin_module_names
-if IS_PYPY:
+if IS_PYPY or not check_requires_list(["scipy", "numpy"]):
     raise ImportError
+
 
 from scipy.optimize import (
     minimize_scalar,

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -536,7 +536,7 @@ class MemoryInUse(Builtin):
     """
     <dl>
       <dt>'MemoryInUse[]'
-      <dd>Returns the amount of memory used by the definitions object. If we can't determine this we return -1.
+      <dd>Returns the amount of memory used by all of the definitions objects if we can determine that; -1 otherwise.
     </dl>
 
     >> MemoryInUse[]

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -15,6 +15,7 @@ from mathics.builtin.base import Builtin, Predefined
 from mathics.core.atoms import (
     Integer,
     Integer0,
+    IntegerM1,
     Real,
     String,
 )
@@ -510,7 +511,7 @@ else:
         name = "$SystemMemory"
 
         def evaluate(self, evaluation) -> Integer:
-            return Integer(-1)
+            return IntegerM1
 
     class MemoryAvailable(Builtin):
         """
@@ -535,7 +536,7 @@ class MemoryInUse(Builtin):
     """
     <dl>
       <dt>'MemoryInUse[]'
-      <dd>Returns the amount of memory used by the definitions object.
+      <dd>Returns the amount of memory used by the definitions object. If we can't determine this we return -1.
     </dl>
 
     >> MemoryInUse[]
@@ -552,7 +553,11 @@ class MemoryInUse(Builtin):
 
         definitions = evaluation.definitions
         seen = set()
-        default_size = getsizeof(0)
+        try:
+            default_size = getsizeof(0)
+        except TypeError:
+            return IntegerM1
+
         handlers = {
             tuple: iter,
             list: iter,

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -10,6 +10,8 @@ FORMAT_RE = re.compile(r"\`(\d*)\`")
 
 import time
 
+IS_PYPY = "__pypy__" in sys.builtin_module_names
+
 # A small, simple timing tool
 MIN_ELAPSE_REPORT = int(os.environ.get("MIN_ELAPSE_REPORT", "0"))
 

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -39,6 +39,7 @@ from mathics import builtin
 from mathics import settings
 from mathics.builtin import get_module_doc
 from mathics.core.evaluation import Message, Print
+from mathics.core.util import IS_PYPY
 from mathics.doc.utils import slugify
 
 # These regular expressions pull out information from docstring or text in a file.
@@ -834,6 +835,11 @@ class MathicsMainDocumentation(Documentation):
                         # user manual
                         if submodule.__doc__ is None:
                             continue
+                        elif IS_PYPY and submodule.__name__ == "builtins":
+                            # PyPy seems to add this module on its own,
+                            # but it is not something htat can be importable
+                            continue
+
                         if submodule in modules_seen:
                             continue
 

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -2,7 +2,6 @@
 """
 NIntegrate[] tests
 
-This also
 """
 import importlib
 import pytest
@@ -10,9 +9,11 @@ from test.helper import evaluate
 
 # From How to check if a Python module exists without importing it:
 # https://stackoverflow.com/a/14050282/546218
-scipy_integrate = importlib.util.find_spec("scipy.integrate")
+scipy_integrate_module = None
+if importlib.util.find_spec("scipy") is not None:
+    scipy_integrate_module = importlib.util.find_spec("scipy.integrate")
 
-if scipy_integrate is not None:
+if scipy_integrate_module is not None:
     methods = ["Automatic", "Romberg", "Internal", "NQuadrature"]
 
     generic_tests_for_nintegrate = [


### PR DESCRIPTION
we can get through pytests and the Gries & Schneider tests.

There is probably a PyPy bug or weirdness around `Binarize`:

```
In[1]:= img = Import["ExampleData/lena.tif"]
Out[1]= -Image-
In[2]:= Binarize[img]
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  IndentationError: ('unexpected indent', ('<string>', 2, 1, '        class pybind11_static_property(property):\n', 2))
```

But let's leave that for later.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/381"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

