### PR TITLE
 Tyding up formatting. Second round.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,12 +9,21 @@ CHANGES
 New Builtins
 +++++++++++
 
+#. ``$BoxForms``
 #. ``ClebschGordan``
 #. ``PauliMatrix``
 #. ``SixJSymbol``
 #. ``ThreeJSymbol``
 
 
+Internals
++++++++++
+
+#. `boxes_to_` methods are now optional for ``BoxElement`` subclasses. Most of the code is now moved to the `mathics.format` submodule, and implemented in a more scalable way.
+#. `mathics.builtin.inout` was splitted in several modules (`inout`, `messages`, `layout`, `makeboxes`) in order to improve the documentation.
+
+
+   
 Enhancements
 ++++++++++++
 

--- a/mathics/algorithm/parts.py
+++ b/mathics/algorithm/parts.py
@@ -8,7 +8,7 @@ from typing import List
 
 from mathics.core.atoms import Integer, Integer1
 from mathics.core.convert.expression import make_expression
-from mathics.core.element import BaseElement, BoxElement
+from mathics.core.element import BaseElement, BoxElementMixin
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Atom, Symbol, SymbolList
@@ -341,7 +341,7 @@ def walk_levels(
     include_pos=False,
     cur_pos=[],
 ):
-    if isinstance(expr, BoxElement):
+    if isinstance(expr, BoxElementMixin):
         expr = expr.to_expression()
     if isinstance(expr, Atom):
         depth = 0

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Union, cast
 
 
 from mathics.builtin.exceptions import (
-    BoxExpressionError,
     MessageException,
 )
 
@@ -713,9 +712,7 @@ class BoxExpression(BuiltinElement, BoxElement):
     # This is the base class for the "Final form"
     # of formatted expressions.
     #
-    # The idea is that this class and their subclasses implement
-    # methods of the form ``boxes_to_*`` that now are in ``mathics.core.Expression``.
-    # Also, these objects should not be evaluated, so in the evaluation process should be
+    # These objects should not be evaluated, so in the evaluation process should be
     # considered "inert". However, it could happend that an Expression having them as an element
     # be evaluable, and try to apply rules. For example,
     # InputForm[ToBoxes[a+b]]
@@ -866,15 +863,6 @@ class BoxExpression(BuiltinElement, BoxElement):
                 option = ensure_context(option)
                 default[option] = parse_builtin_rule(value)
         return default
-
-    def boxes_to_text(self, elements, **options) -> str:
-        raise BoxExpressionError
-
-    def boxes_to_mathml(self, elements, **options) -> str:
-        raise BoxExpressionError
-
-    def boxes_to_tex(self, elements, **options) -> str:
-        raise BoxExpressionError
 
 
 class PatternError(Exception):

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -24,7 +24,7 @@ from mathics.core.convert.expression import to_expression
 from mathics.core.convert.python import from_bool
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.definitions import Definition
-from mathics.core.element import BoxElement
+from mathics.core.element import BoxElementMixin
 from mathics.core.expression import Expression, SymbolDefault
 from mathics.core.list import ListExpression
 from mathics.core.number import get_precision, PrecisionValueError
@@ -708,7 +708,7 @@ class SympyFunction(SympyObject):
         return sympy_expr
 
 
-class BoxExpression(BuiltinElement, BoxElement):
+class BoxExpression(BuiltinElement, BoxElementMixin):
     # This is the base class for the "Final form"
     # of formatted expressions.
     #

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -6,6 +6,7 @@ Boxing Routines for 2D Graphics
 from math import atan2, ceil, cos, degrees, floor, log10, pi, sin
 
 from mathics.builtin.base import BoxExpression
