### PR TITLE
Revise `set_part()` to be more functional

### DIFF
--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -4,9 +4,11 @@
 Algorithms to access and manipulate elements in nested lists / expressions
 """
 
+from typing import List
+
 from mathics.core.atoms import Integer, Integer1
 from mathics.core.convert.expression import make_expression
-from mathics.core.element import BoxElement
+from mathics.core.element import BaseElement, BoxElement
 from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, Symbol
 from mathics.core.systemsymbols import SymbolDirectedInfinity, SymbolInfinity
@@ -60,10 +62,11 @@ def get_part(varlist, indices):
     return rec(varlist, indices).copy()
 
 
-def set_part(varlist, indices, newval):
+def set_part(varlist, indices: List[int], newval) -> BaseElement:
     "Simple part replacement. indices must be a list of python integers."
 
-    def rec(cur, rest):
+    # FIXME: make sure send back copies, and do not mutate the original
+    def rec(cur, rest) -> BaseElement:
         if len(rest) > 1:
             pos = rest[0]
             if isinstance(cur, Atom):
@@ -77,7 +80,8 @@ def set_part(varlist, indices, newval):
                     part = cur.elements[pos]
             except IndexError:
                 raise PartRangeError
-            return rec(part, rest[1:])
+            rec(part, rest[1:])
+            return cur
         elif len(rest) == 1:
             pos = rest[0]
             if isinstance(cur, Atom):
@@ -91,8 +95,9 @@ def set_part(varlist, indices, newval):
                     cur.set_element(pos, newval)
             except IndexError:
                 raise PartRangeError
+            return cur
 
-    rec(varlist, indices)
+    return rec(varlist, indices)
 
 
 def _parts_all_selector():

--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -101,7 +101,10 @@ def set_part(expression, indices: List[int], newval) -> BaseElement:
                     # below, we make use of the fact that a
                     # ``ListExpression``'s Head is ``SymbolList``.
                     head = expression.head
-                    if newval == SymbolList and head != SymbolList:
+                    if head == newval:
+                        # Nothing to modify
+                        pass
+                    elif newval == SymbolList and head != SymbolList:
                         expression = ListExpression(*expression.elements)
                     elif newval not in (SymbolList,) and head in (SymbolList,):
                         expression = Expression(newval, *expression.elements)

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -1302,7 +1302,7 @@ class ReplacePart(Builtin):
                     replace_value = replace.evaluate(evaluation)
                 else:
                     replace_value = replace
-                set_part(new_expr, position, replace_value)
+                new_expr = set_part(new_expr, position, replace_value)
             except PartError:
                 pass
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1291,7 +1291,13 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
         return self._rebuild_cache().sequences
 
-    def set_head(self, head):
+    def set_head(self, head: Symbol):
+        """
+        Change the Head of a ListExpression.
+        Unless this is a ListExpression, this is forbidden here.
+        """
+        if head == SymbolList:
+            raise TypeError("Attempt to turn an Expression into a ListExpression")
         self._head = head
         self._cache = None
 

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 
 from mathics.core.element import ElementsProperties
 from mathics.core.expression import Expression
-from mathics.core.symbols import EvalMixin, SymbolList
+from mathics.core.symbols import EvalMixin, Symbol, SymbolList
 
 
 class ListExpression(Expression):
@@ -126,6 +126,14 @@ class ListExpression(Expression):
             new.evaluate_elements(evaluation)
             return new, False
         return self, False
+
+    def set_head(self, head: Symbol):
+        """
+        Change the Head of an Expression.
+        Unless this is a ListExpression, this is forbidden here.
+        """
+        if head != SymbolList:
+            raise TypeError("Attempt to modify the Head of a ListExpression")
 
     def shallow_copy(self) -> "ListExpression":
         """


### PR DESCRIPTION
When I was revising ListExpression  a while ago, this code looked like it was preventing simpler ListExpression tests. (See below)

Now I am not totally sure. It fixes a potential bug if Part somehow is not able to transform an `Expression` into `ListExpression`, and if in the future we need to transform `Expression` into some other kind of specialized expression.  

Via testing t am not seeing this right now. 

I have made some slight changes to the code so as to hopefully make it easier to understand and modify should we need to in the future. 

Hopefully this will pave the way for simplifying  and replacing `expr.has_form("List", None)` with `isinstance(expr, ListExpression)` possibly after a few other parts of the code are gone over.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/507"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

