### PR TITLE
Use ListExpression where appropriate

### DIFF
--- a/mathics/core/convert/expression.py
+++ b/mathics/core/convert/expression.py
@@ -33,6 +33,21 @@ def to_expression(
     return Expression(head, *elements_tuple, elements_properties=elements_properties)
 
 
+def to_expression_with_specialization(
+    head: Union[str, Symbol],
+    *elements: Any,
+    elements_conversion_fn: Callable = from_python
+) -> Union[ListExpression, Expression]:
+    """
+    This expression constructor will figure out what the right kind of
+    expression to use is, e.g. either Expression or ListExpression.
+    """
+    if head is SymbolList:
+        return ListExpression(*elements)
+    else:
+        return Expression(head, *elements)
+
+
 def to_mathics_list(
     *elements: Any, elements_conversion_fn: Callable = from_python, is_literal=False
 ) -> Expression:

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -6,6 +6,7 @@ import re
 
 from mathics.core.atoms import SymbolString, SymbolI, String, Integer, Rational, Complex
 from mathics.core.element import BaseElement, BoxElement, EvalMixin
+from mathics.core.convert.expression import to_expression_with_specialization
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -464,7 +465,9 @@ def do_format_element(
             ]
             expr_head = expr.head
             do_format = element_formatters.get(type(expr_head), do_format_element)
-            expr = Expression(do_format(expr_head, evaluation, form), *new_elements)
+            head = do_format(expr_head, evaluation, form)
+            expr = to_expression_with_specialization(head, *new_elements)
+
         if include_form:
             expr = Expression(form, expr)
         return expr

--- a/mathics/core/structure.py
+++ b/mathics/core/structure.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from mathics.core.symbols import (
+    SymbolList,
+)
+
+
+class Structure:
+    """
+    Structure helps implementations make the ExpressionCache not invalidate across simple commands
+    such as Take[], Most[], etc. without this, constant reevaluation of lists happens, which results
+    in quadratic runtimes for command like Fold[#1+#2&, Range[x]].
+
+    A good performance test case for Structure: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
+    """
+
+    def __call__(self, elements):
+        # create an Expression with the given list "elements" as elements.
+        # NOTE: the caller guarantees that "elements" only contains items that are from "origins".
+        raise NotImplementedError
+
+    def filter(self, expr, cond):
+        # create an Expression with a subset of "expr".elements (picked out by the filter "cond").
+        # NOTE: the caller guarantees that "expr" is from "origins".
+        raise NotImplementedError
+
+    def slice(self, expr, py_slice):
+        # create an Expression, using the given slice of "expr".elements as elements.
+        # NOTE: the caller guarantees that "expr" is from "origins".
+        raise NotImplementedError
+
+
+class UnlinkedStructure(Structure):
+    """
+    UnlinkedStructure produces Expressions that are not linked to "origins" in terms of cache.
+    This produces the same thing as doing Expression(head, *elements).
+    """
+
+    def __init__(self, head):
+        self._head = head
+        self._cache = None
+
+    def __call__(self, elements):
+        from mathics.core.expression import Expression
+
+        # FIXME: This is possibly the last remaining place where
+        # we seem to to require Expression(System`List, ... )
+        # and can't use ListExpression(...).
+        # It may be in formatting of RowBoxes, so that may take care of itself
+        # when we revise Boxing and formattin.
+        # Also make sure to test via test/test_series.py
+        # Of course, a failure would would be in something poorly documented and the smells hacky
+        # or misguided involving a home-grown caching system.
+        return Expression(self._head, *elements)
+
+        # from mathics.core.convert.expression import to_expression_with_specialization
+        # return to_expression_with_specialization(self._head, *new_elements)
+
+    def filter(self, expr, cond):
+        return self([element for element in expr.elements if cond(element)])
+
+    def slice(self, expr, py_slice):
+        elements = expr.elements
+        lower, upper, step = py_slice.indices(len(elements))
+        if step != 1:
+            raise ValueError("Structure.slice only supports slice steps of 1")
+        return self(elements[lower:upper])
+
+
+class LinkedStructure(Structure):
+    """
+    LinkedStructure produces Expressions that are linked to "origins" in terms of cache. This
+    carries over information from the cache of the originating Expressions into the Expressions
+    that are newly created.
+    """
+
+    def __init__(self, head, cache):
+        self._head = head
+        self._cache = cache
+
+    def __call__(self, elements):
+        from mathics.core.expression import Expression
+
+        expr = Expression(self._head)
+        expr.elements = tuple(elements)
+        expr._cache = self._cache.reordered()
+        return expr
+
+    def filter(self, expr, cond):
+        return self([element for element in expr.elements if cond(element)])
+
+    def slice(self, expr, py_slice):
+        elements = expr.elements
+        lower, upper, step = py_slice.indices(len(elements))
+        if step != 1:
+            raise ValueError("Structure.slice only supports slice steps of 1")
+
+        from mathics.core.expression import Expression
+
+        new = Expression(self._head)
+        new.elements = elements[lower:upper]
+        if expr._cache:
+            new._cache = expr._cache.sliced(lower, upper)
+
+        return new


### PR DESCRIPTION
Here we eliminate most of the uses of  `Expression(SymbolList, ...)` 

However something involving UnlinkedStructure will cause test failures, so Expression is kept there for List, for now.

LInkedStructure and Unlinked structure have been split off into its own module. 

Some small stylistic cleanup done on Expression.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/516"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

