### PR TITLE
Go over Cross and Norm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@
 CHANGES
 =======
 
+5.0.3dev0
+----------
+
+Enhancements
+++++++++++++
+
+#. Vector restriction on ``Norm[]`` removed. "Frobinius" p-form allowed.
+
+
 5.0.2
 -----
 

--- a/mathics/builtin/vectors/math_ops.py
+++ b/mathics/builtin/vectors/math_ops.py
@@ -4,26 +4,92 @@
 Mathematical Operations
 """
 
+from typing import Optional
 import sympy
 
 from mathics.builtin.base import Builtin
-from mathics.core.atoms import Integer, Integer2, Real
+from mathics.core.atoms import Integer, Real, String
+from mathics.core.evaluation import Evaluation
+from mathics.core.expression import Expression
+
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
 from mathics.core.symbols import Symbol
 
 
+def eval_2_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
+    """
+    2-Norm[] evaluation function
+    """
+    sympy_m = to_sympy_matrix(m)
+    if sympy_m is None:
+        return evaluation.message("Norm", "nvm")
+
+    return from_sympy(sympy_m.norm())
+
+
+def eval_p_norm(
+    m: Expression, p: Expression, evaluation: Evaluation
+) -> Optional[Expression]:
+    """
+    p2-Norm[] evaluation function
+    """
+    if isinstance(p, Symbol):
+        sympy_p = p.to_sympy()
+    elif isinstance(p, String):
+        sympy_p = p.value
+        if sympy_p == "Frobenius":
+            sympy_p = "fro"
+    elif isinstance(p, (Real, Integer)) and p.to_python() >= 1:
+        sympy_p = p.to_sympy()
+    else:
+        return evaluation.message("Norm", "ptype", p)
+
+    if sympy_p is None:
+        return
+    matrix = to_sympy_matrix(m)
+
+    if matrix is None:
+        return evaluation.message("Norm", "nvm")
+    if len(matrix) == 0:
+        return
+
+    try:
+        res = matrix.norm(sympy_p)
+    except NotImplementedError:
+        return evaluation.message("Norm", "normnotimplemented")
+
+    return from_sympy(res)
+
+
 class Cross(Builtin):
     """
+    <url>:Cross product: https://en.wikipedia.org/wiki/Cross_product</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/physics/vector/api/functions.html#sympy.physics.vector.functions.cross</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Cross.html</url>)
+
     <dl>
       <dt>'Cross[$a$, $b$]'
       <dd>computes the vector cross product of $a$ and $b$.
     </dl>
 
+    Three-dimensional cross product:
+
     >> Cross[{x1, y1, z1}, {x2, y2, z2}]
      = {y1 z2 - y2 z1, -x1 z2 + x2 z1, x1 y2 - x2 y1}
 
+    Cross is antisymmetric, so:
+
     >> Cross[{x, y}]
      = {-y, x}
+
+    Graph two-Dimensional cross product:
+
+    >> v1 = {1, Sqrt[3]}; v2 = Cross[v1]
+     = {-Sqrt[3], 1}
+
+    Visualize this:
+    >> Graphics[{Arrow[{{0, 0}, v1}], Red, Arrow[{{0, 0}, v2}]}, Axes -> True]
+     = -Graphics-
+
+    #> Clear[v1, v2];
 
     >> Cross[{1, 2}, {3, 4, 5}]
      : The arguments are expected to be vectors of equal length, and the number of arguments is expected to be 1 less than their length.
@@ -57,52 +123,44 @@ class Cross(Builtin):
 
 class Norm(Builtin):
     """
+    <url>:Matrix norms induced by vector p-norms: https://en.wikipedia.org/wiki/Matrix_norm#Matrix_norms_induced_by_vector_p-norms</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/matrices/matrices.html#sympy.matrices.matrices.MatrixBase.norm</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Norm.html</url>)
+
     <dl>
-      <dt>'Norm[$m$, $l$]'
-      <dd>computes the l-norm of matrix m (currently only works for vectors!).
+      <dt>'Norm[$m$, $p$]'
+      <dd>computes the p-norm of matrix m.
 
       <dt>'Norm[$m$]'
-      <dd>computes the 2-norm of matrix m (currently only works for vectors!).
+     <dd>computes the 2-norm of matrix m.
     </dl>
 
-    >> Norm[{1, 2, 3, 4}, 2]
-     = Sqrt[30]
+    The Norm of of a vector is its Euclidian distance:
+    >> Norm[{x, y, z}]
+     = Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2 + Abs[z] ^ 2]
 
+    By default, 2-norm is used for vectors, but you can be explicit:
+    >> Norm[{3, 4}, 2]
+     = 5
+
+    The 1-norm is the sum of the values:
     >> Norm[{10, 100, 200}, 1]
      = 310
 
-    >> Norm[{a, b, c}]
-     = Sqrt[Abs[a] ^ 2 + Abs[b] ^ 2 + Abs[c] ^ 2]
+    >> Norm[{x, y, z}, Infinity]
+     = Max[{Abs[x], Abs[y], Abs[z]}]
 
     >> Norm[{-100, 2, 3, 4}, Infinity]
      = 100
 
+    For complex numbers, 'Norm[$z$]' is 'Abs[$z$]':
     >> Norm[1 + I]
      = Sqrt[2]
+    so the norm is always real even when the input is complex.
 
-    #> Norm[{1, {2, 3}}]
-     : The first Norm argument should be a number, vector, or matrix.
-     = Norm[{1, {2, 3}}]
 
-    #> Norm[{x, y}]
-     = Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2]
+    'Norm'[$m$,"Frobenius"] gives the Frobenius norm of $m$:
+    >> Norm[Array[Subscript[a, ##] &, {2, 2}], "Frobenius"]
+     = Sqrt[Abs[Subscript[a, 1, 1]] ^ 2 + Abs[Subscript[a, 1, 2]] ^ 2 + Abs[Subscript[a, 2, 1]] ^ 2 + Abs[Subscript[a, 2, 2]] ^ 2]
 
-    #> Norm[{x, y}, p]
-     = (Abs[x] ^ p + Abs[y] ^ p) ^ (1 / p)
-
-    #> Norm[{x, y}, 0]
-     : The second argument of Norm, 0, should be a symbol, Infinity, or an integer or real number not less than 1 for vector p-norms; or 1, 2, Infinity, or "Frobenius" for matrix norms.
-     = Norm[{x, y}, 0]
-
-    #> Norm[{x, y}, 0.5]
-     : The second argument of Norm, 0.5, should be a symbol, Infinity, or an integer or real number not less than 1 for vector p-norms; or 1, 2, Infinity, or "Frobenius" for matrix norms.
-     = Norm[{x, y}, 0.5]
-
-    #> Norm[{}]
-     = Norm[{}]
-
-    #> Norm[0]
-     = 0
     """
 
     messages = {
@@ -121,36 +179,13 @@ class Norm(Builtin):
     }
     summary_text = "norm of a vector or matrix"
 
