### PR TITLE
Split off hyperbolic functions from trig fns..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,32 @@ CHANGES
 =======
 
 
+5.0.1
+-----
+
+Mostly a release to fix a Python packaging problem.
+
 Internals
----------
++++++++++
 
 
 #. ``format`` and ``do_format`` methods were removed from the interface of
    ``BaseElement``, becoming non-member functions.
 #. The class ``BoxElement`` was introduced as a base for boxing elements.
 
+New Builtin
++++++++++++
+#. 'Inverse Gudermannian'.
+
+Documentation
++++++++++++++
+
+Hyperbolic functions were split off form trigonometry and exponential functions. More url links were added.
+
+Bugs
+++++
+
+#. Creating a complex number fom Infinity no longer crashes and returns 'I * Infinity'
 
 5.0.0
 ------

--- a/mathics/autoload/rules/GudermannianRules.m
+++ b/mathics/autoload/rules/GudermannianRules.m
@@ -1,5 +1,7 @@
-(* From symja_android_library/symja_android_library/rules/QuantileRules.m *)
+(* Adapted from symja_android_library/symja_android_library/rules/QuantileRules.m *)
+(* This has been added as a Mathics Builtin in mathics.builtin.numbers.hyperbolic
 Begin["System`"]
+
 Gudermannian::usage = "gives the Gudermannian function";
 Gudermannian[Undefined]=Undefined;
 Gudermannian[0]=0;
@@ -9,10 +11,14 @@ Gudermannian[Infinity]=Pi/2;
 Gudermannian[-Infinity]=-Pi/2;
 Gudermannian[ComplexInfinity]=Indeterminate;
 Gudermannian[z_]=2 ArcTan[Tanh[z / 2]];
-(*
+ *)
+
+(* Commented out because ":=" might not work properly...
+
 Gudermannian[z_] := Piecewise[{{1/2*[Pi - 4*ArcCot[E^z]], Re[z]>0||(Re[z]==0&&Im[z]>=0 )}}, 1/2 (-Pi + 4 ArcTan[E^z])];
 D[Gudermannian[f_],x_?NotListQ] := Sech[f] D[f,x];
 Derivative[1][InverseGudermannian] := Sec[#] &;
 Derivative[1][Gudermannian] := Sech[#] &;
-*)
+
 End[]
+*)

--- a/mathics/builtin/numbers/exptrig.py
+++ b/mathics/builtin/numbers/exptrig.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
-r"""
-Exponential, Trigonometric and Hyperbolic Functions
-
-\Mathics basically supports all important trigonometric and hyperbolic functions.
+"""
+Exponential and Trigonometric Functions
 
 Numerical values and derivatives can be computed; however, most special exact values and simplification rules are not implemented yet.
 """
@@ -31,12 +29,8 @@ from mathics.core.symbols import Symbol, SymbolPower
 from mathics.core.systemsymbols import SymbolCos, SymbolE, SymbolSin
 
 SymbolArcCos = Symbol("ArcCos")
-SymbolArcCosh = Symbol("ArcCosh")
 SymbolArcSin = Symbol("ArcSin")
-SymbolArcSinh = Symbol("ArcSinh")
 SymbolArcTan = Symbol("ArcTan")
-SymbolCosh = Symbol("Cosh")
-SymbolSinh = Symbol("Sinh")
 
 
 class Fold:
@@ -356,32 +350,6 @@ class ArcCos(_MPMathFunction):
     }
 
 
-class ArcCosh(_MPMathFunction):
-    """
-    <dl>
-      <dt>'ArcCosh[$z$]'
-      <dd>returns the inverse hyperbolic cosine of $z$.
-    </dl>
-
-    >> ArcCosh[0]
-     = I / 2 Pi
-    >> ArcCosh[0.]
-     = 0. + 1.5708 I
-    >> ArcCosh[0.00000000000000000000000000000000000000]
-     = 1.5707963267948966192313216916397514421 I
-    #> ArcCosh[1.4]
-     = 0.867015
-    """
-
-    summary_text = "inverse hyperbolic cosine function"
-    sympy_name = "acosh"
-    mpmath_name = "acosh"
-
-    rules = {
-        "Derivative[1][ArcCosh]": "1/(Sqrt[#-1]*Sqrt[#+1])&",
-    }
-
-
 class ArcCot(_MPMathFunction):
     """
     <dl>
@@ -403,36 +371,6 @@ class ArcCot(_MPMathFunction):
         "Derivative[1][ArcCot]": "-1/(1+#^2)&",
         "ArcCot[0]": "Pi / 2",
         "ArcCot[1]": "Pi / 4",
-    }
-
-
-class ArcCoth(_MPMathFunction):
-    """
-    <dl>
-      <dt>'ArcCoth[$z$]'
-      <dd>returns the inverse hyperbolic cotangent of $z$.
-    </dl>
-
-    >> ArcCoth[0]
-     = I / 2 Pi
-    >> ArcCoth[1]
-     = Infinity
-    >> ArcCoth[0.0]
-     = 0. + 1.5708 I
-    >> ArcCoth[0.5]
-     = 0.549306 - 1.5708 I
-
-    #> ArcCoth[0.000000000000000000000000000000000000000]
-     = 1.57079632679489661923132169163975144210 I
-    """
-
-    summary_text = "inverse hyperbolic cotangent function"
-    sympy_name = "acoth"
-    mpmath_name = "acoth"
-
-    rules = {
-        "ArcCoth[z:0.0]": "N[I / 2 Pi, Precision[1+z]]",
-        "Derivative[1][ArcCoth]": "1/(1-#^2)&",
     }
 
 
@@ -463,37 +401,6 @@ class ArcCsc(_MPMathFunction):
         if len(expr.elements) == 1:
             return Expression(
                 SymbolArcSin, Expression(SymbolPower, expr.elements[0], Integer(-1))
-            ).to_sympy()
-
-
-class ArcCsch(_MPMathFunction):
-    """
-    <dl>
-      <dt>'ArcCsch[$z$]'
-      <dd>returns the inverse hyperbolic cosecant of $z$.
-    </dl>
-
-    >> ArcCsch[0]
-     = ComplexInfinity
-    >> ArcCsch[1.0]
-     = 0.881374
-    """
-
-    mpmath_name = "acsch"
-
-    rules = {
-        "ArcCsch[0]": "ComplexInfinity",
-        "ArcCsch[0.]": "ComplexInfinity",
-        "Derivative[1][ArcCsch]": "-1 / (Sqrt[1+1/#^2] * #^2) &",
-    }
-
-    summary_text = "inverse hyperbolic cosecant function"
-    sympy_name = ""
-
-    def to_sympy(self, expr, **kwargs):
-        if len(expr.elements) == 1:
-            return Expression(
-                SymbolArcSinh, Expression(SymbolPower, expr.elements[0], IntegerM1)
             ).to_sympy()
 
 
@@ -528,39 +435,6 @@ class ArcSec(_MPMathFunction):
             ).to_sympy()
 
 
