### PR TITLE
Add BernoulliB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+# THis is an EditorConfig file
+# https://EditorConfig.org
+
 root = true
 
 [*]
@@ -10,8 +13,15 @@ indent_size = 4
 [*.yml]
 indent_style = space
 indent_size = 2
+end_of_line = lf
+insert_final_newline = true
 
 [*.py]
 indent_style = space
 indent_size = 4
-trim_trailing_whitespace: true
+end_of_line = lf
+insert_final_newline = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,9 @@ Enhancements
 * ``D`` acts over ``Integrate`` and  ``NIntegrate``. Issue #130.
 * numeric overflows now do not affect the full evaluation, but instead just the element which produce it.
 * ``SameQ`` (``===``) handles chaining, e.g. ``a == b == c`` or ``SameQ[a, b, c]``
-* ``UnsameQ`` (``=!=``) handles chaining, e.g. ``a =!= b =!= c`` or ``UnsameQ[a, b, c]``
 * ``Simplify`` handles properly expressions of the form ``Simplify[0^a]`` Issue #167.
 * ``Simplify`` and ``FullSimplify`` support optional parameters ``Assumptions`` and ``ComplexityFunction``
+* ``UnsameQ`` (``=!=``) handles chaining, e.g. ``a =!= b =!= c`` or ``UnsameQ[a, b, c]``
 * The order of the context name resolution (and ``$ContextPath``) switched putting ``"System`"`` before ``"Global`"``.
 * In assignment to messages associated with symbols, the attribute ``Protected`` is not having into account, following the standard in WMA. With this and the above change, Combinatorical 2.0 works as written.
 * ``Share[]`` performs an explicit call to the Python garbage collection and returns the amount of memory free.
@@ -27,6 +27,7 @@ Documentation
 New Builtins
 ============
 * Euler's ``Beta`` function.
+* ``Bernoulli``.
 * ``Diagonal``. Issue #115.
 * ``EulerPhi``
 * ``$Echo``. Issue #42.

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -538,7 +538,7 @@ class Power(BinaryOperator, _MPMathFunction):
 
     sympy_name = "Pow"
     mpmath_name = "power"
-    nargs = 2
+    nargs = {2}
 
     messages = {
         "infy": "Infinite expression `1` encountered.",

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -16,13 +16,13 @@ import mpmath
 from functools import lru_cache
 
 from mathics.core.attributes import (
-    hold_all as HOLD_ALL,
-    hold_rest as HOLD_REST,
-    listable as LISTABLE,
-    no_attributes as NO_ATTRIBUTES,
-    numeric_function as NUMERIC_FUNCTION,
-    protected as PROTECTED,
-    read_protected as READ_PROTECTED,
+    hold_all as A_HOLD_ALL,
+    hold_rest as A_HOLD_REST,
+    listable as A_LISTABLE,
+    no_attributes as A_NO_ATTRIBUTES,
+    numeric_function as A_NUMERIC_FUNCTION,
+    protected as A_PROTECTED,
+    read_protected as A_READ_PROTECTED,
 )
 
 from mathics.core.evaluators import eval_N
@@ -110,7 +110,7 @@ class _MPMathFunction(SympyFunction):
     # However hey are not correct for some derived classes, like
     # InverseErf or InverseErfc.
     # So those classes should expclicitly set/override this.
-    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
+    attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
     mpmath_name = None
 
@@ -353,7 +353,7 @@ class Re(SympyFunction):
     """
 
     summary_text = "real part"
-    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
+    attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
     sympy_name = "re"
 
     def apply_complex(self, number, evaluation):
@@ -392,7 +392,7 @@ class Im(SympyFunction):
     """
 
     summary_text = "imaginary part"
-    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
+    attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
     def apply_complex(self, number, evaluation):
         "Im[number_Complex]"
@@ -515,7 +515,7 @@ class Arg(_MPMathFunction):
         "Arg[DirectedInfinity[a_]]": "Arg[a]",
     }
 
-    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
+    attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
     options = {"Method": "Automatic"}
 
     numpy_name = "angle"  # for later
@@ -572,7 +572,7 @@ class Sign(SympyFunction):
     sympy_name = "sign"
     # mpmath_name = 'sign'
 
