### PR TITLE
adding a tool for normalize the indentation in docstrings

### DIFF
--- a/admin-tools/normalize_docstrings.py
+++ b/admin-tools/normalize_docstrings.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+
+"""
+This program ensures the indentation inside docstrings.
+"""
+
+import re
+import sys
+import os
+import shutil
+
+
+def process_file(filename: str) -> int:
+    new_lines = []
+    with open(filename, "r") as f_in:
+        for line in f_in.readlines():
+            line = re.sub(r"^[ ]*[<]dl[>]", r"    <dl>", line)
+            line = re.sub(r"^[ ]*[<]/dl[>]", r"    </dl>", line)
+            line = re.sub(r"^[ ]*[<]dt[>]", r"      <dt>", line)
+            line = re.sub(r"^[ ]*[<]dd[>]", r"      <dd>", line)
+            new_lines.append(line)
+
+    # backup the file
+    shutil.copyfile(filename, filename + "~")
+    with open(filename, "w") as f_out:
+        for line in new_lines:
+            f_out.write(line)
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("This tool applies basic rules to normalize the format of docstrings")
+        print("usage:")
+        print("clean_docstring  [filename]")
+        exit(-1)
+    filename = sys.argv[1]
+    print(f"normalizing {filename}. Backup in {filename}~")
+    process_file(filename)

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -244,10 +244,10 @@ def create_infix(items, operator, prec, grouping):
 class DirectedInfinity(SympyFunction):
     """
     <dl>
-    <dt>'DirectedInfinity[$z$]'
-        <dd>represents an infinite multiple of the complex number $z$.
-    <dt>'DirectedInfinity[]'
-        <dd>is the same as 'ComplexInfinity'.
+      <dt>'DirectedInfinity[$z$]'
+      <dd>represents an infinite multiple of the complex number $z$.
+      <dt>'DirectedInfinity[]'
+      <dd>is the same as 'ComplexInfinity'.
     </dl>
 
     >> DirectedInfinity[1]
@@ -335,8 +335,8 @@ class DirectedInfinity(SympyFunction):
 class Re(SympyFunction):
     """
     <dl>
-    <dt>'Re[$z$]'
-        <dd>returns the real component of the complex number $z$.
+      <dt>'Re[$z$]'
+      <dd>returns the real component of the complex number $z$.
     </dl>
 
     >> Re[3+4I]
@@ -473,10 +473,10 @@ class Abs(_MPMathFunction):
 
 class Arg(_MPMathFunction):
     """
-     <dl>
-       <dt>'Arg'[$z$, $method_option$]
-       <dd>returns the argument of a complex value $z$.
-     </dl>
+    <dl>
+      <dt>'Arg'[$z$, $method_option$]
+      <dd>returns the argument of a complex value $z$.
+    </dl>
 
     <ul>
          <li>'Arg'[$z$] is left unevaluated if $z$ is not a numeric quantity.
@@ -542,8 +542,8 @@ class Arg(_MPMathFunction):
 class Sign(SympyFunction):
     """
     <dl>
-    <dt>'Sign[$x$]'
-        <dd>return -1, 0, or 1 depending on whether $x$ is negative, zero, or positive.
+      <dt>'Sign[$x$]'
+      <dd>return -1, 0, or 1 depending on whether $x$ is negative, zero, or positive.
     </dl>
 
     >> Sign[19]
@@ -600,8 +600,8 @@ class Sign(SympyFunction):
 class I(Predefined):
     """
     <dl>
-    <dt>'I'
-        <dd>represents the imaginary number 'Sqrt[-1]'.
+      <dt>'I'
+      <dd>represents the imaginary number 'Sqrt[-1]'.
     </dl>
 
     >> I^2
@@ -708,8 +708,8 @@ class PossibleZeroQ(SympyFunction):
 class RealNumberQ(Test):
     """
     <dl>
-    <dt>'RealNumberQ[$expr$]'
-        <dd>returns 'True' if $expr$ is an explicit number with no imaginary component.
+      <dt>'RealNumberQ[$expr$]'
+      <dd>returns 'True' if $expr$ is an explicit number with no imaginary component.
     </dl>
 
     >> RealNumberQ[10]
@@ -733,8 +733,8 @@ class RealNumberQ(Test):
 class Integer_(Builtin):
     """
     <dl>
-    <dt>'Integer'
-        <dd>is the head of integers.
+      <dt>'Integer'
+      <dd>is the head of integers.
     </dl>
 
     >> Head[5]
@@ -752,8 +752,8 @@ class Integer_(Builtin):
 class Real_(Builtin):
     """
     <dl>
-    <dt>'Real'
-        <dd>is the head of real (inexact) numbers.
+      <dt>'Real'
+      <dd>is the head of real (inexact) numbers.
     </dl>
 
     >> x = 3. ^ -20;
