### PR TITLE
Controlling symbol duplication

### DIFF
--- a/test/test_duplicated.py
+++ b/test/test_duplicated.py
@@ -1,0 +1,44 @@
+import pytest
+import os
+from mathics.builtin import modules, sanity_check, is_builtin, Builtin
+
+
+@pytest.mark.skipif(
+    os.environ.get("LINT"), reason="Lint checking done only when specified"
+)
+def test_check_duplicated():
+    msg = ""
+    builtins_by_name = {}
+    for module in modules:
+        vars = dir(module)
+        for name in vars:
+            var = getattr(module, name)
+            if (
+                hasattr(var, "__module__")
+                and var.__module__.startswith("mathics.builtin.")
+                and var.__module__ != "mathics.builtin.base"
+                and is_builtin(var)
+                and not name.startswith("_")
+                and var.__module__ == module.__name__
+            ):  # nopep8
+                instance = var(expression=False)
+                if isinstance(instance, Builtin):
+                    # This set the default context for symbols in mathics.builtins
+                    if not type(instance).context:
+                        type(instance).context = "System`"
+                    name = instance.get_name()
+                    """
+                    assert (
+                        builtins_by_name.get(name, None) is None
+                        ), f"{name} defined in {module} already defined in {builtins_by_name[name]}."
+                    """
+                    if builtins_by_name.get(name, None) is not None:
+                        print(
+                            f"\n{name} defined in {module} already defined in {builtins_by_name[name]}."
+                        )
+                        msg = (
+                            msg
+                            + f"\n{name} defined in {module} already defined in {builtins_by_name[name]}."
+                        )
+                    builtins_by_name[name] = module
+    assert msg == "", msg

--- a/test/test_duplicated.py
+++ b/test/test_duplicated.py
@@ -4,7 +4,7 @@ from mathics.builtin import modules, sanity_check, is_builtin, Builtin
 
 
 @pytest.mark.skipif(
-    os.environ.get("LINT"), reason="Lint checking done only when specified"
+    not os.environ.get("LINT"), reason="Lint checking done only when specified"
 )
 def test_check_duplicated():
     msg = ""


### PR DESCRIPTION
During the last months, we devoted some time to reorganizing and splitting the modules under builtin. One consequence was that accidentally, some symbols could result in duplications along different modules. This PR fixes the cases I found, and adds a pytest to check that subsequent reorganizations do not produce more duplications.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/522"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

