### PR TITLE
More list expressions

### DIFF
--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -230,7 +230,7 @@ def _part_selectors(indices):
             yield _parts_span_selector(index)
         elif index.get_name() == "System`All":
             yield _parts_all_selector()
-        elif index.has_form("List", None):
+        elif isinstance(index, ListExpression):
             yield _parts_sequence_selector(index.elements)
         elif isinstance(index, Integer):
             yield _parts_sequence_selector(index), lambda x: x[0]
@@ -396,6 +396,8 @@ def python_levelspec(levelspec):
         else:
             return value
 
+    # FIXME: Something in ExportString prevents using isinstance(levelspec, ListExpression).
+    # Track this down and fix.
     if levelspec.has_form("List", None):
         values = [value_to_level(element) for element in levelspec.elements]
         if len(values) == 1:

--- a/test/test_custom_boxconstruct.py
+++ b/test/test_custom_boxconstruct.py
@@ -111,5 +111,5 @@ def test_custom_graphicsbox_constructor():
     formatted = session.format_result().boxes_to_mathml()
     assert (
         formatted
-        == "--custom graphics--: I should plot (<Expression: System`Circle[System`List[0, 0], 1]>,) items"
+        == "--custom graphics--: I should plot (<Expression: System`Circle[<ListExpression: (<Integer: 0>, <Integer: 0>)>, 1]>,) items"
     )


### PR DESCRIPTION
Go over parser/convert  and have it create ListExpression for list expressions
    
Try to make parser/convert less confusing by using more traditional Python practice, and add type annotations.

Do  our first has_form("List", None) removal. Many more will follow, but additional ListExpression cleanup is needed first.
    



<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/508"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