+
 from mathics.builtin.colors.color_directives import (
     _ColorObject,
     ColorError,
@@ -680,9 +681,6 @@ class GraphicsBox(BoxExpression):
 
         return ticks, ticks_small, origin_x
 
-    def boxes_to_mathml(self, elements=None, **options) -> str:
-        return lookup_method(self, "mathml")(self, elements, **options)
-
     def boxes_to_svg(self, elements=None, **options) -> str:
         """This is the top-level function that converts a Mathics Expression
         in to something suitable for SVG rendering.
@@ -700,19 +698,6 @@ class GraphicsBox(BoxExpression):
         format_fn = lookup_method(self, "svg")
         svg_body = format_fn(self, elements, data=data, **options)
         return svg_body
-
-    def boxes_to_tex(self, elements=None, **options) -> str:
-        """This is the top-level function that converts a Mathics Expression
-        in to something suitable for LaTeX.  (Yes, the name "tex" is
-        perhaps misleading of vague.)
-
-        However right now the only LaTeX support for graphics is via Asymptote and
-        that seems to be the package of choice in general for LaTeX.
-        """
-        return lookup_method(self, "tex")(self, elements, **options)
-
-    def boxes_to_text(self, elements=None, **options) -> str:
-        return lookup_method(self, "text")(self, elements, **options)
 
     def create_axes(self, elements, graphics_options, xmin, xmax, ymin, ymax):
         axes = graphics_options.get("System`Axes")

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -392,16 +392,6 @@ class Graphics3DBox(GraphicsBox):
 
         return json_repr
 
-    def boxes_to_mathml(self, elements=None, **options) -> str:
-        """Turn the Graphics3DBox into a MathML string"""
-        return lookup_method(self, "mathml")(self, elements, **options)
-
-    def boxes_to_tex(self, elements=None, **options):
-        return lookup_method(self, "tex")(self, elements, **options)
-
-    def boxes_to_text(self, elements=None, **options):
-        return lookup_method(self, "text")(self, elements, **options)
-
     def create_axes(
         self, elements, graphics_options, xmin, xmax, ymin, ymax, zmin, zmax, boxscale
     ):

--- a/mathics/builtin/box/layout.py
+++ b/mathics/builtin/box/layout.py
@@ -2,10 +2,11 @@
 
 """
 Formatting constructs are represented as a hierarchy of low-level symbolic "boxes".
+
 The routines here assist in boxing at the bottom of the hierarchy. At the other end, the top level, we have a Notebook which is just a collection of Expressions usually contained in boxes.
 """
 
-from mathics.builtin.base import BoxExpression
+from mathics.builtin.base import BoxExpression, Builtin
 from mathics.builtin.exceptions import BoxConstructError
 from mathics.builtin.options import options_to_rules
 
@@ -14,9 +15,6 @@ from mathics.core.attributes import hold_all_complete, protected, read_protected
 from mathics.core.element import BoxElement
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
-from mathics.core.formatter import (
-    _BoxedString,
-)
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolMakeBoxes
 from mathics.core.systemsymbols import SymbolRowBox, SymbolStandardForm
@@ -30,7 +28,6 @@ SymbolSqrtBox = Symbol("System`SqrtBox")
 
 # this temporarily replace the _BoxedString class
 def _boxed_string(string: str, **options):
-    from mathics.builtin.box.layout import StyleBox
     from mathics.core.atoms import String
 
     return StyleBox(String(string), **options)
@@ -42,10 +39,7 @@ def to_boxes(x, evaluation: Evaluation, options={}) -> BoxElement:
     and tries to reduce it to a ``BoxElement``
     expression unsing an evaluation object.
     """
-    if isinstance(x, BoxElement):
-        return x
-    if isinstance(x, String):
-        x = _BoxedString(x.value, **options)
+    if isinstance(x, (String, BoxElement)):
         return x
     if isinstance(x, Atom):
         x = x.atom_to_boxes(SymbolStandardForm, evaluation)
@@ -59,6 +53,30 @@ def to_boxes(x, evaluation: Evaluation, options={}) -> BoxElement:
         if isinstance(x_boxed, Atom):
             return to_boxes(x_boxed, evaluation, options)
     raise Exception(x, "cannot be boxed.")
+
+
+class BoxData(Builtin):
+    """
+    <dl>
+      <dt>'BoxData[...]'
+      <dd>is a low-level representation of the contents of a typesetting
+    cell.
+    </dl>
+    """
+
+    summary_text = "low-level representation of the contents of a typesetting cell"
+
+
+class TextData(Builtin):
+    """
+    <dl>
+      <dt>'TextData[...]'
+      <dd>is a low-level representation of the contents of a textual
+    cell.
+    </dl>
+    """
+
+    summary_text = "low-level representation of the contents of a textual cell."
 
 
 class ButtonBox(BoxExpression):
@@ -119,112 +137,6 @@ class GridBox(BoxExpression):
         if not is_constant_list([len(row) for row in items]):
             raise BoxConstructError
         return items, options
-
-    def boxes_to_tex(self, elements=None, **box_options) -> str:
-        if not elements:
-            elements = self._elements
-        evaluation = box_options.get("evaluation")
-        items, options = self.get_array(elements, evaluation)
-        new_box_options = box_options.copy()
-        new_box_options["inside_list"] = True
-        column_alignments = options["System`ColumnAlignments"].get_name()
-        try:
-            column_alignments = {
-                "System`Center": "c",
-                "System`Left": "l",
-                "System`Right": "r",
-            }[column_alignments]
-        except KeyError:
-            # invalid column alignment
-            raise BoxConstructError
-        column_count = 0
-        for row in items:
-            column_count = max(column_count, len(row))
-        result = r"\begin{array}{%s} " % (column_alignments * column_count)
-        for index, row in enumerate(items):
-            result += " & ".join(
-                item.evaluate(evaluation).boxes_to_tex(**new_box_options)
-                for item in row
-            )
-            if index != len(items) - 1:
-                result += "\\\\ "
-        result += r"\end{array}"
-        return result
-
-    def boxes_to_mathml(self, elements=None, **box_options) -> str:
-        if not elements:
-            elements = self._elements
-        evaluation = box_options.get("evaluation")
-        items, options = self.get_array(elements, evaluation)
-        attrs = {}
-        column_alignments = options["System`ColumnAlignments"].get_name()
-        try:
-            attrs["columnalign"] = {
-                "System`Center": "center",
-                "System`Left": "left",
-                "System`Right": "right",
-            }[column_alignments]
-        except KeyError:
-            # invalid column alignment
-            raise BoxConstructError
-        joined_attrs = " ".join(f'{name}="{value}"' for name, value in attrs.items())
-        result = f"<mtable {joined_attrs}>\n"
-        new_box_options = box_options.copy()
-        new_box_options["inside_list"] = True
-        for row in items:
-            result += "<mtr>"
-            for item in row:
-                result += f"<mtd {joined_attrs}>{item.evaluate(evaluation).boxes_to_mathml(**new_box_options)}</mtd>"
-            result += "</mtr>\n"
-        result += "</mtable>"
-        return result
-
-    def boxes_to_text(self, elements=None, **box_options) -> str:
-        if not elements:
-            elements = self._elements
-        evaluation = box_options.get("evaluation")
-        items, options = self.get_array(elements, evaluation)
-        result = ""
-        if not items:
-            return ""
-        widths = [0] * len(items[0])
-        cells = [
-            [
-                item.evaluate(evaluation).boxes_to_text(**box_options).splitlines()
-                for item in row
-            ]
-            for row in items
-        ]
-        for row in cells:
-            for index, cell in enumerate(row):
-                if index >= len(widths):
-                    raise BoxConstructError
-                for line in cell:
-                    widths[index] = max(widths[index], len(line))
-        for row_index, row in enumerate(cells):
-            if row_index > 0:
-                result += "\n"
-            k = 0
-            while True:
-                line_exists = False
-                line = ""
-                for cell_index, cell in enumerate(row):
-                    if len(cell) > k:
-                        line_exists = True
-                        text = cell[k]
-                    else:
-                        text = ""
-                    line += text
-                    if cell_index < len(row) - 1:
-                        line += " " * (widths[cell_index] - len(text))
-                        # if cell_index < len(row) - 1:
-                        line += "   "
-                if line_exists:
-                    result += line + "\n"
-                else:
-                    break
-                k += 1
-        return result
 
 
 class InterpretationBox(BoxExpression):
@@ -297,33 +209,6 @@ class SubscriptBox(BoxExpression):
         """
         return Expression(SymbolSubscriptBox, self.base, self.subindex)
 
-    def boxes_to_text(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "Subscript[%s, %s]" % (
-            self.base.boxes_to_text(**options),
-            self.subindex.boxes_to_text(**options),
-        )
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "<msub>%s %s</msub>" % (
-            self.base.boxes_to_mathml(**options),
-            self.subindex.boxes_to_mathml(**options),
-        )
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "%s_%s" % (
-            self.tex_block(self.base.boxes_to_tex(**options), True),
-            self.tex_block(self.subindex.boxes_to_tex(**options)),
-        )
-
 
 class SubsuperscriptBox(BoxExpression):
     """
@@ -348,11 +233,7 @@ class SubsuperscriptBox(BoxExpression):
 
     def init(self, a, b, c, **options):
         self.box_options = options.copy()
-        if not (
-            isinstance(a, BoxElement)
-            and isinstance(b, BoxElement)
-            and isinstance(c, BoxElement)
-        ):
+        if not all(isinstance(x, (String, BoxElement)) for x in (a, b, c)):
             raise Exception((a, b, c), "are not boxes")
         self.base = a
         self.subindex = b
@@ -364,37 +245,6 @@ class SubsuperscriptBox(BoxExpression):
         """
         return Expression(
             SymbolSubsuperscriptBox, self.base, self.subindex, self.superindex
-        )
-
-    def boxes_to_text(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "Subsuperscript[%s, %s, %s]" % (
-            self.base.boxes_to_text(**options),
-            self.subindex.boxes_to_text(**options),
-            self.superindex.boxes_to_text(**options),
-        )
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        options["inside_row"] = True
-        return "<msubsup>%s %s %s</msubsup>" % (
-            self.base.boxes_to_mathml(**options),
-            self.subindex.boxes_to_mathml(**options),
-            self.superindex.boxes_to_mathml(**options),
-        )
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "%s_%s^%s" % (
-            self.tex_block(self.base.boxes_to_tex(**options), True),
-            self.tex_block(self.subindex.boxes_to_tex(**options)),
-            self.tex_block(self.superindex.boxes_to_tex(**options)),
         )
 
 
@@ -421,9 +271,7 @@ class SuperscriptBox(BoxExpression):
 
     def init(self, a, b, **options):
         self.box_options = options.copy()
-        if not (
-            isinstance(a, (BoxElement, String)) and isinstance(b, (BoxElement, String))
-        ):
+        if not all(isinstance(x, (String, BoxElement)) for x in (a, b)):
             raise Exception((a, b), "are not boxes")
         self.base = a
         self.superindex = b
@@ -433,56 +281,6 @@ class SuperscriptBox(BoxExpression):
         returns an evaluable expression.
         """
         return Expression(SymbolSuperscriptBox, self.base, self.superindex)
-
-    def boxes_to_text(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        if isinstance(self.superindex, (Atom, _BoxedString)):
-            return "%s^%s" % (
-                self.base.boxes_to_text(**options),
-                self.superindex.boxes_to_text(**options),
-            )
-
-        return "%s^(%s)" % (
-            self.base.boxes_to_text(**options),
-            self.superindex.boxes_to_text(**options),
-        )
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "<msup>%s %s</msup>" % (
-            self.base.boxes_to_mathml(**options),
-            self.superindex.boxes_to_mathml(**options),
-        )
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        tex1 = self.base.boxes_to_tex(**options)
-
-        sup_string = self.superindex.get_string_value()
-        # Handle derivatives
-        if sup_string == "\u2032":
-            return "%s'" % tex1
-        elif sup_string == "\u2032\u2032":
-            return "%s''" % tex1
-        else:
-            base = self.tex_block(tex1, True)
-            superindx = self.tex_block(self.superindex.boxes_to_tex(**options), True)
-            if isinstance(self.superindex, _BoxedString):
-                return "%s^%s" % (
-                    base,
-                    superindx,
-                )
-            else:
-                return "%s^{%s}" % (
-                    base,
-                    superindx,
-                )
 
 
 class RowBox(BoxExpression):
@@ -522,7 +320,7 @@ class RowBox(BoxExpression):
 
         def check_item(item):
             if isinstance(item, String):
-                return _BoxedString(item.value)
+                return item
             if not isinstance(item, BoxElement):
                 raise Exception(
                     item, "is not a List[] or a list of Strings or BoxElement"
@@ -555,55 +353,6 @@ class RowBox(BoxExpression):
             self._elements = Expression(SymbolRowBox, ListExpression(*items))
         return self._elements
 
-    def boxes_to_text(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "".join([element.boxes_to_text(**options) for element in self.items])
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "".join([element.boxes_to_tex(**options) for element in self.items])
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        result = []
-        inside_row = options.get("inside_row")
-        # inside_list = options.get('inside_list')
-        options = options.copy()
-
-        def is_list_interior(content):
-            if all(element.get_string_value() == "," for element in content[1::2]):
-                return True
-            return False
-
-        is_list_row = False
-        if (
-            len(self.items) == 3
-            and self.items[0].get_string_value() == "{"  # nopep8
-            and self.items[2].get_string_value() == "}"
-            and self.items[1].has_form("RowBox", 1)
-        ):
-            content = self.items[1].items
-            if is_list_interior(content):
-                is_list_row = True
-
-        if not inside_row and is_list_interior(self.items):
-            is_list_row = True
-
-        if is_list_row:
-            options["inside_list"] = True
-        else:
-            options["inside_row"] = True
-
-        for element in self.items:
-            result.append(element.boxes_to_mathml(**options))
-        return "<mrow>%s</mrow>" % " ".join(result)
-
 
 class StyleBox(BoxExpression):
     """
@@ -621,25 +370,6 @@ class StyleBox(BoxExpression):
     attributes = protected | read_protected
     summary_text = "associate boxes with styles"
 
-    def boxes_to_text(self, **options):
-        options.pop("evaluation", None)
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return self.boxes.boxes_to_text(**options)
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return self.boxes.boxes_to_tex(**options)
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return self.boxes.boxes_to_mathml(**options)
-
     def apply_options(self, boxes, evaluation, options):
         """StyleBox[boxes_, OptionsPattern[]]"""
         return StyleBox(boxes, style="", **options)
@@ -650,20 +380,18 @@ class StyleBox(BoxExpression):
 
     def get_string_value(self):
         box = self.boxes
-        if isinstance(box, (String, _BoxedString)):
+        if isinstance(box, String):
             return box.value
         return None
 
     def init(self, boxes, style=None, **options):
         # This implementation superseeds Expresion.process_style_box
+        if isinstance(boxes, StyleBox):
+            options.update(boxes.box_options)
+            boxes = boxes.boxes
         self.style = style
         self.box_options = options
-        # Here I need to check that is exactly
-        # String and not a BoxedString
-        if type(boxes) is String:
-            self.boxes = _BoxedString(boxes.value)
-        else:
-            self.boxes = boxes
+        self.boxes = boxes
 
     def to_expression(self):
         if self.style:
@@ -743,37 +471,6 @@ class FractionBox(BoxExpression):
     def to_expression(self):
         return Expression(SymbolFractionBox, self.num, self.den)
 
-    def boxes_to_text(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        num_text = self.num.boxes_to_text(**options)
-        den_text = self.den.boxes_to_text(**options)
-        if isinstance(self.num, RowBox):
-            num_text = f"({num_text})"
-        if isinstance(self.den, RowBox):
-            den_text = f"({den_text})"
-
-        return " / ".join([num_text, den_text])
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "<mfrac>%s %s</mfrac>" % (
-            self.num.boxes_to_mathml(**options),
-            self.den.boxes_to_mathml(**options),
-        )
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        return "\\frac{%s}{%s}" % (
-            self.num.boxes_to_tex(**options),
-            self.den.boxes_to_tex(**options),
-        )
-
 
 class SqrtBox(BoxExpression):
     """
@@ -812,37 +509,3 @@ class SqrtBox(BoxExpression):
         if self.index:
             return Expression(SymbolSqrtBox, self.radicand, self.index)
         return Expression(SymbolSqrtBox, self.radicand)
-
-    def boxes_to_text(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        if self.index:
-            return "Sqrt[%s,%s]" % (
-                self.radicand.boxes_to_text(**options),
-                self.index.boxes_to_text(**options),
-            )
-        return "Sqrt[%s]" % (self.radicand.boxes_to_text(**options))
-
-    def boxes_to_mathml(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        if self.index:
-            return "<mroot> %s %s </mroot>" % (
-                self.radicand.boxes_to_mathml(**options),
-                self.index.boxes_to_mathml(**options),
-            )
-
-        return "<msqrt> %s </msqrt>" % self.radicand.boxes_to_mathml(**options)
-
-    def boxes_to_tex(self, **options):
-        _options = self.box_options.copy()
-        _options.update(options)
-        options = _options
-        if self.index:
-            return "\\sqrt[%s]{%s}" % (
-                self.index.boxes_to_tex(**options),
-                self.radicand.boxes_to_tex(**options),
-            )
-        return "\\sqrt{%s}" % (self.radicand.boxes_to_tex(**options))

--- a/mathics/builtin/colors/color_directives.py
+++ b/mathics/builtin/colors/color_directives.py
@@ -7,9 +7,8 @@ There are many different way to specify color; we support all of the color forma
 from math import atan2, cos, exp, pi, radians, sin, sqrt
 
 
-from mathics.builtin.colors.color_internals import convert_color
-
 from mathics.builtin.base import Builtin
+from mathics.builtin.colors.color_internals import convert_color
 from mathics.builtin.drawing.graphics_internals import _GraphicsDirective, get_class
 from mathics.builtin.exceptions import BoxExpressionError
 from mathics.core.atoms import (

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -28,7 +28,6 @@ from mathics.builtin.colors.color_directives import (
     XYZColor,
 )
 
-
 from mathics.builtin.drawing.graphics_internals import (
     _GraphicsDirective,
     _GraphicsElementBox,

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -492,7 +492,7 @@ class TeXForm(Builtin):
      = \sqrt{a^3}
 
     #> {"hi","you"} //InputForm //TeXForm
-     = \left\{\text{hi}, \text{you}\right\}
+     = \left\{\text{``hi''}, \text{``you''}\right\}
 
     #> TeXForm[a+b*c]
      = a+b c

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -23,7 +23,7 @@ from mathics.core.attributes import (
     hold_all_complete as A_HOLD_ALL_COMPLETE,
     read_protected as A_READ_PROTECTED,
 )
-from mathics.core.element import BoxElement
+from mathics.core.element import BoxElementMixin
 from mathics.core.expression import Expression
 from mathics.core.formatter import format_element
 from mathics.core.list import ListExpression
@@ -479,7 +479,7 @@ class MakeBoxes(Builtin):
     def apply_general(self, expr, f, evaluation):
         """MakeBoxes[expr_,
         f:TraditionalForm|StandardForm|OutputForm|InputForm|FullForm]"""
-        if isinstance(expr, BoxElement):
+        if isinstance(expr, BoxElementMixin):
             expr = expr.to_expression()
         if isinstance(expr, Atom):
             return expr.atom_to_boxes(f, evaluation)

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -1701,13 +1701,11 @@ class Dispatch(Atom):
         return "dispatch"
 
     def atom_to_boxes(self, f, evaluation):
-        from mathics.core.formatter import format_element, _BoxedString
         from mathics.builtin.box.layout import RowBox
+        from mathics.core.formatter import format_element
 
         box_element = format_element(self.src, evaluation, f)
-        return RowBox(
-            _BoxedString("Dispatch"), _BoxedString("["), box_element, _BoxedString("]")
-        )
+        return RowBox(String("Dispatch"), String("["), box_element, String("]"))
 
 
 class DispatchAtom(AtomBuiltin):

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -19,7 +19,6 @@ from mathics.builtin.atomic.strings import (
     mathics_split,
     to_regex,
 )
-from mathics.builtin.box.layout import _BoxedString
 
 from mathics.builtin.base import (
     BinaryOperator,
@@ -194,7 +193,7 @@ class StringDrop(Builtin):
 
     def apply_with_n(self, string, n, evaluation):
         "StringDrop[string_,n_Integer]"
-        if not isinstance(string, (String, _BoxedString)):
+        if not isinstance(string, String):
             return evaluation.message("StringDrop", "strse")
         if isinstance(n, Integer):
             pos = n.value
@@ -212,7 +211,7 @@ class StringDrop(Builtin):
 
     def apply_with_ni_nf(self, string, ni, nf, evaluation):
         "StringDrop[string_,{ni_Integer,nf_Integer}]"
-        if not isinstance(string, (String, _BoxedString)):
+        if not isinstance(string, String):
             return evaluation.message("StringDrop", "strse", string)
 
         if ni.value == 0 or nf.value == 0:
@@ -234,7 +233,7 @@ class StringDrop(Builtin):
 
     def apply_with_ni(self, string, ni, evaluation):
         "StringDrop[string_,{ni_Integer}]"
-        if not isinstance(string, (String, _BoxedString)):
+        if not isinstance(string, String):
             return evaluation.message("StringDrop", "strse", string)
         if ni.value == 0:
             return evaluation.message("StringDrop", "drop", ni, ni)
@@ -249,7 +248,7 @@ class StringDrop(Builtin):
 
     def apply(self, string, something, evaluation):
         "StringDrop[string_,something___]"
-        if not isinstance(string, (String, _BoxedString)):
+        if not isinstance(string, String):
             return evaluation.message("StringDrop", "strse")
         return evaluation.message("StringDrop", "mseqs")
 
@@ -478,7 +477,7 @@ class StringJoin(BinaryOperator):
         else:
             items = items.get_sequence()
         for item in items:
-            if not isinstance(item, (String, _BoxedString)):
+            if not isinstance(item, String):
                 evaluation.message("StringJoin", "string")
                 return
             result += item.value
@@ -509,7 +508,7 @@ class StringLength(Builtin):
 
     def apply(self, str, evaluation):
         "StringLength[str_]"
-        if not isinstance(str, (String, _BoxedString)):
+        if not isinstance(str, String):
             evaluation.message("StringLength", "string")
             return
         return Integer(len(str.value))
@@ -896,11 +895,10 @@ class StringRiffle(Builtin):
         elif len(separators) == 1:
             if separators[0].has_form("List", None):
                 if len(separators[0].elements) != 3 or any(
-                    not isinstance(s, (String, _BoxedString))
-                    for s in separators[0].elements
+                    not isinstance(s, String) for s in separators[0].elements
                 ):
                     return evaluation.message("StringRiffle", "string", Integer(2), exp)
-            elif not isinstance(separators[0], (String, _BoxedString)):
+            elif not isinstance(separators[0], String):
                 return evaluation.message("StringRiffle", "string", Integer(2), exp)
 
         # Validate list of string

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 from functools import lru_cache
 
 
-from mathics.core.element import ImmutableValueMixin
+from mathics.core.element import ImmutableValueMixin, BoxElementMixin
 from mathics.core.number import (
     dps,
     prec,
@@ -691,7 +691,7 @@ class Complex(Number):
         return real_zero and imag_zero
 
 
-class String(Atom, ImmutableValueMixin):
+class String(Atom, BoxElementMixin):
     value: str
     class_head_name = "System`String"
 
@@ -713,25 +713,6 @@ class String(Atom, ImmutableValueMixin):
             return _boxed_string(inner, **{"System`ShowStringCharacters": SymbolTrue})
         return String('"' + inner + '"')
 
-    # These methods belongs to the interface of BoxElement,
-    # but we can not inherit that class. In any case, they are going
-    # to disapear soon.
-
-    def boxes_to_text(self, **options) -> str:
-        from mathics.core.formatter import lookup_method
-
-        return lookup_method(self, "text")(self, **options)
-
-    def boxes_to_tex(self, **options) -> str:
-        from mathics.core.formatter import lookup_method
-
-        return lookup_method(self, "tex")(self, **options)
-
-    def boxes_to_mathml(self, **options) -> str:
-        from mathics.core.formatter import lookup_method
-
-        return lookup_method(self, "mathml")(self, **options)
-
     def do_copy(self) -> "String":
         return String(self.value)
 
@@ -751,6 +732,9 @@ class String(Atom, ImmutableValueMixin):
 
     def get_string_value(self) -> str:
         return self.value
+
+    def to_expression(self):
+        return self
 
     def to_sympy(self, **kwargs):
         return None

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -469,4 +469,17 @@ class BoxElement(ImmutableValueMixin, BaseElement):
     elements
     """
 
-    pass
+    def boxes_to_text(self, **options) -> str:
+        from mathics.core.formatter import lookup_method
+
+        return lookup_method(self, "text")(self, **options)
+
+    def boxes_to_tex(self, **options) -> str:
+        from mathics.core.formatter import lookup_method
+
+        return lookup_method(self, "tex")(self, **options)
+
+    def boxes_to_mathml(self, **options) -> str:
+        from mathics.core.formatter import lookup_method
+
+        return lookup_method(self, "mathml")(self, **options)

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -245,7 +245,7 @@ class BaseElement(KeyComparable):
             return self == rhs
         return None
 
-    def format(self, evaluation, form, **kwargs) -> "BoxElement":
+    def format(self, evaluation, form, **kwargs) -> "BoxElementMixin":
         from mathics.core.formatter import format_element
         from mathics.core.symbols import Symbol
 
@@ -463,7 +463,7 @@ class EvalMixin:
         raise NotImplementedError
 
 
-class BoxElement(ImmutableValueMixin, BaseElement):
+class BoxElementMixin(ImmutableValueMixin):
     """
     The base class for all the boxed
     elements

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -469,17 +469,19 @@ class BoxElementMixin(ImmutableValueMixin):
     elements
     """
 
-    def boxes_to_text(self, **options) -> str:
-        from mathics.core.formatter import lookup_method
+    def boxes_to_format(self, format: str, **options: dict) -> str:
+        from mathics.core.formatter import boxes_to_format
 
-        return lookup_method(self, "text")(self, **options)
+        return boxes_to_format(self, format, **options)
 
-    def boxes_to_tex(self, **options) -> str:
-        from mathics.core.formatter import lookup_method
+    def boxes_to_mathml(self, **options: dict) -> str:
+        """For compatibility deprecated"""
+        return self.boxes_to_format("mathml", **options)
 
-        return lookup_method(self, "tex")(self, **options)
+    def boxes_to_tex(self, **options: dict) -> str:
+        """For compatibility deprecated"""
+        return self.boxes_to_format("tex", **options)
 
-    def boxes_to_mathml(self, **options) -> str:
-        from mathics.core.formatter import lookup_method
-
-        return lookup_method(self, "mathml")(self, **options)
+    def boxes_to_text(self, **options: dict) -> str:
+        """For compatibility deprecated"""
+        return self.boxes_to_format("text", **options)

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -108,7 +108,15 @@ extra_operators = set(
 )
 
 
-def lookup_method(self, format: str, module_fn_name=None) -> Callable:
+def boxes_to_format(boxes, format, **options) -> str:  # Maybe Union[str, bytearray]
+    """
+    Translates a box structure ``boxes`` to a file format ``format``.
+
+    """
+    return lookup_method(boxes, format)(boxes, **options)
+
+
+def lookup_method(self, format: str) -> Callable:
     """
     Find a conversion method for `format` in self's class method resolution order.
     """

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -125,6 +125,17 @@ def lookup_method(self, format: str) -> Callable:
         if format_fn is not None:
             # print(f"format function: {format_fn.__name__} for {type(self).__name__}")
             return format_fn
+    # backward compatibility
+    boxes_to_method = getattr(self, f"boxes_to_{format}", None)
+    if getattr(BoxElementMixin, f"boxes_to_{format}") is boxes_to_method:
+        boxes_to_method = None
+    if boxes_to_method:
+
+        def ret_fn(box, elements=None, **opts):
+            return boxes_to_method(elements, **opts)
+
+        return ret_fn
+
     error_msg = f"Can't find formatter {format} for {type(self).__name__}"
     raise RuntimeError(error_msg)
 

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -4,19 +4,17 @@ from typing import Any, Callable
 import re
 
 
-from mathics.core.atoms import SymbolString, SymbolI, String, Integer, Rational, Complex
+from mathics.core.atoms import SymbolI, String, Integer, Rational, Complex
 from mathics.core.element import BaseElement, BoxElement, EvalMixin
 from mathics.core.convert.expression import to_expression_with_specialization
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
-from mathics.core.parser import is_symbol_name
 from mathics.core.symbols import (
     Symbol,
     SymbolMakeBoxes,
     Atom,
     SymbolDivide,
-    SymbolFalse,
     SymbolFullForm,
     SymbolGraphics,
     SymbolGraphics3D,
@@ -28,7 +26,6 @@ from mathics.core.symbols import (
     SymbolRepeated,
     SymbolRepeatedNull,
     SymbolTimes,
-    SymbolTrue,
     format_symbols,
 )
 from mathics.core.systemsymbols import (
@@ -157,179 +154,6 @@ def add_conversion_fn(cls, module_fn_name=None) -> None:
     format2fn[(conversion_type, cls)] = module_dict[module_fn_name]
 
 
-#
-#   Comment from Rocky:
-#   " More scalable and more comprehensible is doing it inside a module for a particular form like we did for formatter. See [Aspect-Oriented Programming](https://en.wikipedia.org/wiki/Aspect-oriented_programming)
-#
-# Adding a method on the base class which does a lookup on the class I think is a good thing and the way to go. And it more closely maintains API compatibility, were it not for the fact that the form should be a Symbol rather than a str.
-# But in the short term we can do the same as we did for Expression and allow either a str or a Symbol and do the checking inside the .format() routine. Then eventually we'll remove the check."
-#  Also, moving the implementation of boxes_to_mathml / boxes_to_tex etc to specific module would be a following step.
-#
-#
-
-
-class _BoxedString(BoxElement):
-    value: str
-    box_options: dict
-    options = {
-        "System`ShowStringCharacters": "False",
-    }
-
-    @property
-    def head(self):
-        return SymbolString
-
-    def __init__(self, string: str, **options):
-        self.value = string
-        self.box_options = {
-            "System`ShowStringCharacters": SymbolFalse,
-        }
-        self.box_options.update(options)
-
-    def __repr__(self):
-        return self.value
-
-    def __str__(self):
-        return self.value
-
-    def boxes_to_text(self, **options):
-        value = self.value
-        if value.startswith('"') and value.endswith('"'):  # nopep8
-            show_string_characters = options.get("show_string_characters", None)
-            if show_string_characters is None:
-                show_string_characters = (
-                    self.box_options["System`ShowStringCharacters"] is SymbolTrue
-                )
-
-            if not show_string_characters:
-                value = value[1:-1]
-        return value
-
-    def boxes_to_mathml(self, **options) -> str:
-        from mathics.builtin import display_operators_set as operators
-
-        text = self.value
-
-        number_as_text = options.get("number_as_text", None)
-        if number_as_text is None:
-            number_as_text = self.box_options.get("number_as_text", False)
-
-        def render(format, string):
-            encoded_text = encode_mathml(string)
-            return format % encoded_text
-
-        if text.startswith('"') and text.endswith('"'):
-            show_string_characters = options.get("show_string_characters", None)
-            if show_string_characters is None:
-                show_string_characters = (
-                    self.box_options["System`ShowStringCharacters"] is SymbolTrue
-                )
-
-            if show_string_characters:
-                return render("<ms>%s</ms>", text[1:-1])
-            else:
-                outtext = ""
-                for line in text[1:-1].split("\n"):
-                    outtext += render("<mtext>%s</mtext>", line)
-                return outtext
-        elif (
-            text
-            and not number_as_text
-            and ("0" <= text[0] <= "9" or text[0] in (".", "-"))
-        ):
-            return render("<mn>%s</mn>", text)
-        else:
-            if text in operators or text in extra_operators:
-                if text == "\u2146":
-                    return render(
-                        '<mo form="prefix" lspace="0.2em" rspace="0">%s</mo>', text
-                    )
-                if text == "\u2062":
-                    return render(
-                        '<mo form="prefix" lspace="0" rspace="0.2em">%s</mo>', text
-                    )
-                return render("<mo>%s</mo>", text)
-            elif is_symbol_name(text):
-                return render("<mi>%s</mi>", text)
-            else:
-                outtext = ""
-                for line in text.split("\n"):
-                    outtext += render("<mtext>%s</mtext>", line)
-                return outtext
-
-    def boxes_to_tex(self, **options) -> str:
-        text = self.value
-
-        def render(format, string, in_text=False):
-            return format % encode_tex(string, in_text)
-
-        if text.startswith('"') and text.endswith('"'):
-            show_string_characters = options.get("show_string_characters", None)
-            if show_string_characters is None:
-                show_string_characters = (
-                    self.box_options["System`ShowStringCharacters"] is SymbolTrue
-                )
-            # In WMA, ``TeXForm`` never adds quotes to
-            # strings, even if ``InputForm`` or ``FullForm``
-            # is required, to so get the standard WMA behaviour,
-            # this option is set to False:
-            # show_string_characters = False
-
-            if show_string_characters:
-                return render(r"\text{``%s''}", text[1:-1], in_text=True)
-            else:
-                return render(r"\text{%s}", text[1:-1], in_text=True)
-        elif text and text[0] in "0123456789-.":
-            return render("%s", text)
-        else:
-            # FIXME: this should be done in a better way.
-            if text == "\u2032":
-                return "'"
-            elif text == "\u2032\u2032":
-                return "''"
-            elif text == "\u2062":
-                return " "
-            elif text == "\u221e":
-                return r"\infty "
-            elif text == "\u00d7":
-                return r"\times "
-            elif text in ("(", "[", "{"):
-                return render(r"\left%s", text)
-            elif text in (")", "]", "}"):
-                return render(r"\right%s", text)
-            elif text == "\u301a":
-                return r"\left[\left["
-            elif text == "\u301b":
-                return r"\right]\right]"
-            elif text == "," or text == ", ":
-                return text
-            elif text == "\u222b":
-                return r"\int"
-            # Tolerate WL or Unicode DifferentialD
-            elif text in ("\u2146", "\U0001D451"):
-                return r"\, d"
-            elif text == "\u2211":
-                return r"\sum"
-            elif text == "\u220f":
-                return r"\prod"
-            elif len(text) > 1:
-                return render(r"\text{%s}", text, in_text=True)
-            else:
-                return render("%s", text)
-
-    def get_head(self) -> Symbol:
-        return SymbolString
-
-    def get_head_name(self) -> str:
-        return "System`String"
-
-    def get_string_value(self) -> str:
-        return self.value
-
-    def to_expression(self) -> String:
-        return String(self.value)
-
-
 element_formatters = {}
 
 
@@ -339,15 +163,13 @@ def format_element(
     """
     Applies formats associated to the expression, and then calls Makeboxes
     """
-    do_format = element_formatters.get(type(element), do_format_element)
     expr = do_format(element, evaluation, form)
     result = Expression(SymbolMakeBoxes, expr, form)
     result_box = result.evaluate(evaluation)
-
+    if isinstance(result_box, String):
+        return result_box
     if isinstance(result_box, BoxElement):
         return result_box
-    elif isinstance(result_box, String):
-        return _BoxedString(result_box.value)
     else:
         return format_element(element, evaluation, SymbolFullForm, **kwargs)
 

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -5,7 +5,7 @@ import re
 
 
 from mathics.core.atoms import SymbolI, String, Integer, Rational, Complex
-from mathics.core.element import BaseElement, BoxElement, EvalMixin
+from mathics.core.element import BaseElement, BoxElementMixin, EvalMixin
 from mathics.core.convert.expression import to_expression_with_specialization
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
@@ -168,7 +168,7 @@ def format_element(
     result_box = result.evaluate(evaluation)
     if isinstance(result_box, String):
         return result_box
-    if isinstance(result_box, BoxElement):
+    if isinstance(result_box, BoxElementMixin):
         return result_box
     else:
         return format_element(element, evaluation, SymbolFullForm, **kwargs)
@@ -274,7 +274,7 @@ def do_format_element(
             expr = do_format(expr, evaluation, form)
         elif (
             head is not SymbolNumberForm
-            and not isinstance(expr, (Atom, BoxElement))
+            and not isinstance(expr, (Atom, BoxElementMixin))
             and head not in (SymbolGraphics, SymbolGraphics3D)
         ):
             # print("Not inside graphics or numberform, and not is atom")

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -397,10 +397,10 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def __str__(self) -> str:
         return self.name
 
-    def atom_to_boxes(self, f, evaluation) -> "_BoxedString":
-        from mathics.builtin.box.layout import _BoxedString
+    def atom_to_boxes(self, f, evaluation) -> "String":
+        from mathics.core.atoms import String
 
-        return _BoxedString(evaluation.definitions.shorten_name(self.name))
+        return String(evaluation.definitions.shorten_name(self.name))
 
     def default_format(self, evaluation, form) -> str:
         return self.name

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -10,7 +10,6 @@ import html
 
 from mathics.builtin.exceptions import BoxConstructError
 from mathics.builtin.box.layout import (
-    _BoxedString,
     GridBox,
     RowBox,
     SubscriptBox,
@@ -113,7 +112,6 @@ def string(self, **options) -> str:
 
 
 add_conversion_fn(String, string)
-add_conversion_fn(_BoxedString, string)
 
 
 def fractionbox(self, **options) -> str:

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -24,7 +24,7 @@ from mathics.builtin.box.graphics3d import Graphics3DBox
 
 
 from mathics.core.atoms import String
-from mathics.core.element import BoxElement
+from mathics.core.element import BoxElementMixin
 from mathics.core.formatter import (
     lookup_method as lookup_conversion_method,
     add_conversion_fn,
@@ -71,7 +71,7 @@ def string(self, **options) -> str:
     show_string_characters = (
         options.get("System`ShowStringCharacters", None) is SymbolTrue
     )
-    if isinstance(self, BoxElement):
+    if isinstance(self, BoxElementMixin):
         if number_as_text is None:
             number_as_text = options.get("number_as_text", False)
 

--- a/mathics/format/tex.py
+++ b/mathics/format/tex.py
@@ -9,7 +9,6 @@ from mathics.builtin.exceptions import BoxConstructError
 from mathics.builtin.box.graphics import GraphicsBox
 from mathics.builtin.box.graphics3d import Graphics3DBox
 from mathics.builtin.box.layout import (
-    _BoxedString,
     GridBox,
     RowBox,
     StyleBox,
@@ -130,7 +129,6 @@ def string(self, **options) -> str:
 
 
 add_conversion_fn(String, string)
-add_conversion_fn(_BoxedString, string)
 
 
 def fractionbox(self, **options) -> str:

--- a/mathics/format/text.py
+++ b/mathics/format/text.py
@@ -21,8 +21,13 @@ from mathics.builtin.box.layout import (
 from mathics.core.atoms import String
 from mathics.core.formatter import (
     add_conversion_fn,
+    lookup_method,
 )
 from mathics.core.symbols import Atom, SymbolTrue
+
+
+def boxes_to_text(boxes, **options) -> str:
+    return lookup_method(boxes, "text")(boxes, **options)
 
 
 def string(self, **options) -> str:
@@ -43,8 +48,8 @@ def fractionbox(self, **options) -> str:
     _options = self.box_options.copy()
     _options.update(options)
     options = _options
-    num_text = self.num.boxes_to_text(**options)
-    den_text = self.den.boxes_to_text(**options)
+    num_text = boxes_to_text(self.num, **options)
+    den_text = boxes_to_text(self.den, **options)
     if isinstance(self.num, RowBox):
         num_text = f"({num_text})"
     if isinstance(self.den, RowBox):
@@ -67,7 +72,8 @@ def gridbox(self, elements=None, **box_options) -> str:
     widths = [0] * len(items[0])
     cells = [
         [
-            item.evaluate(evaluation).boxes_to_text(**box_options).splitlines()
+            # TODO: check if this evaluation is necesary.
+            boxes_to_text(item.evaluate(evaluation), **box_options).splitlines()
             for item in row
         ]
         for row in items
@@ -113,10 +119,10 @@ def sqrtbox(self, **options) -> str:
     options = _options
     if self.index:
         return "Sqrt[%s,%s]" % (
-            self.radicand.boxes_to_text(**options),
-            self.index.boxes_to_text(**options),
+            boxes_to_text(self.radicand, **options),
+            boxes_to_text(self.index, **options),
         )
-    return "Sqrt[%s]" % (self.radicand.boxes_to_text(**options))
+    return "Sqrt[%s]" % (boxes_to_text(self.radicand, **options))
 
 
 add_conversion_fn(SqrtBox, sqrtbox)
@@ -126,15 +132,10 @@ def superscriptbox(self, **options) -> str:
     _options = self.box_options.copy()
     _options.update(options)
     options = _options
-    if isinstance(self.superindex, Atom):
-        return "%s^%s" % (
-            self.base.boxes_to_text(**options),
-            self.superindex.boxes_to_text(**options),
-        )
-
-    return "%s^(%s)" % (
-        self.base.boxes_to_text(**options),
-        self.superindex.boxes_to_text(**options),
+    fmt_str = "%s^%s" if isinstance(self.superindex, Atom) else "%s^(%s)"
+    return fmt_str % (
+        boxes_to_text(self.base, **options),
+        boxes_to_text(self.superindex, **options),
     )
 
 
@@ -146,8 +147,8 @@ def subscriptbox(self, **options) -> str:
     _options.update(options)
     options = _options
     return "Subscript[%s, %s]" % (
-        self.base.boxes_to_text(**options),
-        self.subindex.boxes_to_text(**options),
+        boxes_to_text(self.base, **options),
+        boxes_to_text(self.subindex, **options),
     )
 
 
@@ -159,9 +160,9 @@ def subsuperscriptbox(self, **options) -> str:
     _options.update(options)
     options = _options
     return "Subsuperscript[%s, %s, %s]" % (
-        self.base.boxes_to_text(**options),
-        self.subindex.boxes_to_text(**options),
-        self.superindex.boxes_to_text(**options),
+        boxes_to_text(self.base, **options),
+        boxes_to_text(self.subindex, **options),
+        boxes_to_text(self.superindex, **options),
     )
 
 
@@ -172,7 +173,7 @@ def rowbox(self, elements=None, **options) -> str:
     _options = self.box_options.copy()
     _options.update(options)
     options = _options
-    return "".join([element.boxes_to_text(**options) for element in self.items])
+    return "".join([boxes_to_text(element, **options) for element in self.items])
 
 
 add_conversion_fn(RowBox, rowbox)
@@ -183,7 +184,7 @@ def stylebox(self, **options) -> str:
     _options = self.box_options.copy()
     _options.update(options)
     options = _options
-    return self.boxes.boxes_to_text(**options)
+    return boxes_to_text(self.boxes, **options)
 
 
 add_conversion_fn(StyleBox, stylebox)

--- a/mathics/format/text.py
+++ b/mathics/format/text.py
@@ -8,7 +8,6 @@ from mathics.builtin.exceptions import BoxConstructError
 from mathics.builtin.box.graphics import GraphicsBox
 from mathics.builtin.box.graphics3d import Graphics3DBox
 from mathics.builtin.box.layout import (
-    _BoxedString,
     GridBox,
     RowBox,
     StyleBox,
@@ -38,7 +37,6 @@ def string(self, **options) -> str:
 
 
 add_conversion_fn(String, string)
-add_conversion_fn(_BoxedString, string)
 
 
 def fractionbox(self, **options) -> str:

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -152,7 +152,7 @@ all_test = {
         "tex": {
             "System`StandardForm": "\\text{Hola!}",
             "System`TraditionalForm": "\\text{Hola!}",
-            "System`InputForm": "\\text{Hola!}",
+            "System`InputForm": "\\text{``Hola!''}",
             "System`OutputForm": "\\text{Hola!}",
         },
     },
@@ -177,7 +177,7 @@ all_test = {
         "tex": {
             "System`StandardForm": "\\text{π is a trascendental number}",
             "System`TraditionalForm": "\\text{π is a trascendental number}",
-            "System`InputForm": "\\text{π is a trascendental number}",
+            "System`InputForm": "\\text{``π is a trascendental number''}",
             "System`OutputForm": "\\text{π is a trascendental number}",
         },
     },
@@ -198,7 +198,7 @@ all_test = {
         "tex": {
             "System`StandardForm": "\\text{-4.32}",
             "System`TraditionalForm": "\\text{-4.32}",
-            "System`InputForm": "\\text{-4.32}",
+            "System`InputForm": "\\text{``-4.32''}",
             "System`OutputForm": "\\text{-4.32}",
         },
     },
@@ -323,7 +323,7 @@ all_test = {
         "tex": {
             "System`StandardForm": "\\begin{array}{cc} \\text{Spanish} & \\text{Hola!}\\\\ \\text{Portuguese} & \\text{Olà!}\\\\ \\text{English} & \\text{Hi!}\\end{array}",
             "System`TraditionalForm": "\\begin{array}{cc} \\text{Spanish} & \\text{Hola!}\\\\ \\text{Portuguese} & \\text{Olà!}\\\\ \\text{English} & \\text{Hi!}\\end{array}",
-            "System`InputForm": r"\text{Grid}\left[\left\{\left\{\text{Spanish}, \text{Hola!}\right\}, \left\{\text{Portuguese}, \text{Olà!}\right\}, \left\{\text{English}, \text{Hi!}\right\}\right\}\right]",
+            "System`InputForm": r"\text{Grid}\left[\left\{\left\{\text{``Spanish''}, \text{``Hola!''}\right\}, \left\{\text{``Portuguese''}, \text{``Olà!''}\right\}, \left\{\text{``English''}, \text{``Hi!''}\right\}\right\}\right]",
             "System`OutputForm": "\\begin{array}{cc} \\text{Spanish} & \\text{Hola!}\\\\ \\text{Portuguese} & \\text{Olà!}\\\\ \\text{English} & \\text{Hi!}\\end{array}",
         },
         "mathml": {


### PR DESCRIPTION
This is the second cut of #492. 
In this round, 
* the interface of boxes_to_* was reformulated to be more scalable. 
* The `inout.py` module was splitter in parts closer to the WR organization.
*  `_BoxedString` was removed in favor of using a `StyleBox` construct, which is simpler.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/515"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

