### PR TITLE
Add more conversion modules

### DIFF
--- a/mathics/algorithm/optimizers.py
+++ b/mathics/algorithm/optimizers.py
@@ -14,11 +14,10 @@ from mathics.core.atoms import (
     Integer2,
     Integer3,
     Integer10,
-    MachineReal,
     Number,
     Real,
-    from_python,
 )
+from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Evaluation
 from mathics.core.evaluators import apply_N
 from mathics.core.expression import Expression

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -31,9 +31,9 @@ from mathics.core.atoms import (
     Rational,
     Real,
     String,
-    from_mpmath,
 )
 from mathics.core.convert.expression import to_expression
+from mathics.core.convert.mpmath import from_mpmath
 from mathics.core.expression import ElementsProperties, Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -35,11 +35,11 @@ from mathics.core.atoms import (
     Rational,
     Real,
     String,
-    from_mpmath,
     from_python,
 )
-from mathics.core.convert.sympy import from_sympy, SympyExpression, sympy_symbol_prefix
 from mathics.core.convert.expression import to_expression
+from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.sympy import from_sympy, SympyExpression, sympy_symbol_prefix
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.number import min_prec, dps, SpecialValueError

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -35,10 +35,10 @@ from mathics.core.atoms import (
     Rational,
     Real,
     String,
-    from_python,
 )
 from mathics.core.convert.expression import to_expression
 from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy, SympyExpression, sympy_symbol_prefix
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression

--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -29,15 +29,15 @@ from mathics.core.atoms import (
     Rational,
     Real,
     SymbolDivide,
-    from_python,
 )
 from mathics.core.attributes import (
     listable,
     protected,
 )
+from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.evaluators import apply_N
 from mathics.core.expression import Expression