@@ -826,10 +826,10 @@ class Real_(Builtin):
 class Rational_(Builtin):
     """
     <dl>
-    <dt>'Rational'
-        <dd>is the head of rational numbers.
-    <dt>'Rational[$a$, $b$]'
-        <dd>constructs the rational number $a$ / $b$.
+      <dt>'Rational'
+      <dd>is the head of rational numbers.
+      <dt>'Rational[$a$, $b$]'
+      <dd>constructs the rational number $a$ / $b$.
     </dl>
 
     >> Head[1/2]
@@ -857,10 +857,10 @@ class Rational_(Builtin):
 class Complex_(Builtin):
     """
     <dl>
-    <dt>'Complex'
-        <dd>is the head of complex numbers.
-    <dt>'Complex[$a$, $b$]'
-        <dd>constructs the complex number '$a$ + I $b$'.
+      <dt>'Complex'
+      <dd>is the head of complex numbers.
+      <dt>'Complex[$a$, $b$]'
+      <dd>constructs the complex number '$a$ + I $b$'.
     </dl>
 
     >> Head[2 + 3*I]
@@ -1076,14 +1076,14 @@ class Sum(_IterationFunction, SympyFunction):
 class Product(_IterationFunction, SympyFunction):
     """
     <dl>
-    <dt>'Product[$expr$, {$i$, $imin$, $imax$}]'
-        <dd>evaluates the discrete product of $expr$ with $i$ ranging from $imin$ to $imax$.
-    <dt>'Product[$expr$, {$i$, $imax$}]'
-        <dd>same as 'Product[$expr$, {$i$, 1, $imax$}]'.
-    <dt>'Product[$expr$, {$i$, $imin$, $imax$, $di$}]'
-        <dd>$i$ ranges from $imin$ to $imax$ in steps of $di$.
-    <dt>'Product[$expr$, {$i$, $imin$, $imax$}, {$j$, $jmin$, $jmax$}, ...]'
-        <dd>evaluates $expr$ as a multiple product, with {$i$, ...}, {$j$, ...}, ... being in outermost-to-innermost order.
+      <dt>'Product[$expr$, {$i$, $imin$, $imax$}]'
+      <dd>evaluates the discrete product of $expr$ with $i$ ranging from $imin$ to $imax$.
+      <dt>'Product[$expr$, {$i$, $imax$}]'
+      <dd>same as 'Product[$expr$, {$i$, 1, $imax$}]'.
+      <dt>'Product[$expr$, {$i$, $imin$, $imax$, $di$}]'
+      <dd>$i$ ranges from $imin$ to $imax$ in steps of $di$.
+      <dt>'Product[$expr$, {$i$, $imin$, $imax$}, {$j$, $jmin$, $jmax$}, ...]'
+      <dd>evaluates $expr$ as a multiple product, with {$i$, ...}, {$j$, ...}, ... being in outermost-to-innermost order.
     </dl>
 
     >> Product[k, {k, 1, 10}]
@@ -1245,7 +1245,7 @@ class Piecewise(SympyFunction):
 class Boole(Builtin):
     """
     <dl>
-    <dt>'Boole[expr]'
+      <dt>'Boole[expr]'
       <dd>returns 1 if expr is True and 0 if expr is False.
     </dl>
 
@@ -1293,7 +1293,7 @@ class Assumptions(Predefined):
 class Assuming(Builtin):
     """
     <dl>
-    <dt>'Assuming[$cond$, $expr$]'
+      <dt>'Assuming[$cond$, $expr$]'
       <dd>Evaluates $expr$ assuming the conditions $cond$.
     </dl>
     >> $Assumptions = { x > 0 }

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -91,8 +91,8 @@ class Attributes(Builtin):
 class SetAttributes(Builtin):
     """
     <dl>
-    <dt>'SetAttributes'[$symbol$, $attrib$]
-        <dd>adds $attrib$ to the list of $symbol$'s attributes.
+      <dt>'SetAttributes'[$symbol$, $attrib$]
+      <dd>adds $attrib$ to the list of $symbol$'s attributes.
     </dl>
 
     >> SetAttributes[f, Flat]
@@ -142,8 +142,8 @@ class SetAttributes(Builtin):
 class ClearAttributes(Builtin):
     """
     <dl>
-    <dt>'ClearAttributes'[$symbol$, $attrib$]
-        <dd>removes $attrib$ from $symbol$'s attributes.
+      <dt>'ClearAttributes'[$symbol$, $attrib$]
+      <dd>removes $attrib$ from $symbol$'s attributes.
     </dl>
 
     >> SetAttributes[f, Flat]
@@ -307,8 +307,8 @@ class Unprotect(Builtin):
 class Protected(Predefined):
     """
     <dl>
