### PR TITLE
Allow text link in URL

### DIFF
--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -1068,11 +1068,10 @@ class Transliterate(Builtin):
         <dd>transliterates a text in some script into an ASCII string.
     </dl>
 
-    ASCII translateration examples can be found in:
+    ASCII translateration examples:
     <ul>
-      <li><url>https://en.wikipedia.org/wiki/Iliad,</url>
-      <li><url>https://en.wikipedia.org/wiki/Russian_language</url>, and
-      <li><url>https://en.wikipedia.org/wiki/Hiragana</url>
+      <li><url>:Russian language: https://en.wikipedia.org/wiki/Russian_language#Transliteration</url>
+      <li><url>:Hiragana: https://en.wikipedia.org/wiki/Hiragana#Table_of_hiragana</url>
     </ul>
     """
 

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -86,7 +86,7 @@ class _NoBoolVector(Exception):
 
 class Binomial(_MPMathFunction):
     """
-    Binomcial Coefficient. See <url>https://en.wikipedia.org/wiki/Binomial_coefficient</url>.
+    <url>:Binomial Coefficient: https://en.wikipedia.org/wiki/Binomial_coefficient</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/functions/combinatorial.html#binomial</url>)
 
     <dl>
       <dt>'Binomial[$n$, $k$]'
@@ -121,7 +121,11 @@ class Binomial(_MPMathFunction):
 
 class CatalanNumber(SympyFunction):
     """
-    Catalan Number. See <url>https://en.wikipedia.org/wiki/Catalan_number</url>.
+    Catalan Number:
+    <ul>
+      <li><url>:Wikipedia: <url>https://en.wikipedia.org/wiki/Catalan_number</url>
+      <li><url>:SymPy: <url>https://docs.sympy.org/latest/modules/functions/combinatorial.html#sympy.functions.combinatorial.numbers.catalan</url>
+    </ul>
 
     <dl>
       <dt>'CatalanNumber[$n$]'

--- a/mathics/builtin/specialfns/__init__.py
+++ b/mathics/builtin/specialfns/__init__.py
@@ -9,7 +9,7 @@ One thing to note is that the technical literature often contains several confli
 
 A number of special functions can be evaluated for arbitrary complex values of their arguments. However defining relations may apply only for some special choices of arguments. Here, the full function corresponds to an extension or "analytic continuation" of the defining relation.
 
-For example, integral representations of functions are only valid when the integral exists, but the functions can usually be defined b by analytic continuation.
+For example, integral representations of functions are only valid when the integral exists, but the functions can usually be defined by analytic continuation.
 
 """
 

--- a/mathics/builtin/specialfns/bessel.py
+++ b/mathics/builtin/specialfns/bessel.py
@@ -30,7 +30,7 @@ class _Bessel(_MPMathFunction):
 
 class AiryAi(_MPMathFunction):
     """
-     Airy function of the first kind. See <url>https://en.wikipedia.org/wiki/Airy_function</url>.
+    <url>:Airy function of the first kind: https://en.wikipedia.org/wiki/Airy_function</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/functions/special.html#sympy.functions.special.bessel.airyai</url>, <url>:WMA: https://reference.wolfram.com/language/ref/AiryAi.html</url>)
     <dl>
       <dt>'AiryAi[$x$]'
       <dd>returns the Airy function Ai($x$).

--- a/mathics/builtin/specialfns/bessel.py
+++ b/mathics/builtin/specialfns/bessel.py
@@ -61,6 +61,7 @@ class AiryAi(_MPMathFunction):
 
 class AiryAiPrime(_MPMathFunction):
     """
