### PR TITLE
Reverse Cython default.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build:
     env:
-      NO_CYTHON: 1
       LDFLAGS: "-L/usr/local/opt/llvm@11/lib"
       CPPFLAGS: "-I/usr/local/opt/llvm@11/include"
     runs-on: macos-latest

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    env:
+      USE_CYTHON: 1
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   build:
-    env:
-      NO_CYTHON: 1
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   build:
-    env:
-      NO_CYTHON: 1
     runs-on: windows-latest
     strategy:
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ try:
 except ImportError:
     pass
 else:
-    if not os.environ.get("NO_CYTHON", False):
+    if os.environ.get("USE_CYTHON", False):
         print("Running Cython over code base")
         EXTENSIONS_DICT = {
             "core": (


### PR DESCRIPTION
Note that for Pyston this slow things down.
For PyPy we can't use it either.

There is benefit in doing this over CPython (probably up to 3.9), but
since it takes minutes to run Cython, for development this often isn't a
big win since it can happen that files you are working on change and so you'll need to
run again, with the 2 minutes again. Or files will stale, sometimes
inadvertently.

So running Cython is worth the effort before building a
wheel (i.e. before release) or using in a docker container.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/398"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