-    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
+    attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
     messages = {
         "argx": "Sign called with `1` arguments; 1 argument is expected.",
@@ -676,7 +676,7 @@ class PossibleZeroQ(SympyFunction):
     """
 
     summary_text = "test whether an expression is estimated to be zero"
-    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
+    attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
     sympy_name = "_iszero"
 
@@ -1187,7 +1187,7 @@ class Piecewise(SympyFunction):
     summary_text = "an arbitrary piecewise function"
     sympy_name = "Piecewise"
 
-    attributes = HOLD_ALL | PROTECTED
+    attributes = A_HOLD_ALL | A_PROTECTED
 
     def apply(self, items, evaluation):
         "%(name)s[items__]"
@@ -1259,7 +1259,7 @@ class Boole(Builtin):
     """
 
     summary_text = "translate 'True' to 1, and 'False' to 0"
-    attributes = LISTABLE | PROTECTED
+    attributes = A_LISTABLE | A_PROTECTED
 
     def apply(self, expr, evaluation):
         "%(name)s[expr_]"
@@ -1280,7 +1280,7 @@ class Assumptions(Predefined):
 
     summary_text = "assumptions used to simplify expressions"
     name = "$Assumptions"
-    attributes = NO_ATTRIBUTES
+    attributes = A_NO_ATTRIBUTES
     rules = {
         "$Assumptions": "True",
     }
@@ -1308,7 +1308,7 @@ class Assuming(Builtin):
     """
 
     summary_text = "set assumptions during the evaluation"
-    attributes = HOLD_REST | PROTECTED
+    attributes = A_HOLD_REST | A_PROTECTED
 
     def apply_assuming(self, assumptions, expr, evaluation):
         "Assuming[assumptions_, expr_]"
@@ -1433,7 +1433,7 @@ class BernoulliB(_MPMathFunction):
      = {1, -1 / 2 + z, 1 / 6 - z + z ^ 2, z / 2 - 3 z ^ 2 / 2 + z ^ 3}
     """
 
-    attributes = NUMERIC_FUNCTION | PROTECTED | READ_PROTECTED
+    attributes = A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
     mpmath_name = "bernoulli"
     nargs = {1, 2}
     summary_text = "Bernoulli number and function"

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -15,6 +15,16 @@ import sympy
 import mpmath
 from functools import lru_cache
 
+from mathics.core.attributes import (
+    hold_all as HOLD_ALL,
+    hold_rest as HOLD_REST,
+    listable as LISTABLE,
+    no_attributes as NO_ATTRIBUTES,
+    numeric_function as NUMERIC_FUNCTION,
+    protected as PROTECTED,
+    read_protected as READ_PROTECTED,
+)
+
 from mathics.core.evaluators import eval_N
 
 from mathics.builtin.base import (
@@ -72,15 +82,6 @@ from mathics.core.systemsymbols import (
     SymbolUndefined,
 )
 
-from mathics.core.attributes import (
-    hold_all,
-    hold_rest,
-    listable,
-    no_attributes,
-    numeric_function,
-    protected,
-)
-
 
 @lru_cache(maxsize=1024)
 def call_mpmath(mpmath_function, mpmath_args):
@@ -109,15 +110,15 @@ class _MPMathFunction(SympyFunction):
     # However hey are not correct for some derived classes, like
     # InverseErf or InverseErfc.
     # So those classes should expclicitly set/override this.
-    attributes = listable | numeric_function | protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
 
     mpmath_name = None
 
-    nargs = 1
+    nargs = {1}
 
     @lru_cache(maxsize=1024)
     def get_mpmath_function(self, args):
-        if self.mpmath_name is None or len(args) != self.nargs:
+        if self.mpmath_name is None or len(args) not in self.nargs:
             return None
         return getattr(mpmath, self.mpmath_name)
 
@@ -352,7 +353,7 @@ class Re(SympyFunction):
     """
 
     summary_text = "real part"
-    attributes = listable | numeric_function | protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
     sympy_name = "re"
 
     def apply_complex(self, number, evaluation):
@@ -374,8 +375,8 @@ class Re(SympyFunction):
 class Im(SympyFunction):
     """
     <dl>
-    <dt>'Im[$z$]'
-        <dd>returns the imaginary component of the complex number $z$.
+      <dt>'Im[$z$]'
+      <dd>returns the imaginary component of the complex number $z$.
     </dl>
 
     >> Im[3+4I]
@@ -391,7 +392,7 @@ class Im(SympyFunction):
     """
 
     summary_text = "imaginary part"
-    attributes = listable | numeric_function | protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
 
     def apply_complex(self, number, evaluation):
         "Im[number_Complex]"
@@ -443,8 +444,8 @@ class Conjugate(_MPMathFunction):
 class Abs(_MPMathFunction):
     """
     <dl>
-    <dt>'Abs[$x$]'
-        <dd>returns the absolute value of $x$.
+      <dt>'Abs[$x$]'
+      <dd>returns the absolute value of $x$.
     </dl>
     >> Abs[-3]
      = 3
@@ -514,7 +515,7 @@ class Arg(_MPMathFunction):
         "Arg[DirectedInfinity[a_]]": "Arg[a]",
     }
 
-    attributes = listable | numeric_function | protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
     options = {"Method": "Automatic"}
 
     numpy_name = "angle"  # for later
@@ -571,7 +572,7 @@ class Sign(SympyFunction):
     sympy_name = "sign"
     # mpmath_name = 'sign'
 
-    attributes = listable | numeric_function | protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
 
     messages = {
         "argx": "Sign called with `1` arguments; 1 argument is expected.",
@@ -675,7 +676,7 @@ class PossibleZeroQ(SympyFunction):
     """
 
     summary_text = "test whether an expression is estimated to be zero"
-    attributes = listable | numeric_function | protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED
 
     sympy_name = "_iszero"
 
@@ -1186,7 +1187,7 @@ class Piecewise(SympyFunction):
     summary_text = "an arbitrary piecewise function"
     sympy_name = "Piecewise"
 
-    attributes = hold_all | protected
+    attributes = HOLD_ALL | PROTECTED
 
     def apply(self, items, evaluation):
         "%(name)s[items__]"
@@ -1258,7 +1259,7 @@ class Boole(Builtin):
     """
 
     summary_text = "translate 'True' to 1, and 'False' to 0"
-    attributes = listable | protected
+    attributes = LISTABLE | PROTECTED
 
     def apply(self, expr, evaluation):
         "%(name)s[expr_]"
@@ -1279,7 +1280,7 @@ class Assumptions(Predefined):
 
     summary_text = "assumptions used to simplify expressions"
     name = "$Assumptions"
-    attributes = no_attributes
+    attributes = NO_ATTRIBUTES
     rules = {
         "$Assumptions": "True",
     }
@@ -1307,7 +1308,7 @@ class Assuming(Builtin):
     """
 
     summary_text = "set assumptions during the evaluation"
-    attributes = hold_rest | protected
+    attributes = HOLD_REST | PROTECTED
 
     def apply_assuming(self, assumptions, expr, evaluation):
         "Assuming[assumptions_, expr_]"
@@ -1406,3 +1407,34 @@ class ConditionalExpression(Builtin):
             (sympy.Symbol(sympy_symbol_prefix + "System`Undefined"), True),
         )
         return sympy.Piecewise(*sympy_cases)
+
+
+class BernoulliB(_MPMathFunction):
+    """
+    <dl>
+      <dt>'BernoulliB[$n$]'
+      <dd>represents the Bernouilli number B_$n$.
+
+      <dt>'BernouilliB[$n$, $x$]'
+      <dd>represents the Bernouilli polynomial B_$n[x]$.
+    </dl>
+
+    >> BernoulliB[42]
+     = 1520097643918070802691 / 1806
+
+    First five Bernoulli numbers:
+
+    >> Table[BernoulliB[k], {k, 0, 5}]
+     = {1, -1 / 2, 1 / 6, 0, -1 / 30, 0}
+
+    First five Bernoulli polynomials:
+
+    >> Table[BernoulliB[k, z], {k, 0, 3}]
+     = {1, -1 / 2 + z, 1 / 6 - z + z ^ 2, z / 2 - 3 z ^ 2 / 2 + z ^ 3}
+    """
+
+    attributes = NUMERIC_FUNCTION | PROTECTED | READ_PROTECTED
+    mpmath_name = "bernoulli"
+    nargs = {1, 2}
+    summary_text = "Bernoulli number and function"
+    sympy_name = "bernoulli"

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -57,7 +57,7 @@ class Binomial(_MPMathFunction):
 
     attributes = listable | numeric_function | protected
 
-    nargs = 2
+    nargs = {2}
     sympy_name = "binomial"
     mpmath_name = "binomial"
     summary_text = "binomial coefficients"

--- a/mathics/builtin/intfns/recurrence.py
+++ b/mathics/builtin/intfns/recurrence.py
@@ -38,7 +38,7 @@ class Fibonacci(_MPMathFunction):
      = 280571172992510140037611932413038677189525
     """
 
-    nargs = 1
+    nargs = {1}
     attributes = listable | numeric_function | protected | read_protected
     sympy_name = "fibonacci"
     mpmath_name = "fibonacci"
@@ -87,7 +87,7 @@ class StirlingS1(Builtin):
 
     attributes = listable | protected
 
-    nargs = 2
+    nargs = {2}
     summary_text = "Stirling numbers of the first kind"
     sympy_name = "functions.combinatorial.stirling"
     mpmath_name = "stirling1"
@@ -113,7 +113,7 @@ class StirlingS2(Builtin):
     """
 
     attributes = listable | protected
-    nargs = 2
+    nargs = {2}
     sympy_name = "functions.combinatorial.numbers.stirling"
     mpmath_name = "stirling2"
     summary_text = "Stirling numbers of the second kind"

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -76,7 +76,7 @@ def sympy_constant(fn, d=None):
 class _Constant_Common(Predefined):
     is_numeric = True
     attributes = constant | protected | read_protected
-    nargs = 0
+    nargs = {0}
     options = {"Method": "Automatic"}
 
     def apply_N(self, precision, evaluation):

--- a/mathics/builtin/numbers/exptrig.py
+++ b/mathics/builtin/numbers/exptrig.py
@@ -941,7 +941,7 @@ class Log(_MPMathFunction):
     """
 
     summary_text = "logarithm function"
-    nargs = 2
+    nargs = {2}
     mpmath_name = "log"
     sympy_name = "log"
 

--- a/mathics/builtin/specialfns/bessel.py
+++ b/mathics/builtin/specialfns/bessel.py
@@ -12,19 +12,19 @@ from mathics.core.number import machine_precision, get_precision, PrecisionValue
 from mathics.core.number import prec as _prec
 
 from mathics.core.attributes import (
-    listable,
-    n_hold_first,
-    numeric_function,
-    protected,
-    read_protected,
+    listable as LISTABLE,
+    n_hold_first as N_HOLD_FIRST,
+    numeric_function as NUMERIC_FUNCTION,
+    protected as PROTECTED,
+    read_protected as READ_PROTECTED,
 )
 
 
 class _Bessel(_MPMathFunction):
 
-    attributes = listable | numeric_function | protected | read_protected
+    attributes = LISTABLE | NUMERIC_FUNCTION | PROTECTED | READ_PROTECTED
 
-    nargs = 2
+    nargs = {2}
 
 
 class AiryAi(_MPMathFunction):
@@ -111,7 +111,7 @@ class AiryAiZero(Builtin):
 
     # TODO: 'AiryAiZero[$k$, $x0$]' - $k$th zero less than x0
 
-    attributes = listable | n_hold_first | numeric_function | protected | read_protected
+    attributes = LISTABLE | N_HOLD_FIRST | NUMERIC_FUNCTION | PROTECTED | READ_PROTECTED
 
     rules = {
         "AiryAi[AiryAiZero[k_]]": "0",
@@ -225,7 +225,7 @@ class AiryBiZero(Builtin):
 
     # TODO: 'AiryBiZero[$k$, $x0$]' - $k$th zero less than x0
 
-    attributes = listable | n_hold_first | numeric_function | protected | read_protected
+    attributes = LISTABLE | N_HOLD_FIRST | NUMERIC_FUNCTION | PROTECTED | READ_PROTECTED
 
     rules = {
         "AiryBi[AiryBiZero[z_]]": "0",

--- a/mathics/builtin/specialfns/expintegral.py
+++ b/mathics/builtin/specialfns/expintegral.py
@@ -20,7 +20,7 @@ class ExpIntegralE(_MPMathFunction):
     """
 
     summary_text = "exponential integral function of order n"
-    nargs = 2
+    nargs = {2}
     sympy_name = "expint"
     mpmath_name = "expint"
 
@@ -94,6 +94,6 @@ class ProductLog(_MPMathFunction):
 #     = 1.12642 - 1.21017 I
 #    """
 #
-#    nargs = 3
+#    nargs = {3}
 #    sympy_name = ''
 #    mpmath_name = ''

--- a/mathics/builtin/specialfns/orthogonal.py
+++ b/mathics/builtin/specialfns/orthogonal.py
@@ -21,7 +21,7 @@ class ChebyshevT(_MPMathFunction):
      = 0.800143 + 1.08198 I
     """
 
-    nargs = 2
+    nargs = {2}
     sympy_name = "chebyshevt"
     mpmath_name = "chebyt"
     summary_text = "Chebyshev's polynomials of the first kind"
@@ -41,7 +41,7 @@ class ChebyshevU(_MPMathFunction):
      = 1.60029 + 0.721322 I
     """
 
-    nargs = 2
+    nargs = {2}
     sympy_name = "chebyshevu"
     mpmath_name = "chebyu"
     summary_text = "Chebyshev's polynomials of the second kind"
@@ -63,7 +63,7 @@ class GegenbauerC(_MPMathFunction):
 
     # TODO: Two argument renormalized form GegenbauerC[n, x]
 
-    nargs = 3
+    nargs = {3}
     sympy_name = "gegenbauer"
     mpmath_name = "gegenbauer"
     summary_text = "Gegenbauer's polynomials"
@@ -86,7 +86,7 @@ class HermiteH(_MPMathFunction):
      = 77.5291
     """
 
-    nargs = 2
+    nargs = {2}
     sympy_name = "hermite"
     mpmath_name = "hermite"
     summary_text = "Hermite's polynomials"
@@ -106,7 +106,7 @@ class JacobiP(_MPMathFunction):
      = 1410.02 + 5797.3 I
     """
 
-    nargs = 4
+    nargs = {4}
     sympy_name = "jacobi"
     mpmath_name = "jacobi"
     summary_text = "Jacobi's polynomials"
@@ -135,7 +135,7 @@ class LaguerreL(_MPMathFunction):
         "LaguerreL[n_, x_]": "LaguerreL[n, 0, x]",
     }
 
-    nargs = 3
+    nargs = {3}
     sympy_name = "laguerre_poly"
     mpmath_name = "laguerre"
     summary_text = "Laguerre's polynomials"
@@ -184,7 +184,7 @@ class LegendreP(_MPMathFunction):
         "Derivative[0,0,1][LegendreP]": "((LegendreP[1 + #1, #2, #3]*(1 + #1 - #2) + LegendreP[#1, #2, #3]*(-1 - #1)*#3)/(-1 + #3^2))&",
     }
 
-    nargs = 3
+    nargs = {3}
     sympy_name = "legendre"
     mpmath_name = "legenp"
     summary_text = "Legendre's polynomials of first kind"
@@ -227,7 +227,7 @@ class LegendreQ(_MPMathFunction):
         "Derivative[0,0,1][LegendreQ]": "((LegendreQ[1 + #1, #2, #3]*(1 + #1 - #2) + LegendreQ[#1, #2, #3]*(-1 - #1)*#3)/(-1 + #3^2))&",
     }
 
-    nargs = 3
+    nargs = {3}
     sympy_name = ""
     mpmath_name = "legenq"
     summary_text = "Legendre's polynomials of second kind"
@@ -256,7 +256,7 @@ class SphericalHarmonicY(_MPMathFunction):
      = -Sqrt[6] E ^ (I y) Sin[x] / (4 Sqrt[Pi])
     """
 
-    nargs = 4
+    nargs = {4}
     sympy_name = "Ynm"
     mpmath_name = "spherharm"
     summary_text = "3D Spherical Harmonic"
@@ -289,6 +289,6 @@ class SphericalHarmonicY(_MPMathFunction):
 #     = 1.12642 - 1.21017 I
 #    """
 #
-#    nargs = 3
+#    nargs = {3}
 #    sympy_name = ''
 #    mpmath_name = ''


### PR DESCRIPTION
and generalize `_MPMathFunction` `nargs` to allow a set of acceptable arguments

@TiagoCavalcante every time I encounter the attribute bitset it feels to me that those should be capitalized to make it more clear that this is a constant and a bitmask. 

If it okay to make the change throughout, I'll do that in a separate PR.  

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/424"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