+    Derivative of Airy function (<url>:Sympy: https://docs.sympy.org/latest/modules/functions/special.html#sympy.functions.special.bessel.airyaiprime</url>, <url>:WMA:https://reference.wolfram.com/language/ref/AiryAiPrime.html</url>)
     <dl>
       <dt>'AiryAiPrime[$x$]'
       <dd>returns the derivative of the Airy function 'AiryAi[$x$]'.
@@ -257,7 +258,7 @@ class AiryBiZero(Builtin):
 
 class AngerJ(_Bessel):
     """
-    Anger function. See <url>https://en.wikipedia.org/wiki/Anger_function</url>.
+    <url>:Anger function: https://en.wikipedia.org/wiki/Anger_function</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/bessel.html#mpmath.angerj</url>, <url>:WMA: https://reference.wolfram.com/language/ref/AngerJ.html</url>)
     <dl>
       <dt>'AngerJ[$n$, $z$]'
       <dd>returns the Anger function J_$n$($z$).
@@ -283,7 +284,7 @@ class AngerJ(_Bessel):
 class BesselI(_Bessel):
     """
 
-    Modified Bessel function of the first kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1</url>.
+    <url>:Modified Bessel function of the first kind: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1</url> (<url>:Sympy: https://docs.sympy.org/latest/modules/functions/special.html#sympy.functions.special.bessel.besseli</url>, <url>:WMA: https://reference.wolfram.com/language/ref/BesselI.html</url>)
 
     <dl>
     <dt>'BesselI[$n$, $z$]'
@@ -308,7 +309,7 @@ class BesselI(_Bessel):
 
 class BesselJ(_Bessel):
     """
-    Bessel function of the first kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1</url>.
+    <url>:Bessel function of the first kind: https://en.wikipedia.org/wiki/Bessel_function#Bessel_functions_of_the_first_kind:_J%CE%B1</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/functions/special.html#sympy.functions.special.bessel.besselj</url>, <url>:WMA: https://reference.wolfram.com/language/ref/BesselJ.html</url>)
 
     <dl>
     <dt>'BesselJ[$n$, $z$]'
@@ -348,7 +349,7 @@ class BesselJ(_Bessel):
 
 class BesselK(_Bessel):
     """
-    Modified Bessel function of the second kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1</url>.
+    <url>:Modified Bessel function of the second kind: https://en.wikipedia.org/wiki/Bessel_function#Modified_Bessel_functions:_I%CE%B1,_K%CE%B1</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/functions/special.html#sympy.functions.special.bessel.besselk</url>, <url>:WMA:https://reference.wolfram.com/language/ref/BesselJ.html</url>)
 
     <dl>
       <dt>'BesselK[$n$, $z$]'
@@ -490,7 +491,7 @@ class HankelH2(_Bessel):
 
 class KelvinBei(_Bessel):
     """
-    Kelvin function bei. See <url>https://en.wikipedia.org/wiki/Kelvin_functions#bei(x)</url>.
+    <url>:Kelvin function bei: https://en.wikipedia.org/wiki/Kelvin_functions#bei(x)</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/bessel.html#bei</url>, <url>:WMA: https://reference.wolfram.com/language/ref/KelvinBei.html</url>)
 
     <dl>
       <dt>'KelvinBei[$z$]'
@@ -525,7 +526,7 @@ class KelvinBei(_Bessel):
 
 class KelvinBer(_Bessel):
     """
-    Kelvin function ber. See <url>https://en.wikipedia.org/wiki/Kelvin_functions#ber(x)</url>.
+    <url>:Kelvin function ber: https://en.wikipedia.org/wiki/Kelvin_functions#ber(x)</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/bessel.html#ber</url>, <url>:WMA: https://reference.wolfram.com/language/ref/KelvinBer.html</url>)
     <dl>
       <dt>'KelvinBer[$z$]'
       <dd>returns the Kelvin function ber($z$).
@@ -559,7 +560,7 @@ class KelvinBer(_Bessel):
 
 class KelvinKei(_Bessel):
     """
-    Kelvin function kei. See <url>https://en.wikipedia.org/wiki/Kelvin_functions#kei(x)</url>.
+    <url>:Kelvin function kei: https://en.wikipedia.org/wiki/Kelvin_functions#kei(x)</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/bessel.html#kei</url>, <url>:WMA: https://reference.wolfram.com/language/ref/KelvinKei.html</url>)
 
     <dl>
       <dt>'KelvinKei[$z$]'
@@ -594,7 +595,7 @@ class KelvinKei(_Bessel):
 
 class KelvinKer(_Bessel):
     """
-    Kelvin function ker. See <url>https://en.wikipedia.org/wiki/Kelvin_functions#kei(x)</url>.
+    <url>:Kelvin function ker: https://en.wikipedia.org/wiki/Kelvin_functions#ker(x)</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/bessel.html#ker</url>, <url>:WMA: https://reference.wolfram.com/language/ref/KelvinKer.html</url>)
 
     <dl>
       <dt>'KelvinKer[$z$]'
@@ -627,7 +628,7 @@ class KelvinKer(_Bessel):
 class SphericalBesselJ(_Bessel):
     """
 
-    Spherical Bessel function of the first kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>.
+    <url>:Spherical Bessel function of the first kind: https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>
 
     <dl>
       <dt>'SphericalBesselJ[$n$, $z$]'
@@ -650,7 +651,7 @@ class SphericalBesselJ(_Bessel):
 
 class SphericalBesselY(_Bessel):
     """
-    Spherical Bessel function of the first kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>.
+    <url>:Spherical Bessel function of the first kind: https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>
 
     <dl>
       <dt>'SphericalBesselY[$n$, $z$]'
@@ -673,7 +674,7 @@ class SphericalBesselY(_Bessel):
 class SphericalHankelH1(_Bessel):
     """
 
-    Spherical Bessel function of the first kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>.
+    <url>:Spherical Bessel function of the first kind: https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>
 
     <dl>
       <dt>'SphericalHankelH1[$n$, $z$]'
@@ -693,7 +694,7 @@ class SphericalHankelH1(_Bessel):
 class SphericalHankelH2(_Bessel):
     """
 
-    Spherical Bessel function of the second kind. See <url>https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>.
+    <url>:Spherical Bessel function of the second kind: https://en.wikipedia.org/wiki/Bessel_function#Spherical_Bessel_functions</url>
 
     <dl>
       <dt>'SphericalHankelH1[$n$, $z$]'
@@ -712,7 +713,7 @@ class SphericalHankelH2(_Bessel):
 
 class StruveH(_Bessel):
     """
-    Struve functions H. See <url>https://en.wikipedia.org/wiki/Struve_function</url>.
+    <url>:Struve functions H: https://en.wikipedia.org/wiki/Struve_function</url>
     <dl>
       <dt>'StruveH[$n$, $z$]'
       <dd>returns the Struve function H_$n$($z$).
@@ -732,7 +733,7 @@ class StruveH(_Bessel):
 
 class StruveL(_Bessel):
     """
-    Modified Struve functions L. See <url>https://en.wikipedia.org/wiki/Struve_function</url>.
+    <url>:Modified Struve functions L: https://en.wikipedia.org/wiki/Struve_function</url>
     <dl>
       <dt>'StruveL[$n$, $z$]'
       <dd>returns the modified Struve function L_$n$($z$).

--- a/mathics/builtin/specialfns/elliptic.py
+++ b/mathics/builtin/specialfns/elliptic.py
@@ -24,8 +24,8 @@ class EllipticE(SympyFunction):
       <dt>'EllipticE[$m$]'
       <dd>computes the complete elliptic integral $E$($m$).
 
-      <dt>'EllipticE[ϕ|$m$]'
-      <dd>computes the complete elliptic integral of the second kind $E$($m$|$ϕ$).
+      <dt>'EllipticE[phi|$m$]'
+      <dd>computes the complete elliptic integral of the second kind $E$($m$|phi).
     </dl>
 
     Elliptic curves give Pi / 2 when evaluated at zero:
@@ -132,7 +132,7 @@ class EllipticK(SympyFunction):
 
     def apply_default(self, args, evaluation):
         "%(name)s[args___]"
-        evaluation.message("EllipticK", "argx", Integer(len(m.elements)))
+        evaluation.message("EllipticK", "argx", Integer(len(args.elements)))
 
     def apply(self, m, evaluation):
         "%(name)s[m_]"

--- a/mathics/builtin/specialfns/elliptic.py
+++ b/mathics/builtin/specialfns/elliptic.py
@@ -1,9 +1,8 @@
 """
-Elliptic Integrals
+<url>:Elliptic Integrals: https://en.wikipedia.org/wiki/Elliptic_integral</url>
 
 In integral calculus, an elliptic integral is one of a number of related functions defined as the value of certain integral. Their name originates from their originally arising in connection with the problem of finding the arc length of an ellipse. These functions often are used in cryptography to encode and decode messages.
 
-See <url>https://en.wikipedia.org/wiki/Elliptic_integral</url>.
 """
 
 from mathics.core.attributes import (
@@ -25,7 +24,7 @@ class EllipticE(SympyFunction):
       <dd>computes the complete elliptic integral $E$($m$).
 
       <dt>'EllipticE[phi|$m$]'
-      <dd>computes the complete elliptic integral of the second kind $E$($m$|phi).
+      <dd>computes the complete elliptic integral of the second kind $E$($m$|$phi$).
     </dl>
 
     Elliptic curves give Pi / 2 when evaluated at zero:

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -80,7 +80,9 @@ PYTHON_RE = re.compile(r"(?s)<python>(.*?)</python>")
 LATEX_CHAR_RE = re.compile(r"(?<!\\)(\^)")
 
 QUOTATIONS_RE = re.compile(r"\"([\w\s,]*?)\"")
-HYPERTEXT_RE = re.compile(r"(?s)<(?P<tag>em|url)>(?P<content>.*?)</(?P=tag)>")
+HYPERTEXT_RE = re.compile(
+    r"(?s)<(?P<tag>em|url)>(\s*:(?P<text>.*?):\s*)?(?P<content>.*?)</(?P=tag)>"
+)
 
 OUTSIDE_ASY_RE = re.compile(r"(?s)((?:^|\\end\{asy\}).*?(?:$|\\begin\{asy\}))")
 LATEX_TEXT_RE = re.compile(
@@ -362,6 +364,7 @@ def escape_latex(text):
             ("\u03b8", r"$\theta$"),
             ("\u03bc", r"$\mu$"),
             ("\u03c0", r"$\pi$"),
+            ("\u03d5", r"$\phi$"),
             ("\u2107", r"$\mathrm{e}$"),
             ("\u222b", r"\int"),
             ("\u2243", r"$\simeq$"),
@@ -422,7 +425,11 @@ def escape_latex(text):
         if tag == "em":
             return r"\emph{%s}" % content
         elif tag == "url":
-            return "\\url{%s}" % content
+            text = match.group("text")
+            if text is None:
+                return "\\url{%s}" % content
+            else:
+                return "\\href{%s}{%s}" % (content, text)
 
     text = QUOTATIONS_RE.sub(repl_quotation, text)
     text = HYPERTEXT_RE.sub(repl_hypertext, text)


### PR DESCRIPTION
This PR really has to separable things. The first part is to allow text links in url. The lack of this I found annoying and it is a direct result of a homegrown implementation that is hard to understand as well as being incomplete.

Because there are substitutions going on various places, I couldn't use either double quote which gets substituted in HTML for &quote) or single quote which is interpreted as code. Vertical bar is used in regexps and escaping that makes this ugly re even more ugly. So I used colon. 

The second aspect of this PR has to do with the builtins. The thought is on each builtin start of with the corresponding Wikipedia name if one exists with this name linked to the corresponding wiki page, and then give Sympy (when appropriate) and WMA links. 

Again we are hamstrung by limitations of the homegrown system in that this all has to appear on one line in the docstring.  And then there is the problem that list items aren't handled properly, which is why this is in parenthesis.

I spent probably too much time trying find something that would render reasonably well in Django and LaTeX. 
Screenshots of examples are below. The PDF rendering in chrome doesn't seem to show the links as links. In Django these appear as blue.

![AiryAi-Tex](https://user-images.githubusercontent.com/8851/181456781-61749115-1ba4-42aa-aafc-29885fc8140e.png)
![AiryAi-Django](https://user-images.githubusercontent.com/8851/181456782-937b6ed9-d108-4180-837d-6cf7ac22fe5d.png)


<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/473"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

I would love to figure out how to get rid of the two column format in LaTeX which is inappropriate for built-in function descriptions.