### PR TITLE
Add vector section but revert test (and chapter) sorting for now.

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -174,12 +174,13 @@ disable_file_module_names = (
 
 for subdir in (
     "arithfns",
-    "atomic",
     "assignments",
+    "atomic",
     "box",
     "colors",
     "distance",
     "drawing",
+    "fileformats",
     "files_io",
     "intfns",
     "list",
@@ -188,7 +189,7 @@ for subdir in (
     "numbers",
     "specialfns",
     "string",
-    "fileformats",
+    "vectors",
 ):
     import_name = f"{__name__}.{subdir}"
 

--- a/mathics/builtin/assignments/assign_binaryop.py
+++ b/mathics/builtin/assignments/assign_binaryop.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Assignmment plus binary operator
+In-place binary assignment operator
 
 There are a number operators and functions that combine assignment with some sort of binary operator.
 

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-Image[] and image related functions
+Image[] and image-related functions
 
 Note that you (currently) need scikit-image installed in order for this module to work.
 """
+
+# This tells documentation how to sort this module
+# Here we are also hiding "drawing" since this erroneously appears at the top level.
+sort_order = "mathics.builtin.image-and-image-related-functions"
 
 from collections import defaultdict
 import base64

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -4,6 +4,8 @@
 Constructing Lists
 
 Functions for constructing lists of various sizes and structure.
+
+See also Constructing Vectors.
 """
 
 from itertools import permutations

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -1231,49 +1231,6 @@ def get_tuples(items):
                 yield [item] + rest
 
 
-class UnitVector(Builtin):
-    """
-    <dl>
-    <dt>'UnitVector[$n$, $k$]'
-        <dd>returns the $n$-dimensional unit vector with a 1 in position $k$.
-    <dt>'UnitVector[$k$]'
-        <dd>is equivalent to 'UnitVector[2, $k$]'.
-    </dl>
-    >> UnitVector[2]
-     = {0, 1}
-    >> UnitVector[4, 3]
-     = {0, 0, 1, 0}
-    """
-
-    messages = {
-        "nokun": "There is no unit vector in direction `1` in `2` dimensions.",
-    }
-
-    rules = {
-        "UnitVector[k_Integer]": "UnitVector[2, k]",
-    }
-    summary_text = "unit vector along a coordinate direction"
-
-    def apply(self, n: Integer, k: Integer, evaluation):
-        "UnitVector[n_Integer, k_Integer]"
-
-        py_n = n.value
-        py_k = k.value
-        if py_n is None or py_k is None:
-            return
-        if not 1 <= py_k <= py_n:
-            evaluation.message("UnitVector", "nokun", k, n)
-            return
-
-        def item(i):
-            if i == py_k:
-                return Integer1
-            else:
-                return Integer0
-
-        return ListExpression(*(item(i) for i in range(1, py_n + 1)))
-
-
 class IntersectingQ(Builtin):
     """
     <dl>

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -6,6 +6,10 @@ Mathematical Constants
 Numeric, Arithmetic, or Symbolic constants like Pi, E, or Infinity.
 """
 
+# This tells documentation how to sort this module
+sort_order = "mathics.builtin.mathematical-constants"
+
+
 import math
 import mpmath
 import numpy

--- a/mathics/builtin/numbers/exptrig.py
+++ b/mathics/builtin/numbers/exptrig.py
@@ -330,35 +330,6 @@ class AnglePathFold(Fold):
             yield x, y, phi
 
 
-class AngleVector(Builtin):
-    """
-    <dl>
-    <dt>'AngleVector[$phi$]'
-        <dd>returns the point at angle $phi$ on the unit circle.
-    <dt>'AngleVector[{$r$, $phi$}]'
-        <dd>returns the point at angle $phi$ on a circle of radius $r$.
-    <dt>'AngleVector[{$x$, $y$}, $phi$]'
-        <dd>returns the point at angle $phi$ on a circle of radius 1 centered at {$x$, $y$}.
-    <dt>'AngleVector[{$x$, $y$}, {$r$, $phi$}]'
-        <dd>returns point at angle $phi$ on a circle of radius $r$ centered at {$x$, $y$}.
-    </dl>
-
-    >> AngleVector[90 Degree]
-     = {0, 1}
-
-    >> AngleVector[{1, 10}, a]
-     = {1 + Cos[a], 10 + Sin[a]}
-    """
-
-    summary_text = "create a vector at a specified angle"
-    rules = {
-        "AngleVector[phi_]": "{Cos[phi], Sin[phi]}",
-        "AngleVector[{r_, phi_}]": "{r * Cos[phi], r * Sin[phi]}",
-        "AngleVector[{x_, y_}, phi_]": "{x + Cos[phi], y + Sin[phi]}",
-        "AngleVector[{x_, y_}, {r_, phi_}]": "{x + r * Cos[phi], y + r * Sin[phi]}",
-    }
-
-
 class ArcCos(_MPMathFunction):
     """
     <dl>

--- a/mathics/builtin/numbers/linalg.py
+++ b/mathics/builtin/numbers/linalg.py
@@ -4,17 +4,18 @@
 Linear algebra
 """
 
+import mpmath
 import sympy
 from sympy import re, im
-from mpmath import mp
 
 
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import Integer, Integer0, Real
 from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
-from mathics.core.convert.mpmath import from_mpmath
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.matrix import matrix_data
+from mathics.core.convert.mpmath import from_mpmath, to_mpmath_matrix
+from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (
     Symbol,
@@ -22,99 +23,11 @@ from mathics.core.symbols import (
 )
 
 
-def matrix_data(m):
-    if not m.has_form("List", None):
-        return None
-    if all(element.has_form("List", None) for element in m.elements):
-        result = [[item.to_sympy() for item in row.elements] for row in m.elements]
-        if not any(None in row for row in result):
-            return result
-    elif not any(element.has_form("List", None) for element in m.elements):
-        result = [item.to_sympy() for item in m.elements]
-        if None not in result:
-            return result
-
-
-def to_sympy_matrix(data, **kwargs):
-    """Convert a Mathics matrix to one that can be used by Sympy.
-    None is returned if we can't convert to a Sympy matrix.
-    """
-    if not isinstance(data, list):
-        data = matrix_data(data)
-    try:
-        return sympy.Matrix(data)
-    except (TypeError, AssertionError, ValueError):
-        return None
-
-
-def to_mpmath_matrix(data, **kwargs):
-    """Convert a Mathics matrix to one that can be used by mpmath.
-    None is returned if we can't convert to a mpmath matrix.
-    """
-
-    def mpmath_matrix_data(m):
-        if not m.has_form("List", None):
-            return None
-        if not all(element.has_form("List", None) for element in m.elements):
-            return None
-        return [[str(item) for item in row.elements] for row in m.elements]
-
-    if not isinstance(data, list):
-        data = mpmath_matrix_data(data)
-    try:
-        return mp.matrix(data)
-    except (TypeError, AssertionError, ValueError):
-        return None
-
-
-class Cross(Builtin):
-    """
-    <dl>
-    <dt>'Cross[$a$, $b$]'
-        <dd>computes the vector cross product of $a$ and $b$.
-    </dl>
-
-    >> Cross[{x1, y1, z1}, {x2, y2, z2}]
-     = {y1 z2 - y2 z1, -x1 z2 + x2 z1, x1 y2 - x2 y1}
-
-    >> Cross[{x, y}]
-     = {-y, x}
-
-    >> Cross[{1, 2}, {3, 4, 5}]
-     : The arguments are expected to be vectors of equal length, and the number of arguments is expected to be 1 less than their length.
-     = Cross[{1, 2}, {3, 4, 5}]
-    """
-
-    messages = {
-        "nonn1": (
-            "The arguments are expected to be vectors of equal length, "
-            "and the number of arguments is expected to be 1 less than "
-            "their length."
-        )
-    }
-    rules = {"Cross[{x_, y_}]": "{-y, x}"}
-    summary_text = "vector cross product"
-
-    def apply(self, a, b, evaluation):
-        "Cross[a_, b_]"
-        a = to_sympy_matrix(a)
-        b = to_sympy_matrix(b)
-
-        if a is None or b is None:
-            return evaluation.message("Cross", "nonn1")
-
-        try:
-            res = a.cross(b)
-        except sympy.ShapeError:
-            return evaluation.message("Cross", "nonn1")
-        return from_sympy(res)
-
-
 class DesignMatrix(Builtin):
     """
     <dl>
-    <dt>'DesignMatrix[$m$, $f$, $x$]'
-        <dd>returns the design matrix for a linear model $f$ in the variables $x$.
+      <dt>'DesignMatrix[$m$, $f$, $x$]'
+      <dd>returns the design matrix for a linear model $f$ in the variables $x$.
     </dl>
 
     >> DesignMatrix[{{2, 1}, {3, 4}, {5, 3}, {7, 6}}, x, x]
@@ -135,8 +48,8 @@ class DesignMatrix(Builtin):
 class Det(Builtin):
     """
     <dl>
-    <dt>'Det[$m$]'
-        <dd>computes the determinant of the matrix $m$.
+      <dt>'Det[$m$]'
+      <dd>computes the determinant of the matrix $m$.
     </dl>
 
     >> Det[{{1, 1, 0}, {1, 0, 1}, {0, 1, 1}}]
@@ -198,7 +111,7 @@ class Eigenvalues(Builtin):
     @staticmethod
     def mp_eig(mp_matrix) -> Expression:
         try:
-            _, ER = mp.eig(mp_matrix)
+            _, ER = mpmath.eig(mp_matrix)
         except:
             return None
 
@@ -874,35 +787,6 @@ class Norm(Builtin):
         return from_sympy(res)
 
 
-class Normalize(Builtin):
-    """
-    <dl>
-    <dt>'Normalize[$v$]'
-        <dd>calculates the normalized vector $v$.
-    <dt>'Normalize[$z$]'
-        <dd>calculates the normalized complex number $z$.
-    </dl>
-
-    >> Normalize[{1, 1, 1, 1}]
-     = {1 / 2, 1 / 2, 1 / 2, 1 / 2}
-
-    >> Normalize[1 + I]
-     = (1 / 2 + I / 2) Sqrt[2]
-
-    #> Normalize[0]
-     = 0
-
-    #> Normalize[{0}]
-     = {0}
-
-    #> Normalize[{}]
-     = {}
-    """
-
-    rules = {"Normalize[v_]": "Module[{norm = Norm[v]}, If[norm == 0, v, v / norm, v]]"}
-    summary_text = "normalizes a vector"
-
-
 class PseudoInverse(Builtin):
     """
     <dl>
@@ -1063,8 +947,8 @@ class SingularValueDecomposition(Builtin):
             # symbolic argument (not implemented)
             evaluation.message("SingularValueDecomposition", "nosymb")
 
-        U, S, V = mp.svd(matrix)
-        S = mp.diag(S)
+        U, S, V = mpmath.svd(matrix)
+        S = mpmath.diag(S)
         U_list = to_mathics_list(*U.tolist())
         S_list = to_mathics_list(*S.tolist())
         V_list = to_mathics_list(*V.tolist())
@@ -1074,8 +958,8 @@ class SingularValueDecomposition(Builtin):
 class Tr(Builtin):
     """
     <dl>
-    <dt>'Tr[$m$]'
-        <dd>computes the trace of the matrix $m$.
+      <dt>'Tr[$m$]'
+      <dd>computes the trace of the matrix $m$.
     </dl>
 
     >> Tr[{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}]
@@ -1099,27 +983,3 @@ class Tr(Builtin):
             return evaluation.message("Tr", "matsq", m)
         tr = matrix.trace()
         return from_sympy(tr)
-
-
-class VectorAngle(Builtin):
-    """
-    <dl>
-    <dt>'VectorAngle[$u$, $v$]'
-        <dd>gives the angles between vectors $u$ and $v$
-    </dl>
-
-    >> VectorAngle[{1, 0}, {0, 1}]
-     = Pi / 2
-
-    >> VectorAngle[{1, 2}, {3, 1}]
-     = Pi / 4
-
-    >> VectorAngle[{1, 1, 0}, {1, 0, 1}]
-     = Pi / 3
-
-    #> VectorAngle[{0, 1}, {0, 1}]
-     = 0
-    """
-
-    rules = {"VectorAngle[u_, v_]": "ArcCos[u.v / (Norm[u] Norm[v])]"}
-    summary_text = "angle between vectors"

--- a/mathics/builtin/vectors/__init__.py
+++ b/mathics/builtin/vectors/__init__.py
@@ -1,0 +1,13 @@
+"""
+Operations on Vectors
+
+In mathematics and physics, a vector is a term that refers colloquially to some quantities that cannot be expressed by a single number. It is also a row or column of a matrix.
+
+In computer science, it is an array datas structure consiting of collection of elements identified by at least on array index or key.
+
+In Mathics vectors as are Lists.  one never needs to distinguish between row and column vectors. As with other objects vectors can mix number and symbolic elements.
+
+Vectors can be long, dense, or sparse.
+
+Here you find functions on Vectors.
+"""

--- a/mathics/builtin/vectors/constructing.py
+++ b/mathics/builtin/vectors/constructing.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+"""
+Constructing Vectors
+
+Functions for constructing lists of various sizes and structure.
+
+See also Constructing Lists.
+"""
+
+from mathics.builtin.base import Builtin
+
+
+class AngleVector(Builtin):
+    """
+    <dl>
+      <dt>'AngleVector[$phi$]'
+      <dd>returns the point at angle $phi$ on the unit circle.
+
+      <dt>'AngleVector[{$r$, $phi$}]'
+      <dd>returns the point at angle $phi$ on a circle of radius $r$.
+
+      <dt>'AngleVector[{$x$, $y$}, $phi$]'
+      <dd>returns the point at angle $phi$ on a circle of radius 1 centered at {$x$, $y$}.
+
+      <dt>'AngleVector[{$x$, $y$}, {$r$, $phi$}]'
+      <dd>returns point at angle $phi$ on a circle of radius $r$ centered at {$x$, $y$}.
+    </dl>
+
+    >> AngleVector[90 Degree]
+     = {0, 1}
+
+    >> AngleVector[{1, 10}, a]
+     = {1 + Cos[a], 10 + Sin[a]}
+    """
+
+    rules = {
+        "AngleVector[phi_]": "{Cos[phi], Sin[phi]}",
+        "AngleVector[{r_, phi_}]": "{r * Cos[phi], r * Sin[phi]}",
+        "AngleVector[{x_, y_}, phi_]": "{x + Cos[phi], y + Sin[phi]}",
+        "AngleVector[{x_, y_}, {r_, phi_}]": "{x + r * Cos[phi], y + r * Sin[phi]}",
+    }
+
+    summary_text = "create a vector at a specified angle"
+
+
+# TODO: FromPolarCoordinates, CirclePoints

--- a/mathics/builtin/vectors/mathops.py
+++ b/mathics/builtin/vectors/mathops.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+"""
+Mathematical Operations
+"""
+
+import sympy
+
+from mathics.builtin.base import Builtin
+from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
+
+
+class Cross(Builtin):
+    """
+    <dl>
+      <dt>'Cross[$a$, $b$]'
+      <dd>computes the vector cross product of $a$ and $b$.
+    </dl>
+
+    >> Cross[{x1, y1, z1}, {x2, y2, z2}]
+     = {y1 z2 - y2 z1, -x1 z2 + x2 z1, x1 y2 - x2 y1}
+
+    >> Cross[{x, y}]
+     = {-y, x}
+
+    >> Cross[{1, 2}, {3, 4, 5}]
+     : The arguments are expected to be vectors of equal length, and the number of arguments is expected to be 1 less than their length.
+     = Cross[{1, 2}, {3, 4, 5}]
+    """
+
+    messages = {
+        "nonn1": (
+            "The arguments are expected to be vectors of equal length, "
+            "and the number of arguments is expected to be 1 less than "
+            "their length."
+        )
+    }
+    rules = {"Cross[{x_, y_}]": "{-y, x}"}
+    summary_text = "vector cross product"
+
+    def apply(self, a, b, evaluation):
+        "Cross[a_, b_]"
+        a = to_sympy_matrix(a)
+        b = to_sympy_matrix(b)
+
+        if a is None or b is None:
+            return evaluation.message("Cross", "nonn1")
+
+        try:
+            res = a.cross(b)
+        except sympy.ShapeError:
+            return evaluation.message("Cross", "nonn1")
+        return from_sympy(res)

--- a/mathics/builtin/vectors/vector_space_operations.py
+++ b/mathics/builtin/vectors/vector_space_operations.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+"""
+Vector Space Operations
+"""
+
+from mathics.builtin.base import Builtin
+from mathics.core.atoms import Integer, Integer0, Integer1
+from mathics.core.list import ListExpression
+
+
+class Normalize(Builtin):
+    """
+    <dl>
+      <dt>'Normalize[$v$]'
+      <dd>calculates the normalized vector $v$.
+
+      <dt>'Normalize[$z$]'
+      <dd>calculates the normalized complex number $z$.
+    </dl>
+
+    >> Normalize[{1, 1, 1, 1}]
+     = {1 / 2, 1 / 2, 1 / 2, 1 / 2}
+
+    >> Normalize[1 + I]
+     = (1 / 2 + I / 2) Sqrt[2]
+
+    #> Normalize[0]
+     = 0
+
+    #> Normalize[{0}]
+     = {0}
+
+    #> Normalize[{}]
+     = {}
+    """
+
+    rules = {"Normalize[v_]": "Module[{norm = Norm[v]}, If[norm == 0, v, v / norm, v]]"}
+    summary_text = "normalizes a vector"
+
+
+class UnitVector(Builtin):
+    """
+    <dl>
+      <dt>'UnitVector[$n$, $k$]'
+      <dd>returns the $n$-dimensional unit vector with a 1 in position $k$.
+
+      <dt>'UnitVector[$k$]'
+      <dd>is equivalent to 'UnitVector[2, $k$]'.
+    </dl>
+
+    >> UnitVector[2]
+     = {0, 1}
+    >> UnitVector[4, 3]
+     = {0, 0, 1, 0}
+    """
+
+    messages = {
+        "nokun": "There is no unit vector in direction `1` in `2` dimensions.",
+    }
+
+    rules = {
+        "UnitVector[k_Integer]": "UnitVector[2, k]",
+    }
+    summary_text = "unit vector along a coordinate direction"
+
+    def apply(self, n: Integer, k: Integer, evaluation):
+        "UnitVector[n_Integer, k_Integer]"
+
+        py_n = n.value
+        py_k = k.value
+        if py_n is None or py_k is None:
+            return
+        if not 1 <= py_k <= py_n:
+            evaluation.message("UnitVector", "nokun", k, n)
+            return
+
+        def item(i):
+            if i == py_k:
+                return Integer1
+            else:
+                return Integer0
+
+        return ListExpression(*(item(i) for i in range(1, py_n + 1)))
+
+
+class VectorAngle(Builtin):
+    """
+    <dl>
+      <dt>'VectorAngle[$u$, $v$]'
+      <dd>gives the angles between vectors $u$ and $v$
+    </dl>
+
+    >> VectorAngle[{1, 0}, {0, 1}]
+     = Pi / 2
+
+    >> VectorAngle[{1, 2}, {3, 1}]
+     = Pi / 4
+
+    >> VectorAngle[{1, 1, 0}, {1, 0, 1}]
+     = Pi / 3
+
+    #> VectorAngle[{0, 1}, {0, 1}]
+     = 0
+    """
+
+    rules = {"VectorAngle[u_, v_]": "ArcCos[u.v / (Norm[u] Norm[v])]"}
+    summary_text = "angle between vectors"
+
+
+# TODO: Projection, Orthogonalize, KroneckerProduct

--- a/mathics/core/convert/matrix.py
+++ b/mathics/core/convert/matrix.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"low-level Functions involving matrices"
+
+
+def matrix_data(m):
+    if not m.has_form("List", None):
+        return None
+    if all(element.has_form("List", None) for element in m.elements):
+        result = [[item.to_sympy() for item in row.elements] for row in m.elements]
+        if not any(None in row for row in result):
+            return result
+    elif not any(element.has_form("List", None) for element in m.elements):
+        result = [item.to_sympy() for item in m.elements]
+        if None not in result:
+            return result

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -8,6 +8,7 @@ from mathics.core.atoms import (
     MachineReal,
     PrecisionReal,
 )
+from mathics.core.symbols import SymbolList
 
 
 @lru_cache(maxsize=1024)
@@ -27,3 +28,24 @@ def from_mpmath(value, prec=None):
         return Complex(real, imag)
     else:
         raise TypeError(type(value))
+
+
+def to_mpmath_matrix(data, **kwargs):
+    """
+    Convert a Mathics matrix to one that can be used by mpmath.
+    None is returned if we can't convert to a mpmath matrix.
+    """
+
+    def mpmath_matrix_data(m):
+        if not m.has_form("List", None):
+            return None
+        if not all(element.has_form("List", None) for element in m.elements):
+            return None
+        return [[str(item) for item in row.elements] for row in m.elements]
+
+    if not isinstance(data, list):
+        data = mpmath_matrix_data(data)
+    try:
+        return mpmath.matrix(data)
+    except (TypeError, AssertionError, ValueError):
+        return None

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -7,6 +7,7 @@ Conversion to SymPy is handled directly in BaseElement descendants.
 
 import sympy
 
+from typing import Optional
 
 BasicSympy = sympy.Expr
 
@@ -35,13 +36,14 @@ from mathics.core.systemsymbols import (
     SymbolO,
     SymbolPiecewise,
     SymbolSlot,
+    SymbolUnequal,
 )
 
+from mathics.core.convert.matrix import matrix_data
 
 SymbolPrime = Symbol("Prime")
 SymbolRoot = Symbol("Root")
 SymbolRootSum = Symbol("RootSum")
-SymbolUnequal = Symbol("Unequal")
 
 
 def is_Cn_expr(name) -> bool:
@@ -53,6 +55,18 @@ def is_Cn_expr(name) -> bool:
     if n and n.isdigit():
         return True
     return False
+
+
+def to_sympy_matrix(data, **kwargs) -> Optional[sympy.MutableDenseMatrix]:
+    """Convert a Mathics matrix to one that can be used by Sympy.
+    None is returned if we can't convert to a Sympy matrix.
+    """
+    if not isinstance(data, list):
+        data = matrix_data(data)
+    try:
+        return sympy.Matrix(data)
+    except (TypeError, AssertionError, ValueError):
+        return None
 
 
 class SympyExpression(BasicSympy):

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,7 @@ setup(
         "mathics.builtin.scipy_utils",
         "mathics.builtin.specialfns",
         "mathics.builtin.string",
+        "mathics.builtin.vectors",
         "mathics.doc",
         "mathics.format",
     ],


### PR DESCRIPTION
This code keeps the vector split from #418 but remove the sorting part.

Something in the sorting part of #418 causes testing slow down  a lot, like several minutes in `Plot[]` routines like `Plot[KelvinKer[x]]` and `Plot[KlevenKei[x]`

I don't believe it is the code in the sorting tests that is a problem, but instead more a latent performance problem in our code base that sorting happens to trigger.  Until this is isolated and fixed, I am reverting this for now.  There will be a separate PR in the future to reinstate this after the problem is more thoroughly isolated. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/420"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