-class ArcSech(_MPMathFunction):
-    """
-    <dl>
-      <dt>'ArcSech[$z$]'
-      <dd>returns the inverse hyperbolic secant of $z$.
-    </dl>
-
-    >> ArcSech[0]
-     = Infinity
-    >> ArcSech[1]
-     = 0
-    >> ArcSech[0.5]
-     = 1.31696
-    """
-
-    mpmath_name = "asech"
-
-    rules = {
-        "ArcSech[0]": "Infinity",
-        "ArcSech[0.]": "Indeterminate",
-        "Derivative[1][ArcSech]": "-1 / (# * Sqrt[(1-#)/(1+#)] (1+#)) &",
-    }
-
-    summary_text = "inverse hyperbolic secant function"
-    sympy_name = ""
-
-    def to_sympy(self, expr, **kwargs):
-        if len(expr.elements) == 1:
-            return Expression(
-                SymbolArcCosh, Expression(SymbolPower, expr.elements[0], IntegerM1)
-            ).to_sympy()
-
-
 class ArcSin(_MPMathFunction):
     """
     <dl>
@@ -584,30 +458,6 @@ class ArcSin(_MPMathFunction):
 
     summary_text = "inverse sine function"
     sympy_name = "asin"
-
-
-class ArcSinh(_MPMathFunction):
-    """
-    <dl>
-      <dt>'ArcSinh[$z$]'
-      <dd>returns the inverse hyperbolic sine of $z$.
-    </dl>
-
-    >> ArcSinh[0]
-     = 0
-    >> ArcSinh[0.]
-     = 0.
-    >> ArcSinh[1.0]
-     = 0.881374
-    """
-
-    summary_text = "inverse hyperbolic sine function"
-    sympy_name = "asinh"
-    mpmath_name = "asinh"
-
-    rules = {
-        "Derivative[1][ArcSinh]": "1/Sqrt[1+#^2]&",
-    }
 
 
 class ArcTan(_MPMathFunction):
@@ -657,36 +507,6 @@ class ArcTan(_MPMathFunction):
     sympy_name = "atan"
 
 
-class ArcTanh(_MPMathFunction):
-    """
-    <dl>
-    <dt>'ArcTanh[$z$]'
-        <dd>returns the inverse hyperbolic tangent of $z$.
-    </dl>
-
-    >> ArcTanh[0]
-     = 0
-    >> ArcTanh[1]
-     = Infinity
-    >> ArcTanh[0]
-     = 0
-    >> ArcTanh[.5 + 2 I]
-     = 0.0964156 + 1.12656 I
-    >> ArcTanh[2 + I]
-     = ArcTanh[2 + I]
-    """
-
-    mpmath_name = "atanh"
-    numpy_name = "arctanh"
-
-    rules = {
-        "Derivative[1][ArcTanh]": "1/(1-#^2)&",
-    }
-
-    summary_text = "inverse hyperbolic tangent function"
-    sympy_name = "atanh"
-
-
 class Cos(_MPMathFunction):
     """
     <dl>