-    <dt>'Protected'
-        <dd>is an attribute that prevents values on a symbol from
+      <dt>'Protected'
+      <dd>is an attribute that prevents values on a symbol from
         being modified.
     </dl>
 
@@ -350,8 +350,8 @@ class Protected(Predefined):
 class ReadProtected(Predefined):
     """
     <dl>
-    <dt>'ReadProtected'
-        <dd>is an attribute that prevents values on a symbol from
+      <dt>'ReadProtected'
+      <dd>is an attribute that prevents values on a symbol from
         being read.
     </dl>
 
@@ -372,8 +372,8 @@ class ReadProtected(Predefined):
 class Locked(Predefined):
     """
     <dl>
-    <dt>'Locked'
-        <dd>is an attribute that prevents attributes on a symbol from
+      <dt>'Locked'
+      <dd>is an attribute that prevents attributes on a symbol from
         being modified.
     </dl>
 
@@ -400,8 +400,8 @@ class Locked(Predefined):
 class Flat(Predefined):
     """
     <dl>
-    <dt>'Flat'
-        <dd>is an attribute that specifies that nested occurrences of
+      <dt>'Flat'
+      <dd>is an attribute that specifies that nested occurrences of
         a function should be automatically flattened.
     </dl>
 
@@ -444,8 +444,8 @@ class Flat(Predefined):
 
 class Orderless(Predefined):
     """<dl>
-        <dt>'Orderless'
-        <dd>is an attribute that can be assigned to a symbol $f$ to
+      <dt>'Orderless'
+      <dd>is an attribute that can be assigned to a symbol $f$ to
         indicate that the elements $ei$ in expressions of the form
         $f$[$e1$, $e2$, ...] should automatically be sorted into
         canonical order. This property is accounted for in pattern
@@ -475,8 +475,8 @@ class Orderless(Predefined):
 class OneIdentity(Predefined):
     """
     <dl>
-    <dt>'OneIdentity'
-        <dd>is an attribute specifying that '$f$[$x$]' should be treated
+      <dt>'OneIdentity'
+      <dd>is an attribute specifying that '$f$[$x$]' should be treated
         as equivalent to $x$ in pattern matching.
     </dl>
 
@@ -495,8 +495,8 @@ class OneIdentity(Predefined):
 class SequenceHold(Predefined):
     """
     <dl>
-    <dt>'SequenceHold'
-        <dd>is an attribute that prevents 'Sequence' objects from being
+      <dt>'SequenceHold'
+      <dd>is an attribute that prevents 'Sequence' objects from being
         spliced into a function's arguments.
     </dl>
 
@@ -522,8 +522,8 @@ class SequenceHold(Predefined):
 class HoldFirst(Predefined):
     """
     <dl>
-    <dt>'HoldFirst'
-        <dd>is an attribute specifying that the first argument of a
+      <dt>'HoldFirst'
+      <dd>is an attribute specifying that the first argument of a
         function should be left unevaluated.
     </dl>
 
@@ -537,8 +537,8 @@ class HoldFirst(Predefined):
 class HoldRest(Predefined):
     """
     <dl>
-    <dt>'HoldRest'
-        <dd>is an attribute specifying that all but the first argument
+      <dt>'HoldRest'
+      <dd>is an attribute specifying that all but the first argument
         of a function should be left unevaluated.
     </dl>
 
@@ -554,8 +554,8 @@ class HoldRest(Predefined):
 class HoldAll(Predefined):
     """
     <dl>
-    <dt>'HoldAll'
-        <dd>is an attribute specifying that all arguments of a
+      <dt>'HoldAll'
+      <dd>is an attribute specifying that all arguments of a
         function should be left unevaluated.
     </dl>
 
@@ -569,8 +569,8 @@ class HoldAll(Predefined):
 class HoldAllComplete(Predefined):
     """
     <dl>
-    <dt>'HoldAllComplete'
-        <dd>is an attribute that includes the effects of 'HoldAll' and
+      <dt>'HoldAllComplete'
+      <dd>is an attribute that includes the effects of 'HoldAll' and
         'SequenceHold', and also protects the function from being
         affected by the upvalues of any arguments.
     </dl>
@@ -591,8 +591,8 @@ class HoldAllComplete(Predefined):
 class NHoldAll(Predefined):
     """
     <dl>
-    <dt>'NHoldAll'
-        <dd>is an attribute that protects all arguments of a
+      <dt>'NHoldAll'
+      <dd>is an attribute that protects all arguments of a
         function from numeric evaluation.
     </dl>
 
@@ -609,8 +609,8 @@ class NHoldAll(Predefined):
 class NHoldFirst(Predefined):
     """
     <dl>
