### PR TITLE
fix build element properties in Expression.__init__ and Expression.rewrite_apply_eval

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -209,8 +209,8 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         self._head = head
         self._elements = elements
         self.elements_properties = elements_properties
-        if elements_properties is None:
-            self._build_elements_properties()
+        #        if elements_properties is None:
+        #            self._build_elements_properties()
 
         self._sequences = None
         self._cache = None
@@ -1046,13 +1046,13 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             # FIXME: see if we can preserve elements properties in eval_elements()
             recompute_properties = eval_elements()
 
-        new = Expression(
-            head,
-            *elements,
-            elements_properties=None
-            if recompute_properties
-            else self.elements_properties
-        )
+        if recompute_properties:
+            new = Expression(head, *elements, elements_properties=None)
+            new._build_elements_properties()
+        else:
+            new = Expression(
+                head, *elements, elements_properties=self.elements_properties
+            )
 
         # Step 3: Now, process the attributes of head
         # If there are sequence, flatten them if the attributes allow it.

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1034,13 +1034,12 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         # * evaluate elements,
         # * run to_python() on them in Expression construction, or
         # * convert Expression elements from a tuple to a list and back
-
+        recompute_properties = False
         if self.elements_properties.elements_fully_evaluated:
             elements = self._elements
         else:
             elements = self.get_mutable_elements()
             # FIXME: see if we can preserve elements properties in eval_elements()
-            recompute_properties = False
             eval_elements()
 
         if recompute_properties:


### PR DESCRIPTION
This PR fixes the issue that screwed the sorting property and made test_series.py fail.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/403"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