@@ -714,26 +534,6 @@ class Cos(_MPMathFunction):
     summary_text = "cosine function"
 
 
-class Cosh(_MPMathFunction):
-    """
-    <dl>
-      <dt>'Cosh[$z$]'
-      <dd>returns the hyperbolic cosine of $z$.
-    </dl>
-
-    >> Cosh[0]
-     = 1
-    """
-
-    mpmath_name = "cosh"
-
-    rules = {
-        "Derivative[1][Cosh]": "Sinh[#]&",
-    }
-
-    summary_text = "hyperbolic cosine function"
-
-
 class Cot(_MPMathFunction):
     """
     <dl>
@@ -755,28 +555,6 @@ class Cot(_MPMathFunction):
     }
 
     summary_text = "cotangent function"
-
-
-class Coth(_MPMathFunction):
-    """
-    <dl>
-      <dt>'Coth[$z$]'
-      <dd>returns the hyperbolic cotangent of $z$.
-    </dl>
-
-    >> Coth[0]
-     = ComplexInfinity
-    """
-
-    mpmath_name = "coth"
-
-    rules = {
-        "Coth[0]": "ComplexInfinity",
-        "Coth[0.]": "ComplexInfinity",
-        "Derivative[1][Coth]": "-Csch[#1]^2&",
-    }
-
-    summary_text = "hyperbolic cotangent function"
 
 
 class Csc(_MPMathFunction):
@@ -807,35 +585,6 @@ class Csc(_MPMathFunction):
         if len(expr.elements) == 1:
             return Expression(
                 SymbolPower, Expression(SymbolSin, expr.elements[0]), Integer(-1)
-            ).to_sympy()
-
-
-class Csch(_MPMathFunction):
-    """
-    <dl>
-    <dt>'Csch[$z$]'
-        <dd>returns the hyperbolic cosecant of $z$.
-    </dl>
-
-    >> Csch[0]
-     = ComplexInfinity
-    """
-
-    mpmath_name = "csch"
-
-    rules = {
-        "Csch[0]": "ComplexInfinity",
-        "Csch[0.]": "ComplexInfinity",
-        "Derivative[1][Csch]": "-Coth[#1] Csch[#1]&",
-    }
-
-    summary_text = "hyperbolic cosecant function"
-    sympy_name = ""
-
-    def to_sympy(self, expr, **kwargs):
-        if len(expr.elements) == 1:
-            return Expression(
-                SymbolPower, Expression(SymbolSinh, expr.elements[0]), IntegerM1
             ).to_sympy()
 
 
@@ -884,7 +633,7 @@ class Haversine(_MPMathFunction):
      = -1.15082 + 0.869405 I
     """
 
-    summary_text = "haversine function"
+    summary_text = "Haversine function"
     rules = {"Haversine[z_]": "Power[Sin[z/2], 2]"}
 
 