-    def apply_single(self, m, evaluation):
+    def apply_two_norm(self, m, evaluation):
         "Norm[m_]"
-        return self.apply(m, Integer2, evaluation)
+        return eval_2_Norm(m, evaluation)
 
-    def apply(self, m, l, evaluation):
-        "Norm[m_, l_]"
-
-        if isinstance(l, Symbol):
-            pass
-        elif isinstance(l, (Real, Integer)) and l.to_python() >= 1:
-            pass
-        else:
-            return evaluation.message("Norm", "ptype", l)
-
-        l = l.to_sympy()
-        if l is None:
-            return
-        matrix = to_sympy_matrix(m)
-
-        if matrix is None:
-            return evaluation.message("Norm", "nvm")
-        if len(matrix) == 0:
-            return
-
-        try:
-            res = matrix.norm(l)
-        except NotImplementedError:
-            return evaluation.message("Norm", "normnotimplemented")
-
-        return from_sympy(res)
+    def apply_p_norm(self, m, p, evaluation):
+        "Norm[m_, p_]"
+        return eval_p_norm(m, p, evaluation)
 
 
 # TODO: Curl, Div

--- a/test/builtin/atomic/test_numbers.py
+++ b/test/builtin/atomic/test_numbers.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests for mathics.atomic.numbers
+Unit tests for mathics.builtin.atomic.numbers
 
-In particular, RealDigits.
+In particular, RealDigits[] and N[]
 """
 
 from test.helper import check_evaluation

--- a/test/builtin/atomic/test_strings.py
+++ b/test/builtin/atomic/test_strings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests from mathics.builtins.atomic.strings.
+Unit tests from mathics.builtin.atomic.strings.
 
 In particular, Alphabet
 """

--- a/test/builtin/vectors/test_mathops.py
+++ b/test/builtin/vectors/test_mathops.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtin.vectors.math_ops
+
+In particular, Norm[].
+"""
+
+from test.helper import check_evaluation
+
+
+def test_norm():
+    for str_expr, expected_message in (
+        (
+            "Norm[{1, {2, 3}}]",
+            "The first Norm argument should be a number, vector, or matrix.",
+        ),
+        (
+            "Norm[{x, y}, 0]",
+            'The second argument of Norm, 0, should be a symbol, Infinity, or an integer or real number not less than 1 for vector p-norms; or 1, 2, Infinity, or "Frobenius" for matrix norms.',
+        ),
+        (
+            "Norm[{x, y}, 0.5]",
+            'The second argument of Norm, 0.5, should be a symbol, Infinity, or an integer or real number not less than 1 for vector p-norms; or 1, 2, Infinity, or "Frobenius" for matrix norms.',
+        ),
+    ):
+        check_evaluation(
+            str_expr=str_expr,
+            str_expected=str_expr,
+            expected_messages=[expected_message],
+        )
+
+    for str_expr, str_expected in (
+        (
+            "Norm[{x, y}]",
+            "Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2]",
+        ),
+        (
+            "Norm[{x, y}, p]",
+            "(Abs[x] ^ p + Abs[y] ^ p) ^ (1 / p)",
+        ),
+        (
+            "Norm[{}]",
+            "Norm[{}]",
+        ),
+        (
+            "Norm[0]",
+            "0",
+        ),
+    ):
+        check_evaluation(str_expr=str_expr, str_expected=str_expected)


### PR DESCRIPTION
This is in preparation ofr adding Builtin Curl which is going to be used
as a tutorial example.

Norm:
* Remove vector restriction on parameter m when parameter p not specified.
* Pull out its unit tests, and expand on the doctess
* Start pulling out eval methods here too.
* Allow "Frobenius" in parameter p

Some small test doc typos corrected.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/504"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

