### PR TITLE
Sort chapters and sections in pdf doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ clean-cython:
 #: Remove Python cache files
 clean-cache:
 	find mathics -name *.py[co] -type f -delete; \
-	find mathics -name __pycache__ -type d -delete
+	find mathics -name __pycache__ -type d -delete || true
 
 #: Remove derived files
 clean: clean-cython clean-cache

--- a/mathics/doc/tex/Makefile
+++ b/mathics/doc/tex/Makefile
@@ -13,7 +13,7 @@ all doc texdoc: mathics.pdf
 
 #: Create internal Document Data from .mdoc and Python builtin module docstrings
 doc-data $(DOC_TEX_DATA_PCL):
-	(cd ../.. && $(PYTHON) docpipeline.py --output --keep-going)
+	(cd ../.. && $(PYTHON) docpipeline.py --output --keep-going --want-sorting)
 
 #: Build mathics PDF
 mathics.pdf: mathics.tex documentation.tex logo-text-nodrop.pdf logo-heptatom.pdf version-info.tex $(DOC_TEX_DATA_PCL)
@@ -45,6 +45,7 @@ clean:
 	rm -f test-mathics.aux test-mathics.idx test-mathics.log test-mathics.mtc test-mathics.mtc* test-mathics.out test-mathics.toc || true
 	rm -f mathics.fdb_latexmk mathics.ilg mathics.ind mathics.maf mathics.pre || true
 	rm -f mathics_*.* || true
-	rm -f mathics-*.* documentation.tex $(DOC_TEX_DATA_PCL) || true
+	rm -f mathics-test.asy mathics-test.aux mathics-test.idx mathics-test.log mathics-test.mtc mathicsest.mtc* mathics-test.out mathics-test.toc || true
+	rm -f documentation.tex $(DOC_TEX_DATA_PCL) || true
 	rm -f mathics.pdf mathics.dvi test-mathics.pdf test-mathics.dvi || true
 	rm -f mathics-test.pdf mathics-test.dvi version-info.tex || true

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -41,7 +41,7 @@ sep = "-" * 70 + "\n"
 
 # Global variables
 definitions = None
-documentation = MathicsMainDocumentation()
+documentation = None
 check_partial_enlapsed_time = False
 logfile = None
 
@@ -229,6 +229,7 @@ def test_chapters(
     stop_on_failure=False,
     generate_output=False,
     reload=False,
+    want_sorting=False,
 ):
     failed = 0
     index = 0
@@ -269,6 +270,7 @@ def test_sections(
     stop_on_failure=False,
     generate_output=False,
     reload=False,
+    want_sorting=False,
 ):
     failed = 0
     index = 0
@@ -325,6 +327,7 @@ def test_all(
     texdatafolder=None,
     doc_even_if_error=False,
     excludes=[],
+    want_sorting=False,
 ):
     if not quiet:
         print(f"Testing {version_string}")
@@ -341,7 +344,7 @@ def test_all(
         total = failed = skipped = 0
         failed_symbols = set()
         output_data = {}
-        for tests in documentation.get_tests():
+        for tests in documentation.get_tests(want_sorting=want_sorting):
             sub_total, sub_failed, sub_skipped, symbols, index = test_tests(
                 tests,
                 index,
@@ -541,7 +544,20 @@ def main():
         default=MAX_TESTS,
         help="run only  N tests",
     )
-
+    # FIXME: there is some weird interacting going on with
+    # mathics when tests in sorted order. Some of the Plot
+    # show a noticeable 2 minute delay in processing.
+    # I think the problem is in Mathics itself rather than
+    # sorting, but until we figure that out, use
+    # sort as an option only. For normal testing we don't
+    # want it for speed. But for document building which is
+    # rarely done, we do want sorting of the sections and chapters.
+    parser.add_argument(
+        "--want-sorting",
+        dest="want_sorting",
+        action="store_true",
+        help="Sort chapters and sections",
+    )
     global logfile
 
     args = parser.parse_args()
@@ -553,6 +569,8 @@ def main():
     if args.logfilename:
         logfile = open(args.logfilename, "wt")
 
+    global documentation
+    documentation = MathicsMainDocumentation(want_sorting=args.want_sorting)
     if args.sections:
         sections = set(args.sections.split(","))
         if args.pymathics:  # in case the section is in a pymathics module...
@@ -594,6 +612,7 @@ def main():
                 count=args.count,
                 doc_even_if_error=args.keep_going,
                 excludes=excludes,
+                want_sorting=args.want_sorting,
             )
             end_time = datetime.now()
             print("Tests took ", end_time - start_time)


### PR DESCRIPTION
Makes mathics.pdf look a little more organized.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/439"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

