### PR TITLE
Reduce temp file garbage in Close doctests

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -1205,20 +1205,17 @@ class Close(Builtin):
     >> Close[StringToStream["123abc"]]
      = String
 
-    >> Close[OpenWrite[]]
+    >> file=Close[OpenWrite[]]
      = ...
 
-    #> Streams[] == (Close[OpenWrite[]]; Streams[])
-     = True
+    Closing a file doesn't delete it from the filesystem
+    >> DeleteFile[file];
 
     #> Close["abc"]
      : abc is not open.
      = Close[abc]
 
-    #> strm = OpenWrite[];
-    #> Close[strm];
-    #> Quiet[Close[strm]]
-     = Close[OutputStream[...]]
+    #> Clear[file]
     """
 
     summary_text = "close a stream"

--- a/test/builtin/files_io/test_files.py
+++ b/test/builtin/files_io/test_files.py
@@ -48,13 +48,30 @@ def test_get_path_search():
 
 
 @pytest.mark.skipif(
-    sys.platform in ("win32",), reason="$Path does not work on Windows?"
+    sys.platform in ("win32",),
+    reason="Need to fix some sort of Unicode decode problem on Windows",
 )
-def test_temptream():
+def test_temp_stream():
     temp_filename = evaluate("Close[OpenWrite[BinaryFormat -> True]]").value
     assert osp.exists(
         temp_filename
+    ), f"temporary filename {temp_filename} should appear"
+    result = evaluate(f"""DeleteFile["{temp_filename}"]""").to_python()
+    assert result is None
+    assert not osp.exists(
+        temp_filename
     ), f"temporary filename {temp_filename} should not appear"
+
+
+@pytest.mark.skipif(
+    sys.platform in ("win32",),
+    reason="Need to fix some sort of Unicode decode problem on Windows",
+)
+def test_close():
+    temp_filename = evaluate("Close[OpenWrite[]]").value
+    assert osp.exists(
+        temp_filename
+    ), f"temporary filename {temp_filename} should appear"
     result = evaluate(f"""DeleteFile["{temp_filename}"]""").to_python()
     assert result is None
     assert not osp.exists(


### PR DESCRIPTION
Put more testing inside pytest and remove from doctest.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/409"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

