### PR TITLE
Removing conversions from Expression.__init__

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -398,11 +398,11 @@ class Plus(BinaryOperator, SympyFunction):
             else:
                 count = rest = None
                 if item.has_form("Times", None):
-                    for leaf in item.elements:
-                        if isinstance(leaf, Number):
-                            count = leaf.to_sympy()
+                    for element in item.elements:
+                        if isinstance(element, Number):
+                            count = element.to_sympy()
                             rest = item.get_mutable_elements()
-                            rest.remove(leaf)
+                            rest.remove(element)
                             if len(rest) == 1:
                                 rest = rest[0]
                             else:

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -73,7 +73,7 @@ def build_rulopc(optval):
 
 def get_symbol_list(list, error_callback):
     if list.has_form("List", None):
-        list = list.leaves
+        list = list.elements
     else:
         list = [list]
     values = []
@@ -152,12 +152,12 @@ def rejected_because_protected(self, lhs, tag, evaluation, ignore=False):
 
 def find_tag_and_check(lhs, tags, evaluation):
     name = lhs.get_head_name()
-    if len(lhs.leaves) != 1:
-        evaluation.message_args(name, len(lhs.leaves), 1)
+    if len(lhs.elements) != 1:
+        evaluation.message_args(name, len(lhs.elements), 1)
         raise AssignmentException(lhs, None)
-    tag = lhs.leaves[0].get_name()
+    tag = lhs.elements[0].get_name()
     if not tag:
-        evaluation.message(name, "sym", lhs.leaves[0], 1)
+        evaluation.message(name, "sym", lhs.elements[0], 1)
         raise AssignmentException(lhs, None)
     if tags is not None and tags != [tag]:
         evaluation.message(name, "tag", Symbol(name), Symbol(tag))
@@ -194,7 +194,7 @@ def unroll_conditions(lhs):
     condition = []
     # This handle the case of many sucesive conditions:
     # f[x_]/; cond1 /; cond2 ... ->  f[x_]/; And[cond1, cond2, ...]
-    while name == "System`Condition" and len(lhs.leaves) == 2:
+    while name == "System`Condition" and len(lhs.elements) == 2:
         condition.append(lhs_elements[1])
         lhs = lhs_elements[0]
         if isinstance(lhs, Atom):
@@ -331,7 +331,7 @@ def process_assign_minprecision(self, lhs, rhs, evaluation, tags, upset):
 def process_assign_maxprecision(self, lhs, rhs, evaluation, tags, upset):
     lhs_name = lhs.get_name()
     rhs_int_value = rhs.get_int_value()
-    if rhs.has_form("DirectedInfinity", 1) and rhs.leaves[0].get_int_value() == 1:
+    if rhs.has_form("DirectedInfinity", 1) and rhs.elements[0].get_int_value() == 1:
         return False
     elif rhs_int_value is not None and rhs_int_value > 0:
         min_prec = evaluation.definitions.get_config_value("$MinPrecision")
@@ -356,7 +356,7 @@ def process_assign_definition_values(self, lhs, rhs, evaluation, tags, upset):
 
 
 def process_assign_options(self, lhs, rhs, evaluation, tags, upset):
-    lhs_elements = lhs.leaves
+    lhs_elements = lhs.elements
     name = lhs.get_head_name()
     if len(lhs_elements) != 1:
         evaluation.message_args(name, len(lhs_elements), 1)
@@ -411,14 +411,14 @@ def process_assign_n(self, lhs, rhs, evaluation, tags, upset):
     if lhs is SymbolN:
         return assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset)
 
-    if len(lhs.leaves) not in (1, 2):
-        evaluation.message_args("N", len(lhs.leaves), 1, 2)
+    if len(lhs.elements) not in (1, 2):
+        evaluation.message_args("N", len(lhs.elements), 1, 2)
         raise AssignmentException(lhs, None)
-    if len(lhs.leaves) == 1:
+    if len(lhs.elements) == 1:
         nprec = SymbolMachinePrecision
     else:
