### PR TITLE
Add pymathics to docs

### DIFF
--- a/mathics/core/evaluators.py
+++ b/mathics/core/evaluators.py
@@ -46,21 +46,20 @@ def eval_N(
 
 def eval_load_module(module_name: str, evaluation: Evaluation) -> str:
     try:
-        evaluation.definitions.load_pymathics_module(module_name)
+        _, context_name = evaluation.definitions.load_pymathics_module(module_name)
     except (PyMathicsLoadException, ImportError):
         raise
-    else:
-        # Add Pymathics` to $ContextPath so that when user does not
-        # have to qualify Pymathics variables and functions,
-        # as the those in the module just loaded.
-        # Follow the $ContextPath example in the WL
-        # reference manual where PackletManager appears first in
-        # the list, it seems to be preferable to add this PyMathics
-        # at the beginning.
-        context_path = list(evaluation.definitions.get_context_path())
-        if "Pymathics`" not in context_path:
-            context_path.insert(0, "Pymathics`")
-            evaluation.definitions.set_context_path(context_path)
+
+    # Add to the beginning of $ContextPath a module-specific path under the Pymathics`
+    # namespace.
+    # By doing this, Pymathics variables and functions are available using a short name.
+    # Similar to PackletManager, in WMA, the name is added at the beginning so that when
+    # two short names are the same the Pymthathics name takes precedence.
+    context_path = list(evaluation.definitions.get_context_path())
+
+    if context_name not in context_path:
+        context_path.insert(0, context_name)
+        evaluation.definitions.set_context_path(context_path)
     return module_name
 
 

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -26,17 +26,20 @@ Things are such a mess, that it is too difficult to contemplate this right now.
 
 """
 
-import importlib
 import os.path as osp
+import importlib
 import pkgutil
 import re
+
 from os import getenv, listdir
 from types import ModuleType
 from typing import Callable
 
-from mathics import builtin, settings
+from mathics import builtin
+from mathics import settings
 from mathics.builtin import get_module_doc, is_builtin
 from mathics.builtin.base import Builtin, check_requires_list
+
 from mathics.core.evaluation import Message, Print
 from mathics.core.util import IS_PYPY
 from mathics.doc.utils import slugify

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -26,18 +26,17 @@ Things are such a mess, that it is too difficult to contemplate this right now.
 
 """
 
+import importlib
 import os.path as osp
 import pkgutil
 import re
-
 from os import getenv, listdir
 from types import ModuleType
 from typing import Callable
 
-from mathics import builtin
-from mathics import settings
-from mathics.builtin import get_module_doc
-from mathics.builtin.base import check_requires_list
+from mathics import builtin, settings
+from mathics.builtin import get_module_doc, is_builtin
+from mathics.builtin.base import Builtin, check_requires_list
 from mathics.core.evaluation import Message, Print
 from mathics.core.util import IS_PYPY
 from mathics.doc.utils import slugify
@@ -755,7 +754,7 @@ class MathicsMainDocumentation(Documentation):
         self.latex_file = settings.DOC_LATEX_FILE
         self.parts = []
         self.parts_by_slug = {}
-        self.pymathics_doc_loaded = False
+        self.pymathics_docs_loaded = []
         self.doc_data_file = settings.get_doc_tex_data_path(should_be_readable=True)
         self.title = "Overview"
         files = listdir(self.doc_dir)
@@ -992,22 +991,10 @@ class MathicsMainDocumentation(Documentation):
         )
         section.subsections.append(subsection)
 
-    def load_pymathics_doc(self):
-        if self.pymathics_doc_loaded:
-            return
-        from mathics.settings import default_pymathics_modules
-
+    def load_pymathics_doc(self, pymathics_modules: list):
         pymathicspart = None
-        # Look the "Pymathics Modules" part, and if it does not exist, create it.
-        for part in self.parts:
-            if part.title == "Pymathics Modules":
-                pymathicspart = part
-        if pymathicspart is None:
-            pymathicspart = DocPart(self, "Pymathics Modules", is_reference=True)
-            self.parts.append(pymathicspart)
-
         # For each module, create the documentation object and load the chapters in the pymathics part.
-        for pymmodule in default_pymathics_modules:
+        for pymmodule in pymathics_modules:
             pymathicsdoc = PyMathicsDocumentation(pymmodule)
             for part in pymathicsdoc.parts:
                 for ch in part.chapters:
@@ -1020,108 +1007,64 @@ class MathicsMainDocumentation(Documentation):
 
 
 class PyMathicsDocumentation(Documentation):
