### PR TITLE
Move timing out of `mathics.core.crunch_util`

### DIFF
--- a/mathics/algorithm/clusters.py
+++ b/mathics/algorithm/clusters.py
@@ -7,9 +7,17 @@ import bisect
 import math
 
 from mpmath import fsum
-from mathics.core.util import robust_min
 
-# publications used for this file:
+
+def robust_min(iterable):
+    minimum = None
+    for i in iterable:
+        if minimum is None or i < minimum:
+            minimum = i
+    return minimum
+
+
+# Publications used for this file:
 
 # [Kurita1991] Takito Kurita: "An Efficient Agglomerative Clustering Algorithm Using A Heap", Pattern Recognition,
 # Volume 24 Issue 3, 1991.

--- a/mathics/builtin/numbers/hyperbolic.py
+++ b/mathics/builtin/numbers/hyperbolic.py
@@ -300,7 +300,10 @@ class InverseGudermannian(Builtin):
     >> InverseGudermannian[-.5] ==  -InverseGudermannian[.5]
      = True
 
-    >> Plot[InverseGudermannian[x], {x, -10, 10}]
+    InverseGudermannian is 0 at multiples of 8 Pi:
+     = 0
+
+    >> Plot[InverseGudermannian[x], {x, -2 Pi, 2 Pi}]
      = -Graphics-
     """
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -53,7 +53,7 @@ from mathics.core.systemsymbols import (
     SymbolUnevaluated,
 )
 
-# from mathics.core.util import timeit
+# from mathics.timing import timeit
 
 SymbolBlankSequence = Symbol("System`BlankSequence")
 SymbolBlankNullSequence = Symbol("System`BlankNullSequence")

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -1,14 +1,22 @@
-#!/usr/bin/env python3
 # cython: language_level=3
 # -*- coding: utf-8 -*-
+
+from inspect import signature
 
 from mathics.core.element import KeyComparable
 from mathics.core.expression import Expression
 from mathics.core.symbols import strip_context
 from mathics.core.pattern import Pattern, StopGenerator
-from mathics.core.util import function_arguments
 
 from itertools import chain
+
+
+def _python_function_arguments(f):
+    return signature(f).parameters.keys()
+
+
+def function_arguments(f):
+    return _python_function_arguments(f)
 
 
 class StopGenerator_BaseRule(StopGenerator):

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -14,65 +14,10 @@ except ImportError:
 
 FORMAT_RE = re.compile(r"\`(\d*)\`")
 
-import time
-
 IS_PYPY = "__pypy__" in sys.builtin_module_names
 
 # A small, simple timing tool
 MIN_ELAPSE_REPORT = int(os.environ.get("MIN_ELAPSE_REPORT", "0"))
-
-
-# FIXME: move this up out of mathics.core
-def timeit(method):
-    """Add this as a decorator to time parts of the code.
-
-    For example:
-        @timeit
-        def long_running_function():
-            ...
-    """
-
-    def timed(*args, **kw):
-        method_name = method.__name__
-        # print(f"{date.today()}	{method_name} starts")
-        ts = time.time()
-        result = method(*args, **kw)
-        te = time.time()
-        elapsed = (te - ts) * 1000
-        if elapsed > MIN_ELAPSE_REPORT:
-            if "log_time" in kw:
-                name = kw.get("log_name", method.__name__.upper())
-                kw["log_time"][name] = elapsed
-            else:
-                print("%r  %2.2f ms" % (method_name, elapsed))
-        # print(f"{date.today()}	{method_name} ends")
-        return result
-
-    return timed
-
-
-# FIXME: move this up out of mathics.core
-class TimeitContextManager:
-    """Add this as a context manager to time parts of the code.
-
-    For example:
-        with TimeitContextManager("testing my loop"):
-           for x in collection:
-               ...
-    """
-
-    def __init__(self, name: str):
-        self.name = name
-
-    def __enter__(self):
-        # print(f"{date.today()}	{method_name} starts")
-        self.ts = time.time()
-
-    def __exit__(self, exc_type, exc_value, exc_tb):
-        te = time.time()
-        elapsed = (te - self.ts) * 1000
-        if elapsed > MIN_ELAPSE_REPORT:
-            print("%r  %2.2f ms" % (self.name, elapsed))
 
 
 def interpolate_string(text, get_param) -> str:

--- a/mathics/core/util.py
+++ b/mathics/core/util.py
@@ -11,50 +11,9 @@ except ImportError:
     Pattern = re._pattern_type
 
 
-FORMAT_RE = re.compile(r"\`(\d*)\`")
-
 IS_PYPY = "__pypy__" in sys.builtin_module_names
 
-
-def dict_with_escaped_keys(d: dict) -> dict:
-    """Takes a dictionary and returns a copy of it where the keys are escaped
-    with re.escape"""
-    return {re.escape(k): v for k, v in d.items()}
-
-
-def interpolate_string(text, get_param) -> str:
-    index = [1]
-
-    def get_item(index):
-        if 1 <= index <= len(args):
-            return args[index - 1]
-        else:
-            return ""
-
-    if isinstance(get_param, list):
-        args = get_param
-        get_param = get_item
-
-    def repl(match):
-        arg = match.group(1)
-        if arg == "" or arg == "0":
-            arg = index[0]
-        else:
-            arg = int(arg)
-        index[0] += 1
-        param = get_param(arg)
-        return param
-
-    return FORMAT_RE.sub(repl, text)
-
-
-"""
-NOTE: Maybe see
-http://www.cosc.canterbury.ac.nz/tad.takaoka/isaac.pdf
-resp.
-http://www.cosc.canterbury.ac.nz/tad.takaoka/perm.p
-for a permutation generating algorithm for multisets.
-"""
+# FIXME: These functions are used pattern.py
 
 
 def permutations(items, without_duplicates=True):
@@ -69,14 +28,6 @@ def permutations(items, without_duplicates=True):
         for sub in permutations(items[:index] + items[index + 1 :]):
             yield [item] + sub
             # already_taken.add(item)
-
-
-def re_from_keys(d: dict) -> Pattern:
-    """Returns a regex that matches any of the keys of the dictionary"""
-
-    # The keys are sorted to prevent shorter keys from obscuring longer keys
-    # when pattern matching
-    return re.compile("|".join(sorted(d.keys(), key=lambda k: (-len(k), k))))
 
 
 def subsets(items, min, max, included=None, less_first=False):
@@ -110,53 +61,6 @@ def subsets(items, min, max, included=None, less_first=False):
             yield chosen, ([], not_chosen)
 
 
-def subsets_2(items, min, max, without_duplicates=True):
-    """max may only be 1 or None (= infinity).
-    Respects include property of items
-    """
-
-    if min <= max == 1:
-        for index in range(len(items)):
-            if items[index].include:
-                yield [items[index]], ([], items[:index] + items[index + 1 :])
-        if min == 0:
-            yield [], ([], items)
-    else:
-        counts = {}
-        for item in items:
-            if item.include:
-                if item in counts:
-                    counts[item] += 1
-                else:
-                    counts[item] = 1
-        already = set()
-
-        def decide(chosen, not_chosen, rest):
-            if not rest:
-                if len(chosen) >= min:
-                    """if False and len(chosen) > 1 and (
-                            permutate_until is None or
-                            len(chosen) <= permutate_until):
-                        for perm in permutations(chosen):
-                            yield perm, ([], not_chosen)
-                    else:"""
-                    yield chosen, ([], not_chosen)
-            else:
-                if rest[0].include:
-                    for set in decide(chosen + [rest[0]], not_chosen, rest[1:]):
-                        yield set
-                for set in decide(chosen, not_chosen + [rest[0]], rest[1:]):
-                    yield set
-
-        for subset in decide([], [], list(counts.keys())):
-            t = tuple(subset[0])
-            if t not in already:
-                yield subset
-                already.add(t)
-            else:
-                print("already taken")
-
-
 def subranges(
     items, min_count, max, flexible_start=False, included=None, less_first=False
 ):
@@ -181,26 +85,3 @@ def subranges(
                 items[start : start + length],
                 (items[:start], items[start + length :]),
             )
-
-
-def unicode_superscript(value) -> str:
-    def repl_char(c):
-        if c == "1":
-            value = 185
-        elif c == "2":
-            value = 178
-        elif c == "3":
-            value = 179
-        elif "0" <= c <= "9":
-            value = 8304 + (ord(c) - ord("0"))
-        elif c == "-":
-            value = 8315
-        elif c == "(":
-            value = 8317
-        elif c == ")":
-            value = 8318
-        else:
-            value = ord(c)
-        return chr(value)
-
-    return "".join(repl_char(c) for c in value)

--- a/mathics/timing.py
+++ b/mathics/timing.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+Mathics timing method(s) and timing context manager.
+"""
+
+import os
+import time
+
+MIN_ELAPSE_REPORT = int(os.environ.get("MIN_ELAPSE_REPORT", "0"))
+
+
+# A small, simple timing tool
+def timeit(method):
+    """Add this as a decorator to time parts of the code.
+
+    For example:
+        @timeit
+        def long_running_function():
+            ...
+    """
+
+    def timed(*args, **kw):
+        method_name = method.__name__
+        # print(f"{date.today()}	{method_name} starts")
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        elapsed = (te - ts) * 1000
+        if elapsed > MIN_ELAPSE_REPORT:
+            if "log_time" in kw:
+                name = kw.get("log_name", method.__name__.upper())
+                kw["log_time"][name] = elapsed
+            else:
+                print("%r  %2.2f ms" % (method_name, elapsed))
+        # print(f"{date.today()}	{method_name} ends")
+        return result
+
+    return timed
+
+
+class TimeitContextManager:
+    """Add this as a context manager to time parts of the code.
+
+    For example:
+        with TimeitContextManager("testing my loop"):
+           for x in collection:
+               ...
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __enter__(self):
+        # print(f"{date.today()}	{method_name} starts")
+        self.ts = time.time()
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        te = time.time()
+        elapsed = (te - self.ts) * 1000
+        if elapsed > MIN_ELAPSE_REPORT:
+            print("%r  %2.2f ms" % (self.name, elapsed))


### PR DESCRIPTION
* `robust_min()`: is used only one place. Move this function there
<strike>*  `IS_PYPY`: move to `mathics.system_info`</strike>
* timing routines: move to `mathics.timing` module
* `function_arguments()`: We had more complex to support older Pythons which we don't support anymore. Move code to `rules.py` where it is the only place it is used.

The parts removed will be separated into another PR.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/495"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

