### PR TITLE
fix get_sort_key to reproduce the canonical order in WMA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,9 @@ Enhancements
 * Allow scipy and skimage to be optional. In particular:
    - Revise ``Nintegrate[]`` to use ``Method="Internal"`` when scipy isn't available.
 * Pyston up to versions from 2.2 to 2.3.4 are supported as are PyPy versions from 3.7-7.3.9.0 up 3.9-7.3.9. However those Python interpreters may have limitations and limitations on packages that they support.
+* Compatibility with the default way in which WMA sorts expressions was improved: Now expressions with fewer elements come first (issue #458).
 
+  
 Documentation
 .............
 

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -2088,7 +2088,7 @@ class Image(Atom):
             # but with a `2` instead of `1` in the 5th position,
             # and adding two extra fields: the length in the 5th position,
             # and a hash in the 6th place.
-            return (1, 3, SymbolImage, tuple(), 2, len(self.pixels), hash(self))
+            return (1, 3, SymbolImage, len(self.pixels), tuple(), 2, hash(self))
 
     def sameQ(self, other) -> bool:
         """Mathics SameQ"""

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -1256,8 +1256,7 @@ class ExpandAll(_Expand):
      = Sin[x ^ 2 + 2 x y + y ^ 2]
 
     >> ExpandAll[Sin[(x+y)^2], Trig->True]
-     = -Sin[x ^ 2] Sin[2 x y] Sin[y ^ 2] + Cos[x ^ 2] Cos[2 x y] Sin[y ^ 2] + Cos[x ^ 2] Cos[y ^ 2] Sin[2 x y] + Cos[2 x y] Cos[y ^ 2] Sin[x ^ 2]
-
+     = Cos[x ^ 2] Cos[2 x y] Sin[y ^ 2] + Cos[x ^ 2] Cos[y ^ 2] Sin[2 x y] + Cos[2 x y] Cos[y ^ 2] Sin[x ^ 2] - Sin[x ^ 2] Sin[2 x y] Sin[y ^ 2]
     'ExpandAll' also expands heads
     >> ExpandAll[((1 + x)(1 + y))[x]]
      = (1 + x + y + x y)[x]

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -580,7 +580,7 @@ class Integrate(SympyFunction):
      = f[b] - f[a]
     and,
     >> D[Integrate[f[u, x],{u, a[x], b[x]}], x]
-     = Integrate[Derivative[0, 1][f][u, x], {u, a[x], b[x]}] - f[a[x], x] a'[x] + f[b[x], x] b'[x]
+     = Integrate[Derivative[0, 1][f][u, x], {u, a[x], b[x]}] + f[b[x], x] b'[x] - f[a[x], x] a'[x]
     >> N[Integrate[Sin[Exp[-x^2 /2 ]],{x,1,2}]]
      = 0.330804
     """

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -836,7 +836,14 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                     1,
                 )
             else:
-                return (1 if self.is_numeric() else 2, 3, head, self._elements, 1)
+                return (
+                    1 if self.is_numeric() else 2,
+                    3,
+                    head,
+                    len(self._elements),
+                    self._elements,
+                    1,
+                )
 
     @property
     def head(self):

--- a/test/core/test_expression.py
+++ b/test/core/test_expression.py
@@ -11,6 +11,14 @@ from mathics.builtin.base import check_requires_list
 )
 def test_canonical_sort():
     check_evaluation(
-        'Sort[{Import["ExampleData/Einstein.jpg"], 5}]',
-        '{5, Import["ExampleData/Einstein.jpg"]}',
+        r'Sort[{Import["ExampleData/Einstein.jpg"], 5}]',
+        r'{5, Import["ExampleData/Einstein.jpg"]}',
+    )
+    check_evaluation(
+        r"Sort[Table[IntegerDigits[2^n], {n, 10}]]",
+        r"{{2}, {4}, {8}, {1, 6}, {3, 2}, {6, 4}, {1, 2, 8}, {2, 5, 6}, {5, 1, 2}, {1, 0, 2, 4}}",
+    )
+    check_evaluation(
+        r"SortBy[Table[IntegerDigits[2^n], {n, 10}], First]",
+        r"{{1, 6}, {1, 2, 8}, {1, 0, 2, 4}, {2}, {2, 5, 6}, {3, 2}, {4}, {5, 1, 2}, {6, 4}, {8}}",
     )


### PR DESCRIPTION
This PR fixes #458.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/467"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