-    def __init__(self, module=None):
-        self.title = "Overview"
+    def __init__(self):
+        self.doc_data_file = settings.get_doc_tex_data_path(should_be_readable=True)
+        self.doc_dir = settings.DOC_DIR
+        self.latex_file = settings.DOC_LATEX_FILE
         self.parts = []
         self.parts_by_slug = {}
-        self.doc_dir = None
-        self.doc_data_file = None
-        self.latex_file = None
         self.symbols = {}
-        if module is None:
-            return
+        self.title = "Overview"
 
-        import importlib
-
-        # Load the module and verifies it is a pymathics module
+    def load_pymathics_module(self, module_name: str):
+        """
+        Load pymathics module `module_name` and extract
+        symbols.
+        """
+        # Load the module and verify that is smells like a pymathics module
+        full_module_name = f"pymathics.{module_name}"
         try:
-            self.pymathicsmodule = importlib.import_module(module)
+            pymathicsmodule = importlib.import_module(full_module_name)
         except ImportError:
-            print("Module does not exist")
-            self.pymathicsmodule = None
-            self.parts = []
+            print(f"Module {module_name} does not exist")
             return
 
-        try:
-            if "name" in self.pymathicsmodule.pymathics_version_data:
-                self.name = self.version = self.pymathicsmodule.pymathics_version_data[
-                    "name"
-                ]
-            else:
-                self.name = (self.pymathicsmodule.__package__)[10:]
-            self.version = self.pymathicsmodule.pymathics_version_data["version"]
-            self.author = self.pymathicsmodule.pymathics_version_data["author"]
-        except (AttributeError, KeyError, IndexError):
-            print(module + " is not a pymathics module.")
-            self.pymathicsmodule = None
-            self.parts = []
+        if not hasattr(pymathicsmodule, "pymathics_version_data"):
+            print(
+                f"{full_module_name} does not have pymathics_version_data; it it a pymathics module?"
+            )
             return
 
-        # Paths
-        self.doc_dir = self.pymathicsmodule.__path__[0] + "/doc/"
-        self.doc_data_file = self.doc_dir + "tex/data"
-        self.latex_file = self.doc_dir + "tex/documentation.tex"
+        pymathics_version_data = pymathicsmodule.pymathics_version_data
+        if not isinstance(pymathics_version_data, dict):
+            print(
+                f"{full_module_name}.pymathics_version_data is not a Python dictionary; it it a pymathics module?"
+            )
+            return
 
-        # Load the dictionary of mathics symbols defined in the module
-        self.symbols = {}
-        from mathics.builtin import is_builtin, Builtin
+        for field in ("version", "author", "name"):
+            if field not in pymathics_version_data:
+                print(
+                    f"{full_module_name}.pymathics_version_data does not contain a '{field}' field; it it a pymathics module?"
+                )
+                return
 
-        print("loading symbols")
-        for name in dir(self.pymathicsmodule):
-            var = getattr(self.pymathicsmodule, name)
+        print(f"adding symbols for {full_module_name}")
+        for name in dir(pymathicsmodule):
+            var = getattr(pymathicsmodule, name)
             if (
                 hasattr(var, "__module__")
-                and var.__module__ != "mathics.builtin.base"
                 and is_builtin(var)
                 and not name.startswith("_")
-                and var.__module__[: len(self.pymathicsmodule.__name__)]
-                == self.pymathicsmodule.__name__
             ):  # nopep8
                 instance = var(expression=False)
                 if isinstance(instance, Builtin):
                     self.symbols[instance.get_name()] = instance
-        # Defines de default first part, in case we are building an independent documentation module.
-        self.title = "Overview"
-        self.parts = []
-        self.parts_by_slug = {}
-        try:
-            files = listdir(self.doc_dir)
-            files.sort()
-        except FileNotFoundError:
-            self.doc_dir = ""
-            self.doc_data_file = ""
-            self.latex_file = ""
-            files = []
-        appendix = []
-        for file in files:
-            part_title = file[2:]
-            if part_title.endswith(".mdoc"):
-                part_title = part_title[: -len(".mdoc")]
-                part = DocPart(self, part_title)
-                text = open(self.doc_dir + file, "rb").read().decode("utf8")
-                text = filter_comments(text)
-                chapters = CHAPTER_RE.findall(text)
-                for title, text in chapters:
-                    chapter = DocChapter(part, title)
-                    text += '<section title=""></section>'
-                    sections = SECTION_RE.findall(text)
-                    for pre_text, title, text in sections:
-                        if not chapter.doc:
-                            chapter.doc = XMLDoc(pre_text)
-                        if title:
-                            section = DocSection(chapter, title, text)
-                            chapter.sections.append(section)
-                    part.chapters.append(chapter)
-                if file[0].isdigit():
-                    self.parts.append(part)
-                else:
-                    part.is_appendix = True
-                    appendix.append(part)
 