-    <dt>'NHoldFirst'
-        <dd>is an attribute that protects the first argument of a
+      <dt>'NHoldFirst'
+      <dd>is an attribute that protects the first argument of a
         function from numeric evaluation.
     </dl>
     """
@@ -621,8 +621,8 @@ class NHoldFirst(Predefined):
 class NHoldRest(Predefined):
     """
     <dl>
-    <dt>'NHoldRest'
-        <dd>is an attribute that protects all but the first argument
+      <dt>'NHoldRest'
+      <dd>is an attribute that protects all but the first argument
         of a function from numeric evaluation.
     </dl>
     """
@@ -633,8 +633,8 @@ class NHoldRest(Predefined):
 class Listable(Predefined):
     """
     <dl>
-    <dt>'Listable'
-        <dd>is an attribute specifying that a function should be
+      <dt>'Listable'
+      <dd>is an attribute specifying that a function should be
         automatically applied to each element of a list.
     </dl>
 
@@ -653,8 +653,8 @@ class Listable(Predefined):
 class Constant(Predefined):
     """
     <dl>
-    <dt>'Constant'
-        <dd>is an attribute that indicates that a symbol is a constant.
+      <dt>'Constant'
+      <dd>is an attribute that indicates that a symbol is a constant.
     </dl>
 
     Mathematical constants like 'E' have attribute 'Constant':
@@ -674,8 +674,8 @@ class Constant(Predefined):
 class NumericFunction(Predefined):
     """
     <dl>
-    <dt>'NumericFunction'
-        <dd>is an attribute that indicates that a symbol is the head of a numeric function.
+      <dt>'NumericFunction'
+      <dd>is an attribute that indicates that a symbol is the head of a numeric function.
     </dl>
 
     Mathematical functions like 'Sqrt' have attribute 'NumericFunction':

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -453,8 +453,8 @@ class BooleanQ(Builtin):
 class Inequality(Builtin):
     """
     <dl>
-    <dt>'Inequality'
-        <dd>is the head of expressions involving different inequality
+      <dt>'Inequality'
+      <dd>is the head of expressions involving different inequality
         operators (at least temporarily). Thus, it is possible to
         write chains of inequalities.
     </dl>
@@ -822,10 +822,10 @@ class Less(_ComparisonOperator, _SympyComparison):
 
 class LessEqual(_ComparisonOperator, _SympyComparison):
     """
-     <dl>
-       <dt>'LessEqual[$x$, $y$, ...]' or $x$ <= $y$ or $x$ \u2264 $y$
-       <dd>yields 'True' if $x$ is known to be less than or equal to $y$.
-     </dl>
+    <dl>
+      <dt>'LessEqual[$x$, $y$, ...]' or $x$ <= $y$ or $x$ \u2264 $y$
+      <dd>yields 'True' if $x$ is known to be less than or equal to $y$.
+    </dl>
 
     LessEqual operator can be chained:
     >> LessEqual[1, 3, 3, 2]
@@ -915,8 +915,8 @@ class Positive(Builtin):
 class Negative(Builtin):
     """
     <dl>
-    <dt>'Negative[$x$]'
-        <dd>returns 'True' if $x$ is a negative real number.
+      <dt>'Negative[$x$]'
+      <dd>returns 'True' if $x$ is a negative real number.
     </dl>
     >> Negative[0]
      = False
@@ -964,8 +964,8 @@ class NonNegative(Builtin):
 class NonPositive(Builtin):
     """
     <dl>
-    <dt>'NonPositive[$x$]'
-        <dd>returns 'True' if $x$ is a negative real number or zero.
+      <dt>'NonPositive[$x$]'
+      <dd>returns 'True' if $x$ is a negative real number or zero.
     </dl>
 
     >> {Negative[0], NonPositive[0]}

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -463,11 +463,11 @@ def number_form(expr, n, f, evaluation, options):
 class MakeBoxes(Builtin):
     """
     <dl>
-    <dt>'MakeBoxes[$expr$]'
-        <dd>is a low-level formatting primitive that converts $expr$
+      <dt>'MakeBoxes[$expr$]'
+      <dd>is a low-level formatting primitive that converts $expr$
         to box form, without evaluating it.
-    <dt>'\\( ... \\)'
-        <dd>directly inputs box objects.
+      <dt>'\\( ... \\)'
+      <dd>directly inputs box objects.
     </dl>
 
     String representation of boxes
@@ -732,8 +732,8 @@ class MakeBoxes(Builtin):
 class ToBoxes(Builtin):
     """
     <dl>