-        nprec = lhs.leaves[1]
-    focus = lhs.leaves[0]
+        nprec = lhs.elements[1]
+    focus = lhs.elements[0]
     lhs = Expression(SymbolN, focus, nprec)
     tags = process_tags_and_upset_dont_allow_custom(
         tags, upset, self, lhs, focus, evaluation
@@ -460,12 +460,12 @@ def process_assign_other(self, lhs, rhs, evaluation, tags=None, upset=False):
 
 def process_assign_attributes(self, lhs, rhs, evaluation, tags, upset):
     name = lhs.get_head_name()
-    if len(lhs.leaves) != 1:
-        evaluation.message_args(name, len(lhs.leaves), 1)
+    if len(lhs.elements) != 1:
+        evaluation.message_args(name, len(lhs.elements), 1)
         raise AssignmentException(lhs, rhs)
-    tag = lhs.leaves[0].get_name()
+    tag = lhs.elements[0].get_name()
     if not tag:
-        evaluation.message(name, "sym", lhs.leaves[0], 1)
+        evaluation.message(name, "sym", lhs.elements[0], 1)
         raise AssignmentException(lhs, rhs)
     if tags is not None and tags != [tag]:
         evaluation.message(name, "tag", Symbol(name), Symbol(tag))
@@ -503,10 +503,10 @@ def process_assign_default(self, lhs, rhs, evaluation, tags, upset):
     count = 0
     defs = evaluation.definitions
 
-    if len(lhs.leaves) not in (1, 2, 3):
-        evaluation.message_args(SymbolDefault, len(lhs.leaves), 1, 2, 3)
+    if len(lhs.elements) not in (1, 2, 3):
+        evaluation.message_args(SymbolDefault, len(lhs.elements), 1, 2, 3)
         raise AssignmentException(lhs, None)
-    focus = lhs.leaves[0]
+    focus = lhs.elements[0]
     tags = process_tags_and_upset_dont_allow_custom(
         tags, upset, self, lhs, focus, evaluation
     )
@@ -526,13 +526,13 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
     count = 0
     defs = evaluation.definitions
 
-    if len(lhs.leaves) not in (1, 2):
-        evaluation.message_args("Format", len(lhs.leaves), 1, 2)
+    if len(lhs.elements) not in (1, 2):
+        evaluation.message_args("Format", len(lhs.elements), 1, 2)
         raise AssignmentException(lhs, None)
-    if len(lhs.leaves) == 2:
-        form = lhs.leaves[1].get_name()
+    if len(lhs.elements) == 2:
+        form = lhs.elements[1].get_name()
         if not form:
-            evaluation.message("Format", "fttp", lhs.leaves[1])
+            evaluation.message("Format", "fttp", lhs.elements[1])
             raise AssignmentException(lhs, None)
     else:
         form = system_symbols(
@@ -543,7 +543,7 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
             "MathMLForm",
         )
         form = [f.name for f in form]
-    lhs = focus = lhs.leaves[0]
+    lhs = focus = lhs.elements[0]
     tags = process_tags_and_upset_dont_allow_custom(
         tags, upset, self, lhs, focus, evaluation
     )
@@ -562,10 +562,10 @@ def process_assign_messagename(self, lhs, rhs, evaluation, tags, upset):
     lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
     count = 0
     defs = evaluation.definitions
-    if len(lhs.leaves) != 2:
-        evaluation.message_args("MessageName", len(lhs.leaves), 2)
+    if len(lhs.elements) != 2:
+        evaluation.message_args("MessageName", len(lhs.elements), 2)
         raise AssignmentException(lhs, None)
-    focus = lhs.leaves[0]
+    focus = lhs.elements[0]
     tags = process_tags_and_upset_dont_allow_custom(
         tags, upset, self, lhs, focus, evaluation
     )
@@ -585,13 +585,15 @@ def process_rhs_conditions(lhs, rhs, condition, evaluation):
     rulopc = build_rulopc(lhs.get_head())
     rhs_name = rhs.get_head_name()
     while rhs_name == "System`Condition":
-        if len(rhs.leaves) != 2:
-            evaluation.message_args("Condition", len(rhs.leaves), 2)
+        if len(rhs.elements) != 2:
+            evaluation.message_args("Condition", len(rhs.elements), 2)
             raise AssignmentException(lhs, None)
         lhs = Expression(
-            SymbolCondition, lhs, rhs.leaves[1].do_apply_rules([rulopc], evaluation)[0]
+            SymbolCondition,
+            lhs,
+            rhs.elements[1].do_apply_rules([rulopc], evaluation)[0],
         )
-        rhs = rhs.leaves[0]
+        rhs = rhs.elements[0]
         rhs_name = rhs.get_head_name()
 
     # Now, let's add the conditions on the LHS
@@ -599,7 +601,7 @@ def process_rhs_conditions(lhs, rhs, condition, evaluation):
         lhs = Expression(
             SymbolCondition,
             lhs,
-            condition.leaves[1].do_apply_rules([rulopc], evaluation)[0],
+            condition.elements[1].do_apply_rules([rulopc], evaluation)[0],
         )
     return lhs, rhs
 
@@ -649,8 +651,8 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
         if isinstance(focus, Atom):
             evaluation.message(self.get_name(), "normal")
             raise AssignmentException(lhs, None)
-        for leaf in focus.leaves:
-            name = leaf.get_lookup_name()
+        for element in focus.elements:
+            name = element.get_lookup_name()
             tags.append(name)
     else:
         allowed_names = [focus.get_lookup_name()]
@@ -658,18 +660,18 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
             if not isinstance(element, Symbol) and element.get_head_name() in (
                 "System`HoldPattern",
             ):
-                element = element.leaves[0]
+                element = element.elements[0]
             if not isinstance(element, Symbol) and element.get_head_name() in (
                 "System`Pattern",
             ):
-                element = element.leaves[1]
+                element = element.elements[1]
             if not isinstance(element, Symbol) and element.get_head_name() in (
                 "System`Blank",
                 "System`BlankSequence",
                 "System`BlankNullSequence",
             ):
-                if len(element.leaves) == 1:
-                    element = element.leaves[0]
+                if len(element.elements) == 1:
+                    element = element.elements[0]
 
             allowed_names.append(element.get_lookup_name())
         for name in tags:
@@ -722,23 +724,23 @@ class _SetOperator:
         lhs._format_cache = None
         defs = evaluation.definitions
         if lhs.get_head_name() == "System`List":
-            if not (rhs.get_head_name() == "System`List") or len(lhs.leaves) != len(
-                rhs.leaves
+            if not (rhs.get_head_name() == "System`List") or len(lhs.elements) != len(
+                rhs.elements
             ):  # nopep8
 
                 evaluation.message(self.get_name(), "shape", lhs, rhs)
                 return False
             else:
                 result = True
-                for left, right in zip(lhs.leaves, rhs.leaves):
+                for left, right in zip(lhs.elements, rhs.elements):
                     if not self.assign(left, right, evaluation):
                         result = False
                 return result
         elif lhs.get_head_name() == "System`Part":
-            if len(lhs.leaves) < 1:
+            if len(lhs.elements) < 1:
                 evaluation.message(self.get_name(), "setp", lhs)
                 return False
-            symbol = lhs.leaves[0]
+            symbol = lhs.elements[0]
             name = symbol.get_name()
             if not name:
                 evaluation.message(self.get_name(), "setps", symbol)
@@ -750,7 +752,7 @@ class _SetOperator:
             if rule is None:
                 evaluation.message(self.get_name(), "noval", symbol)
                 return False
-            indices = lhs.leaves[1:]
+            indices = lhs.elements[1:]
             return walk_parts([rule.replace], indices, evaluation, rhs)
         else:
             return self.assign_elementary(lhs, rhs, evaluation)

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -694,7 +694,7 @@ class SympyFunction(SympyObject):
         else:
             return PrecisionReal(sympy_fn.n(d))
 
-    def get_sympy_function(self, leaves=None):
+    def get_sympy_function(self, elements=None):
         if self.sympy_name:
             return getattr(sympy, self.sympy_name)
         return None
@@ -864,11 +864,11 @@ class BoxExpression(BuiltinElement):
     def flatten_with_respect_to_head(self, symbol):
         return self.to_expression().flatten_with_respect_to_head(symbol)
 
-    def get_option_values(self, leaves, **options):
+    def get_option_values(self, elements, **options):
         evaluation = options.get("evaluation", None)
         if evaluation:
             default = evaluation.definitions.get_options(self.get_name()).copy()
-            options = ListExpression(*leaves).get_option_values(evaluation)
+            options = ListExpression(*elements).get_option_values(evaluation)
             default.update(options)
         else:
             from mathics.core.parser import parse_builtin_rule
@@ -914,7 +914,7 @@ class PatternObject(BuiltinElement, Pattern):
                 self.error_args(len(expr.elements), *self.arg_counts)
         self.expr = expr
         self.head = Pattern.create(expr.head)
-        self.leaves = [Pattern.create(element) for element in expr.elements]
+        self.elements = [Pattern.create(element) for element in expr.elements]
 
     def error(self, tag, *args):
         raise PatternError(self.get_name(), tag, *args)

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -82,7 +82,7 @@ def sympy_factor(expr_sympy):
 
 def cancel(expr):
     if expr.has_form("Plus", None):
-        return Expression(SymbolPlus, *[cancel(leaf) for leaf in expr.leaves])
+        return Expression(SymbolPlus, *[cancel(element) for element in expr.elements])
     else:
         try:
             result = expr.to_sympy()

--- a/mathics/builtin/numbers/integer.py
+++ b/mathics/builtin/numbers/integer.py
@@ -461,8 +461,10 @@ class FromDigits(Builtin):
         "FromDigits[l_, b_]"
         if l.get_head_name() == "System`List":
             value = Integer0
-            for leaf in l.leaves:
-                value = Expression(SymbolPlus, Expression(SymbolTimes, value, b), leaf)
+            for element in l.elements:
+                value = Expression(
+                    SymbolPlus, Expression(SymbolTimes, value, b), element
+                )
             return value
         elif isinstance(l, String):
             value = FromDigits._parse_string(l.get_string_value(), b)

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1121,7 +1121,7 @@ class Optional(BinaryOperator, PatternObject):
     ):
         if expression.has_form("Sequence", 0):
             if self.default is None:
-                if head is None:  # head should be given by match_leaf!
+                if head is None:  # head should be given by match_element!
                     default = None
                 else:
                     name = head.get_name()

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -429,7 +429,7 @@ class Definitions:
         packages = self.get_ownvalue("System`$Packages")
         packages = packages.replace
         assert packages.has_form("System`List", None)
-        packages = [c.get_string_value() for c in packages.leaves]
+        packages = [c.get_string_value() for c in packages.elements]
         return packages
 
         # return sorted({name.split("`")[0] for name in self.get_names()})
@@ -773,15 +773,15 @@ def get_tag_position(pattern, name) -> Optional[str]:
         head_name = pattern.get_head_name()
         if head_name == name:
             return "down"
-        elif head_name == "System`N" and len(pattern.leaves) == 2:
+        elif head_name == "System`N" and len(pattern.elements) == 2:
             return "n"
-        elif head_name == "System`Condition" and len(pattern.leaves) > 0:
-            return get_tag_position(pattern.leaves[0], name)
+        elif head_name == "System`Condition" and len(pattern.elements) > 0:
+            return get_tag_position(pattern.elements[0], name)
         elif pattern.get_lookup_name() == name:
             return "sub"
         else:
-            for leaf in pattern.leaves:
-                if leaf.get_lookup_name() == name:
+            for element in pattern.elements:
+                if element.get_lookup_name() == name:
                     return "up"
         return None
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -187,7 +187,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         - *elements - optional: the remaining elements
 
     Keyword Arguments:
-        - element_properties -- properties of the collection of elements
+        - elements_properties -- properties of the collection of elements
     """
 
     head: "Symbol"
@@ -199,9 +199,9 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
     ):
         self.options = None
         self.pattern_sequence = False
-        if isinstance(head, str):
-            # We should fix or convert to to_expression all nonSymbol uses.
-            head = Symbol(head)
+        assert isinstance(head, BaseElement)
+        assert isinstance(elements, tuple)
+        assert all(isinstance(e, BaseElement) for e in elements)
 
         self._head = head
 
@@ -214,12 +214,27 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         # Note: After we make a pass over all Expression() calls, these lines will get removed
         # and replaced with the two commented-out lines below them:
 
-        self._elements, self.elements_properties = convert_expression_elements(
-            elements, from_python
-        )
-        assert isinstance(self._elements, tuple)
-        # self._elements = elements
-        # self.elements_properties = elements_properties
+        # self._elements, self.elements_properties = convert_expression_elements(
+        #    elements, lambda x:x
+        # )
+        # assert isinstance(self._elements, tuple)
+        self._elements = elements
+
+        self._build_elements_properties()
+        #
+        # comment mmatera: I found that in certain cases, the elements_properties
+        # passed as the parameter does not matches with those we generate with build:elements_properties.
+        # This is the cause of the error in the test_series.py pytest.
+        # Once it be fixed, we can uncomment the following code and remove the previous line
+        # assert (elements_properties is None or
+        #        self.elements_properties == elements_properties), ("element properties do not match",
+        #                                                           self, (self.elements_properties,
+        #                                                                  elements_properties)
+        #                                                           )
+        # if elements_properties not is None:
+        #    self.elements_properties = elements_properties
+        # else:
+        #    self._build_elements_properties()
 
         self._sequences = None
         self._cache = None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -195,13 +195,16 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
     _sequences: Any
 
     def __init__(
-        self, head, *elements, elements_properties: Optional[ElementsProperties] = None
+        self,
+        head: BaseElement,
+        *elements,
+        elements_properties: Optional[ElementsProperties] = None
     ):
         self.options = None
         self.pattern_sequence = False
-        assert isinstance(head, BaseElement)
-        assert isinstance(elements, tuple)
-        assert all(isinstance(e, BaseElement) for e in elements)
+        # assert isinstance(head, BaseElement)
+        # assert isinstance(elements, tuple)
+        # assert all(isinstance(e, BaseElement) for e in elements)
 
         self._head = head
 

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -131,7 +131,7 @@ class Pattern:
         return self.expr.get_elements()
 
     # Compatibily with old code. Deprecated, but remove after a little bit
-    get_elements = get_elements
+    get_leaves = get_elements
 
     def get_sort_key(self, pattern_sort=False):
         return self.expr.get_sort_key(pattern_sort=pattern_sort)

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -3,7 +3,7 @@
 # -*- coding: utf-8 -*-
 
 
-from mathics.core.element import ensure_context
+from mathics.core.element import ensure_context, BaseElement
 from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, Symbol, system_symbols
 from mathics.core.systemsymbols import SymbolSequence
@@ -131,7 +131,7 @@ class Pattern:
         return self.expr.get_elements()
 
     # Compatibily with old code. Deprecated, but remove after a little bit
-    get_leaves = get_elements
+    get_elements = get_elements
 
     def get_sort_key(self, pattern_sort=False):
         return self.expr.get_sort_key(pattern_sort=pattern_sort)
@@ -151,14 +151,18 @@ class Pattern:
     def has_form(self, *args):
         return self.expr.has_form(*args)
 
-    def get_match_candidates(self, leaves, expression, attributes, evaluation, vars={}):
+    def get_match_candidates(
+        self, elements, expression, attributes, evaluation, vars={}
+    ):
         return []
 
     def get_match_candidates_count(
-        self, leaves, expression, attributes, evaluation, vars={}
+        self, elements, expression, attributes, evaluation, vars={}
     ):
         return len(
-            self.get_match_candidates(leaves, expression, attributes, evaluation, vars)
+            self.get_match_candidates(
+                elements, expression, attributes, evaluation, vars
+            )
         )
 
 
@@ -189,9 +193,9 @@ class AtomPattern(Pattern):
             yield_func(vars, None)
 
     def get_match_symbol_candidates(
-        self, leaves, expression, attributes, evaluation, vars={}
+        self, elements, expression, attributes, evaluation, vars={}
     ):
-        return [leaf for leaf in leaves if (leaf is self.atom)]
+        return [element for element in elements if (element is self.atom)]
 
     def match(
         self,
@@ -209,11 +213,13 @@ class AtomPattern(Pattern):
             # yield vars, None
             yield_func(vars, None)
 
-    def get_match_candidates(self, leaves, expression, attributes, evaluation, vars={}):
+    def get_match_candidates(
+        self, elements, expression, attributes, evaluation, vars={}
+    ):
         return [
-            leaf
-            for leaf in leaves
-            if (isinstance(leaf, Atom) and leaf.sameQ(self.atom))
+            element
+            for element in elements
+            if (isinstance(element, Atom) and element.sameQ(self.atom))
         ]
 
     def get_match_count(self, vars={}):
@@ -246,17 +252,17 @@ class ExpressionPattern(Pattern):
             fully = True
         if not isinstance(expression, Atom):
             # don't do this here, as self.get_pre_choices changes the
-            # ordering of the leaves!
-            # if self.leaves:
-            #    next_leaf = self.leaves[0]
-            #    next_elements = self.leaves[1:]
+            # ordering of the elements!
+            # if self.elements:
+            #    next_element = self.elements[0]
+            #    next_elements = self.elements[1:]
 
             def yield_choice(pre_vars):
-                next_leaf = self.leaves[0]
-                next_elements = self.leaves[1:]
+                next_element = self.elements[0]
+                next_elements = self.elements[1:]
 
                 # "leading_blanks" below handles expressions with leading Blanks H[x_, y_, ...]
-                # much more efficiently by not calling get_match_candidates_count() on leaves
+                # much more efficiently by not calling get_match_candidates_count() on elements
                 # that have already been matched with one of the leading Blanks. this approach
                 # is only valid for Expressions that are not Orderless (as with Orderless, the
                 # concept of leading items does not exist).
@@ -270,11 +276,11 @@ class ExpressionPattern(Pattern):
                 # without "leading_blanks", Range[5000] will be tested against {a__, b_} in a
                 # call to get_match_candidates_count(), which is slow.
 
-                unmatched_elements = expression.leaves
+                unmatched_elements = expression.elements
                 leading_blanks = not orderless & attributes
 
-                for leaf in self.leaves:
-                    match_count = leaf.get_match_count()
+                for element in self.elements:
+                    match_count = element.get_match_count()
 
                     if leading_blanks:
                         if tuple(match_count) == (
@@ -283,7 +289,7 @@ class ExpressionPattern(Pattern):
                         ):  # Blank? (i.e. length exactly 1?)
                             if not unmatched_elements:
                                 raise StopGenerator_ExpressionPattern_match()
-                            if not leaf.does_match(
+                            if not element.does_match(
                                 unmatched_elements[0], evaluation, pre_vars
                             ):
                                 raise StopGenerator_ExpressionPattern_match()
@@ -292,7 +298,7 @@ class ExpressionPattern(Pattern):
                             leading_blanks = False
 
                     if not leading_blanks:
-                        candidates = leaf.get_match_candidates_count(
+                        candidates = element.get_match_candidates_count(
                             unmatched_elements,
                             expression,
                             attributes,
@@ -302,32 +308,32 @@ class ExpressionPattern(Pattern):
                         if candidates < match_count[0]:
                             raise StopGenerator_ExpressionPattern_match()
 
-                # for new_vars, rest in self.match_leaf(    # nopep8
-                #    self.leaves[0], self.leaves[1:], ([], expression.leaves),
+                # for new_vars, rest in self.match_element(    # nopep8
+                #    self.elements[0], self.elements[1:], ([], expression.elements),
                 #    pre_vars, expression, attributes, evaluation, first=True,
-                #    fully=fully, element_count=len(self.leaves),
+                #    fully=fully, element_count=len(self.elements),
                 #    wrap_oneid=expression.get_head_name() != 'System`MakeBoxes'):
-                # def yield_leaf(new_vars, rest):
+                # def yield_element(new_vars, rest):
                 #    yield_func(new_vars, rest)
-                self.match_leaf(
+                self.match_element(
                     yield_func,
-                    next_leaf,
+                    next_element,
                     next_elements,
-                    ([], expression.leaves),
+                    ([], expression.elements),
                     pre_vars,
                     expression,
                     attributes,
                     evaluation,
                     first=True,
                     fully=fully,
-                    element_count=len(self.leaves),
+                    element_count=len(self.elements),
                     wrap_oneid=expression.get_head_name() != "System`MakeBoxes",
                 )
 
             # for head_vars, _ in self.head.match(expression.get_head(), vars,
             # evaluation):
             def yield_head(head_vars, _):
-                if self.leaves:
+                if self.elements:
                     # pre_choices = self.get_pre_choices(
                     #    expression, attributes, head_vars)
                     # for pre_vars in pre_choices:
@@ -336,7 +342,7 @@ class ExpressionPattern(Pattern):
                         yield_choice, expression, attributes, head_vars
                     )
                 else:
-                    if not expression.leaves:
+                    if not expression.elements:
                         yield_func(head_vars, None)
                     else:
                         return
@@ -355,26 +361,26 @@ class ExpressionPattern(Pattern):
             # and not OneIdentity &
             # (expression.get_attributes(evaluation.definitions) |
             # expression.get_head().get_attributes(evaluation.definitions)):
-            new_expression = Expression(self.head, expression)
-            for leaf in self.leaves:
-                leaf.match_count = leaf.get_match_count()
-                leaf.candidates = [expression]
-                # leaf.get_match_candidates(
-                #    new_expression.leaves, new_expression, attributes,
+            new_expression = Expression(self.head.expr, expression)
+            for element in self.elements:
+                element.match_count = element.get_match_count()
+                element.candidates = [expression]
+                # element.get_match_candidates(
+                #    new_expression.elements, new_expression, attributes,
                 #    evaluation, vars)
-                if len(leaf.candidates) < leaf.match_count[0]:
+                if len(element.candidates) < element.match_count[0]:
                     return
-            # for new_vars, rest in self.match_leaf(
-            #    self.leaves[0], self.leaves[1:],
+            # for new_vars, rest in self.match_element(
+            #    self.elements[0], self.elements[1:],
             #    ([], [expression]), vars, new_expression, attributes,
             #    evaluation, first=True, fully=fully,
-            #    element_count=len(self.leaves), wrap_oneid=True):
-            # def yield_leaf(new_vars, rest):
+            #    element_count=len(self.elements), wrap_oneid=True):
+            # def yield_element(new_vars, rest):
             #    yield_func(new_vars, rest)
-            self.match_leaf(
+            self.match_element(
                 yield_func,
-                self.leaves[0],
-                self.leaves[1:],
+                self.elements[0],
+                self.elements[1:],
                 ([], [expression]),
                 vars,
                 new_expression,
@@ -382,7 +388,7 @@ class ExpressionPattern(Pattern):
                 evaluation,
                 first=True,
                 fully=fully,
-                element_count=len(self.leaves),
+                element_count=len(self.elements),
                 wrap_oneid=True,
             )
 
@@ -393,7 +399,7 @@ class ExpressionPattern(Pattern):
             groups = {}
             prev_pattern = prev_name = None
             for pattern in patterns:
-                name = pattern.leaves[0].get_name()
+                name = pattern.elements[0].get_name()
                 existing = vars.get(name, None)
                 if existing is None:
                     # There's no need for pre-choices if the variable is
@@ -405,12 +411,12 @@ class ExpressionPattern(Pattern):
                             groups[name] = [prev_pattern, pattern]
                     prev_pattern = pattern
                     prev_name = name
-            # prev_leaf = None
+            # prev_element = None
 
-            # count duplicate leaves
+            # count duplicate elements
             expr_groups = {}
-            for leaf in expression.leaves:
-                expr_groups[leaf] = expr_groups.get(leaf, 0) + 1
+            for element in expression.elements:
+                expr_groups[element] = expr_groups.get(element, 0) + 1
 
             def per_name(yield_name, groups, vars):
                 """
@@ -484,12 +490,14 @@ class ExpressionPattern(Pattern):
 
     def __init__(self, expr):
         self.head = Pattern.create(expr.head)
-        self.leaves = [Pattern.create(leaf) for leaf in expr.leaves]
+        self.elements = [Pattern.create(element) for element in expr.elements]
         self.expr = expr
 
     def filter_elements(self, head_name):
         head_name = ensure_context(head_name)
-        return [leaf for leaf in self.leaves if leaf.get_head_name() == head_name]
+        return [
+            element for element in self.elements if element.get_head_name() == head_name
+        ]
 
     def __repr__(self):
         return "<ExpressionPattern: %s>" % self.expr
@@ -522,10 +530,10 @@ class ExpressionPattern(Pattern):
             if flat & attributes and include_flattened:
                 yield_func(Expression(expression.get_head(), *items))
 
-    def match_leaf(
+    def match_element(
         self,
         yield_func,
-        leaf,
+        element,
         rest_elements,
         rest_expression,
         vars,
@@ -545,25 +553,25 @@ class ExpressionPattern(Pattern):
 
         evaluation.check_stopped()
 
-        match_count = leaf.get_match_count(vars)
-        leaf_candidates = leaf.get_match_candidates(
-            rest_expression[1],  # leaf.candidates,
+        match_count = element.get_match_count(vars)
+        element_candidates = element.get_match_candidates(
+            rest_expression[1],  # element.candidates,
             expression,
             attributes,
             evaluation,
             vars,
         )
 
-        if len(leaf_candidates) < match_count[0]:
+        if len(element_candidates) < match_count[0]:
             return
 
         candidates = rest_expression[1]
 
-        # "Artificially" only use more leaves than specified for some kind
+        # "Artificially" only use more elements than specified for some kind
         # of pattern.
         # TODO: This could be further optimized!
         try_flattened = flat & attributes and (
-            leaf.get_head() in SYSTEM_SYMBOLS_PATTERNS
+            element.get_head() in SYSTEM_SYMBOLS_PATTERNS
         )
 
         if try_flattened:
@@ -571,41 +579,41 @@ class ExpressionPattern(Pattern):
         else:
             set_lengths = match_count
 
-        # try_flattened is used later to decide whether wrapping of leaves
+        # try_flattened is used later to decide whether wrapping of elements
         # into one operand may occur.
         # This can of course also be when flat and same head.
         try_flattened = try_flattened or (
-            flat & attributes and leaf.get_head() == expression.head
+            flat & attributes and element.get_head() == expression.head
         )
 
         less_first = len(rest_elements) > 0
 
         if orderless & attributes:
-            # we only want leaf_candidates to be a set if we're orderless.
+            # we only want element_candidates to be a set if we're orderless.
             # otherwise, constructing a set() is very slow for large lists.
             # performance test case:
             # x = Range[100000]; Timing[Combinatorica`BinarySearch[x, 100]]
-            leaf_candidates = set(leaf_candidates)  # for fast lookup
+            element_candidates = set(element_candidates)  # for fast lookup
 
             sets = None
-            if leaf.get_head_name() == "System`Pattern":
-                varname = leaf.leaves[0].get_name()
+            if element.get_head_name() == "System`Pattern":
+                varname = element.elements[0].get_name()
                 existing = vars.get(varname, None)
                 if existing is not None:
                     head = existing.get_head()
                     if head.get_name() == "System`Sequence" or (
                         flat & attributes and head == expression.get_head()
                     ):
-                        needed = existing.leaves
+                        needed = existing.elements
                     else:
                         needed = [existing]
                     available = list(candidates)
-                    for needed_leaf in needed:
+                    for needed_element in needed:
                         if (
-                            needed_leaf in available
-                            and needed_leaf in leaf_candidates  # nopep8
+                            needed_element in available
+                            and needed_element in element_candidates  # nopep8
                         ):
-                            available.remove(needed_leaf)
+                            available.remove(needed_element)
                         else:
                             return
                     sets = [(needed, ([], available))]
@@ -613,7 +621,7 @@ class ExpressionPattern(Pattern):
             if sets is None:
                 sets = subsets(
                     candidates,
-                    included=leaf_candidates,
+                    included=element_candidates,
                     less_first=less_first,
                     *set_lengths
                 )
@@ -621,13 +629,13 @@ class ExpressionPattern(Pattern):
             sets = subranges(
                 candidates,
                 flexible_start=first and not fully,
-                included=leaf_candidates,
+                included=element_candidates,
                 less_first=less_first,
                 *set_lengths
             )
 
         if rest_elements:
-            next_leaf = rest_elements[0]
+            next_element = rest_elements[0]
             next_rest_elements = rest_elements[1:]
         next_depth = depth + 1
         next_index = element_index + 1
@@ -637,12 +645,12 @@ class ExpressionPattern(Pattern):
             # - in that case we would match the same expression over and over.
 
             include_flattened = try_flattened and 0 < len(items) < len(
-                expression.leaves
+                expression.elements
             )
 
             # Don't try flattened when the expression would remain the same!
 
-            def leaf_yield(next_vars, next_rest):
+            def element_yield(next_vars, next_rest):
                 # if next_rest is None:
                 #    next_rest = ([], [])
                 # yield_func(next_vars, (rest_expression[0] + items_rest[0],
@@ -659,9 +667,9 @@ class ExpressionPattern(Pattern):
 
             def match_yield(new_vars, _):
                 if rest_elements:
-                    self.match_leaf(
-                        leaf_yield,
-                        next_leaf,
+                    self.match_element(
+                        element_yield,
+                        next_element,
                         next_rest_elements,
                         items_rest,
                         new_vars,
@@ -679,7 +687,7 @@ class ExpressionPattern(Pattern):
                         yield_func(new_vars, items_rest)
 
             def yield_wrapping(item):
-                leaf.match(
+                element.match(
                     match_yield,
                     item,
                     vars,
@@ -700,31 +708,37 @@ class ExpressionPattern(Pattern):
                 include_flattened=include_flattened,
             )
 
-    def get_match_candidates(self, leaves, expression, attributes, evaluation, vars={}):
+    def get_match_candidates(
+        self, elements, expression, attributes, evaluation, vars={}
+    ):
         """
-        Finds possible leaves that could match the pattern, ignoring future
+        Finds possible elements that could match the pattern, ignoring future
         pattern variable definitions, but taking into account already fixed
         variables.
         """
         # TODO: fixed_vars!
 
-        return [leaf for leaf in leaves if self.does_match(leaf, evaluation, vars)]
+        return [
+            element
+            for element in elements
+            if self.does_match(element, evaluation, vars)
+        ]
 
     def get_match_candidates_count(
-        self, leaves, expression, attributes, evaluation, vars={}
+        self, elements, expression, attributes, evaluation, vars={}
     ):
         """
-        Finds possible leaves that could match the pattern, ignoring future
+        Finds possible elements that could match the pattern, ignoring future
         pattern variable definitions, but taking into account already fixed
         variables.
         """
         # TODO: fixed_vars!
 
         count = 0
-        for leaf in leaves:
-            if self.does_match(leaf, evaluation, vars):
+        for element in elements:
+            if self.does_match(element, evaluation, vars):
                 count += 1
         return count
 
     def sort(self):
-        self.leaves.sort(key=lambda e: e.get_sort_key(pattern_sort=True))
+        self.elements.sort(key=lambda e: e.get_sort_key(pattern_sort=True))

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -3,7 +3,7 @@
 # -*- coding: utf-8 -*-
 
 
-from mathics.core.element import ensure_context, BaseElement
+from mathics.core.element import ensure_context
 from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, Symbol, system_symbols
 from mathics.core.systemsymbols import SymbolSequence


### PR DESCRIPTION
and more replacements from `leaves` to `elements`.

The nontrivial changes are essentially those proposed in the first patch in #400.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/401"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