-        # Builds the automatic documentation
+        # Build module documentation
         builtin_part = DocPart(self, "Pymathics Modules", is_reference=True)
-        title, text = get_module_doc(self.pymathicsmodule)
-        chapter = DocChapter(builtin_part, title, XMLDoc(text))
+        title, text = get_module_doc(pymathicsmodule)
+        chapter = DocChapter(builtin_part, title, XMLDoc(text, title))
         for name in self.symbols:
             instance = self.symbols[name]
             installed = check_requires_list(getattr(instance, "requires", []))
@@ -1136,8 +1079,6 @@ class PyMathicsDocumentation(Documentation):
         builtin_part.chapters.append(chapter)
         self.parts.append(builtin_part)
         # Adds possible appendices
-        for part in appendix:
-            self.parts.append(part)
 
         # set keys of tests
         for tests in self.get_tests():

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -14,16 +14,20 @@ import os.path as osp
 import pickle
 import re
 import sys
+
 from argparse import ArgumentParser
 from datetime import datetime
 
 import mathics
-from mathics import settings, version_string
-from mathics.builtin import builtins_dict
+
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.evaluators import eval_load_module
 from mathics.core.parser import MathicsSingleLineFeeder
+from mathics.builtin import builtins_dict
+
+from mathics import version_string
+from mathics import settings
 from mathics.doc.common_doc import MathicsMainDocumentation, PyMathicsDocumentation
 
 builtins = builtins_dict()