-    <dt>'ToBoxes[$expr$]'
-        <dd>evaluates $expr$ and converts the result to box form.
+      <dt>'ToBoxes[$expr$]'
+      <dd>evaluates $expr$ and converts the result to box form.
     </dl>
 
     Unlike 'MakeBoxes', 'ToBoxes' evaluates its argument:
@@ -761,8 +761,8 @@ class ToBoxes(Builtin):
 class BoxData(Builtin):
     """
     <dl>
-    <dt>'BoxData[...]'
-        <dd>is a low-level representation of the contents of a typesetting
+      <dt>'BoxData[...]'
+      <dd>is a low-level representation of the contents of a typesetting
     cell.
     </dl>
     """
@@ -773,8 +773,8 @@ class BoxData(Builtin):
 class TextData(Builtin):
     """
     <dl>
-    <dt>'TextData[...]'
-        <dd>is a low-level representation of the contents of a textual
+      <dt>'TextData[...]'
+      <dd>is a low-level representation of the contents of a textual
     cell.
     </dl>
     """
@@ -785,8 +785,8 @@ class TextData(Builtin):
 class Row(Builtin):
     """
     <dl>
-    <dt>'Row[{$expr$, ...}]'
-        <dd>formats several expressions inside a 'RowBox'.
+      <dt>'Row[{$expr$, ...}]'
+      <dd>formats several expressions inside a 'RowBox'.
     </dl>
     """
 
@@ -824,8 +824,8 @@ def is_constant_list(list):
 class GridBox(BoxConstruct):
     r"""
     <dl>
-    <dt>'GridBox[{{...}, {...}}]'
-        <dd>is a box construct that represents a sequence of boxes
+      <dt>'GridBox[{{...}, {...}}]'
+      <dd>is a box construct that represents a sequence of boxes
         arranged in a grid.
     </dl>
 
@@ -972,8 +972,8 @@ class GridBox(BoxConstruct):
 class Grid(Builtin):
     """
     <dl>
-    <dt>'Grid[{{$a1$, $a2$, ...}, {$b1$, $b2$, ...}, ...}]'
-        <dd>formats several expressions inside a 'GridBox'.
+      <dt>'Grid[{{$a1$, $a2$, ...}, {$b1$, $b2$, ...}, ...}]'
+      <dd>formats several expressions inside a 'GridBox'.
     </dl>
 
     >> Grid[{{a, b}, {c, d}}]
@@ -1010,8 +1010,8 @@ SymbolTableDepth = Symbol("TableDepth")
 class TableForm(Builtin):
     """
     <dl>
-    <dt>'TableForm[$expr$]'
-        <dd>displays $expr$ as a table.
+      <dt>'TableForm[$expr$]'
+      <dd>displays $expr$ as a table.
     </dl>
 
     >> TableForm[Array[a, {3,2}],TableDepth->1]
@@ -1102,8 +1102,8 @@ class TableForm(Builtin):
 class MatrixForm(TableForm):
     """
     <dl>
-    <dt>'MatrixForm[$m$]'
-        <dd>displays a matrix $m$, hiding the underlying list
+      <dt>'MatrixForm[$m$]'
+      <dd>displays a matrix $m$, hiding the underlying list
         structure.
     </dl>
 
@@ -1140,8 +1140,8 @@ class MatrixForm(TableForm):
 class Superscript(Builtin):
     """
     <dl>
-    <dt>'Superscript[$x$, $y$]'
-        <dd>displays as $x$^$y$.
+      <dt>'Superscript[$x$, $y$]'
+      <dd>displays as $x$^$y$.
     </dl>
 
     >> Superscript[x,3] // TeXForm
@@ -1159,8 +1159,8 @@ class Superscript(Builtin):
 class Subscript(Builtin):
     """
     <dl>
-    <dt>'Subscript[$a$, $i$]'
-        <dd>displays as $a_i$.
+      <dt>'Subscript[$a$, $i$]'
+      <dd>displays as $a_i$.
     </dl>
 
     >> Subscript[x,1,2,3] // TeXForm
@@ -1183,8 +1183,8 @@ class Subscript(Builtin):
 class Subsuperscript(Builtin):
     """
     <dl>
-    <dt>'Subsuperscript[$a$, $b$, $c$]'
-        <dd>displays as $a_b^c$.
+      <dt>'Subsuperscript[$a$, $b$, $c$]'
+      <dd>displays as $a_b^c$.
     </dl>
 
     >> Subsuperscript[a, b, c] // TeXForm
@@ -1203,8 +1203,8 @@ class Subsuperscript(Builtin):
 class Postfix(BinaryOperator):
     """
     <dl>
-    <dt>'$x$ // $f$'
-        <dd>is equivalent to '$f$[$x$]'.
+      <dt>'$x$ // $f$'
+      <dd>is equivalent to '$f$[$x$]'.
     </dl>
 
     >> b // a
