### PR TITLE
Allow long lines in linters...

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,13 +11,9 @@ description_file = README.rst
 # This config file MUST be ASCII to prevent weird flake8 dropouts
 
 [flake8]
-# max-line-length setting: NO we do not want everyone writing 120-character lines!
-# We are setting the maximum line length big here because there are longer
-# lines allowed by black in some cases that are forbidden by flake8. Since
-# black has the final say about code formatting issues, this setting is here to
-# make sure that flake8 doesn't fail the build on longer lines allowed by
-# black.
-max-line-length = 120
+# About max-line-length setting:
+# Our homegrown autodoc has brain-dead line wrapping which forces long lines in docstrings
+max-line-length = 300
 max-complexity = 12
 select = E,F,W,C,B,B9
 ignore =
@@ -38,3 +34,10 @@ ignore =
     # module level import not at top of file. This is too restrictive. Can't even have a
     # docstring higher.
     E402
+
+[pycodestyle]
+max-line-length = 300
+
+[pylint]
+max-line-length = 300
+statistics = True


### PR DESCRIPTION
Since our brain-dead autodoc can't handle line wrapping. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/497"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