@@ -263,6 +267,7 @@ def test_chapters(
 
 
 def test_sections(
+    documentation,
     sections: set,
     quiet=False,
     stop_on_failure=False,
@@ -586,7 +591,7 @@ def main():
         for doc in docs:
             test_sections(
                 doc,
-                sections,
+                set(sections),
                 stop_on_failure=args.stop_on_failure,
                 generate_output=args.output,
                 reload=args.reload,
@@ -596,7 +601,7 @@ def main():
         for doc in docs:
             test_chapters(
                 documentation,
-                chapters,
+                set(chapters),
                 stop_on_failure=args.stop_on_failure,
                 reload=args.reload,
             )
@@ -621,7 +626,7 @@ def main():
                 excludes=excludes,
                 want_sorting=args.want_sorting,
             )
-            end_time = datetime.now()
+        end_time = datetime.now()
         print("Tests took ", end_time - start_time)
 
     if logfile:

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -14,20 +14,17 @@ import os.path as osp
 import pickle
 import re
 import sys
-
 from argparse import ArgumentParser
 from datetime import datetime
 
 import mathics
-
+from mathics import settings, version_string
+from mathics.builtin import builtins_dict
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
+from mathics.core.evaluators import eval_load_module
 from mathics.core.parser import MathicsSingleLineFeeder
-from mathics.builtin import builtins_dict
-
-from mathics import version_string
-from mathics import settings
-from mathics.doc.common_doc import MathicsMainDocumentation
+from mathics.doc.common_doc import MathicsMainDocumentation, PyMathicsDocumentation
 
 builtins = builtins_dict()
 
@@ -40,7 +37,7 @@ class TestOutput(Output):
 sep = "-" * 70 + "\n"
 
 # Global variables
-definitions = None
+definitions = Definitions(add_builtin=True)
 documentation = None
 check_partial_enlapsed_time = False
 logfile = None
@@ -224,6 +221,7 @@ def create_output(tests, doc_data, format="tex"):
 
 
 def test_chapters(
+    documentation,
     chapters: set,
     quiet=False,
     stop_on_failure=False,
@@ -319,6 +317,7 @@ def open_ensure_dir(f, *args, **kwargs):
 
 
 def test_all(
+    documentation,
     quiet=False,
     generate_output=True,
     stop_on_failure=False,
@@ -436,10 +435,8 @@ def extract_doc_from_source(quiet=False, reload=False):
 
 
 def main():
-    global definitions
     global logfile
     global check_partial_enlapsed_time
-    definitions = Definitions(add_builtin=True)
 
     parser = ArgumentParser(description="Mathics test suite.", add_help=False)
     parser.add_argument(
@@ -451,27 +448,27 @@ def main():
     parser.add_argument(
         "--chapters",
         "-c",
+        action="append",
         dest="chapters",
         metavar="CHAPTER",
-        help="only test CHAPTER(s). "
-        "You can list multiple chapters by adding a comma (and no space) in between chapter names.",
+        help="only test CHAPTER(s). " "You can use this option multiple times.",
     )
     parser.add_argument(
         "--sections",
         "-s",
+        action="append",
         dest="sections",
         metavar="SECTION",
-        help="only test SECTION(s). "
-        "You can list multiple sections by adding a comma (and no space) in between section names.",
+        help="only test SECTION(s). " "You can use this option multiple times.",
     )
     parser.add_argument(
         "--exclude",
         "-X",
+        action="append",
         default="",
         dest="exclude",
         metavar="SECTION",
-        help="excude SECTION(s). "
-        "You can list multiple sections by adding a comma (and no space) in between section names.",
+        help="excude SECTION(s). " "You can use this option multiple times.",
     )
     parser.add_argument(
         "--logfile",
@@ -482,9 +479,9 @@ def main():
     )
     parser.add_argument(
         "--pymathics",
-        "-l",
+        "-p",
+        action="append",
         dest="pymathics",
-        action="store_true",
         help="also checks pymathics modules.",
     )
     parser.add_argument(
@@ -570,41 +567,51 @@ def main():
         logfile = open(args.logfilename, "wt")
 
     global documentation
-    documentation = MathicsMainDocumentation(want_sorting=args.want_sorting)
+    docs = [MathicsMainDocumentation(want_sorting=args.want_sorting)]
+    docs = []
+    if args.pymathics:
+        print(f"Including pymathics documentation for: {', '.join(args.pymathics)}")
+        pymathics_documentation = PyMathicsDocumentation()
+        evaluation = Evaluation(definitions, catch_interrupt=True, output=TestOutput())
+        for pymathics_module_name in args.pymathics:
+            try:
+                eval_load_module(f"pymathics.{pymathics_module_name}", evaluation)
+            except Exception:
+                continue
+            pymathics_documentation.load_pymathics_module(pymathics_module_name)
+        docs.append(pymathics_documentation)
+
     if args.sections:
-        sections = set(args.sections.split(","))
-        if args.pymathics:  # in case the section is in a pymathics module...
-            documentation.load_pymathics_doc()
-
-        test_sections(
-            sections,
-            stop_on_failure=args.stop_on_failure,
-            generate_output=args.output,
-            reload=args.reload,
-        )
-    elif args.chapters:
-        chapters = set(args.chapters.split(","))
-        if args.pymathics:  # in case the section is in a pymathics module...
-            documentation.load_pymathics_doc()
-
-        test_chapters(
-            chapters, stop_on_failure=args.stop_on_failure, reload=args.reload
-        )
-    else:
-        # if we want to check also the pymathics modules
-        if args.pymathics:
-            print("Building pymathics documentation object")
-            documentation.load_pymathics_doc()
-        elif args.doc_only:
-            extract_doc_from_source(
-                quiet=args.quiet,
+        sections = args.sections
+        for doc in docs:
+            test_sections(
+                doc,
+                sections,
+                stop_on_failure=args.stop_on_failure,
+                generate_output=args.output,
                 reload=args.reload,
             )
-        else:
-            excludes = set(args.exclude.split(","))
-            start_at = args.skip + 1
-            start_time = datetime.now()
+    elif args.chapters:
+        chapters = args.chapters
+        for doc in docs:
+            test_chapters(
+                documentation,
+                chapters,
+                stop_on_failure=args.stop_on_failure,
+                reload=args.reload,
+            )
+    elif args.doc_only:
+        extract_doc_from_source(
+            quiet=args.quiet,
+            reload=args.reload,
+        )
+    else:
+        excludes = set(args.exclude.split(","))
+        start_at = args.skip + 1
+        start_time = datetime.now()
+        for doc in docs:
             test_all(
+                doc,
                 quiet=args.quiet,
                 generate_output=args.output,
                 stop_on_failure=args.stop_on_failure,
@@ -615,7 +622,8 @@ def main():
                 want_sorting=args.want_sorting,
             )
             end_time = datetime.now()
-            print("Tests took ", end_time - start_time)
+        print("Tests took ", end_time - start_time)
+
     if logfile:
         logfile.close()
 

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -3,7 +3,6 @@
 NIntegrate[] tests
 
 """
-import importlib
 import pytest
 from test.helper import evaluate
 from mathics.builtin.base import check_requires_list


### PR DESCRIPTION
This doesn't fully work but it is a step in the right direction.

The context for pymathics modules should have the Pymathics module name, e.g. `Pymathics``Graph` or `Pymathics``Natlang`` rather than simply `Pymathics`.

But this messes up both testing and interactive use.

@mmatera if you can move this forward that would be good. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/453"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

