### PR TITLE
Fix crash in NestWhile when supplying "All" as the fourth argument, add more examples, and add some test cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,7 @@ Bugs
 * Fix a bug in handling arguments of pythonized expressions, that are produced by ``Compile`` when the llvmlite compiler fails.
 * ``N`` now handles arbitrary precision numbers when the number of digits is not specified.
 * `N[Indeterminate]` now produces `Indeterminate` instead a `PrecisionReal(nan)`.
+* Fix crash in ``NestWhile`` when supplying ``All`` as the fourth argument.
 
 
 

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -641,6 +641,23 @@ class NestWhile(Builtin):
     Divide by 2 until the result is no longer an integer:
     >> NestWhile[#/2&, 10000, IntegerQ]
      = 625 / 2
+
+    Calculate the sum of third powers of the digits of a number until the
+    same result appears twice:
+    >> NestWhile[Total[IntegerDigits[#]^3] &, 5, UnsameQ, All]
+     = 371
+
+    Print the intermediate results:
+    >> NestWhile[Total[IntegerDigits[#]^3] &, 5, (Print[{##}]; UnsameQ[##]) &, All]
+     | {5}
+     | {5, 125}
+     | {5, 125, 134}
+     | {5, 125, 134, 92}
+     | {5, 125, 134, 92, 737}
+     | {5, 125, 134, 92, 737, 713}
+     | {5, 125, 134, 92, 737, 713, 371}
+     | {5, 125, 134, 92, 737, 713, 371, 371}
+     = 371
     """
 
     summary_text = "nest while a condition is satisfied returning the last expression"
@@ -654,7 +671,7 @@ class NestWhile(Builtin):
 
         results = [expr]
         while True:
-            if m.get_name() == "All":
+            if m.get_name() == "System`All":
                 test_elements = results
             else:
                 test_elements = results[-m.value :]

--- a/test/builtin/test_procedural.py
+++ b/test/builtin/test_procedural.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import pytest
+from test.helper import check_evaluation, session
+
+# NestWhile tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected"),
+    [
+        ("NestWhile[#/2&, 10000, IntegerQ]", "625/2"),
+        ("NestWhile[Total[IntegerDigits[#]^3] &, 5, UnsameQ, All]", "371"),
+        ("NestWhile[Total[IntegerDigits[#]^3] &, 6, UnsameQ, All]", "153"),
+    ],
+)
+def test_nestwhile(str_expr, str_expected):
+    print(str_expr)
+    print(session.evaluate(str_expr))
+    check_evaluation(
+        str_expr, str_expected, to_string_expr=True, to_string_expected=True
+    )


### PR DESCRIPTION
Before:
```
In[1]:= NestWhile[Total[IntegerDigits[#]^3] &, 5, UnsameQ, All]
Traceback (most recent call last):
  File "/home/temp/mathics-core/mathics/core/rules.py", line 214, in do_replace
    return self.function(evaluation=evaluation, **vars_noctx)
  File "/home/temp/mathics-core/mathics/builtin/procedural.py", line 681, in apply
    test_elements = results[-m.value :]
AttributeError: 'Symbol' object has no attribute 'value'

...
...
  File "/home/temp/mathics-core/mathics/core/rules.py", line 214, in do_replace
    return self.function(evaluation=evaluation, **vars_noctx)
  File "/home/temp/mathics-core/mathics/builtin/procedural.py", line 681, in apply
    test_elements = results[-m.value :]
AttributeError: 'Symbol' object has no attribute 'value'

```

After:
```
In[1]:= NestWhile[Total[IntegerDigits[#]^3] &, 5, UnsameQ, All]
Out[1]= 371
```