### PR TITLE
Correct  order of parameters in asy rectanglebox ..

### DIFF
--- a/mathics/format/asy.py
+++ b/mathics/format/asy.py
@@ -91,7 +91,7 @@ class _ASYTransform:
         return self._template % (" * ".join(self.transforms), asy)
 
 
-def arcbox(self, **options) -> str:
+def arcbox(self: _ArcBox, **options) -> str:
     """
     Aymptote formatting for an arc of a circle or an ellipse.
     """
@@ -130,7 +130,7 @@ def arcbox(self, **options) -> str:
 
         return arc_path
 
-    l = self.style.get_line_width(face_element=self.face_element)
+    stroke_width = self.style.get_line_width(face_element=self.face_element)
     edge_opacity_value = self.edge_opacity.opacity if self.edge_opacity else None
     face_opacity_value = self.face_opacity.opacity if self.face_opacity else None
 
@@ -139,7 +139,7 @@ def arcbox(self, **options) -> str:
         face_color=self.face_color,
         edge_opacity=edge_opacity_value,
         face_opacity=face_opacity_value,
-        stroke_width=l,
+        stroke_width=stroke_width,
         is_face_element=self.face_element,
     )
     command = "filldraw" if self.face_element else "draw"
@@ -153,7 +153,7 @@ def arcbox(self, **options) -> str:
 add_conversion_fn(_ArcBox, arcbox)
 
 
-def arrow_box(self, **options) -> str:
+def arrow_box(self: ArrowBox, **options) -> str:
     width = self.style.get_line_width(face_element=False)
     edge_opacity_value = self.edge_opacity.opacity if self.edge_opacity else None
     pen = asy_create_pens(
@@ -223,7 +223,7 @@ def arrow3dbox(self, **options) -> str:
 add_conversion_fn(Arrow3DBox)
 
 
-def bezier_curve_box(self, **options) -> str:
+def bezier_curve_box(self: BezierCurveBox, **options) -> str:
     """
     Asymptote formatter for BezierCurveBox.
     """
@@ -252,7 +252,7 @@ def bezier_curve_box(self, **options) -> str:
 add_conversion_fn(BezierCurveBox, bezier_curve_box)
 
 
-def cone3dbox(self, **options) -> str:
+def cone3dbox(self: Cone3DBox, **options) -> str:
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)
     opacity = self.face_opacity
     color_str = build_3d_pen_color(face_color, opacity)
@@ -290,7 +290,7 @@ def cone3dbox(self, **options) -> str:
 add_conversion_fn(Cone3DBox)
 
 
-def cuboid3dbox(self, **options) -> str:
+def cuboid3dbox(self: Cuboid3DBox, **options) -> str:
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)
     opacity = self.face_opacity
     color_str = build_3d_pen_color(face_color, opacity)
@@ -325,7 +325,7 @@ def cuboid3dbox(self, **options) -> str:
 add_conversion_fn(Cuboid3DBox)
 
 
-def cylinder3dbox(self, **options) -> str:
+def cylinder3dbox(self: Cylinder3DBox, **options) -> str:
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)
     opacity = self.face_opacity
     color_str = build_3d_pen_color(face_color, opacity)
@@ -389,7 +389,7 @@ def graphics_elements(self, **options) -> str:
     for element in self.elements:
         try:
             format_fn = lookup_method(element, "asy")
-        except:
+        except Exception:
             # Note error and continue
             result.append(f"""unhandled {element}""")
             continue
@@ -449,7 +449,7 @@ def line3dbox(self, **options) -> str:
 add_conversion_fn(Line3DBox)
 
 
-def line_box(self) -> str:
+def line_box(self: LineBox) -> str:
     line_width = self.style.get_line_width(face_element=False)
     edge_opacity_value = self.edge_opacity.opacity if self.edge_opacity else None
     pen = asy_create_pens(
@@ -468,7 +468,7 @@ def line_box(self) -> str:
 add_conversion_fn(LineBox, line_box)
 
 
-def point3dbox(self, **options) -> str:
+def point3dbox(self: Point3DBox, **options) -> str:
     """
     Aymptote 3D formatter for Point3DBox
     """
@@ -501,7 +501,7 @@ def point3dbox(self, **options) -> str:
 add_conversion_fn(Point3DBox)
 
 
-def pointbox(self, **options) -> str:
+def pointbox(self: PointBox, **options) -> str:
 
     point_size, _ = self.style.get_style(PointSize, face_element=False)
     if point_size is None:
@@ -530,11 +530,11 @@ def pointbox(self, **options) -> str:
 add_conversion_fn(PointBox)
 
 
-def polygon_3d_box(self, **options) -> str:
+def polygon_3d_box(self: Polygon3DBox, **options) -> str:
     """
     Asymptote formatting of a Polygon3DBox.
     """
-    l = self.style.get_line_width(face_element=True)
+    stroke_width = self.style.get_line_width(face_element=True)
     if self.vertex_colors is None:
         face_color = self.face_color
         face_opacity_value = self.face_opacity.opacity if self.face_opacity else None
@@ -548,7 +548,7 @@ def polygon_3d_box(self, **options) -> str:
         face_color=face_color,
         edge_opacity=edge_opacity_value,
         face_opacity=face_opacity_value,
-        stroke_width=l,
+        stroke_width=stroke_width,
         is_face_element=True,
     )
 
