### PR TITLE
Add parentheses around negative numbers in formatting output in infix notation - issue 332

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,7 +116,7 @@ Bugs
 * `N[Indeterminate]` now produces `Indeterminate` instead a `PrecisionReal(nan)`.
 * Fix crash in ``NestWhile`` when supplying ``All`` as the fourth argument.
 * Fix the comparison between ``Image`` and other expressions.
-
+* Fix a bug in formatting expressions of the form ``(-1)^a`` without the parenthesis (issue #332).
 
 4.0.1
 -----

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -517,7 +517,7 @@ class Power(BinaryOperator, _MPMathFunction):
     #> (3/2+1/2I)^2
      = 2 + 3 I / 2
     #> I ^ I
-     = -1 ^ (I / 2)
+     = (-1) ^ (I / 2)
 
     #> 2 ^ 2.0
      = 4.

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -209,12 +209,11 @@ def parenthesize(precedence, element, element_boxes, when_equal):
         element = element.elements[0]
 
     if element.has_form(("Infix", "Prefix", "Postfix"), 3, None):
-        element_prec = element.elements[2].get_int_value()
+        element_prec = element.elements[2].value
     elif element.has_form("PrecedenceForm", 2):
-        element_prec = element.elements[1].get_int_value()
+        element_prec = element.elements[1].value
     # For negative values, ensure that the element_precedence is at least the precedence. (Fixes #332)
     elif isinstance(element, (Integer, Real)) and element.value < 0:
-        print("element is a signed number")
         element_prec = precedence
     else:
         element_prec = builtins_precedence.get(element.get_head_name())

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -206,10 +206,14 @@ def parenthesize(precedence, element, element_boxes, when_equal):
 
     while element.has_form("HoldForm", 1):
         element = element.elements[0]
+
     if element.has_form(("Infix", "Prefix", "Postfix"), 3, None):
         element_prec = element.elements[2].get_int_value()
     elif element.has_form("PrecedenceForm", 2):
         element_prec = element.elements[1].get_int_value()
+    # For negative values, ensure that the element_precedence is at least the precedence. (Fixes #332)
+    elif isinstance(element, Integer) and element.value < 0:
+        element_prec = precedence
     else:
         element_prec = builtins_precedence.get(element.get_head_name())
     if precedence is not None and element_prec is not None:

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -27,12 +27,13 @@ from mathics.builtin.lists import list_boxes
 from mathics.builtin.options import options_to_rules
 
 from mathics.core.atoms import (
-    String,
-    StringFromPython,
     Integer,
+    Number,
     Real,
     MachineReal,
     PrecisionReal,
+    String,
+    StringFromPython,
 )
 from mathics.core.element import EvalMixin
 from mathics.core.expression import Expression, BoxError
@@ -212,7 +213,8 @@ def parenthesize(precedence, element, element_boxes, when_equal):
     elif element.has_form("PrecedenceForm", 2):
         element_prec = element.elements[1].get_int_value()
     # For negative values, ensure that the element_precedence is at least the precedence. (Fixes #332)
-    elif isinstance(element, Integer) and element.value < 0:
+    elif isinstance(element, (Integer, Real)) and element.value < 0:
+        print("element is a signed number")
         element_prec = precedence
     else:
         element_prec = builtins_precedence.get(element.get_head_name())

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -35,7 +35,7 @@ class RSolve(Builtin):
 
     No boundary conditions gives two general paramaters:
     >> RSolve[{a[n + 2] == a[n]}, a, n]
-     = {{a -> (Function[{n}, C[0] + C[1] -1 ^ n])}}
+     = {{a -> (Function[{n}, C[0] + C[1] (-1) ^ n])}}
 
     Include one boundary condition:
     >> RSolve[{a[n + 2] == a[n], a[0] == 1}, a, n]
@@ -46,7 +46,7 @@ class RSolve(Builtin):
 
     Geta "pure function" solution for a with two boundary conditions:
     >> RSolve[{a[n + 2] == a[n], a[0] == 1, a[1] == 4}, a, n]
-     = {{a -> (Function[{n}, 5 / 2 - 3 -1 ^ n / 2])}}
+     = {{a -> (Function[{n}, 5 / 2 - 3 (-1) ^ n / 2])}}
     """
 
     messages = {

--- a/test/builtin/test_comparison.py
+++ b/test/builtin/test_comparison.py
@@ -209,12 +209,12 @@ def test_unsameq(str_expr, str_expected):
 #     tests.append(newtest)
 
 tests1 = [
-    ("Sqrt[I] Infinity", "2 + 3 a", '"-1 ^ (1 / 4) Infinity == 2 + 3 a"'),
-    ("a", "Sqrt[I] Infinity", '"a == -1 ^ (1 / 4) Infinity"'),
+    ("Sqrt[I] Infinity", "2 + 3 a", '"(-1) ^ (1 / 4) Infinity == 2 + 3 a"'),
+    ("a", "Sqrt[I] Infinity", '"a == (-1) ^ (1 / 4) Infinity"'),
     ('"a"', "2 + 3 a", '"a == 2 + 3 a"'),
     ('"a"', "Infinity", '"a == Infinity"'),
     ('"a"', "-Infinity", '"a == -Infinity"'),
-    ('"a"', "Sqrt[I] Infinity", '"a == -1 ^ (1 / 4) Infinity"'),
+    ('"a"', "Sqrt[I] Infinity", '"a == (-1) ^ (1 / 4) Infinity"'),
     ('"a"', "a", '"a == a"'),
     ("Graphics[{Disk[{0,0},1]}]", "2 + 3 a", '"-Graphics- == 2 + 3 a"'),
     ("Graphics[{Disk[{0,0},1]}]", "Infinity", '"-Graphics- == Infinity"'),
@@ -222,7 +222,7 @@ tests1 = [
     (
         "Graphics[{Disk[{0,0},1]}]",
         "Sqrt[I] Infinity",
-        '"-Graphics- == -1 ^ (1 / 4) Infinity"',
+        '"-Graphics- == (-1) ^ (1 / 4) Infinity"',
     ),
     ("Graphics[{Disk[{0,0},1]}]", "a", '"-Graphics- == a"'),
     ("Graphics[{Disk[{0,0},1]}]", '"a"', '"-Graphics- == a"'),
@@ -249,7 +249,7 @@ tests1 = [
     ('"1 / 4"', "2 + 3 a", '"1 / 4 == 2 + 3 a"'),
     ('"1 / 4"', "Infinity", '"1 / 4 == Infinity"'),
     ('"1 / 4"', "-Infinity", '"1 / 4 == -Infinity"'),
-    ('"1 / 4"', "Sqrt[I] Infinity", '"1 / 4 == -1 ^ (1 / 4) Infinity"'),
+    ('"1 / 4"', "Sqrt[I] Infinity", '"1 / 4 == (-1) ^ (1 / 4) Infinity"'),
     ('"1 / 4"', "a", '"1 / 4 == a"'),
     ("Sqrt[2]", '"1 / 4"', '"Sqrt[2] == 1 / 4"'),
     ("BesselJ[0, 2]", '"1 / 4"', '"BesselJ[0, 2] == 1 / 4"'),
@@ -272,7 +272,7 @@ tests1 = [
     (
         'TestFunction["Tengo una vaca lechera"]',
         "Sqrt[I] Infinity",
-        '"TestFunction[Tengo una vaca lechera] == -1 ^ (1 / 4) Infinity"',
+        '"TestFunction[Tengo una vaca lechera] == (-1) ^ (1 / 4) Infinity"',
     ),
     (
         'TestFunction["Tengo una vaca lechera"]',
@@ -352,7 +352,7 @@ tests1 = [
     (
         "Compile[{x}, Sqrt[x]]",
         "Sqrt[I] Infinity",
-        '"CompiledFunction[{x}, Sqrt[x], -PythonizedCode-] == -1 ^ (1 / 4) Infinity"',
+        '"CompiledFunction[{x}, Sqrt[x], -PythonizedCode-] == (-1) ^ (1 / 4) Infinity"',
     ),
     (
         "Compile[{x}, Sqrt[x]]",


### PR DESCRIPTION
This PR fixes formatting  issue in ``Power`` that was behind the one reported in #332.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/460"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