@@ -1227,8 +1227,8 @@ class Postfix(BinaryOperator):
 class Prefix(BinaryOperator):
     """
     <dl>
-    <dt>'$f$ @ $x$'
-        <dd>is equivalent to '$f$[$x$]'.
+      <dt>'$f$ @ $x$'
+      <dd>is equivalent to '$f$[$x$]'.
     </dl>
 
     >> a @ b
@@ -1261,8 +1261,8 @@ class Prefix(BinaryOperator):
 class Infix(Builtin):
     """
     <dl>
-    <dt>'Infix[$expr$, $oper$, $prec$, $assoc$]'
-        <dd>displays $expr$ with the infix operator $oper$, with
+      <dt>'Infix[$expr$, $oper$, $prec$, $assoc$]'
+      <dd>displays $expr$ with the infix operator $oper$, with
         precedence $prec$ and associativity $assoc$.
     </dl>
 
@@ -1301,8 +1301,8 @@ class Infix(Builtin):
 class NonAssociative(Builtin):
     """
     <dl>
-    <dt>'NonAssociative'
-        <dd>is used with operator formatting constructs to specify a
+      <dt>'NonAssociative'
+      <dd>is used with operator formatting constructs to specify a
         non-associative operator.
     </dl>
     """
@@ -1313,8 +1313,8 @@ class NonAssociative(Builtin):
 class Left(Builtin):
     """
     <dl>
-    <dt>'Left'
-        <dd>is used with operator formatting constructs to specify a
+      <dt>'Left'
+      <dd>is used with operator formatting constructs to specify a
         left-associative operator.
     </dl>
     """
@@ -1325,8 +1325,8 @@ class Left(Builtin):
 class Right(Builtin):
     """
     <dl>
-    <dt>'Right'
-        <dd>is used with operator formatting constructs to specify a
+      <dt>'Right'
+      <dd>is used with operator formatting constructs to specify a
         right-associative operator.
     </dl>
     """
@@ -1337,8 +1337,8 @@ class Right(Builtin):
 class Center(Builtin):
     """
     <dl>
-    <dt>'Center'
-        <dd>is used with the 'ColumnAlignments' option to 'Grid' or
+      <dt>'Center'
+      <dd>is used with the 'ColumnAlignments' option to 'Grid' or
         'TableForm' to specify a centered column.
     </dl>
     """
@@ -1349,8 +1349,8 @@ class Center(Builtin):
 class StringForm(Builtin):
     """
     <dl>
-    <dt>'StringForm[$str$, $expr1$, $expr2$, ...]'
-        <dd>displays the string $str$, replacing placeholders in $str$
+      <dt>'StringForm[$str$, $expr1$, $expr2$, ...]'
+      <dd>displays the string $str$, replacing placeholders in $str$
         with the corresponding expressions.
     </dl>
 
@@ -1398,8 +1398,8 @@ class StringForm(Builtin):
 class Message(Builtin):
     """
     <dl>
-    <dt>'Message[$symbol$::$msg$, $expr1$, $expr2$, ...]'
-        <dd>displays the specified message, replacing placeholders in
+      <dt>'Message[$symbol$::$msg$, $expr1$, $expr2$, ...]'
+      <dd>displays the specified message, replacing placeholders in
         the message text with the corresponding expressions.
     </dl>
 
@@ -1439,10 +1439,10 @@ def check_message(expr) -> bool:
 class Check(Builtin):
     """
     <dl>
-    <dt>'Check[$expr$, $failexpr$]'
-        <dd>evaluates $expr$, and returns the result, unless messages were generated, in which case it evaluates and $failexpr$ will be returned.
-    <dt>'Check[$expr$, $failexpr$, {s1::t1,s2::t2,...}]'
-        <dd>checks only for the specified messages.
+      <dt>'Check[$expr$, $failexpr$]'
+      <dd>evaluates $expr$, and returns the result, unless messages were generated, in which case it evaluates and $failexpr$ will be returned.
+      <dt>'Check[$expr$, $failexpr$, {s1::t1,s2::t2,...}]'
+      <dd>checks only for the specified messages.
     </dl>
 
     Return err when a message is generated:
@@ -1571,14 +1571,14 @@ class Check(Builtin):
 class Quiet(Builtin):
     """
     <dl>