-from mathics.core.convert.expression import to_mathics_list
 from mathics.core.list import ListExpression
 from mathics.core.number import (
     dps,

--- a/mathics/builtin/colors/color_directives.py
+++ b/mathics/builtin/colors/color_directives.py
@@ -19,9 +19,9 @@ from mathics.core.atoms import (
     Real,
     MachineReal,
     String,
-    from_python,
 )
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.element import ImmutableValueMixin
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression

--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -17,12 +17,12 @@ from mathics.core.atoms import (
     String,
 )
 from mathics.core.attributes import hold_all, protected
-from mathics.core.atoms import from_python
+from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.element import ImmutableValueMixin
 from mathics.core.evaluation import Evaluation
 from mathics.core.evaluators import apply_N
 from mathics.core.expression import Expression, SymbolCompiledFunction
-from mathics.core.convert.expression import to_mathics_list
 from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolBlank,

--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -16,9 +16,10 @@ from datetime import datetime, timedelta
 import dateutil.parser
 
 from mathics.builtin.base import Builtin, Predefined
-from mathics.core.atoms import Integer, Real, String, from_python
+from mathics.core.atoms import Integer, Real, String
 from mathics.core.attributes import hold_all, no_attributes, protected, read_protected
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.evaluation import TimeoutInterrupt, run_with_timeout_and_stack
 from mathics.core.element import ImmutableValueMixin
 from mathics.core.expression import Expression

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -39,10 +39,10 @@ from mathics.core.atoms import (
     Rational,
     Real,
     SymbolDivide,
-    from_python,
 )
-from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.python import from_python
+from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolNull, SymbolTrue
 from mathics.core.systemsymbols import SymbolRule, SymbolSimplify

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -25,11 +25,11 @@ from mathics.core.atoms import (
     Integer,
     Integer0,
     Integer1,
-    from_python,
 )
 from mathics.core.attributes import hold_all, protected
-from mathics.core.evaluators import apply_N
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
+from mathics.core.evaluators import apply_N
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolList, SymbolN, SymbolPower, SymbolTrue

--- a/mathics/builtin/fileformats/htmlformat.py
+++ b/mathics/builtin/fileformats/htmlformat.py
@@ -9,15 +9,15 @@ Basic implementation for a HTML importer
 """
 
 
-from mathics.builtin.base import Builtin
+from mathics.builtin.base import Builtin, MessageException
 from mathics.builtin.files_io.files import MathicsOpen
+from mathics.core.atoms import String
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
-from mathics.core.atoms import String, from_python
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolRule
-from mathics.builtin.base import MessageException
 
 from io import BytesIO
 import platform

--- a/mathics/builtin/fileformats/xmlformat.py
+++ b/mathics/builtin/fileformats/xmlformat.py
@@ -7,8 +7,9 @@ XML
 
 from mathics.builtin.base import Builtin
 from mathics.builtin.files_io.files import MathicsOpen
-from mathics.core.atoms import String, from_python
+from mathics.core.atoms import String
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolFailed

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -19,7 +19,6 @@ from itertools import chain
 
 
 from mathics_scanner import TranslateError
-from mathics.core.parser import MathicsFileLineFeeder, parse
 from mathics.core import read
 from mathics.core.atoms import (
     Complex,
@@ -27,11 +26,12 @@ from mathics.core.atoms import (
     MachineReal,
     Real,
     String,
-    from_python,
 )
 from mathics.core.convert.expression import to_expression, to_mathics_list
 from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.python import from_python
 from mathics.core.expression import BoxError, Expression
+from mathics.core.parser import MathicsFileLineFeeder, parse
 from mathics.core.symbols import Symbol, SymbolNull, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolDirectedInfinity,

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -27,10 +27,10 @@ from mathics.core.atoms import (
     MachineReal,
     Real,
     String,
-    from_mpmath,
     from_python,
 )
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.mpmath import from_mpmath
 from mathics.core.expression import BoxError, Expression
 from mathics.core.symbols import Symbol, SymbolNull, SymbolTrue
 from mathics.core.systemsymbols import (

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -18,7 +18,7 @@ from mathics.builtin.files_io.files import INITIAL_DIR  # noqa is used via globa
 from mathics.builtin.files_io.files import DIRECTORY_STACK, MathicsOpen
 from mathics.builtin.string.operations import Hash
 
-from mathics.core.atoms import Integer, Real, String, from_python
+from mathics.core.atoms import Integer, Real, String
 from mathics.core.attributes import (
     listable,
     locked,
@@ -27,6 +27,7 @@ from mathics.core.attributes import (
     read_protected,
 )
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.streams import (
     HOME_DIR,

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -23,13 +23,11 @@ from mathics.builtin.base import (
 
 from mathics.builtin.pymimesniffer import magic
 
-from mathics.core.atoms import (
-    ByteArrayAtom,
-    from_python,
-)
+from mathics.core.atoms import ByteArrayAtom
 from mathics.core.attributes import no_attributes, protected, read_protected
 from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.list import ListExpression
 from mathics.core.streams import stream_manager
 from mathics.core.symbols import (

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -56,7 +56,6 @@ from mathics.core.atoms import (
     Number,
     Real,
     String,
-    from_python,
     machine_precision,
     min_prec,
 )
@@ -68,9 +67,10 @@ from mathics.core.attributes import (
     protected,
     read_protected,
 )
+from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.evaluators import apply_N
-from mathics.core.convert.expression import to_expression, to_mathics_list
 from mathics.core.expression import Expression, structure
 
 from mathics.core.interrupt import BreakInterrupt, ContinueInterrupt, ReturnInterrupt

--- a/mathics/builtin/manipulate.py
+++ b/mathics/builtin/manipulate.py
@@ -4,8 +4,9 @@
 from mathics import settings
 
 from mathics.builtin.base import Builtin
-from mathics.core.atoms import Integer, String, from_python
+from mathics.core.atoms import Integer, String
 from mathics.core.attributes import hold_all, protected
+from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Output
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -38,7 +38,6 @@ from mathics.core.atoms import (
     Number,
     Rational,
     Real,
-    from_python,
 )
 from mathics.core.attributes import (
     constant,
@@ -49,6 +48,7 @@ from mathics.core.attributes import (
     read_protected,
 )
 from mathics.core.convert.expression import to_expression, to_mathics_list
+from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import sympy_symbol_prefix, SympyExpression, from_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.evaluators import apply_N

--- a/mathics/builtin/numbers/exptrig.py
+++ b/mathics/builtin/numbers/exptrig.py
@@ -22,9 +22,9 @@ from mathics.core.atoms import (
     Integer0,
     IntegerM1,
     Real,
-    from_python,
 )
 from mathics.core.attributes import listable, numeric_function, protected
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolPower

--- a/mathics/builtin/numbers/linalg.py
+++ b/mathics/builtin/numbers/linalg.py
@@ -10,10 +10,11 @@ from mpmath import mp
 
 
 from mathics.builtin.base import Builtin
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.atoms import Integer, Integer0, Real
 from mathics.core.expression import Expression
-from mathics.core.atoms import Integer, Integer0, Real, from_mpmath
 from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.sympy import from_sympy
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (
     Symbol,

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -15,7 +15,6 @@ from mathics.core.atoms import (
     Integer10,
     Rational,
     SymbolDivide,
-    from_python,
 )
 from mathics.core.attributes import (
     listable,
@@ -25,6 +24,7 @@ from mathics.core.attributes import (
     read_protected,
 )
 from mathics.core.convert.sympy import from_sympy, SympyPrime
+from mathics.core.convert.python import from_python
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.evaluators import apply_N
 from mathics.core.expression import Expression

--- a/mathics/builtin/optimization.py
+++ b/mathics/builtin/optimization.py
@@ -13,8 +13,9 @@ import sympy
 
 from mathics.builtin.base import Builtin
 
-from mathics.core.atoms import IntegerM1, from_python
+from mathics.core.atoms import IntegerM1
 from mathics.core.attributes import constant, protected, read_protected
+from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression

--- a/mathics/builtin/physchemdata.py
+++ b/mathics/builtin/physchemdata.py
@@ -15,8 +15,8 @@ from mathics.builtin.base import Builtin
 from mathics.core.atoms import (
     Integer,
     String,
-    from_python,
 )
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol, strip_context
 

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -15,8 +15,9 @@ from mathics.builtin.base import Builtin, BinaryOperator
 from mathics.builtin.lists import _IterationFunction
 from mathics.builtin.patterns import match
 
-from mathics.core.atoms import Integer1, from_python
+from mathics.core.atoms import Integer1
 from mathics.core.attributes import hold_all, hold_rest, protected, read_protected
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.interrupt import (
     AbortInterrupt,

--- a/mathics/builtin/specialfns/bessel.py
+++ b/mathics/builtin/specialfns/bessel.py
@@ -7,7 +7,7 @@ import mpmath
 
 from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.builtin.base import Builtin
-from mathics.core.atoms import from_mpmath
+from mathics.core.convert.mpmath import from_mpmath
 from mathics.core.number import machine_precision, get_precision, PrecisionValueError
 from mathics.core.number import prec as _prec
 

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -16,14 +16,14 @@ from mathics.core.atoms import (
     Integer0,
     Integer1,
     Number,
-    from_mpmath,
     from_python,
 )
 from mathics.core.attributes import listable, numeric_function, protected
-from mathics.core.number import min_prec, dps
-from mathics.core.convert.sympy import from_sympy
 from mathics.core.expression import Expression
 from mathics.core.evaluators import apply_N
+from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.sympy import from_sympy
+from mathics.core.number import min_prec, dps
 from mathics.core.symbols import Symbol, SymbolSequence
 from mathics.core.systemsymbols import (
     SymbolAutomatic,

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -16,13 +16,13 @@ from mathics.core.atoms import (
     Integer0,
     Integer1,
     Number,
-    from_python,
 )
 from mathics.core.attributes import listable, numeric_function, protected
+from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.python import from_python
+from mathics.core.convert.sympy import from_sympy
 from mathics.core.expression import Expression
 from mathics.core.evaluators import apply_N
-from mathics.core.convert.mpmath import from_mpmath
-from mathics.core.convert.sympy import from_sympy
 from mathics.core.number import min_prec, dps
 from mathics.core.symbols import Symbol, SymbolSequence
 from mathics.core.systemsymbols import (

--- a/mathics/builtin/specialfns/zeta.py
+++ b/mathics/builtin/specialfns/zeta.py
@@ -8,7 +8,7 @@ import mpmath
 
 
 from mathics.builtin.arithmetic import _MPMathFunction
-from mathics.core.atoms import from_mpmath
+from mathics.core.convert.mpmath import from_mpmath
 
 
 class LerchPhi(_MPMathFunction):

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -30,7 +30,6 @@ from mathics.core.atoms import (
     Integer,
     Integer1,
     String,
-    from_python,
 )
 from mathics.core.attributes import (
     flat,
@@ -39,6 +38,7 @@ from mathics.core.attributes import (
     protected,
     read_protected,
 )
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression, string_list
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -15,7 +15,6 @@ from functools import lru_cache
 from mathics.core.element import ImmutableValueMixin
 from mathics.core.number import (
     dps,
-    get_type,
     prec,
     min_prec,
     machine_digits,
@@ -23,11 +22,9 @@ from mathics.core.number import (
 )
 from mathics.core.symbols import (
     Atom,
-    BaseElement,
     NumericOperators,
     Symbol,
     SymbolDivide,
-    SymbolFalse,
     SymbolFullForm,
     SymbolHoldForm,
     SymbolNull,
@@ -41,7 +38,6 @@ from mathics.core.systemsymbols import (
     SymbolComplex,
     SymbolMinus,
     SymbolRational,
-    SymbolRule,
 )
 
 # Imperical number that seems to work.
@@ -891,63 +887,3 @@ class StringFromPython(String):
         if math.inf == value:
             self.value = "math.inf"
         return self
-
-
-# FIXME: it would be nice to be able to move this out of Atom
-def from_python(arg):
-    """Converts a Python expression into a Mathics expression.
-
-    TODO: I think there are number of subtleties to be explained here.
-    In particular, the expression might beeen the result of evaluation
-    a sympy expression which contains sympy symbols.
-
-    If the end result is to go back into Mathics for further
-    evaluation, then probably no problem.  However if the end result
-    is produce say a Python string, then at a minimum we may want to
-    convert backtick (context) symbols into some Python identifier
-    symbol like underscore.
-    """
-    from mathics.core.convert.expression import to_mathics_list
-    from mathics.core.expression import Expression
-    from mathics.core.list import ListExpression
-
-    if isinstance(arg, BaseElement):
-        return arg
-
-    number_type = get_type(arg)
-    if arg is None:
-        return SymbolNull
-    if isinstance(arg, bool):
-        return SymbolTrue if arg else SymbolFalse
-    if isinstance(arg, int) or number_type == "z":
-        return Integer(arg)
-    elif isinstance(arg, float) or number_type == "f":
-        return Real(arg)
-    elif number_type == "q":
-        return Rational(arg)
-    elif isinstance(arg, complex):
-        return Complex(Real(arg.real), Real(arg.imag))
-    elif number_type == "c":
-        return Complex(arg.real, arg.imag)
-    elif isinstance(arg, str):
-        return String(arg)
-        # if arg[0] == arg[-1] == '"':
-        #     return String(arg[1:-1])
-        # else:
-        #     return Symbol(arg)
-    elif isinstance(arg, dict):
-        entries = [
-            Expression(
-                SymbolRule,
-                from_python(key),
-                from_python(arg[key]),
-            )
-            for key in arg
-        ]
-        return ListExpression(*entries)
-    elif isinstance(arg, list) or isinstance(arg, tuple):
-        return to_mathics_list(*arg, elements_conversion_fn=from_python)
-    elif isinstance(arg, bytearray) or isinstance(arg, bytes):
-        return Expression(SymbolByteArray, ByteArrayAtom(arg))
-    else:
-        raise NotImplementedError

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -53,25 +53,6 @@ SymbolI = Symbol("I")
 SYSTEM_SYMBOLS_INPUT_OR_FULL_FORM = system_symbols("InputForm", "FullForm")
 
 
-@lru_cache(maxsize=1024)
-def from_mpmath(value, prec=None):
-    "Converts mpf or mpc to Number."
-    if isinstance(value, mpmath.mpf):
-        if prec is None:
-            return MachineReal(float(value))
-        else:
-            # HACK: use str here to prevent loss of precision
-            return PrecisionReal(sympy.Float(str(value), prec))
-    elif isinstance(value, mpmath.mpc):
-        if value.imag == 0.0:
-            return from_mpmath(value.real, prec)
-        real = from_mpmath(value.real, prec)
-        imag = from_mpmath(value.imag, prec)
-        return Complex(real, imag)
-    else:
-        raise TypeError(type(value))
-
-
 class Number(Atom, ImmutableValueMixin, NumericOperators):
     """
     Different kinds of Mathics Numbers, the main built-in subclasses
@@ -912,6 +893,7 @@ class StringFromPython(String):
         return self
 
 
+# FIXME: it would be nice to be able to move this out of Atom
 def from_python(arg):
     """Converts a Python expression into a Mathics expression.
 

--- a/mathics/core/convert/expression.py
+++ b/mathics/core/convert/expression.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import Any, Callable, Union
 
-from mathics.core.atoms import from_python
+from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression, convert_expression_elements
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolList

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+import mpmath
+import sympy
+from functools import lru_cache
+from mathics.core.atoms import (
+    Complex,
+    MachineReal,
+    PrecisionReal,
+)
+
+
+@lru_cache(maxsize=1024)
+def from_mpmath(value, prec=None):
+    "Converts mpf or mpc to Number."
+    if isinstance(value, mpmath.mpf):
+        if prec is None:
+            return MachineReal(float(value))
+        else:
+            # HACK: use str here to prevent loss of precision
+            return PrecisionReal(sympy.Float(str(value), prec))
+    elif isinstance(value, mpmath.mpc):
+        if value.imag == 0.0:
+            return from_mpmath(value.real, prec)
+        real = from_mpmath(value.real, prec)
+        imag = from_mpmath(value.imag, prec)
+        return Complex(real, imag)
+    else:
+        raise TypeError(type(value))

--- a/mathics/core/convert/python.py
+++ b/mathics/core/convert/python.py
@@ -1,0 +1,75 @@
+from mathics.core.number import get_type
+
+from mathics.core.atoms import (
+    Complex,
+    Integer,
+    Real,
+    Rational,
+    String,
+)
+from mathics.core.symbols import (
+    BaseElement,
+    SymbolFalse,
+    SymbolNull,
+    SymbolTrue,
+)
+from mathics.core.systemsymbols import SymbolRule
+
+
+def from_python(arg):
+    """Converts a Python expression into a Mathics expression.
+
+    TODO: I think there are number of subtleties to be explained here.
+    In particular, the expression might beeen the result of evaluation
+    a sympy expression which contains sympy symbols.
+
+    If the end result is to go back into Mathics for further
+    evaluation, then probably no problem.  However if the end result
+    is produce say a Python string, then at a minimum we may want to
+    convert backtick (context) symbols into some Python identifier
+    symbol like underscore.
+    """
+    from mathics.core.convert.expression import to_mathics_list
+    from mathics.core.expression import Expression
+    from mathics.core.list import ListExpression
+
+    if isinstance(arg, BaseElement):
+        return arg
+
+    number_type = get_type(arg)
+    if arg is None:
+        return SymbolNull
+    if isinstance(arg, bool):
+        return SymbolTrue if arg else SymbolFalse
+    if isinstance(arg, int) or number_type == "z":
+        return Integer(arg)
+    elif isinstance(arg, float) or number_type == "f":
+        return Real(arg)
+    elif number_type == "q":
+        return Rational(arg)
+    elif isinstance(arg, complex):
+        return Complex(Real(arg.real), Real(arg.imag))
+    elif number_type == "c":
+        return Complex(arg.real, arg.imag)
+    elif isinstance(arg, str):
+        return String(arg)
+        # if arg[0] == arg[-1] == '"':
+        #     return String(arg[1:-1])
+        # else:
+        #     return Symbol(arg)
+    elif isinstance(arg, dict):
+        entries = [
+            Expression(
+                SymbolRule,
+                from_python(key),
+                from_python(arg[key]),
+            )
+            for key in arg
+        ]
+        return ListExpression(*entries)
+    elif isinstance(arg, list) or isinstance(arg, tuple):
+        return to_mathics_list(*arg, elements_conversion_fn=from_python)
+    elif isinstance(arg, bytearray) or isinstance(arg, bytes):
+        return Expression(SymbolByteArray, ByteArrayAtom(arg))
+    else:
+        raise NotImplementedError

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -14,7 +14,8 @@ from mathics_scanner import TranslateError
 
 from mathics import settings
 
-from mathics.core.atoms import from_python, Integer, String
+from mathics.core.atoms import Integer, String
+from mathics.core.convert.python import from_python
 from mathics.core.element import KeyComparable, ensure_context
 from mathics.core.interrupt import (
     AbortInterrupt,
@@ -533,7 +534,7 @@ class Evaluation:
         self.output.out(self.out[-1])
 
     def print_out(self, text) -> None:
-        from mathics.core.atoms import from_python
+        from mathics.core.convert.python import from_python
 
         if self.definitions.trace_evaluation:
             self.definitions.trace_evaluation = False

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Iterable, Optional, Tuple
 from itertools import chain
 from bisect import bisect_left
 
-from mathics.core.atoms import from_python, Number, Integer, String
+from mathics.core.atoms import Integer, Number, String
 
 # FIXME: adjust mathics.core.attributes to uppercase attribute names
 from mathics.core.attributes import (
@@ -26,6 +26,7 @@ from mathics.core.attributes import (
     sequence_hold as SEQUENCE_HOLD,
 )
 from mathics.core.convert.sympy import sympy_symbol_prefix, SympyExpression
+from mathics.core.convert.python import from_python
 from mathics.core.element import ensure_context, ElementsProperties
 from mathics.core.evaluation import Evaluation
 from mathics.core.interrupt import ReturnInterrupt

--- a/test/core/test_sympy_python_convert.py
+++ b/test/core/test_sympy_python_convert.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
-
+import random
 import sympy
+import sys
+import unittest
+
 from mathics.core.symbols import Symbol
 from mathics.core.atoms import (
-    from_python,
     Complex,
     Integer,
     Integer0,
@@ -14,6 +16,7 @@ from mathics.core.atoms import (
     Real,
     String,
 )
+from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -25,9 +28,6 @@ from mathics.core.systemsymbols import (
     SymbolIntegrate,
     SymbolSin,
 )
-import random
-import sys
-import unittest
 
 
 class SympyConvert(unittest.TestCase):


### PR DESCRIPTION
Move out of atom the conversion modules to mathics.core.convert

Conceptually and organizationally this helps me out. I think it also reduces the likelihood of circular imports. Smaller more self-contained modules. In general conversion modules pull in a lot. The basic class types like Expression and the kinds of Atoms should not be pulling in a lot. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/399"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

