### PR TITLE
Add sort Key for `Image` type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -115,7 +115,7 @@ Bugs
 * ``N`` now handles arbitrary precision numbers when the number of digits is not specified.
 * `N[Indeterminate]` now produces `Indeterminate` instead a `PrecisionReal(nan)`.
 * Fix crash in ``NestWhile`` when supplying ``All`` as the fourth argument.
-
+* Fix the comparison between ``Image`` and other expressions.
 
 
 4.0.1

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -2079,10 +2079,15 @@ class Image(Atom):
     def default_format(self, evaluation, form):
         return "-Image-"
 
-    def get_sort_key(self, pattern_sort=False):
+    def get_sort_key(self, pattern_sort=False) -> list:
         if pattern_sort:
+            # If pattern_sort=True, returns the sort key that matches to an Atom.
             return super(Image, self).get_sort_key(True)
         else:
+            # If pattern is False, return a sort_key for the expression `Image[]`,
+            # but with a `2` instead of `1` in the 5th position,
+            # and adding two extra fields: the length in the 5th position,
+            # and a hash in the 6th place.
             return [1, 3, SymbolImage, tuple(), 2, len(self.pixels), hash(self)]
 
     def sameQ(self, other) -> bool:

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -2083,7 +2083,7 @@ class Image(Atom):
         if pattern_sort:
             return super(Image, self).get_sort_key(True)
         else:
-            return hash(self)
+            return [1, 3, SymbolImage, tuple(), 2, len(self.pixels), hash(self)]
 
     def sameQ(self, other) -> bool:
         """Mathics SameQ"""

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -2079,6 +2079,7 @@ class Image(Atom):
     def default_format(self, evaluation, form):
         return "-Image-"
 
+    # FIXME: return type should be a specific kind of Tuple, not a list.
     def get_sort_key(self, pattern_sort=False) -> list:
         if pattern_sort:
             # If pattern_sort=True, returns the sort key that matches to an Atom.

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -144,21 +144,24 @@ class KeyComparable:
     is the primative from which all other comparsions are based on.
     """
 
+    # FIXME: return type should be a specific kind of Tuple, not a list.
     def get_sort_key(self) -> list:
         """
-        This method should provide a list in a way that
-        if ``expr`` is another expression,
+        This returns a list (but should be a tuple) in a way that
+        it can be used to compare in expressions.
+
+        If ``expr`` is another expression,
 
         `self.get_sort_key() <= expr.get_sort_key()`
 
         implies that [self, expr] are canonically sorted.
 
-        The first element in the list is choosen according to
-        the type of element:
+        The first element in the tuple represents a type category
+        of the element according to the following encoding
 
-        0: atom
-        1: Numeric expression
-        2: Algebraic / general Expression
+          0: atom
+          1: Numeric expression
+          2: Algebraic / general Expression
 
         The following elements of the list depend on the kind of element.
         """

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -144,7 +144,7 @@ class KeyComparable:
     is the primative from which all other comparsions are based on.
     """
 
-    def get_sort_key(self):
+    def get_sort_key(self) -> list:
         """
         This method should provide a list in a way that
         if ``expr`` is another expression,

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -145,6 +145,23 @@ class KeyComparable:
     """
 
     def get_sort_key(self):
+        """
+        This method should provide a list in a way that
+        if ``expr`` is another expression,
+
+        `self.get_sort_key() <= expr.get_sort_key()`
+
+        implies that [self, expr] are canonically sorted.
+
+        The first element in the list is choosen according to
+        the type of element:
+
+        0: atom
+        1: Numeric expression
+        2: Algebraic / general Expression
+
+        The following elements of the list depend on the kind of element.
+        """
         raise NotImplementedError
 
     def __eq__(self, other) -> bool:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -800,6 +800,14 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                     1,
                 ]
         else:
+            """
+            General sort key structure:
+            0: 1/2:        Numeric / General Expression
+            1: 2/3         Special arithmetic (Times / Power) / General Expression
+            2: Element:        Head
+            3: tuple:        list of Elements
+            4: 1:        No clue...
+            """
             exps = {}
             head = self._head
             if head is SymbolTimes:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -698,6 +698,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                 option_values[name] = option.elements[1]
         return option_values
 
+    # FIXME: return type should be a specific kind of Tuple, not a list.
     def get_sort_key(self, pattern_sort=False) -> list:
 
         if pattern_sort:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -698,7 +698,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                 option_values[name] = option.elements[1]
         return option_values
 
-    def get_sort_key(self, pattern_sort=False):
+    def get_sort_key(self, pattern_sort=False) -> list:
 
         if pattern_sort:
             """

--- a/test/core/test_expression.py
+++ b/test/core/test_expression.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from test.helper import check_evaluation
+from mathics.builtin.base import check_requires_list
+
+# FIXME: come up with an example that doesn't require skimage.
+@pytest.mark.skipif(
+    not check_requires_list(["skimage"]),
+    reason="Right now need scikit-image for this to work",
+)
+def test_canonical_sort():
+    check_evaluation(
+        'Sort[{Import["ExampleData/Einstein.jpg"], 5}]',
+        '{5, Import["ExampleData/Einstein.jpg"]}',
+    )


### PR DESCRIPTION
This PR fixes #446, providing a canonical sort key to `Image` atoms.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