-    <dt>'Quiet[$expr$, {$s1$::$t1$, ...}]'
-        <dd>evaluates $expr$, without messages '{$s1$::$t1$, ...}' being displayed.
-    <dt>'Quiet[$expr$, All]'
-        <dd>evaluates $expr$, without any messages being displayed.
-    <dt>'Quiet[$expr$, None]'
-        <dd>evaluates $expr$, without all messages being displayed.
-    <dt>'Quiet[$expr$, $off$, $on$]'
-        <dd>evaluates $expr$, with messages $off$ being suppressed, but messages $on$ being displayed.
+      <dt>'Quiet[$expr$, {$s1$::$t1$, ...}]'
+      <dd>evaluates $expr$, without messages '{$s1$::$t1$, ...}' being displayed.
+      <dt>'Quiet[$expr$, All]'
+      <dd>evaluates $expr$, without any messages being displayed.
+      <dt>'Quiet[$expr$, None]'
+      <dd>evaluates $expr$, without all messages being displayed.
+      <dt>'Quiet[$expr$, $off$, $on$]'
+      <dd>evaluates $expr$, with messages $off$ being suppressed, but messages $on$ being displayed.
     </dl>
 
     Evaluate without generating messages:
@@ -1699,8 +1699,8 @@ class Quiet(Builtin):
 class Off(Builtin):
     """
     <dl>
-    <dt>'Off[$symbol$::$tag$]'
-        <dd>turns a message off so it is no longer printed.
+      <dt>'Off[$symbol$::$tag$]'
+      <dd>turns a message off so it is no longer printed.
     </dl>
 
     >> Off[Power::infy]
@@ -1746,8 +1746,8 @@ class Off(Builtin):
 class On(Builtin):
     """
     <dl>
-    <dt>'On[$symbol$::$tag$]'
-        <dd>turns a message on for printing.
+      <dt>'On[$symbol$::$tag$]'
+      <dd>turns a message on for printing.
     </dl>
 
     >> Off[Power::infy]
@@ -1793,9 +1793,9 @@ class On(Builtin):
 class MessageName(BinaryOperator):
     """
     <dl>
-    <dt>'MessageName[$symbol$, $tag$]'
-    <dt>'$symbol$::$tag$'
-        <dd>identifies a message.
+      <dt>'MessageName[$symbol$, $tag$]'
+      <dt>'$symbol$::$tag$'
+      <dd>identifies a message.
     </dl>
 
     'MessageName' is the head of message IDs of the form 'symbol::tag'.
@@ -1836,8 +1836,8 @@ class MessageName(BinaryOperator):
 class Syntax(Builtin):
     r"""
     <dl>
-    <dt>'Syntax'
-        <dd>is a symbol to which all syntax messages are assigned.
+      <dt>'Syntax'
+      <dd>is a symbol to which all syntax messages are assigned.
     </dl>
 
     >> 1 +
@@ -1940,8 +1940,8 @@ class Syntax(Builtin):
 class General(Builtin):
     """
     <dl>
-    <dt>'General'
-        <dd>is a symbol to which all general-purpose messages are assigned.
+      <dt>'General'
+      <dd>is a symbol to which all general-purpose messages are assigned.
     </dl>
 
     >> General::argr
@@ -2035,8 +2035,8 @@ class General(Builtin):
 class Echo_(Predefined):
     """
     <dl>
-    <dt>'$Echo'
-        <dd>gives a list of files and pipes to which all input is echoed.
+      <dt>'$Echo'
+      <dd>gives a list of files and pipes to which all input is echoed.
 
     </dl>
     """
@@ -2050,8 +2050,8 @@ class Echo_(Predefined):
 class Print(Builtin):
     """
     <dl>
-    <dt>'Print[$expr$, ...]'
-        <dd>prints each $expr$ in string form.
+      <dt>'Print[$expr$, ...]'
+      <dd>prints each $expr$ in string form.
     </dl>
 
     >> Print["Hello world!"]
@@ -2078,8 +2078,8 @@ class Print(Builtin):
 class FullForm(Builtin):
     """
     <dl>
-    <dt>'FullForm[$expr$]'
-        <dd>displays the underlying form of $expr$.
+      <dt>'FullForm[$expr$]'
+      <dd>displays the underlying form of $expr$.
     </dl>
 
     >> FullForm[a + b * c]
@@ -2096,8 +2096,8 @@ class FullForm(Builtin):
 class StandardForm(Builtin):
     """
     <dl>
-    <dt>'StandardForm[$expr$]'
-        <dd>displays $expr$ in the default form.
+      <dt>'StandardForm[$expr$]'
+      <dd>displays $expr$ in the default form.
     </dl>
 
     >> StandardForm[a + b * c]
@@ -2117,8 +2117,8 @@ class StandardForm(Builtin):
 class TraditionalForm(Builtin):
     """
     <dl>
-    <dt>'TraditionalForm[$expr$]'
-        <dd>displays $expr$ in a format similar to the traditional mathematical notation, where
+      <dt>'TraditionalForm[$expr$]'
+      <dd>displays $expr$ in a format similar to the traditional mathematical notation, where
            function evaluations are represented by brackets instead of square brackets.
     </dl>
 
@@ -2133,8 +2133,8 @@ class TraditionalForm(Builtin):
 class InputForm(Builtin):
     r"""
     <dl>
