### PR TITLE
Fix fn call mismatches in process_assign_other

### DIFF
--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -5,17 +5,13 @@ Forms of Assignment
 
 
 from mathics.builtin.base import Builtin, BinaryOperator
-from mathics.core.symbols import Symbol
-
+from mathics.builtin.assignments.internals import _SetOperator
+from mathics.core.attributes import hold_all, hold_first, protected, sequence_hold
+from mathics.core.definitions import PyMathicsLoadException
+from mathics.core.symbols import SymbolNull
 from mathics.core.systemsymbols import (
     SymbolFailed,
 )
-
-from mathics.core.definitions import PyMathicsLoadException
-
-from mathics.builtin.assignments.internals import _SetOperator
-
-from mathics.core.attributes import hold_all, hold_first, protected, sequence_hold
 
 
 class Set(BinaryOperator, _SetOperator):
@@ -95,11 +91,6 @@ class Set(BinaryOperator, _SetOperator):
     operator = "="
     precedence = 40
 
-    messages = {
-        "setraw": "Cannot assign to raw object `1`.",
-        "shape": "Lists `1` and `2` are not the same shape.",
-    }
-
     summary_text = "assign a value"
 
     def apply(self, lhs, rhs, evaluation):
@@ -112,9 +103,10 @@ class Set(BinaryOperator, _SetOperator):
 class SetDelayed(Set):
     """
     <dl>
-    <dt>'SetDelayed[$expr$, $value$]'
-    <dt>$expr$ := $value$
-        <dd>assigns $value$ to $expr$, without evaluating $value$.
+      <dt>'SetDelayed[$expr$, $value$]'
+
+      <dt>$expr$ := $value$
+      <dd>assigns $value$ to $expr$, without evaluating $value$.
     </dl>
 
     'SetDelayed' is like 'Set', except it has attribute 'HoldAll', thus it does not evaluate the right-hand side immediately, but evaluates it when needed.
@@ -159,7 +151,7 @@ class SetDelayed(Set):
         "lhs_ := rhs_"
 
         if self.assign(lhs, rhs, evaluation):
-            return Symbol("Null")
+            return SymbolNull
         else:
             return SymbolFailed
 
@@ -233,7 +225,7 @@ class TagSetDelayed(TagSet):
             return
 
         if self.assign_elementary(lhs, rhs, evaluation, tags=[name]):
-            return Symbol("Null")
+            return SymbolNull
         else:
             return SymbolFailed
 

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -438,15 +438,15 @@ def process_assign_other(self, lhs, rhs, evaluation, tags=None, upset=False):
     )
     lhs_name = lhs.get_name()
     if lhs_name == "System`$RecursionLimit":
-        process_assign_recursion_limit(self, lhs, rhs, evaluation, tags, upset)
+        process_assign_recursion_limit(lhs, rhs, evaluation)
     elif lhs_name in ("System`$Line", "System`$HistoryLength"):
         process_assign_line_number_and_history_length(
             self, lhs, rhs, evaluation, tags, upset
         )
     elif lhs_name == "System`$IterationLimit":
-        process_assign_iteration_limit(self, lhs, rhs, evaluation, tags, upset)
+        process_assign_iteration_limit(lhs, rhs, evaluation)
     elif lhs_name == "System`$ModuleNumber":
-        process_assign_module_number(self, lhs, rhs, evaluation, tags, upset)
+        process_assign_module_number(lhs, rhs, evaluation)
     elif lhs_name == "System`$MinPrecision":
         process_assign_minprecision(self, lhs, rhs, evaluation, tags, upset)
     elif lhs_name == "System`$MaxPrecision":

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -11,9 +11,8 @@ from mathics.core.attributes import hold_all, hold_all_complete, protected
 class RecursionLimit(Predefined):
     """
     <dl>
-    <dt>'$RecursionLimit'
-        <dd>specifies the maximum allowable recursion depth after
-        which a calculation is terminated.
+      <dt>'$RecursionLimit'
+      <dd>specifies the maximum allowable recursion depth after which a calculation is terminated.
     </dl>
 
     Calculations terminated by '$RecursionLimit' return '$Aborted':

--- a/test/builtin/test_assignment.py
+++ b/test/builtin/test_assignment.py
@@ -242,3 +242,33 @@ def test_predecrement():
 
 def test_assign_list():
     check_evaluation("G[x_Real]=x^2; a={G[x]}; {x=1.; a, x=.; a}", "{{1.}, {G[x]}}")
+
+
+def test_process_assign_other():
+    # FIXME: beef up check_evaluation so it allows regexps in matching.
+    # Then this code would be less fragile.
+    for prefix in ("", "System`"):
+        for kind, suffix in (
+            (
+                "Recursion",
+                "512; use the MATHICS_MAX_RECURSION_DEPTH environment variable to allow higher limits",
+            ),
+            ("Iteration", "Infinity"),
+        ):
+            limit = f"${kind}Limit"
+            check_evaluation(f"{prefix}{limit} = 511", "511")
+            check_evaluation(
+                f"{prefix}{limit} = 2",
+                "2",
+                expected_messages=[
+                    f"Cannot set {limit} to 2; value must be an integer between 20 and {suffix}."
+                ],
+            )
+        check_evaluation(f"{prefix}$ModuleNumber = 3", "3")
+        check_evaluation(
+            f"{prefix}$ModuleNumber = -1",
+            "-1",
+            expected_messages=[
+                "Cannot set $ModuleNumber to -1; value must be a positive integer."
+            ],
+        )


### PR DESCRIPTION
In particular:
* process_assign_recursion_limit
* process_assign_iteration_limit
* process_assign_module_number

only take 3 args, not 6

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/388"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

