### PR TITLE
Improve the implementation of mathics.core.list

### DIFF
--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -36,11 +36,7 @@ class ListExpression(Expression):
         self._elements = elements
         self._is_literal = False
         self.python_list = None
-        self.elements_properties = (
-            self._build_elements_properties()
-            if elements_properties is None
-            else elements_properties
-        )
+        self.elements_properties = elements_properties
 
         # FIXME: get rid of this junk
         self._sequences = None
@@ -109,10 +105,10 @@ class ListExpression(Expression):
 
         if self.elements_properties is None:
             self._build_elements_properties()
-
         if not self.elements_properties.elements_fully_evaluated:
-            self.evaluate_elements(evaluation)
-
+            new = self.shallow_copy()
+            new.evaluate_elements(evaluation)
+            return new, False
         return self, False
 
     def shallow_copy(self) -> "ListExpression":


### PR DESCRIPTION
* avoid building properties in the List constructor
* rewrite_apply_eval keeps `self` untouched, and returns a new object if the elements must be reevaluated.

Here there is a comparison between master and this branch for the combinatorial benchmark.

Pyston 2.3.4 (3.8.12)
NO_CYTHON=1
using SymPy 1.8, mpmath 1.2.1, numpy 1.21.4

|   test                                        |   master           |   #404            |
| --------------------------------------------- | ------------------ |------------------ |
| load_combinatorica 				|   179.93 ms        |  181.15 ms        |   
| test_permutations_1_1   		       	|   932.17 ms	  | 	930.90 ms   	 |
| test_permutations_groups_1_2   		|   5801.66 m	  | 	5642.51 ms  	 |
| test_inversions_and_inversion_vectors_1_3   	|   667.19 ms	  | 	530.34 ms   	 |
| test_special_classes_of_permutations_1_4   	|   374.42 ms	  | 	291.73 ms   	 |
| test_combinations_1_5   			|   614.28 ms	  | 	456.43 ms   	 |
| test_2_1_to_2_3   				|   81.67 ms 	  | 	67.99 ms    	 |
| test_combinatorica_rest   			|   122.90 ms	  | 	124.77 ms   	 |








<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/404"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