@@ -906,7 +655,7 @@ class InverseHaversine(_MPMathFunction):
      = 1.76459 + 2.33097 I
     """
 
-    summary_text = "inverse haversine function"
+    summary_text = "inverse Haversine function"
     rules = {"InverseHaversine[z_]": "2 * ArcSin[Sqrt[z]]"}
 
 
@@ -1067,32 +816,6 @@ class Sec(_MPMathFunction):
             ).to_sympy()
 
 
-class Sech(_MPMathFunction):
-    """
-    <dl>
-      <dt>'Sech[$z$]'
-      <dd>returns the hyperbolic secant of $z$.
-    </dl>
-
-    >> Sech[0]
-     = 1
-    """
-
-    mpmath_name = "sech"
-
-    rules = {
-        "Derivative[1][Sech]": "-Sech[#1] Tanh[#1]&",
-    }
-    summary_text = "hyperbolic secant function"
-    sympy_name = ""
-
-    def to_sympy(self, expr, **kwargs):
-        if len(expr.elements) == 1:
-            return Expression(
-                SymbolPower, Expression(SymbolCosh, expr.elements[0]), IntegerM1
-            ).to_sympy()
-
-
 class Sin(_MPMathFunction):
     """
     <dl>
@@ -1128,25 +851,6 @@ class Sin(_MPMathFunction):
     }
 
 
-class Sinh(_MPMathFunction):
-    """
-    <dl>
-      <dt>'Sinh[$z$]'
-      <dd>returns the hyperbolic sine of $z$.
-    </dl>
-
-    >> Sinh[0]
-     = 0
-    """
-
-    summary_text = "hyperbolic sine function"
-    mpmath_name = "sinh"
-
-    rules = {
-        "Derivative[1][Sinh]": "Cosh[#]&",
-    }
-
-
 class Tan(_MPMathFunction):
     """
     <dl>
@@ -1170,23 +874,4 @@ class Tan(_MPMathFunction):
         "Tan[(1/2) * Pi]": "ComplexInfinity",
         "Tan[0]": "0",
         "Derivative[1][Tan]": "Sec[#]^2&",
-    }
-
-
-class Tanh(_MPMathFunction):
-    """
-    <dl>
-      <dt>'Tanh[$z$]'
-      <dd>returns the hyperbolic tangent of $z$.
-    </dl>
-
-    >> Tanh[0]
-     = 0
-    """
-
-    summary_text = "hyperbolic tangent function"
-    mpmath_name = "tanh"
-
-    rules = {
-        "Derivative[1][Tanh]": "Sech[#1]^2&",
     }

--- a/mathics/builtin/numbers/hyperbolic.py
+++ b/mathics/builtin/numbers/hyperbolic.py
@@ -241,7 +241,7 @@ class Coth(_MPMathFunction):
 
 class Gudermannian(Builtin):
     """
-    <url>:Gudermannian function: https://en.wikipedia.org/wiki/Gudermannian_function</url> (<url>:WMA: https://reference.wolfram.com/language/ref/Indeterminate.html<url></url>)
+    <url>:Gudermannian function: https://en.wikipedia.org/wiki/Gudermannian_function</url> (<url>:WMA: https://reference.wolfram.com/language/ref/Gudermannian.html</url>, <url>:MathWorld: https://mathworld.wolfram.com/Gudermannian.html</url>)
     <dl>
       <dt>'Gudermannian[$z$]'
        <dd>returns the Gudermannian function $gd$($z$).
@@ -250,7 +250,7 @@ class Gudermannian(Builtin):
     >> Gudermannian[4.2]
      = 1.54081
 
-    'Gudermannian[-$z$]' == - 'Gudermannian[$z$]'. So:
+    'Gudermannian[-$z$]' == - 'Gudermannian[$z$]':
 
     >> Gudermannian[-4.2] ==  -Gudermannian[4.2]
      = True
@@ -282,6 +282,34 @@ class Gudermannian(Builtin):
     }
 
     summary_text = "Gudermannian function gd(z)"
+
+
+class InverseGudermannian(Builtin):
+    """
+    <url>:Inverse Gudermannian function: https://en.wikipedia.org/wiki/Gudermannian_function</url> (<url>:WMA: https://reference.wolfram.com/language/ref/InverseGudermannian.html</url>, <url>:MathWorld: https://mathworld.wolfram.com/InverseGudermannian.html</url>)
+    <dl>
+      <dt>'InverseGudermannian[$z$]'
+       <dd>returns the inverse Gudermannian function $gd$^-1($z$).
+    </dl>
+
+    >> InverseGudermannian[.5]
+     = 0.522238
+
+    'InverseGudermannian[-$z$]' == -'InversGudermannian[$z$]':
+
+    >> InverseGudermannian[-.5] ==  -InverseGudermannian[.5]
+     = True
+
+    >> Plot[InverseGudermannian[x], {x, -10, 10}]
+     = -Graphics-
+    """
+
+    rules = {
+        "InverseGudermannian[z_]": "Log[Tan[Pi/4 + z/2]]",
+        # Derivative[1][InverseGudermannian] := Sec[#] &;
+    }
+
+    summary_text = "inverse Gudermannian function gd^-1(z)"
 
 
 class Sech(_MPMathFunction):

