### PR TITLE
Correct D[] bug in passing wrong parameter type

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -228,9 +228,9 @@ class D(SympyFunction):
         elif f == x:
             return Integer1
         elif isinstance(f, Atom):  # Shouldn't happen
-            1 / 0
-            return
-        # So, this is not an atom...
+            raise TypeError(f"D[] function slot {f} is an instance of an Atom")
+
+        # f is not a pattern, nor an Atom, and f != x
 
         head = f.get_head()
         if head is SymbolPlus:
@@ -344,7 +344,7 @@ class D(SympyFunction):
         "D[expr_, {x_, other___}]"
 
         arg = ListExpression(x, *other.get_sequence())
-        evaluation.message(SymbolD, "dvar", arg)
+        evaluation.message("D", "dvar", arg)
         return Expression(SymbolD, expr, arg)
 
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -222,15 +222,19 @@ class D(SympyFunction):
 
     def apply(self, f, x, evaluation):
         "D[f_, x_?NotListQ]"
+
+        # Handle partial derivative special cases:
+        #   (dx / dx) == 1 and
+        #   dx / d(expression not containing x) == 0
+
+        if f == x:
+            return Integer1
+
         x_pattern = Pattern.create(x)
         if f.is_free(x_pattern, evaluation):
             return Integer0
-        elif f == x:
-            return Integer1
-        elif isinstance(f, Atom):  # Shouldn't happen
-            raise TypeError(f"D[] function slot {f} is an instance of an Atom")
 
-        # f is not a pattern, nor an Atom, and f != x
+        # f is neither x nor does it not contain x
 
         head = f.get_head()
         if head is SymbolPlus:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, Tuple
 from mathics.core.attributes import no_attributes
 
 
-def ensure_context(name, context="System`") -> str:
+def ensure_context(name: str, context="System`") -> str:
     assert isinstance(name, str)
     assert name != ""
     if "`" in name:

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -500,12 +500,12 @@ class Evaluation:
             return []
         return value.elements
 
-    def message(self, symbol, tag, *args) -> None:
+    def message(self, symbol_name: str, tag, *args) -> None:
         from mathics.core.expression import Expression
 
         # Allow evaluation.message('MyBuiltin', ...) (assume
         # System`MyBuiltin)
-        symbol = ensure_context(symbol)
+        symbol = ensure_context(symbol_name)
         quiet_messages = set(self.get_quiet_messages())
 
         pattern = Expression(SymbolMessageName, Symbol(symbol), String(tag))

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -9,7 +9,7 @@ FindRoot[], FindMinimum[], NFindMaximum[] tests
 
 """
 import pytest
-from test.helper import evaluate
+from test.helper import evaluate, check_evaluation
 from mathics.builtin.base import check_requires_list
 
 
@@ -68,31 +68,61 @@ tests_for_integrate = [
 ]
 
 
-@pytest.mark.parametrize("str_expr, str_expected, msg", tests_for_findminimum)
-def test_findminimum(str_expr: str, str_expected: str, msg: str, message=""):
+@pytest.mark.parametrize(
+    "str_expr, str_expected, assert_fail_message", tests_for_findminimum
+)
+def test_findminimum(
+    str_expr: str, str_expected: str, assert_fail_message: str, message=""
+):
     result = evaluate(str_expr)
     expected = evaluate(str_expected)
-    if msg:
-        assert result == expected, msg
+    if assert_fail_message:
+        assert result == expected, assert_fail_message
     else:
         assert result == expected
 
 
-@pytest.mark.parametrize("str_expr, str_expected, msg", tests_for_findroot)
-def test_findroot(str_expr: str, str_expected: str, msg: str, message=""):
+@pytest.mark.parametrize(
+    "str_expr, str_expected, assert_fail_message", tests_for_findroot
+)
+def test_findroot(
+    str_expr: str, str_expected: str, assert_fail_message: str, message=""
+):
     result = evaluate(str_expr)
     expected = evaluate(str_expected)
-    if msg:
-        assert result == expected, msg
+    if assert_fail_message:
+        assert result == expected, assert_fail_message
     else:
         assert result == expected
 
 
-@pytest.mark.parametrize("str_expr, str_expected, msg", tests_for_integrate)
-def test_integrate(str_expr: str, str_expected: str, msg: str, message=""):
+@pytest.mark.parametrize(
+    "str_expr, str_expected, assert_fail_message", tests_for_integrate
+)
+def test_integrate(str_expr: str, str_expected: str, assert_fail_message):
     result = evaluate(str_expr)
     expected = evaluate(str_expected)
-    if msg:
-        assert result == expected, msg
+    if assert_fail_message:
+        assert result == expected, assert_fail_message
     else:
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    "str_expr, str_expected, expected_messages",
+    [
+        (
+            "D[{y, -x}[2], {x, y}]",
+            "D[{y, -x}[2], {x, y}]",
+            [
+                "Multiple derivative specifier {x, y} does not have the form {variable, n}, where n is a non-negative machine integer."
+            ],
+        ),
+    ],  # Issue #502
+)
+def test_D(str_expr: str, str_expected: str, expected_messages):
+    check_evaluation(
+        str_expr=str_expr,
+        str_expected=str_expected,
+        expected_messages=expected_messages,
+    )

--- a/test/builtin/test_comparison.py
+++ b/test/builtin/test_comparison.py
@@ -4,7 +4,7 @@ from test.helper import check_evaluation, session
 
 
 @pytest.mark.parametrize(
-    ("str_expr", "str_expected", "fail_msg"),
+    ("str_expr", "str_expected", "assert_fail_message"),
     [
         # Equal (==)
         (
@@ -99,12 +99,17 @@ from test.helper import check_evaluation, session
         ("g[1]!=g[1]==g[2]", "False", "This evaluates first the inequality"),
     ],
 )
-def test_compare_many_members(str_expr: str, str_expected: str, fail_msg: str):
+def test_compare_many_members(
+    str_expr: str, str_expected: str, assert_fail_message: str
+):
     #    if str_expr is None:
     #        reset_session()
     result = session.evaluate(f"ToString[{str_expr}]").value
     print("result:", result)
-    assert result == str_expected  # , fail_msg
+    if assert_fail_message:
+        assert result == str_expected, assert_fail_message
+    else:
+        assert result == str_expected
 
 
 # SameQ test


### PR DESCRIPTION
Also:

remove overloaded type-changing variable
reduce vaguess in vargueness "msg" - is what message message back from
evaluation? message given on assertion failure? Some other kind of message?

Fixes #502 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/503"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

