### PR TITLE
ListExpression class changes

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -258,6 +258,10 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                 self.elements_properties.elements_fully_evaluated = False
             if isinstance(element, Expression):
                 self.elements_properties.is_flat = False
+                if element.elements_properties is None:
+                    if hasattr(self, "_is_literal"):
+                        self._is_literal = False
+                    element._build_elements_properties()
                 if self.elements_properties.elements_fully_evaluated:
                     self._elements_fully_evaluated = (
                         element.elements_properties.elements_fully_evaluated
@@ -269,6 +273,9 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                 except Exception:
                     self.elements_properties.is_ordered = False
             last_element = element
+
+        if self.is_literal:
+            assert self.elements_properties.elements_fully_evaluated
 
     def _flatten_sequence(self, sequence, evaluation) -> "Expression":
         indices = self.sequences()
@@ -1951,6 +1958,9 @@ def convert_expression_elements(
             elements_properties.elements_fully_evaluated = False
         if isinstance(converted_elt, Expression):
             elements_properties.is_flat = False
+            if converted_elt.elements_properties is None:
+                converted_elt._build_elements_properties()
+
             if elements_properties.elements_fully_evaluated:
                 elements_properties.elements_fully_evaluated = (
                     converted_elt.elements_properties.elements_fully_evaluated

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import reprlib
 from typing import Optional, Tuple
 
 from mathics.core.element import ElementsProperties
@@ -21,7 +22,10 @@ class ListExpression(Expression):
     """
 
     def __init__(
-        self, *elements, elements_properties: Optional[ElementsProperties] = None
+        self,
+        *elements,
+        elements_properties: Optional[ElementsProperties] = None,
+        is_literal: Optional[bool] = False,
     ):
         self.options = None
         self.pattern_sequence = False
@@ -34,7 +38,10 @@ class ListExpression(Expression):
         #          from trepan.api import debug; debug()
 
         self._elements = elements
-        self._is_literal = False
+        # TODO: consider adding _is_literal as an elements property.
+        self._is_literal = (
+            is_literal if is_literal else all(e.is_literal for e in elements)
+        )
         self.python_list = None
         self.elements_properties = elements_properties
 
@@ -42,9 +49,21 @@ class ListExpression(Expression):
         self._sequences = None
         self._cache = None
 
-    # Add this when it is safe to do.
+    def __getitem__(self, index: int):
+        """
+        Allows ListExpression elements to accessed via [], e.g.
+        ListExpression[Integer1, Integer0][0] == Integer1
+        """
+        return self._elements[index]
+
     def __repr__(self) -> str:
-        return "<ListExpression: %s>" % self
+        """(reprlib.repr)-limited display or ListExpression"""
+        list_data = reprlib.repr(self._elements)
+        return f"<ListExpression: {list_data}>"
+
+    def __str__(self) -> str:
+        """str() representation of ListExpression. May be longer than repr()"""
+        return f"<ListExpression: {self._elements}>"
 
     # @timeit
     def evaluate_elements(self, evaluation):


### PR DESCRIPTION
* Better ListExpression literal detection
* Allow [] access to ListExpression's
* Better formatting of ListExpressions:
   * str() gives a longer form
   * repr() limits to reprlib.repr limits (30 characters)

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/505"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