-    <dt>'InputForm[$expr$]'
-        <dd>displays $expr$ in an unambiguous form suitable for input.
+      <dt>'InputForm[$expr$]'
+      <dd>displays $expr$ in an unambiguous form suitable for input.
     </dl>
 
     >> InputForm[a + b * c]
@@ -2156,8 +2156,8 @@ class InputForm(Builtin):
 class OutputForm(Builtin):
     """
     <dl>
-    <dt>'OutputForm[$expr$]'
-        <dd>displays $expr$ in a plain-text form.
+      <dt>'OutputForm[$expr$]'
+      <dd>displays $expr$ in a plain-text form.
     </dl>
 
     >> OutputForm[f'[x]]
@@ -2176,8 +2176,8 @@ class OutputForm(Builtin):
 class MathMLForm(Builtin):
     """
     <dl>
-    <dt>'MathMLForm[$expr$]'
-        <dd>displays $expr$ as a MathML expression.
+      <dt>'MathMLForm[$expr$]'
+      <dd>displays $expr$ as a MathML expression.
     </dl>
 
     >> MathMLForm[HoldForm[Sqrt[a^3]]]
@@ -2295,8 +2295,8 @@ class SympyForm(Builtin):
 class TeXForm(Builtin):
     r"""
     <dl>
-    <dt>'TeXForm[$expr$]'
-        <dd>displays $expr$ using TeX math mode commands.
+      <dt>'TeXForm[$expr$]'
+      <dd>displays $expr$ using TeX math mode commands.
     </dl>
 
     >> TeXForm[HoldForm[Sqrt[a^3]]]
@@ -2342,27 +2342,27 @@ class TeXForm(Builtin):
 class Style(Builtin):
     """
     <dl>
-    <dt>'Style[$expr$, options]'
-    <dd>displays $expr$ formatted using the specified option settings.
-    <dt>'Style[$expr$, "style"]'
-    <dd> uses the option settings for the specified style in the current notebook.
-    <dt>'Style[$expr$, $color$]'
-    <dd>displays using the specified color.
-    <dt>'Style[$expr$, $Bold$]'
-    <dd>displays with fonts made bold.
-    <dt>'Style[$expr$, $Italic$]'
-    <dd>displays with fonts made italic.
-    <dt>'Style[$expr$, $Underlined$]'
-    <dd>displays with fonts underlined.
-    <dt>'Style[$expr$, $Larger$]
-    <dd>displays with fonts made larger.
-    <dt>'Style[$expr$, $Smaller$]'
-    <dd>displays with fonts made smaller.
-    <dt>'Style[$expr$, $n$]'
-    <dd>displays with font size n.
-    <dt>'Style[$expr$, $Tiny$]'
-    <dt>'Style[$expr$, $Small$]', etc.
-    <dd>display with fonts that are tiny, small, etc.
+      <dt>'Style[$expr$, options]'
+      <dd>displays $expr$ formatted using the specified option settings.
+      <dt>'Style[$expr$, "style"]'
+      <dd> uses the option settings for the specified style in the current notebook.
+      <dt>'Style[$expr$, $color$]'
+      <dd>displays using the specified color.
+      <dt>'Style[$expr$, $Bold$]'
+      <dd>displays with fonts made bold.
+      <dt>'Style[$expr$, $Italic$]'
+      <dd>displays with fonts made italic.
+      <dt>'Style[$expr$, $Underlined$]'
+      <dd>displays with fonts underlined.
+      <dt>'Style[$expr$, $Larger$]
+      <dd>displays with fonts made larger.
+      <dt>'Style[$expr$, $Smaller$]'
+      <dd>displays with fonts made smaller.
+      <dt>'Style[$expr$, $n$]'
+      <dd>displays with font size n.
+      <dt>'Style[$expr$, $Tiny$]'
+      <dt>'Style[$expr$, $Small$]', etc.
+      <dd>display with fonts that are tiny, small, etc.
     </dl>
     """
 
@@ -2380,8 +2380,8 @@ class Style(Builtin):
 class Precedence(Builtin):
     """
     <dl>
-    <dt>'Precedence[$op$]'
-        <dd>returns the precedence of the built-in operator $op$.
+      <dt>'Precedence[$op$]'
+      <dd>returns the precedence of the built-in operator $op$.
     </dl>
 
     >> Precedence[Plus]


### PR DESCRIPTION
Previously, @rocky had noticed that among many other things,  tags in  ``__docstring__``  are not properly indented.  This PR adds a basic tool for start fixing this ubiquitous issue.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/521"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