--- a/mathics/builtin/numbers/hyperbolic.py
+++ b/mathics/builtin/numbers/hyperbolic.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+
+"""
+Hyperbolic Functions
+
+<url>:Hyperbolic functions: https://en.wikipedia.org/wiki/Hyperbolic_functions</url> are analogues of the ordinary trigonometric functions, but defined using the hyperbola rather than the circle.
+
+Numerical values and derivatives can be computed; however, most special exact values and simplification rules are not implemented yet.
+"""
+
+from typing import Optional
+from mathics.core.convert.sympy import SympyExpression
+
+from mathics.builtin.arithmetic import _MPMathFunction
+from mathics.builtin.base import Builtin
+from mathics.core.atoms import IntegerM1
+from mathics.core.expression import Expression
+from mathics.core.symbols import Symbol, SymbolPower
+
+SymbolArcCosh = Symbol("ArcCosh")
+SymbolArcSinh = Symbol("ArcSinh")
+SymbolCosh = Symbol("Cosh")
+SymbolSinh = Symbol("Sinh")
+
+
+class ArcCosh(_MPMathFunction):
+    """
+    <dl>
+      <dt>'ArcCosh[$z$]'
+      <dd>returns the inverse hyperbolic cosine of $z$.
+    </dl>
+
+    >> ArcCosh[0]
+     = I / 2 Pi
+    >> ArcCosh[0.]
+     = 0. + 1.5708 I
+    >> ArcCosh[0.00000000000000000000000000000000000000]
+     = 1.5707963267948966192313216916397514421 I
+    #> ArcCosh[1.4]
+     = 0.867015
+    """
+
+    summary_text = "inverse hyperbolic cosine function"
+    sympy_name = "acosh"
+    mpmath_name = "acosh"
+
+    rules = {
+        "Derivative[1][ArcCosh]": "1/(Sqrt[#-1]*Sqrt[#+1])&",
+    }
+
+
+class ArcCoth(_MPMathFunction):
+    """
+    <dl>
+      <dt>'ArcCoth[$z$]'
+      <dd>returns the inverse hyperbolic cotangent of $z$.
+    </dl>
+
+    >> ArcCoth[0]
+     = I / 2 Pi
+    >> ArcCoth[1]
+     = Infinity
+    >> ArcCoth[0.0]
+     = 0. + 1.5708 I
+    >> ArcCoth[0.5]
+     = 0.549306 - 1.5708 I
+
+    #> ArcCoth[0.000000000000000000000000000000000000000]
+     = 1.57079632679489661923132169163975144210 I
+    """
+
+    summary_text = "inverse hyperbolic cotangent function"
+    sympy_name = "acoth"
+    mpmath_name = "acoth"
+
+    rules = {
+        "ArcCoth[z:0.0]": "N[I / 2 Pi, Precision[1+z]]",
+        "Derivative[1][ArcCoth]": "1/(1-#^2)&",
+    }
+
+
+class ArcCsch(_MPMathFunction):
+    """
+    <dl>
+      <dt>'ArcCsch[$z$]'
+      <dd>returns the inverse hyperbolic cosecant of $z$.
+    </dl>
+
+    >> ArcCsch[0]
+     = ComplexInfinity
+    >> ArcCsch[1.0]
+     = 0.881374
+    """
+
+    mpmath_name = "acsch"
+
+    rules = {
+        "ArcCsch[0]": "ComplexInfinity",
+        "ArcCsch[0.]": "ComplexInfinity",
+        "Derivative[1][ArcCsch]": "-1 / (Sqrt[1+1/#^2] * #^2) &",
+    }
+
+    summary_text = "inverse hyperbolic cosecant function"
+    sympy_name = ""
+
+    def to_sympy(self, expr, **kwargs) -> Optional[SympyExpression]:
+        if len(expr.elements) == 1:
+            return Expression(
+                SymbolArcSinh, Expression(SymbolPower, expr.elements[0], IntegerM1)
+            ).to_sympy()
+
+
+class ArcSech(_MPMathFunction):
+    """
+    <dl>
+      <dt>'ArcSech[$z$]'
+      <dd>returns the inverse hyperbolic secant of $z$.
+    </dl>
+
+    >> ArcSech[0]
+     = Infinity
+    >> ArcSech[1]
+     = 0
+    >> ArcSech[0.5]
+     = 1.31696
+    """
+
+    mpmath_name = "asech"
+
+    rules = {
+        "ArcSech[0]": "Infinity",
+        "ArcSech[0.]": "Indeterminate",
+        "Derivative[1][ArcSech]": "-1 / (# * Sqrt[(1-#)/(1+#)] (1+#)) &",
+    }
+
+    summary_text = "inverse hyperbolic secant function"
+    sympy_name = ""
+
+    def to_sympy(self, expr, **kwargs) -> Optional[SympyExpression]:
+        if len(expr.elements) == 1:
+            return Expression(
+                SymbolArcCosh, Expression(SymbolPower, expr.elements[0], IntegerM1)
+            ).to_sympy()
+
+
+class ArcSinh(_MPMathFunction):
+    """
+    <dl>
+      <dt>'ArcSinh[$z$]'
+      <dd>returns the inverse hyperbolic sine of $z$.
+    </dl>
+
+    >> ArcSinh[0]
+     = 0
+    >> ArcSinh[0.]
+     = 0.
+    >> ArcSinh[1.0]
+     = 0.881374
+    """
+
+    summary_text = "inverse hyperbolic sine function"
+    sympy_name = "asinh"
+    mpmath_name = "asinh"
+
+    rules = {
+        "Derivative[1][ArcSinh]": "1/Sqrt[1+#^2]&",
+    }
+
+
+class ArcTanh(_MPMathFunction):
+    """
+    <dl>
+    <dt>'ArcTanh[$z$]'
+        <dd>returns the inverse hyperbolic tangent of $z$.
+    </dl>
+
+    >> ArcTanh[0]
+     = 0
+    >> ArcTanh[1]
+     = Infinity
+    >> ArcTanh[0]
+     = 0
+    >> ArcTanh[.5 + 2 I]
+     = 0.0964156 + 1.12656 I
+    >> ArcTanh[2 + I]
+     = ArcTanh[2 + I]
+    """
+
+    mpmath_name = "atanh"
+    numpy_name = "arctanh"
+
+    rules = {
+        "Derivative[1][ArcTanh]": "1/(1-#^2)&",
+    }
+
+    summary_text = "inverse hyperbolic tangent function"
+    sympy_name = "atanh"
+
+
+class Cosh(_MPMathFunction):
+    """
+    <dl>
+      <dt>'Cosh[$z$]'
+      <dd>returns the hyperbolic cosine of $z$.
+    </dl>
+
+    >> Cosh[0]
+     = 1
+    """
+
+    mpmath_name = "cosh"
+
+    rules = {
+        "Derivative[1][Cosh]": "Sinh[#]&",
+    }
+
+    summary_text = "hyperbolic cosine function"
+
+
+class Coth(_MPMathFunction):
+    """
+    <dl>
+      <dt>'Coth[$z$]'
+      <dd>returns the hyperbolic cotangent of $z$.
+    </dl>
+
+    >> Coth[0]
+     = ComplexInfinity
+    """
+
+    mpmath_name = "coth"
+
+    rules = {
+        "Coth[0]": "ComplexInfinity",
+        "Coth[0.]": "ComplexInfinity",
+        "Derivative[1][Coth]": "-Csch[#1]^2&",
+    }
+
+    summary_text = "hyperbolic cotangent function"
+
+
+class Gudermannian(Builtin):
+    """
+    <url>:Gudermannian function: https://en.wikipedia.org/wiki/Gudermannian_function</url> (<url>:WMA: https://reference.wolfram.com/language/ref/Indeterminate.html<url></url>)
+    <dl>
+      <dt>'Gudermannian[$z$]'
+       <dd>returns the Gudermannian function $gd$($z$).
+    </dl>
+
+    >> Gudermannian[4.2]
+     = 1.54081
+
+    'Gudermannian[-$z$]' == - 'Gudermannian[$z$]'. So:
+
+    >> Gudermannian[-4.2] ==  -Gudermannian[4.2]
+     = True
+
+    >> Plot[Gudermannian[x], {x, -10, 10}]
+     = -Graphics-
+    """
+
+    # See https://mathworld.wolfram.com/Gudermannian.html for a number
+    # of relatiions to trigonometric and hyperbolic functions that could be
+    # used if needed.
+    rules = {
+        "Gudermannian[Undefined]": "Undefined",
+        "Gudermannian[0]": "0",
+        "Gudermannian[2*Pi*I]": "0",
+        "Gudermannian[6/4*Pi*I]": "DirectedInfinity[-I]",
+        "Gudermannian[Infinity]": "Pi/2",
+        "Gudermannian[-Infinity]": "Pi/2",
+        # Below, we don't use instead of ComplexInfinity that gets
+        # substituted out for DirectedInfinity[] before we match on
+        # Gudermannian[...]
+        "Gudermannian[DirectedInfinity[]]": "Indeterminate",
+        "Gudermannian[z_]": "2 ArcTan[Tanh[z / 2]]",
+        # Commented out because := might not work properly
+        # Gudermannian[z_] := Piecewise[{{1/2*[Pi - 4*ArcCot[E^z]], Re[z]>0||(Re[z]==0&&Im[z]>=0 )}}, 1/2 (-Pi + 4 ArcTan[E^z])];
+        # D[Gudermannian[f_],x_?NotListQ] := Sech[f] D[f,x];
+        # Derivative[1][InverseGudermannian] := Sec[#] &;
+        # Derivative[1][Gudermannian] := Sech[#] &;
+    }
+
+    summary_text = "Gudermannian function gd(z)"
+
+
+class Sech(_MPMathFunction):
+    """
+    <dl>
+      <dt>'Sech[$z$]'
+      <dd>returns the hyperbolic secant of $z$.
+    </dl>
+
+    >> Sech[0]
+     = 1
+    """
+
+    mpmath_name = "sech"
+
+    rules = {
+        "Derivative[1][Sech]": "-Sech[#1] Tanh[#1]&",
+    }
+    summary_text = "hyperbolic secant function"
+    sympy_name = ""
+
+    def to_sympy(self, expr, **kwargs) -> Optional[SympyExpression]:
+        if len(expr.elements) == 1:
+            return Expression(
+                SymbolPower, Expression(SymbolCosh, expr.elements[0]), IntegerM1
+            ).to_sympy()
+
+
+class Sinh(_MPMathFunction):
+    """
+    <dl>
+      <dt>'Sinh[$z$]'
+      <dd>returns the hyperbolic sine of $z$.
+    </dl>
+
+    >> Sinh[0]
+     = 0
+    """
+
+    summary_text = "hyperbolic sine function"
+    mpmath_name = "sinh"
+
+    rules = {
+        "Derivative[1][Sinh]": "Cosh[#]&",
+    }
+
+
+class Tanh(_MPMathFunction):
+    """
+    <dl>
+      <dt>'Tanh[$z$]'
+      <dd>returns the hyperbolic tangent of $z$.
+    </dl>
+
+    >> Tanh[0]
+     = 0
+    """
+
+    summary_text = "hyperbolic tangent function"
+    mpmath_name = "tanh"
+
+    rules = {
+        "Derivative[1][Tanh]": "Sech[#1]^2&",
+    }

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -28,6 +28,7 @@ from mathics.core.symbols import (
     SymbolTrue,
     system_symbols,
 )
+from mathics.core.systemsymbols import SymbolInfinity
 
 # Imperical number that seems to work.
 # We have to be able to match mpmath values with sympy values
@@ -561,6 +562,8 @@ class Complex(Number):
         self = super().__new__(cls)
         if isinstance(real, Complex) or not isinstance(real, Number):
             raise ValueError("Argument 'real' must be a real number.")
+        if imag is SymbolInfinity:
+            return SymbolI * SymbolInfinity
         if isinstance(imag, Complex) or not isinstance(imag, Number):
             raise ValueError("Argument 'imag' must be a real number.")
 


### PR DESCRIPTION
Add Gudermannian from autoload Guidermannian.m

Exponential functions should also be split from Trig functions. And both gone over. But that is for some other time. 

All of this could have the URLs gone over.

This is going to be the last of the url and doc improvements before 5.0.1

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/491"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