@@ -568,7 +568,7 @@ def polygon_3d_box(self, **options) -> str:
 add_conversion_fn(Polygon3DBox, polygon_3d_box)
 
 
-def polygonbox(self, **options) -> str:
+def polygonbox(self: PolygonBox, **options) -> str:
     line_width = self.style.get_line_width(face_element=True)
     if self.vertex_colors is None:
         face_color = self.face_color
@@ -622,7 +622,7 @@ def polygonbox(self, **options) -> str:
 add_conversion_fn(PolygonBox)
 
 
-def rectanglebox(self, **options) -> str:
+def rectanglebox(self: RectangleBox, **options) -> str:
     line_width = self.style.get_line_width(face_element=True)
     x1, y1 = self.p1.pos()
     x2, y2 = self.p2.pos()
@@ -631,10 +631,10 @@ def rectanglebox(self, **options) -> str:
     pens = asy_create_pens(
         self.edge_color,
         self.face_color,
-        line_width,
-        is_face_element=True,
         edge_opacity=edge_opacity_value,
         face_opacity=face_opacity_value,
+        stroke_width=line_width,
+        is_face_element=True,
     )
     x1, x2, y1, y2 = asy_number(x1), asy_number(x2), asy_number(y1), asy_number(y2)
     asy = "// RectangleBox\n"
@@ -656,7 +656,7 @@ def rectanglebox(self, **options) -> str:
 add_conversion_fn(RectangleBox)
 
 
-def _roundbox(self):
+def _roundbox(self: _RoundBox):
     x, y = self.c.pos()
     rx, ry = self.r.pos()
     rx -= x
@@ -686,7 +686,7 @@ def _roundbox(self):
 add_conversion_fn(_RoundBox)
 
 
-def sphere3dbox(self, **options) -> str:
+def sphere3dbox(self: Sphere3DBox, **options) -> str:
     # l = self.style.get_line_width(face_element=True)
 
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)
@@ -704,7 +704,7 @@ def sphere3dbox(self, **options) -> str:
 add_conversion_fn(Sphere3DBox)
 
 
-def tube_3d_box(self, **options) -> str:
+def tube_3d_box(self: Tube3DBox, **options) -> str:
     if not (hasattr(self.graphics, "tube_import_added") and self.tube_import_added):
 
         self.graphics.tube_import_added = True
@@ -731,7 +731,7 @@ def tube_3d_box(self, **options) -> str:
 add_conversion_fn(Tube3DBox, tube_3d_box)
 
 
-def uniform_polyhedron_3d_box(self, **options) -> str:
+def uniform_polyhedron_3d_box(self: RectangleBox, **options) -> str:
     # l = self.style.get_line_width(face_element=True)
 
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)

--- a/test/format/test_asy.py
+++ b/test/format/test_asy.py
@@ -91,7 +91,6 @@ def test_asy_arrowbox():
 
 
 def test_asy_bezier_curve():
-
     expression = Expression(
         SymbolGraphics,
         Expression(
@@ -107,6 +106,20 @@ def test_asy_bezier_curve():
 
     matches = re.match(r"// BezierCurveBox\nimport graph;", inner_asy)
     # TODO: Match line and arrowbox
+    assert matches
+
+
+def test_asy_rectanglebox():
+    expression = Expression(
+        SymbolGraphics,
+        ListExpression(
+            Expression(Symbol("Rectangle"), ListExpression(Integer0, Integer0))
+        ),
+    )
+    asy = get_asy(expression)
+    inner_asy = extract_asy_body(asy)
+
+    matches = re.match(r"// RectangleBox\n", inner_asy)
     assert matches
 
 


### PR DESCRIPTION
this caused the Dice example in the manual to fail - it uses rectanglebox.

Also, add type annotations on functions.

I think when one of the opacity parameters was added not all of the routines were adjusted. And we didn't have a test to check this either.

We have a test now.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

