### PR TITLE
Yet another pass over describing "get_sort_key()"

### DIFF
--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -147,23 +147,27 @@ class KeyComparable:
     # FIXME: return type should be a specific kind of Tuple, not a list.
     def get_sort_key(self) -> list:
         """
-        This returns a list (but should be a tuple) in a way that
-        it can be used to compare in expressions.
 
-        If ``expr`` is another expression,
+        Returns a particular encoded list (better though would be a tuple) that is used
+        in ``Sort[]`` comparisons and in the ordering that occurs
+        in an M-Expression which has the ``Orderless`` property.
 
-        `self.get_sort_key() <= expr.get_sort_key()`
+        The encoded tuple/list is selected to have the property: when
+        compared against element ``expr`` in a compound expression, if
 
-        implies that [self, expr] are canonically sorted.
+           `self.get_sort_key() <= expr.get_sort_key()`
 
-        The first element in the tuple represents a type category
-        of the element according to the following encoding
+        then self comes before expr.
 
-          0: atom
-          1: Numeric expression
-          2: Algebraic / general Expression
+        The values in the positions of the list/tuple are used to indicate how comparison should be
+        treated for specific element classes.
 
-        The following elements of the list depend on the kind of element.
+        position  type class
+          0:      atom
+          1:      Numeric expression
+          2:      Algebraic / general Expression
+
+        Subsequent positions of the tuple/list depend on the kind of element.
         """
         raise NotImplementedError
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1124,9 +1124,10 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             if new.elements_properties is None:
                 new._build_elements_properties()
 
-        # If the attribute `Orderless` is set, sort the elements, according to the
-        # `get_sort` criteria.
-        # the most expensive part of this is to build the sort key.
+        # If the attribute ``Orderless`` is set, sort the elements, according to the
+        # element's ``get_sort_key()`` method.
+        # Sorting can be time consuming which is why we note this in ``elements_properties``.
+        # Checking for sortedness takes O(n) while sorting take O(n log n).
         if not new.elements_properties.is_ordered and (A_ORDERLESS & attributes):
             new.sort()
 


### PR DESCRIPTION
It so happens `get_sort_key()` also comes up in the pymathics graph module I have been working to get fully converted. 

I spent a little more time then to try to understand this, and describe it.