### PR TITLE
Tidy `Solve` and `calculus.py` a little

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -31,7 +31,6 @@ from mathics.builtin.base import Builtin, PostfixOperator, SympyFunction
 from mathics.builtin.scoping import dynamic_scoping
 
 from mathics.core.atoms import (
-    String,
     Atom,
     Integer,
     Integer0,
@@ -41,15 +40,17 @@ from mathics.core.atoms import (
     Number,
     Rational,
     Real,
+    String,
 )
 from mathics.core.attributes import (
-    constant,
-    hold_all,
-    listable,
-    n_hold_all,
-    protected,
-    read_protected,
+    constant as A_CONSTANT,
+    hold_all as A_HOLD_ALL,
+    listable as A_LISTABLE,
+    n_hold_all as A_N_HOLD_ALL,
+    protected as A_PROTECTED,
+    read_protected as A_READ_PROTECTED,
 )
+
 from mathics.core.convert.expression import to_expression, to_mathics_list
 from mathics.core.convert.function import expression_to_callable_and_args
 from mathics.core.convert.python import from_python
@@ -410,7 +411,7 @@ class Derivative(PostfixOperator, SympyFunction):
      = Hold[Derivative[1][Derivative[x][4]]]
     """
 
-    attributes = n_hold_all
+    attributes = A_N_HOLD_ALL
     default_formats = False
     operator = "'"
     precedence = 670
@@ -504,635 +505,6 @@ class Derivative(PostfixOperator, SympyFunction):
             return
 
 
-class Integrate(SympyFunction):
-    r"""
-    <dl>
-      <dt>'Integrate[$f$, $x$]'
-      <dd>integrates $f$ with respect to $x$. The result does not contain the additive integration constant.
-
-      <dt>'Integrate[$f$, {$x$, $a$, $b$}]'
-      <dd>computes the definite integral of $f$ with respect to $x$ from $a$ to $b$.
-    </dl>
-
-    Integrate a polynomial:
-    >> Integrate[6 x ^ 2 + 3 x ^ 2 - 4 x + 10, x]
-     = x (10 - 2 x + 3 x ^ 2)
-
-    Integrate trigonometric functions:
-    >> Integrate[Sin[x] ^ 5, x]
-     = Cos[x] (-1 - Cos[x] ^ 4 / 5 + 2 Cos[x] ^ 2 / 3)
-
-    Definite integrals:
-    >> Integrate[x ^ 2 + x, {x, 1, 3}]
-     = 38 / 3
-    >> Integrate[Sin[x], {x, 0, Pi/2}]
-     = 1
-
-    Some other integrals:
-    >> Integrate[1 / (1 - 4 x + x^2), x]
-     = Sqrt[3] (Log[-2 - Sqrt[3] + x] - Log[-2 + Sqrt[3] + x]) / 6
-    >> Integrate[4 Sin[x] Cos[x], x]
-     = 2 Sin[x] ^ 2
-
-    > Integrate[-Infinity, {x, 0, Infinity}]
-     = -Infinity
-
-    > Integrate[-Infinity, {x, Infinity, 0}]
-     = Infinity
-
-    Integration in TeX:
-    >> Integrate[f[x], {x, a, b}] // TeXForm
-     = \int_a^b f\left[x\right] \, dx
-
-    #> DownValues[Integrate]
-     = {}
-    #> Definition[Integrate]
-     = Attributes[Integrate] = {Protected, ReadProtected}
-     .
-     . Options[Integrate] = {Assumptions -> $Assumptions, GenerateConditions -> Automatic, PrincipalValue -> False}
-    #> Integrate[Hold[x + x], {x, a, b}]
-     = Integrate[Hold[x + x], {x, a, b}]
-    #> Integrate[sin[x], x]
-     = Integrate[sin[x], x]
-
-    #> Integrate[x ^ 3.5 + x, x]
-     = x ^ 2 / 2 + 0.222222 x ^ 4.5
-
-    Sometimes there is a loss of precision during integration.
-    You can check the precision of your result with the following sequence
-    of commands.
-    >> Integrate[Abs[Sin[phi]], {phi, 0, 2Pi}] // N
-     = 4.
-     >> % // Precision
-     = MachinePrecision
-
-    #> Integrate[1/(x^5+1), x]
-     = RootSum[1 + 5 #1 + 25 #1 ^ 2 + 125 #1 ^ 3 + 625 #1 ^ 4&, Log[x + 5 #1] #1&] + Log[1 + x] / 5
-
-    #> Integrate[ArcTan(x), x]
-     = x ^ 2 ArcTan / 2
-    #> Integrate[E[x], x]
-     = Integrate[E[x], x]
-
-    #> Integrate[Exp[-(x/2)^2],{x,-Infinity,+Infinity}]
-     = 2 Sqrt[Pi]
-
-    #> Integrate[Exp[-1/(x^2)], x]
-     = x E ^ (-1 / x ^ 2) + Sqrt[Pi] Erf[1 / x]
-
-    >> Integrate[ArcSin[x / 3], x]
-     = x ArcSin[x / 3] + Sqrt[9 - x ^ 2]
-
-    >> Integrate[f'[x], {x, a, b}]
-     = f[b] - f[a]
-    and,
-    >> D[Integrate[f[u, x],{u, a[x], b[x]}], x]
-     = Integrate[Derivative[0, 1][f][u, x], {u, a[x], b[x]}] + f[b[x], x] b'[x] - f[a[x], x] a'[x]
-    >> N[Integrate[Sin[Exp[-x^2 /2 ]],{x,1,2}]]
-     = 0.330804
-    """
-    # Reinstate as a unit test or describe why it should be an example and fix.
-    # >> Integrate[x/Exp[x^2/t], {x, 0, Infinity}]
-    # = ConditionalExpression[t / 2, Abs[Arg[t]] < Pi / 2]
-    # This should work after merging the more sophisticated predicate_evaluation routine
-    # be merged...
-    # >> Assuming[Abs[Arg[t]] < Pi / 2, Integrate[x/Exp[x^2/t], {x, 0, Infinity}]]
-    # = t / 2
-    attributes = protected | read_protected
-
-    options = {
-        "Assumptions": "$Assumptions",
-        "GenerateConditions": "Automatic",
-        "PrincipalValue": "False",
-    }
-
-    messages = {
-        "idiv": "Integral of `1` does not converge on `2`.",
-        "ilim": "Invalid integration variable or limit(s).",
-        "iconstraints": "Additional constraints needed: `1`",
-    }
-
-    rules = {
-        "N[Integrate[f_, x__List]]": "NIntegrate[f, x]",
-        "Integrate[list_List, x_]": "Integrate[#, x]& /@ list",
-        "MakeBoxes[Integrate[f_, x_], form:StandardForm|TraditionalForm]": r"""RowBox[{"\[Integral]","\[InvisibleTimes]", MakeBoxes[f, form], "\[InvisibleTimes]",
-                RowBox[{"\[DifferentialD]", MakeBoxes[x, form]}]}]""",
-        "MakeBoxes[Integrate[f_, {x_, a_, b_}], "
-        "form:StandardForm|TraditionalForm]": r"""RowBox[{SubsuperscriptBox["\[Integral]", MakeBoxes[a, form],
-                MakeBoxes[b, form]], "\[InvisibleTimes]" , MakeBoxes[f, form], "\[InvisibleTimes]",
-                RowBox[{"\[DifferentialD]", MakeBoxes[x, form]}]}]""",
-    }
-
-    summary_text = "symbolic integrals in one or more dimensions"
-    sympy_name = "Integral"
-
-    def prepare_sympy(self, elements):
-        if len(elements) == 2:
-            x = elements[1]
-            if x.has_form("List", 3):
-                return [elements[0]] + x.elements
-        return elements
-
-    def from_sympy(self, sympy_name, elements):
-        args = []
-        for element in elements[1:]:
-            if element.has_form("List", 1):
-                # {x} -> x
-                args.append(element.elements[0])
-            else:
-                args.append(element)
-        new_elements = [elements[0]] + args
-        return Expression(Symbol(self.get_name()), *new_elements)
-
-    def apply(self, f, xs, evaluation, options):
-        "Integrate[f_, xs__, OptionsPattern[]]"
-        f_sympy = f.to_sympy()
-        if f_sympy.is_infinite:
-            return Expression(SymbolIntegrate, Integer1, xs).evaluate(evaluation) * f
-        if f_sympy is None or isinstance(f_sympy, SympyExpression):
-            return
-        xs = xs.get_sequence()
-        vars = []
-        prec = None
-        for x in xs:
-            if x.has_form("List", 3):
-                x, a, b = x.elements
-                prec_a = a.get_precision()
-                prec_b = b.get_precision()
-                if prec_a is not None and prec_b is not None:
-                    prec_new = min(prec_a, prec_b)
-                    if prec is None or prec_new < prec:
-                        prec = prec_new
-                a = a.to_sympy()
-                b = b.to_sympy()
-                if a is None or b is None:
-                    return
-            else:
-                a = b = None
-            if not x.get_name():
-                evaluation.message("Integrate", "ilim")
-                return
-            x = x.to_sympy()
-            if x is None:
-                return
-            if a is None or b is None:
-                vars.append(x)
-            else:
-                vars.append((x, a, b))
-        try:
-            sympy_result = sympy.integrate(f_sympy, *vars)
-            pass
-        except sympy.PolynomialError:
-            return
-        except ValueError:
-            # e.g. ValueError: can't raise polynomial to a negative power
-            return
-        except NotImplementedError:
-            # e.g. NotImplementedError: Result depends on the sign of
-            # -sign(_Mathics_User_j)*sign(_Mathics_User_w)
-            return
-        if prec is not None and isinstance(sympy_result, sympy.Integral):
-            # TODO MaxExtraPrecision -> maxn
-            sympy_result = sympy_result.evalf(dps(prec))
-
-        result = from_sympy(sympy_result)
-        # If we obtain an atom (number or symbol)
-        # just return...
-        if isinstance(result, Atom):
-            return result
-        # If the result is defined as a Piecewise expression,
-        # use ConditionalExpression.
-        # This does not work now because the form sympy returns the values
-
-        local_assumptions = options.get("System`Assumptions", None)
-        old_assumptions = None
-        if local_assumptions and local_assumptions is not Symbol("$Assumptions"):
-            old_assumptions = evaluation.definitions.get_ownvalues(
-                "System`$Assumptions"
-            )
-            assuming = local_assumptions.evaluate(evaluation)
-            evaluation.definitions.set_ownvalue("System`$Assumptions", assuming)
-        # Set the $Assumptions
-
-        if result.get_head_name() == "System`Piecewise":
-            cases = result.elements[0].elements
-            if len(result.elements) == 1:
-                if cases[-1].elements[1] is SymbolTrue:
-                    default = cases[-1].elements[0]
-                    cases = result.elements[0].elements[:-1]
-                else:
-                    default = SymbolUndefined
-            else:
-                cases = result.elements[0].elements
-                default = result.elements[1]
-            if default.has_form("Integrate", None):
-                if default.elements[0] == f:
-                    default = SymbolUndefined
-            simplified_cases = []
-            for case in cases:
-                # TODO: if something like 0^n or 1/expr appears,
-                # put the condition n!=0 or expr!=0 accordingly in the list of
-                # conditions...
-                cond = Expression(SymbolSimplify, case.elements[1]).evaluate(evaluation)
-                resif = Expression(SymbolSimplify, case.elements[0]).evaluate(
-                    evaluation
-                )
-                if cond is SymbolTrue:
-                    if old_assumptions:
-                        evaluation.definitions.set_ownvalue(
-                            "System`$Assumptions", old_assumptions
-                        )
-                    return resif
-                if resif.has_form("ConditionalExpression", 2):
-                    cond = Expression(SymbolAnd, resif.elements[1], cond)
-                    cond = Expression(SymbolSimplify, cond).evaluate(evaluation)
-                    resif = resif.elements[0]
-                simplified_cases.append(ListExpression(resif, cond))
-            cases = simplified_cases
-            if default is SymbolUndefined and len(cases) == 1:
-                cases = cases[0]
-                result = Expression(SymbolConditionalExpression, *(cases.elements))
-            else:
-                # FIXME: there is a bug in from_sympy which is leaving an integer
-                # untranslated. Fix this and we can use Expression()
-                result = to_expression(result._head, cases, default)
-        else:
-            if result.get_head() is SymbolIntegrate:
-                if result.elements[0].evaluate(evaluation).sameQ(f):
-                    # Sympy returned the same expression, so it can't be evaluated.
-                    if old_assumptions:
-                        evaluation.definitions.set_ownvalue(
-                            "System`$Assumptions", old_assumptions
-                        )
-                    return
-            result = Expression(SymbolSimplify, result)
-            result = result.evaluate(evaluation)
-
-        if old_assumptions:
-            evaluation.definitions.set_ownvalue("System`$Assumptions", old_assumptions)
-        return result
-
-    def apply_D(self, func, domain, var, evaluation, options):
-        """D[%(name)s[func_, domain__, OptionsPattern[%(name)s]], var_Symbol]"""
-        return apply_D_to_Integral(
-            func, domain, var, evaluation, options, SymbolIntegrate
-        )
-
-
-class Root(SympyFunction):
-    """
-    <dl>
-    <dt>'Root[$f$, $i$]'
-        <dd>represents the i-th complex root of the polynomial $f$
-    </dl>
-
-    >> Root[#1 ^ 2 - 1&, 1]
-     = -1
-    >> Root[#1 ^ 2 - 1&, 2]
-     = 1
-
-    Roots that can't be represented by radicals:
-    >> Root[#1 ^ 5 + 2 #1 + 1&, 2]
-     = Root[#1 ^ 5 + 2 #1 + 1&, 2]
-    """
-
-    messages = {
-        "nuni": "Argument `1` at position 1 is not a univariate polynomial function",
-        "nint": "Argument `1` at position 2 is not an integer",
-        "iidx": "Argument `1` at position 2 is out of bounds",
-    }
-
-    summary_text = "the i-th root of a polynomial."
-    sympy_name = "CRootOf"
-
-    def apply(self, f, i, evaluation):
-        "Root[f_, i_]"
-
-        try:
-            if not f.has_form("Function", 1):
-                raise sympy.PolynomialError
-
-            body = f.elements[0]
-            poly = body.replace_slots([f, Symbol("_1")], evaluation)
-            idx = i.to_sympy() - 1
-
-            # Check for negative indeces (they are not allowed in Mathematica)
-            if idx < 0:
-                evaluation.message("Root", "iidx", i)
-                return
-
-            r = sympy.CRootOf(poly.to_sympy(), idx)
-        except sympy.PolynomialError:
-            evaluation.message("Root", "nuni", f)
-            return
-        except TypeError:
-            evaluation.message("Root", "nint", i)
-            return
-        except IndexError:
-            evaluation.message("Root", "iidx", i)
-            return
-
-        return from_sympy(r)
-
-    def to_sympy(self, expr, **kwargs):
-        try:
-            if not expr.has_form("Root", 2):
-                return None
-
-            f = expr.elements[0]
-
-            if not f.has_form("Function", 1):
-                return None
-
-            body = f.elements[0].replace_slots([f, Symbol("_1")], None)
-            poly = body.to_sympy(**kwargs)
-
-            i = expr.elements[1].get_int_value(**kwargs) - 1
-
-            if i is None:
-                return None
-
-            return sympy.CRootOf(poly, i)
-        except Exception:
-            return None
-
-
-class Solve(Builtin):
-    """
-    <url>:Equation solving: https://en.wikipedia.org/wiki/Equation_solving</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/solvers/solvers.html#module-sympy.solvers</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Solve.html</url>)
-    <dl>
-      <dt>'Solve[$equation$, $vars$]'
-      <dd>attempts to solve $equation$ for the variables $vars$.
-
-      <dt>'Solve[$equation$, $vars$, $domain$]'
-      <dd>restricts variables to $domain$, which can be 'Complexes' or 'Reals' or 'Integers'.
-    </dl>
-
-    >> Solve[x ^ 2 - 3 x == 4, x]
-     = {{x -> -1}, {x -> 4}}
-    >> Solve[4 y - 8 == 0, y]
-     = {{y -> 2}}
-
-    Apply the solution:
-    >> sol = Solve[2 x^2 - 10 x - 12 == 0, x]
-     = {{x -> -1}, {x -> 6}}
-    >> x /. sol
-     = {-1, 6}
-
-    Contradiction:
-    >> Solve[x + 1 == x, x]
-     = {}
-
-    Tautology:
-    >> Solve[x ^ 2 == x ^ 2, x]
-     = {{}}
-
-    Rational equations:
-    >> Solve[x / (x ^ 2 + 1) == 1, x]
-     = {{x -> 1 / 2 - I / 2 Sqrt[3]}, {x -> 1 / 2 + I / 2 Sqrt[3]}}
-    >> Solve[(x^2 + 3 x + 2)/(4 x - 2) == 0, x]
-     = {{x -> -2}, {x -> -1}}
-
-    Transcendental equations:
-    >> Solve[Cos[x] == 0, x]
-     = {{x -> Pi / 2}, {x -> 3 Pi / 2}}
-
-    Solve can only solve equations with respect to symbols or functions:
-
-    >> Solve[f[x + y] == 3, f[x + y]]
-     = {{f[x + y] -> 3}}
-    >> Solve[a + b == 2, a + b]
-     : a + b is not a valid variable.
-     = Solve[a + b == 2, a + b]
-
-    This happens when solving with respect to an assigned symbol:
-    >> x = 3;
-    >> Solve[x == 2, x]
-     : 3 is not a valid variable.
-     = Solve[False, 3]
-    >> Clear[x]
-    >> Solve[a < b, a]
-     : a < b is not a well-formed equation.
-     = Solve[a < b, a]
-
-    Solve a system of equations:
-    >> eqs = {3 x ^ 2 - 3 y == 0, 3 y ^ 2 - 3 x == 0};
-    >> sol = Solve[eqs, {x, y}] // Simplify
-     = {{x -> 0, y -> 0}, {x -> 1, y -> 1}, {x -> -1 / 2 + I / 2 Sqrt[3], y -> -1 / 2 - I / 2 Sqrt[3]}, {x -> -1 / 2 - I / 2 Sqrt[3], y -> -1 / 2 + I / 2 Sqrt[3]}}
-    >> eqs /. sol // Simplify
-     = {{True, True}, {True, True}, {True, True}, {True, True}}
-
-    Solve when given an underdetermined system:
-    >> Solve[x^2 == 1 && z^2 == -1, {x, y, z}]
-     : Equations may not give solutions for all "solve" variables.
-     = {{x -> -1, z -> -I}, {x -> -1, z -> I}, {x -> 1, z -> -I}, {x -> 1, z -> I}}
-
-    Examples using specifying the Domain in solutions:
-    >> Solve[x^2 == -1, x, Reals]
-     = {}
-    >> Solve[x^2 == 1, x, Reals]
-     = {{x -> -1}, {x -> 1}}
-    >> Solve[x^2 == -1, x, Complexes]
-     = {{x -> -I}, {x -> I}}
-    >> Solve[4 - 4 * x^2 - x^4 + x^6 == 0, x, Integers]
-     = {{x -> -1}, {x -> 1}}
-    """
-
-    messages = {
-        "eqf": "`1` is not a well-formed equation.",
-        "svars": 'Equations may not give solutions for all "solve" variables.',
-    }
-
-    # FIXME: the problem with removing the domain parameter from the outside
-    # is that the we can't make use of this information inside
-    # the evaluation method where it is may be needed.
-    rules = {
-        "Solve[eqs_, vars_, Complexes]": "Solve[eqs, vars]",
-        "Solve[eqs_, vars_, Reals]": (
-            "Cases[Solve[eqs, vars], {Rule[x_,y_?RealNumberQ]}]"
-        ),
-        "Solve[eqs_, vars_, Integers]": (
-            "Cases[Solve[eqs, vars], {Rule[x_,y_Integer]}]"
-        ),
-    }
-    summary_text = "find generic solutions for variables"
-
-    def apply(self, eqs, vars, evaluation):
-        "Solve[eqs_, vars_]"
-
-        vars_original = vars
-        head_name = vars.get_head_name()
-        if head_name == "System`List":
-            vars = vars.elements
-        else:
-            vars = [vars]
-        for var in vars:
-            if (
-                (isinstance(var, Atom) and not isinstance(var, Symbol))
-                or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
-                or constant & var.get_attributes(evaluation.definitions)
-            ):
-
-                evaluation.message("Solve", "ivar", vars_original)
-                return
-        if eqs.get_head_name() in ("System`List", "System`And"):
-            eq_list = eqs.elements
-        else:
-            eq_list = [eqs]
-        sympy_eqs = []
-        sympy_denoms = []
-        for eq in eq_list:
-            if eq is SymbolTrue:
-                pass
-            elif eq is SymbolFalse:
-                return ListExpression()
-            elif not eq.has_form("Equal", 2):
-                return evaluation.message("Solve", "eqf", eqs)
-            else:
-                left, right = eq.elements
-                left = left.to_sympy()
-                right = right.to_sympy()
-                if left is None or right is None:
-                    return
-                eq = left - right
-                eq = sympy.together(eq)
-                eq = sympy.cancel(eq)
-                sympy_eqs.append(eq)
-                numer, denom = eq.as_numer_denom()
-                sympy_denoms.append(denom)
-
-        vars_sympy = [var.to_sympy() for var in vars]
-        if None in vars_sympy:
-            return
-
-        # delete unused variables to avoid SymPy's
-        # PolynomialError: Not a zero-dimensional system
-        # in e.g. Solve[x^2==1&&z^2==-1,{x,y,z}]
-        all_vars = vars[:]
-        all_vars_sympy = vars_sympy[:]
-        vars = []
-        vars_sympy = []
-        for var, var_sympy in zip(all_vars, all_vars_sympy):
-            pattern = Pattern.create(var)
-            if not eqs.is_free(pattern, evaluation):
-                vars.append(var)
-                vars_sympy.append(var_sympy)
-
-        def transform_dict(sols):
-            if not sols:
-                yield sols
-            for var, sol in sols.items():
-                rest = sols.copy()
-                del rest[var]
-                rest = transform_dict(rest)
-                if not isinstance(sol, (tuple, list)):
-                    sol = [sol]
-                if not sol:
-                    for r in rest:
-                        yield r
-                else:
-                    for r in rest:
-                        for item in sol:
-                            new_sols = r.copy()
-                            new_sols[var] = item
-                            yield new_sols
-                break
-
-        def transform_solution(sol):
-            if not isinstance(sol, dict):
-                if not isinstance(sol, (list, tuple)):
-                    sol = [sol]
-                sol = dict(list(zip(vars_sympy, sol)))
-            return transform_dict(sol)
-
-        if not sympy_eqs:
-            sympy_eqs = True
-        elif len(sympy_eqs) == 1:
-            sympy_eqs = sympy_eqs[0]
-
-        try:
-            if isinstance(sympy_eqs, bool):
-                result = sympy_eqs
-            else:
-                result = sympy.solve(sympy_eqs, vars_sympy)
-            if not isinstance(result, list):
-                result = [result]
-            if isinstance(result, list) and len(result) == 1 and result[0] is True:
-                return ListExpression(ListExpression())
-            if result == [None]:
-                return ListExpression()
-            results = []
-            for sol in result:
-                results.extend(transform_solution(sol))
-            result = results
-            if any(
-                sol and any(var not in sol for var in all_vars_sympy) for sol in result
-            ):
-                evaluation.message("Solve", "svars")
-
-            # Filter out results for which denominator is 0
-            # (SymPy should actually do that itself, but it doesn't!)
-            result = [
-                sol
-                for sol in result
-                if all(sympy.simplify(denom.subs(sol)) != 0 for denom in sympy_denoms)
-            ]
-
-            return ListExpression(
-                *(
-                    ListExpression(
-                        *(
-                            Expression(SymbolRule, var, from_sympy(sol[var_sympy]))
-                            for var, var_sympy in zip(vars, vars_sympy)
-                            if var_sympy in sol
-                        ),
-                    )
-                    for sol in result
-                ),
-            )
-        except sympy.PolynomialError:
-            # raised for e.g. Solve[x^2==1&&z^2==-1,{x,y,z}] when not deleting
-            # unused variables beforehand
-            pass
-        except NotImplementedError:
-            pass
-        except TypeError as exc:
-            if str(exc).startswith("expected Symbol, Function or Derivative"):
-                evaluation.message("Solve", "ivar", vars_original)
-
-
-class Integers(Builtin):
-    """
-    <dl>
-      <dt>'Integers'
-      <dd>the domain of integer numbers, as in $x$ in Integers.
-    </dl>
-
-    Limit a solution to integer numbers:
-    >> Solve[-4 - 4 x + x^4 + x^5 == 0, x, Integers]
-     = {{x -> -1}}
-    >> Solve[x^4 == 4, x, Integers]
-     = {}
-    """
-
-    summary_text = "the domain integers numbers"
-
-
-class Reals(Builtin):
-    """
-    <dl>
-    <dt>'Reals'
-        <dd>is the domain real numbers, as in $x$ in Reals.
-    </dl>
-
-    Limit a solution to real numbers:
-    >> Solve[x^3 == 1, x, Reals]
-     = {{x -> 1}}
-    """
-
-    summary_text = "the domain of the Real numbers"
-
-
 class Complexes(Builtin):
     """
     <dl>
@@ -1142,86 +514,6 @@ class Complexes(Builtin):
     """
 
     summary_text = "the domain complex numbers"
-
-
-class Limit(Builtin):
-    """
-    <dl>
-      <dt>'Limit[$expr$, $x$->$x0$]'
-      <dd>gives the limit of $expr$ as $x$ approaches $x0$.
-
-      <dt>'Limit[$expr$, $x$->$x0$, Direction->1]'
-      <dd>approaches $x0$ from smaller values.
-
-      <dt>'Limit[$expr$, $x$->$x0$, Direction->-1]'
-      <dd>approaches $x0$ from larger values.
-    </dl>
-
-    >> Limit[x, x->2]
-     = 2
-    >> Limit[Sin[x] / x, x->0]
-     = 1
-    >> Limit[1/x, x->0, Direction->-1]
-     = Infinity
-    >> Limit[1/x, x->0, Direction->1]
-     = -Infinity
-
-    #> Limit[x, x -> x0, Direction -> x]
-     : Value of Direction -> x should be -1 or 1.
-     = Limit[x, x -> x0, Direction -> x]
-    """
-
-    """
-    The following test is currently causing PyPy to segfault...
-     #> Limit[(1 + cos[x]) / x, x -> 0]
-     = Limit[(1 + cos[x]) / x, x -> 0]
-    """
-
-    attributes = listable | protected
-
-    messages = {
-        "ldir": "Value of Direction -> `1` should be -1 or 1.",
-    }
-    options = {
-        "Direction": "1",
-    }
-
-    summary_text = "directed and undirected limits"
-
-    def apply(self, expr, x, x0, evaluation, options={}):
-        "Limit[expr_, x_->x0_, OptionsPattern[Limit]]"
-
-        expr = expr.to_sympy()
-        x = x.to_sympy()
-        x0 = x0.to_sympy()
-
-        if expr is None or x is None or x0 is None:
-            return
-
-        direction = self.get_option(options, "Direction", evaluation)
-        value = direction.get_int_value()
-        if value == -1:
-            dir_sympy = "+"
-        elif value == 1:
-            dir_sympy = "-"
-        else:
-            return evaluation.message("Limit", "ldir", direction)
-
-        try:
-            result = sympy.limit(expr, x, x0, dir_sympy)
-        except sympy.PoleError:
-            pass
-        except RuntimeError:
-            # Bug in Sympy: RuntimeError: maximum recursion depth exceeded
-            # while calling a Python object
-            pass
-        except NotImplementedError:
-            pass
-        except TypeError:
-            # Unknown SymPy0.7.6 bug
-            pass
-        else:
-            return from_sympy(result)
 
 
 class DiscreteLimit(Builtin):
@@ -1243,7 +535,7 @@ class DiscreteLimit(Builtin):
     >> DiscreteLimit[(n/(n + 2)) E^(-m/(m + 1)), {m -> Infinity, n -> Infinity}]
      = 1 / E
     """
-    attributes = listable | protected
+    attributes = A_LISTABLE | A_PROTECTED
 
     messages = {
         "dltrials": "The value of Trials should be a positive integer",
@@ -1283,7 +575,7 @@ class _BaseFinder(Builtin):
     This class is the basis class for FindRoot, FindMinimum and FindMaximum.
     """
 
-    attributes = hold_all | protected
+    attributes = A_HOLD_ALL | A_PROTECTED
     methods = {}
     messages = {
         "snum": "Value `1` is not a number.",
@@ -1595,6 +887,651 @@ class FindMaximum(_BaseFinder):
         pass
 
 
+class Integers(Builtin):
+    """
+    <dl>
+      <dt>'Integers'
+      <dd>the domain of integer numbers, as in $x$ in Integers.
+    </dl>
+
+    Limit a solution to integer numbers:
+    >> Solve[-4 - 4 x + x^4 + x^5 == 0, x, Integers]
+     = {{x -> -1}}
+    >> Solve[x^4 == 4, x, Integers]
+     = {}
+    """
+
+    summary_text = "the domain integers numbers"
+
+
+class Integrate(SympyFunction):
+    r"""
+    <dl>
+      <dt>'Integrate[$f$, $x$]'
+      <dd>integrates $f$ with respect to $x$. The result does not contain the additive integration constant.
+
+      <dt>'Integrate[$f$, {$x$, $a$, $b$}]'
+      <dd>computes the definite integral of $f$ with respect to $x$ from $a$ to $b$.
+    </dl>
+
+    Integrate a polynomial:
+    >> Integrate[6 x ^ 2 + 3 x ^ 2 - 4 x + 10, x]
+     = x (10 - 2 x + 3 x ^ 2)
+
+    Integrate trigonometric functions:
+    >> Integrate[Sin[x] ^ 5, x]
+     = Cos[x] (-1 - Cos[x] ^ 4 / 5 + 2 Cos[x] ^ 2 / 3)
+
+    Definite integrals:
+    >> Integrate[x ^ 2 + x, {x, 1, 3}]
+     = 38 / 3
+    >> Integrate[Sin[x], {x, 0, Pi/2}]
+     = 1
+
+    Some other integrals:
+    >> Integrate[1 / (1 - 4 x + x^2), x]
+     = Sqrt[3] (Log[-2 - Sqrt[3] + x] - Log[-2 + Sqrt[3] + x]) / 6
+    >> Integrate[4 Sin[x] Cos[x], x]
+     = 2 Sin[x] ^ 2
+
+    > Integrate[-Infinity, {x, 0, Infinity}]
+     = -Infinity
+
+    > Integrate[-Infinity, {x, Infinity, 0}]
+     = Infinity
+
+    Integration in TeX:
+    >> Integrate[f[x], {x, a, b}] // TeXForm
+     = \int_a^b f\left[x\right] \, dx
+
+    #> DownValues[Integrate]
+     = {}
+    #> Definition[Integrate]
+     = Attributes[Integrate] = {Protected, ReadProtected}
+     .
+     . Options[Integrate] = {Assumptions -> $Assumptions, GenerateConditions -> Automatic, PrincipalValue -> False}
+    #> Integrate[Hold[x + x], {x, a, b}]
+     = Integrate[Hold[x + x], {x, a, b}]
+    #> Integrate[sin[x], x]
+     = Integrate[sin[x], x]
+
+    #> Integrate[x ^ 3.5 + x, x]
+     = x ^ 2 / 2 + 0.222222 x ^ 4.5
+
+    Sometimes there is a loss of precision during integration.
+    You can check the precision of your result with the following sequence
+    of commands.
+    >> Integrate[Abs[Sin[phi]], {phi, 0, 2Pi}] // N
+     = 4.
+     >> % // Precision
+     = MachinePrecision
+
+    #> Integrate[1/(x^5+1), x]
+     = RootSum[1 + 5 #1 + 25 #1 ^ 2 + 125 #1 ^ 3 + 625 #1 ^ 4&, Log[x + 5 #1] #1&] + Log[1 + x] / 5
+
+    #> Integrate[ArcTan(x), x]
+     = x ^ 2 ArcTan / 2
+    #> Integrate[E[x], x]
+     = Integrate[E[x], x]
+
+    #> Integrate[Exp[-(x/2)^2],{x,-Infinity,+Infinity}]
+     = 2 Sqrt[Pi]
+
+    #> Integrate[Exp[-1/(x^2)], x]
+     = x E ^ (-1 / x ^ 2) + Sqrt[Pi] Erf[1 / x]
+
+    >> Integrate[ArcSin[x / 3], x]
+     = x ArcSin[x / 3] + Sqrt[9 - x ^ 2]
+
+    >> Integrate[f'[x], {x, a, b}]
+     = f[b] - f[a]
+    and,
+    >> D[Integrate[f[u, x],{u, a[x], b[x]}], x]
+     = Integrate[Derivative[0, 1][f][u, x], {u, a[x], b[x]}] + f[b[x], x] b'[x] - f[a[x], x] a'[x]
+    >> N[Integrate[Sin[Exp[-x^2 /2 ]],{x,1,2}]]
+     = 0.330804
+    """
+    # Reinstate as a unit test or describe why it should be an example and fix.
+    # >> Integrate[x/Exp[x^2/t], {x, 0, Infinity}]
+    # = ConditionalExpression[t / 2, Abs[Arg[t]] < Pi / 2]
+    # This should work after merging the more sophisticated predicate_evaluation routine
+    # be merged...
+    # >> Assuming[Abs[Arg[t]] < Pi / 2, Integrate[x/Exp[x^2/t], {x, 0, Infinity}]]
+    # = t / 2
+    attributes = A_PROTECTED | A_READ_PROTECTED
+
+    options = {
+        "Assumptions": "$Assumptions",
+        "GenerateConditions": "Automatic",
+        "PrincipalValue": "False",
+    }
+
+    messages = {
+        "idiv": "Integral of `1` does not converge on `2`.",
+        "ilim": "Invalid integration variable or limit(s).",
+        "iconstraints": "Additional constraints needed: `1`",
+    }
+
+    rules = {
+        "N[Integrate[f_, x__List]]": "NIntegrate[f, x]",
+        "Integrate[list_List, x_]": "Integrate[#, x]& /@ list",
+        "MakeBoxes[Integrate[f_, x_], form:StandardForm|TraditionalForm]": r"""RowBox[{"\[Integral]","\[InvisibleTimes]", MakeBoxes[f, form], "\[InvisibleTimes]",
+                RowBox[{"\[DifferentialD]", MakeBoxes[x, form]}]}]""",
+        "MakeBoxes[Integrate[f_, {x_, a_, b_}], "
+        "form:StandardForm|TraditionalForm]": r"""RowBox[{SubsuperscriptBox["\[Integral]", MakeBoxes[a, form],
+                MakeBoxes[b, form]], "\[InvisibleTimes]" , MakeBoxes[f, form], "\[InvisibleTimes]",
+                RowBox[{"\[DifferentialD]", MakeBoxes[x, form]}]}]""",
+    }
+
+    summary_text = "symbolic integrals in one or more dimensions"
+    sympy_name = "Integral"
+
+    def prepare_sympy(self, elements):
+        if len(elements) == 2:
+            x = elements[1]
+            if x.has_form("List", 3):
+                return [elements[0]] + x.elements
+        return elements
+
+    def from_sympy(self, sympy_name, elements):
+        args = []
+        for element in elements[1:]:
+            if element.has_form("List", 1):
+                # {x} -> x
+                args.append(element.elements[0])
+            else:
+                args.append(element)
+        new_elements = [elements[0]] + args
+        return Expression(Symbol(self.get_name()), *new_elements)
+
+    def apply(self, f, xs, evaluation, options):
+        "Integrate[f_, xs__, OptionsPattern[]]"
+        f_sympy = f.to_sympy()
+        if f_sympy.is_infinite:
+            return Expression(SymbolIntegrate, Integer1, xs).evaluate(evaluation) * f
+        if f_sympy is None or isinstance(f_sympy, SympyExpression):
+            return
+        xs = xs.get_sequence()
+        vars = []
+        prec = None
+        for x in xs:
+            if x.has_form("List", 3):
+                x, a, b = x.elements
+                prec_a = a.get_precision()
+                prec_b = b.get_precision()
+                if prec_a is not None and prec_b is not None:
+                    prec_new = min(prec_a, prec_b)
+                    if prec is None or prec_new < prec:
+                        prec = prec_new
+                a = a.to_sympy()
+                b = b.to_sympy()
+                if a is None or b is None:
+                    return
+            else:
+                a = b = None
+            if not x.get_name():
+                evaluation.message("Integrate", "ilim")
+                return
+            x = x.to_sympy()
+            if x is None:
+                return
+            if a is None or b is None:
+                vars.append(x)
+            else:
+                vars.append((x, a, b))
+        try:
+            sympy_result = sympy.integrate(f_sympy, *vars)
+            pass
+        except sympy.PolynomialError:
+            return
+        except ValueError:
+            # e.g. ValueError: can't raise polynomial to a negative power
+            return
+        except NotImplementedError:
+            # e.g. NotImplementedError: Result depends on the sign of
+            # -sign(_Mathics_User_j)*sign(_Mathics_User_w)
+            return
+        if prec is not None and isinstance(sympy_result, sympy.Integral):
+            # TODO MaxExtraPrecision -> maxn
+            sympy_result = sympy_result.evalf(dps(prec))
+
+        result = from_sympy(sympy_result)
+        # If we obtain an atom (number or symbol)
+        # just return...
+        if isinstance(result, Atom):
+            return result
+        # If the result is defined as a Piecewise expression,
+        # use ConditionalExpression.
+        # This does not work now because the form sympy returns the values
+
+        local_assumptions = options.get("System`Assumptions", None)
+        old_assumptions = None
+        if local_assumptions and local_assumptions is not Symbol("$Assumptions"):
+            old_assumptions = evaluation.definitions.get_ownvalues(
+                "System`$Assumptions"
+            )
+            assuming = local_assumptions.evaluate(evaluation)
+            evaluation.definitions.set_ownvalue("System`$Assumptions", assuming)
+        # Set the $Assumptions
+
+        if result.get_head_name() == "System`Piecewise":
+            cases = result.elements[0].elements
+            if len(result.elements) == 1:
+                if cases[-1].elements[1] is SymbolTrue:
+                    default = cases[-1].elements[0]
+                    cases = result.elements[0].elements[:-1]
+                else:
+                    default = SymbolUndefined
+            else:
+                cases = result.elements[0].elements
+                default = result.elements[1]
+            if default.has_form("Integrate", None):
+                if default.elements[0] == f:
+                    default = SymbolUndefined
+            simplified_cases = []
+            for case in cases:
+                # TODO: if something like 0^n or 1/expr appears,
+                # put the condition n!=0 or expr!=0 accordingly in the list of
+                # conditions...
+                cond = Expression(SymbolSimplify, case.elements[1]).evaluate(evaluation)
+                resif = Expression(SymbolSimplify, case.elements[0]).evaluate(
+                    evaluation
+                )
+                if cond is SymbolTrue:
+                    if old_assumptions:
+                        evaluation.definitions.set_ownvalue(
+                            "System`$Assumptions", old_assumptions
+                        )
+                    return resif
+                if resif.has_form("ConditionalExpression", 2):
+                    cond = Expression(SymbolAnd, resif.elements[1], cond)
+                    cond = Expression(SymbolSimplify, cond).evaluate(evaluation)
+                    resif = resif.elements[0]
+                simplified_cases.append(ListExpression(resif, cond))
+            cases = simplified_cases
+            if default is SymbolUndefined and len(cases) == 1:
+                cases = cases[0]
+                result = Expression(SymbolConditionalExpression, *(cases.elements))
+            else:
+                # FIXME: there is a bug in from_sympy which is leaving an integer
+                # untranslated. Fix this and we can use Expression()
+                result = to_expression(result._head, cases, default)
+        else:
+            if result.get_head() is SymbolIntegrate:
+                if result.elements[0].evaluate(evaluation).sameQ(f):
+                    # Sympy returned the same expression, so it can't be evaluated.
+                    if old_assumptions:
+                        evaluation.definitions.set_ownvalue(
+                            "System`$Assumptions", old_assumptions
+                        )
+                    return
+            result = Expression(SymbolSimplify, result)
+            result = result.evaluate(evaluation)
+
+        if old_assumptions:
+            evaluation.definitions.set_ownvalue("System`$Assumptions", old_assumptions)
+        return result
+
+    def apply_D(self, func, domain, var, evaluation, options):
+        """D[%(name)s[func_, domain__, OptionsPattern[%(name)s]], var_Symbol]"""
+        return apply_D_to_Integral(
+            func, domain, var, evaluation, options, SymbolIntegrate
+        )
+
+
+class Limit(Builtin):
+    """
+    <dl>
+      <dt>'Limit[$expr$, $x$->$x0$]'
+      <dd>gives the limit of $expr$ as $x$ approaches $x0$.
+
+      <dt>'Limit[$expr$, $x$->$x0$, Direction->1]'
+      <dd>approaches $x0$ from smaller values.
+
+      <dt>'Limit[$expr$, $x$->$x0$, Direction->-1]'
+      <dd>approaches $x0$ from larger values.
+    </dl>
+
+    >> Limit[x, x->2]
+     = 2
+    >> Limit[Sin[x] / x, x->0]
+     = 1
+    >> Limit[1/x, x->0, Direction->-1]
+     = Infinity
+    >> Limit[1/x, x->0, Direction->1]
+     = -Infinity
+
+    #> Limit[x, x -> x0, Direction -> x]
+     : Value of Direction -> x should be -1 or 1.
+     = Limit[x, x -> x0, Direction -> x]
+    """
+
+    """
+    The following test is currently causing PyPy to segfault...
+     #> Limit[(1 + cos[x]) / x, x -> 0]
+     = Limit[(1 + cos[x]) / x, x -> 0]
+    """
+
+    attributes = A_LISTABLE | A_PROTECTED
+
+    messages = {
+        "ldir": "Value of Direction -> `1` should be -1 or 1.",
+    }
+    options = {
+        "Direction": "1",
+    }
+
+    summary_text = "directed and undirected limits"
+
+    def apply(self, expr, x, x0, evaluation, options={}):
+        "Limit[expr_, x_->x0_, OptionsPattern[Limit]]"
+
+        expr = expr.to_sympy()
+        x = x.to_sympy()
+        x0 = x0.to_sympy()
+
+        if expr is None or x is None or x0 is None:
+            return
+
+        direction = self.get_option(options, "Direction", evaluation)
+        value = direction.get_int_value()
+        if value == -1:
+            dir_sympy = "+"
+        elif value == 1:
+            dir_sympy = "-"
+        else:
+            return evaluation.message("Limit", "ldir", direction)
+
+        try:
+            result = sympy.limit(expr, x, x0, dir_sympy)
+        except sympy.PoleError:
+            pass
+        except RuntimeError:
+            # Bug in Sympy: RuntimeError: maximum recursion depth exceeded
+            # while calling a Python object
+            pass
+        except NotImplementedError:
+            pass
+        except TypeError:
+            # Unknown SymPy0.7.6 bug
+            pass
+        else:
+            return from_sympy(result)
+
+
+class NIntegrate(Builtin):
+    """
+    <dl>
+       <dt>'NIntegrate[$expr$, $interval$]'
+       <dd>returns a numeric approximation to the definite integral of $expr$ with limits $interval$ and with a precision of $prec$ digits.
+
+        <dt>'NIntegrate[$expr$, $interval1$, $interval2$, ...]'
+        <dd>returns a numeric approximation to the multiple integral of $expr$ with limits $interval1$, $interval2$ and with a precision of $prec$ digits.
+    </dl>
+
+    >> NIntegrate[Exp[-x],{x,0,Infinity},Tolerance->1*^-6, Method->"Internal"]
+     = 1.
+    >> NIntegrate[Exp[x],{x,-Infinity, 0},Tolerance->1*^-6, Method->"Internal"]
+     = 1.
+    >> NIntegrate[Exp[-x^2/2.],{x,-Infinity, Infinity},Tolerance->1*^-6, Method->"Internal"]
+     = 2.5066...
+
+    """
+
+    # ## The Following tests fails if sympy is not installed.
+    # >> Table[1./NIntegrate[x^k,{x,0,1},Tolerance->1*^-6], {k,0,6}]
+    # : The specified method failed to return a number. Falling back into the internal evaluator.
+    # = {1., 2., 3., 4., 5., 6., 7.}
+
+    # >> NIntegrate[1 / z, {z, -1 - I, 1 - I, 1 + I, -1 + I, -1 - I}, Tolerance->1.*^-4]
+    # ## = 6.2832 I
+
+    # Integrate singularities with weak divergences:
+    # >> Table[ NIntegrate[x^(1./k-1.), {x,0,1.}, Tolerance->1*^-6], {k,1,7.}]
+    # = {1., 2., 3., 4., 5., 6., 7.}
+
+    # Mutiple Integrals :
+    # >> NIntegrate[x * y,{x, 0, 1}, {y, 0, 1}]
+    # = 0.25
+
+    messages = {
+        "bdmtd": "The Method option should be a built-in method name.",
+        "inumr": (
+            "The integrand `1` has evaluated to non-numerical "
+            + "values for all sampling points in the region "
+            + "with boundaries `2`"
+        ),
+        "nlim": "`1` = `2` is not a valid limit of integration.",
+        "ilim": "Invalid integration variable or limit(s) in `1`.",
+        "mtdfail": (
+            "The specified method failed to return a "
+            + "number. Falling back into the internal "
+            + "evaluator."
+        ),
+        "cmpint": ("Integration over a complex domain is not " + "implemented yet"),
+    }
+
+    methods = {
+        "Automatic": (None, False),
+    }
+    options = {
+        "Method": '"Automatic"',
+        "Tolerance": "1*^-10",
+        "Accuracy": "1*^-10",
+        "MaxRecursion": "10",
+    }
+
+    summary_text = "numerical integration in one or several variables"
+
+    try:
+        # builtin integrators
+        from mathics.algorithm.integrators import (
+            integrator_methods,
+            integrator_messages,
+        )
+
+        methods.update(integrator_methods)
+        messages.update(integrator_messages)
+    except Exception:
+        pass
+
+    try:
+        # scipy integrators
+        from mathics.builtin.scipy_utils.integrators import (
+            scipy_nintegrate_methods,
+            scipy_nintegrate_messages,
+        )
+
+        methods.update(scipy_nintegrate_methods)
+        messages.update(scipy_nintegrate_messages)
+    except Exception:
+        pass
+
+    messages.update(
+        {
+            "bdmtd": "The Method option should be a "
+            + "built-in method name in {`"
+            + "`, `".join(list(methods))
+            + "`}. Using `Automatic`"
+        }
+    )
+
+    def apply_with_func_domain(self, func, domain, evaluation, options):
+        "%(name)s[func_, domain__, OptionsPattern[%(name)s]]"
+        if func.is_numeric() and func.is_zero:
+            return Integer0
+        method = options["System`Method"].evaluate(evaluation)
+        method_options = {}
+        if method.has_form("System`List", 2):
+            method = method.elements[0]
+            method_options.update(method.elements[1].get_option_values())
+        if isinstance(method, String):
+            method = method.value
+        elif isinstance(method, Symbol):
+            method = method.get_name()
+            # strip context
+            method = method[method.rindex("`") + 1 :]
+        else:
+            evaluation.message("NIntegrate", "bdmtd", method)
+            return
+        tolerance = options["System`Tolerance"].evaluate(evaluation)
+        tolerance = float(tolerance.value)
+        accuracy = options["System`Accuracy"].evaluate(evaluation)
+        accuracy = accuracy.value
+        maxrecursion = options["System`MaxRecursion"].evaluate(evaluation)
+        maxrecursion = maxrecursion.value
+        nintegrate_method = self.methods.get(method, None)
+        if nintegrate_method is None:
+            evaluation.message("NIntegrate", "bdmtd", method)
+            nintegrate_method = self.methods.get("Automatic")
+        if type(nintegrate_method) is tuple:
+            nintegrate_method, is_multidimensional = nintegrate_method
+        else:
+            is_multidimensional = False
+
+        domain = decompose_domain(domain, evaluation)
+        if not domain:
+            return
+        if not isinstance(domain, list):
+            domain = [domain]
+
+        coords = [axis[0] for axis in domain]
+        # If any of the points in the integration domain is complex,
+        # stop the evaluation...
+        if any([c.get_head_name() == "System`List" for c in coords]):
+            evaluation.message("NIntegrate", "cmpint")
+            return
+
+        integrand, cargs = expression_to_callable_and_args(func, coords, evaluation)
+
+        if integrand is None:
+            evaluation.message("inumer", func, domain)
+            return
+        results = []
+        for subdomain in product(*[axis[1] for axis in domain]):
+            # On each subdomain, check if the region is bounded.
+            # If not, implement a coordinate map
+            func2 = integrand
+            subdomain2 = []
+            coordtransform = []
+            nulldomain = False
+            for i, r in enumerate(subdomain):
+                a = r[0].evaluate(evaluation)
+                b = r[1].evaluate(evaluation)
+                if a == b:
+                    nulldomain = True
+                    break
+                elif a.get_head_name() == "System`DirectedInfinity":
+                    if b.get_head_name() == "System`DirectedInfinity":
+                        a = a.to_python()
+                        b = b.to_python()
+                        le = 1 - machine_epsilon
+                        if a == b:
+                            nulldomain = True
+                            break
+                        elif a < b:
+                            subdomain2.append([-le, le])
+                        else:
+                            subdomain2.append([le, -le])
+                        coordtransform.append(
+                            (np.arctanh, lambda u: 1.0 / (1.0 - u**2))
+                        )
+                    else:
+                        if not b.is_numeric(evaluation):
+                            evaluation.message("nlim", coords[i], b)
+                            return
+                        z = a.elements[0].value
+                        b = b.value
+                        subdomain2.append([machine_epsilon, 1.0])
+                        coordtransform.append(
+                            (lambda u: b - z + z / u, lambda u: -z * u ** (-2.0))
+                        )
+                elif b.get_head_name() == "System`DirectedInfinity":
+                    if not a.is_numeric(evaluation):
+                        evaluation.message("nlim", coords[i], a)
+                        return
+                    a = a.value
+                    z = b.elements[0].value
+                    subdomain2.append([machine_epsilon, 1.0])
+                    coordtransform.append(
+                        (lambda u: a - z + z / u, lambda u: z * u ** (-2.0))
+                    )
+                elif a.is_numeric(evaluation) and b.is_numeric(evaluation):
+                    a = eval_N(a, evaluation).value
+                    b = eval_N(b, evaluation).value
+                    subdomain2.append([a, b])
+                    coordtransform.append(None)
+                else:
+                    for x in (a, b):
+                        if not x.is_numeric(evaluation):
+                            evaluation.message("nlim", coords[i], x)
+                    return
+
+            if nulldomain:
+                continue
+            if any(coordtransform):
+
+                def func2_(*u):
+                    x_u = (
+                        x[0](u[i]) if x else u[i] for i, x in enumerate(coordtransform)
+                    )
+                    punctual_value = integrand(*x_u)
+                    jac_factors = tuple(
+                        jac[1](u[i]) for i, jac in enumerate(coordtransform) if jac
+                    )
+                    val_jac = np.prod(jac_factors)
+                    return punctual_value * val_jac
+
+                func2 = func2_
+            opts = {
+                "acur": accuracy,
+                "tol": tolerance,
+                "maxrec": maxrecursion,
+            }
+            opts.update(method_options)
+            try:
+                if len(subdomain2) > 1:
+                    if is_multidimensional:
+                        nintegrate_method(func2, subdomain2, **opts)
+                    else:
+                        val = _fubini(
+                            func2, subdomain2, integrator=nintegrate_method, **opts
+                        )
+                else:
+                    val = nintegrate_method(func2, *(subdomain2[0]), **opts)
+            except Exception:
+                val = None
+
+            if val is None:
+                evaluation.message("NIntegrate", "mtdfail")
+                if len(subdomain2) > 1:
+                    val = _fubini(
+                        func2,
+                        subdomain2,
+                        integrator=_internal_adaptative_simpsons_rule,
+                        **opts,
+                    )
+                else:
+                    try:
+                        val = _internal_adaptative_simpsons_rule(
+                            func2, *(subdomain2[0]), **opts
+                        )
+                    except Exception:
+                        return None
+            results.append(val)
+
+        result = sum([r[0] for r in results])
+        # error = sum([r[1] for r in results]) -> use it when accuracy
+        #                                         be implemented...
+        return from_python(result)
+
+    def apply_D(self, func, domain, var, evaluation, options):
+        """D[%(name)s[func_, domain__, OptionsPattern[%(name)s]], var_Symbol]"""
+        return apply_D_to_Integral(
+            func, domain, var, evaluation, options, SymbolNIntegrate
+        )
+
+
 class O_(Builtin):
     """
     <dl>
@@ -1617,6 +1554,99 @@ class O_(Builtin):
         "O[x_Symbol]": "SeriesData[x, 0, {}, 1, 1, 1]",
     }
     summary_text = "symbolic representation of a higher-order series term"
+
+
+class Reals(Builtin):
+    """
+    <dl>
+    <dt>'Reals'
+        <dd>is the domain real numbers, as in $x$ in Reals.
+    </dl>
+
+    Limit a solution to real numbers:
+    >> Solve[x^3 == 1, x, Reals]
+     = {{x -> 1}}
+    """
+
+    summary_text = "the domain of the Real numbers"
+
+
+class Root(SympyFunction):
+    """
+    <dl>
+    <dt>'Root[$f$, $i$]'
+        <dd>represents the i-th complex root of the polynomial $f$
+    </dl>
+
+    >> Root[#1 ^ 2 - 1&, 1]
+     = -1
+    >> Root[#1 ^ 2 - 1&, 2]
+     = 1
+
+    Roots that can't be represented by radicals:
+    >> Root[#1 ^ 5 + 2 #1 + 1&, 2]
+     = Root[#1 ^ 5 + 2 #1 + 1&, 2]
+    """
+
+    messages = {
+        "nuni": "Argument `1` at position 1 is not a univariate polynomial function",
+        "nint": "Argument `1` at position 2 is not an integer",
+        "iidx": "Argument `1` at position 2 is out of bounds",
+    }
+
+    summary_text = "the i-th root of a polynomial."
+    sympy_name = "CRootOf"
+
+    def apply(self, f, i, evaluation):
+        "Root[f_, i_]"
+
+        try:
+            if not f.has_form("Function", 1):
+                raise sympy.PolynomialError
+
+            body = f.elements[0]
+            poly = body.replace_slots([f, Symbol("_1")], evaluation)
+            idx = i.to_sympy() - 1
+
+            # Check for negative indeces (they are not allowed in Mathematica)
+            if idx < 0:
+                evaluation.message("Root", "iidx", i)
+                return
+
+            r = sympy.CRootOf(poly.to_sympy(), idx)
+        except sympy.PolynomialError:
+            evaluation.message("Root", "nuni", f)
+            return
+        except TypeError:
+            evaluation.message("Root", "nint", i)
+            return
+        except IndexError:
+            evaluation.message("Root", "iidx", i)
+            return
+
+        return from_sympy(r)
+
+    def to_sympy(self, expr, **kwargs):
+        try:
+            if not expr.has_form("Root", 2):
+                return None
+
+            f = expr.elements[0]
+
+            if not f.has_form("Function", 1):
+                return None
+
+            body = f.elements[0].replace_slots([f, Symbol("_1")], None)
+            poly = body.to_sympy(**kwargs)
+
+            i = expr.elements[1].get_int_value(**kwargs) - 1
+
+            if i is None:
+                return None
+
+            return sympy.CRootOf(poly, i)
+        except Exception:
+            return None
 
 
 class Series(Builtin):
@@ -2020,277 +2050,248 @@ class SeriesData(Builtin):
         return format_element(expansion, evaluation, form)
 
 
-class NIntegrate(Builtin):
+class Solve(Builtin):
     """
+    <url>:Equation solving: https://en.wikipedia.org/wiki/Equation_solving</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/solvers/solvers.html#module-sympy.solvers</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Solve.html</url>)
     <dl>
-       <dt>'NIntegrate[$expr$, $interval$]'
-       <dd>returns a numeric approximation to the definite integral of $expr$ with limits $interval$ and with a precision of $prec$ digits.
+      <dt>'Solve[$equation$, $vars$]'
+      <dd>attempts to solve $equation$ for the variables $vars$.
 
-        <dt>'NIntegrate[$expr$, $interval1$, $interval2$, ...]'
-        <dd>returns a numeric approximation to the multiple integral of $expr$ with limits $interval1$, $interval2$ and with a precision of $prec$ digits.
+      <dt>'Solve[$equation$, $vars$, $domain$]'
+      <dd>restricts variables to $domain$, which can be 'Complexes' or 'Reals' or 'Integers'.
     </dl>
 
-    >> NIntegrate[Exp[-x],{x,0,Infinity},Tolerance->1*^-6, Method->"Internal"]
-     = 1.
-    >> NIntegrate[Exp[x],{x,-Infinity, 0},Tolerance->1*^-6, Method->"Internal"]
-     = 1.
-    >> NIntegrate[Exp[-x^2/2.],{x,-Infinity, Infinity},Tolerance->1*^-6, Method->"Internal"]
-     = 2.5066...
+    >> Solve[x ^ 2 - 3 x == 4, x]
+     = {{x -> -1}, {x -> 4}}
+    >> Solve[4 y - 8 == 0, y]
+     = {{y -> 2}}
 
+    Apply the solution:
+    >> sol = Solve[2 x^2 - 10 x - 12 == 0, x]
+     = {{x -> -1}, {x -> 6}}
+    >> x /. sol
+     = {-1, 6}
+
+    Contradiction:
+    >> Solve[x + 1 == x, x]
+     = {}
+
+    Tautology:
+    >> Solve[x ^ 2 == x ^ 2, x]
+     = {{}}
+
+    Rational equations:
+    >> Solve[x / (x ^ 2 + 1) == 1, x]
+     = {{x -> 1 / 2 - I / 2 Sqrt[3]}, {x -> 1 / 2 + I / 2 Sqrt[3]}}
+    >> Solve[(x^2 + 3 x + 2)/(4 x - 2) == 0, x]
+     = {{x -> -2}, {x -> -1}}
+
+    Transcendental equations:
+    >> Solve[Cos[x] == 0, x]
+     = {{x -> Pi / 2}, {x -> 3 Pi / 2}}
+
+    Solve can only solve equations with respect to symbols or functions:
+
+    >> Solve[f[x + y] == 3, f[x + y]]
+     = {{f[x + y] -> 3}}
+    >> Solve[a + b == 2, a + b]
+     : a + b is not a valid variable.
+     = Solve[a + b == 2, a + b]
+
+    This happens when solving with respect to an assigned symbol:
+    >> x = 3;
+    >> Solve[x == 2, x]
+     : 3 is not a valid variable.
+     = Solve[False, 3]
+    >> Clear[x]
+    >> Solve[a < b, a]
+     : a < b is not a well-formed equation.
+     = Solve[a < b, a]
+
+    Solve a system of equations:
+    >> eqs = {3 x ^ 2 - 3 y == 0, 3 y ^ 2 - 3 x == 0};
+    >> sol = Solve[eqs, {x, y}] // Simplify
+     = {{x -> 0, y -> 0}, {x -> 1, y -> 1}, {x -> -1 / 2 + I / 2 Sqrt[3], y -> -1 / 2 - I / 2 Sqrt[3]}, {x -> -1 / 2 - I / 2 Sqrt[3], y -> -1 / 2 + I / 2 Sqrt[3]}}
+    >> eqs /. sol // Simplify
+     = {{True, True}, {True, True}, {True, True}, {True, True}}
+
+    Solve when given an underdetermined system:
+    >> Solve[x^2 == 1 && z^2 == -1, {x, y, z}]
+     : Equations may not give solutions for all "solve" variables.
+     = {{x -> -1, z -> -I}, {x -> -1, z -> I}, {x -> 1, z -> -I}, {x -> 1, z -> I}}
+
+    Examples using specifying the Domain in solutions:
+    >> Solve[x^2 == -1, x, Reals]
+     = {}
+    >> Solve[x^2 == 1, x, Reals]
+     = {{x -> -1}, {x -> 1}}
+    >> Solve[x^2 == -1, x, Complexes]
+     = {{x -> -I}, {x -> I}}
+    >> Solve[4 - 4 * x^2 - x^4 + x^6 == 0, x, Integers]
+     = {{x -> -1}, {x -> 1}}
     """
 
-    # ## The Following tests fails if sympy is not installed.
-    # >> Table[1./NIntegrate[x^k,{x,0,1},Tolerance->1*^-6], {k,0,6}]
-    # : The specified method failed to return a number. Falling back into the internal evaluator.
-    # = {1., 2., 3., 4., 5., 6., 7.}
-
-    # >> NIntegrate[1 / z, {z, -1 - I, 1 - I, 1 + I, -1 + I, -1 - I}, Tolerance->1.*^-4]
-    # ## = 6.2832 I
-
-    # Integrate singularities with weak divergences:
-    # >> Table[ NIntegrate[x^(1./k-1.), {x,0,1.}, Tolerance->1*^-6], {k,1,7.}]
-    # = {1., 2., 3., 4., 5., 6., 7.}
-
-    # Mutiple Integrals :
-    # >> NIntegrate[x * y,{x, 0, 1}, {y, 0, 1}]
-    # = 0.25
-
     messages = {
-        "bdmtd": "The Method option should be a built-in method name.",
-        "inumr": (
-            "The integrand `1` has evaluated to non-numerical "
-            + "values for all sampling points in the region "
-            + "with boundaries `2`"
+        "eqf": "`1` is not a well-formed equation.",
+        "svars": 'Equations may not give solutions for all "solve" variables.',
+    }
+
+    # FIXME: the problem with removing the domain parameter from the outside
+    # is that the we can't make use of this information inside
+    # the evaluation method where it is may be needed.
+    rules = {
+        "Solve[eqs_, vars_, Complexes]": "Solve[eqs, vars]",
+        "Solve[eqs_, vars_, Reals]": (
+            "Cases[Solve[eqs, vars], {Rule[x_,y_?RealNumberQ]}]"
         ),
-        "nlim": "`1` = `2` is not a valid limit of integration.",
-        "ilim": "Invalid integration variable or limit(s) in `1`.",
-        "mtdfail": (
-            "The specified method failed to return a "
-            + "number. Falling back into the internal "
-            + "evaluator."
+        "Solve[eqs_, vars_, Integers]": (
+            "Cases[Solve[eqs, vars], {Rule[x_,y_Integer]}]"
         ),
-        "cmpint": ("Integration over a complex domain is not " + "implemented yet"),
     }
+    summary_text = "find generic solutions for variables"
 
-    methods = {
-        "Automatic": (None, False),
-    }
-    options = {
-        "Method": '"Automatic"',
-        "Tolerance": "1*^-10",
-        "Accuracy": "1*^-10",
-        "MaxRecursion": "10",
-    }
+    def apply(self, eqs, vars, evaluation):
+        "Solve[eqs_, vars_]"
 
-    summary_text = "numerical integration in one or several variables"
-
-    try:
-        # builtin integrators
-        from mathics.algorithm.integrators import (
-            integrator_methods,
-            integrator_messages,
-        )
-
-        methods.update(integrator_methods)
-        messages.update(integrator_messages)
-    except Exception:
-        pass
-
-    try:
-        # scipy integrators
-        from mathics.builtin.scipy_utils.integrators import (
-            scipy_nintegrate_methods,
-            scipy_nintegrate_messages,
-        )
-
-        methods.update(scipy_nintegrate_methods)
-        messages.update(scipy_nintegrate_messages)
-    except Exception:
-        pass
-
-    messages.update(
-        {
-            "bdmtd": "The Method option should be a "
-            + "built-in method name in {`"
-            + "`, `".join(list(methods))
-            + "`}. Using `Automatic`"
-        }
-    )
-
-    def apply_with_func_domain(self, func, domain, evaluation, options):
-        "%(name)s[func_, domain__, OptionsPattern[%(name)s]]"
-        if func.is_numeric() and func.is_zero:
-            return Integer0
-        method = options["System`Method"].evaluate(evaluation)
-        method_options = {}
-        if method.has_form("System`List", 2):
-            method = method.elements[0]
-            method_options.update(method.elements[1].get_option_values())
-        if isinstance(method, String):
-            method = method.value
-        elif isinstance(method, Symbol):
-            method = method.get_name()
-            # strip context
-            method = method[method.rindex("`") + 1 :]
+        vars_original = vars
+        head_name = vars.get_head_name()
+        if head_name == "System`List":
+            vars = vars.elements
         else:
-            evaluation.message("NIntegrate", "bdmtd", method)
-            return
-        tolerance = options["System`Tolerance"].evaluate(evaluation)
-        tolerance = float(tolerance.value)
-        accuracy = options["System`Accuracy"].evaluate(evaluation)
-        accuracy = accuracy.value
-        maxrecursion = options["System`MaxRecursion"].evaluate(evaluation)
-        maxrecursion = maxrecursion.value
-        nintegrate_method = self.methods.get(method, None)
-        if nintegrate_method is None:
-            evaluation.message("NIntegrate", "bdmtd", method)
-            nintegrate_method = self.methods.get("Automatic")
-        if type(nintegrate_method) is tuple:
-            nintegrate_method, is_multidimensional = nintegrate_method
+            vars = [vars]
+        for var in vars:
+            if (
+                (isinstance(var, Atom) and not isinstance(var, Symbol))
+                or head_name in ("System`Plus", "System`Times", "System`Power")  # noqa
+                or A_CONSTANT & var.get_attributes(evaluation.definitions)
+            ):
+
+                evaluation.message("Solve", "ivar", vars_original)
+                return
+        if eqs.get_head_name() in ("System`List", "System`And"):
+            eq_list = eqs.elements
         else:
-            is_multidimensional = False
-
-        domain = decompose_domain(domain, evaluation)
-        if not domain:
-            return
-        if not isinstance(domain, list):
-            domain = [domain]
-
-        coords = [axis[0] for axis in domain]
-        # If any of the points in the integration domain is complex,
-        # stop the evaluation...
-        if any([c.get_head_name() == "System`List" for c in coords]):
-            evaluation.message("NIntegrate", "cmpint")
-            return
-
-        integrand, cargs = expression_to_callable_and_args(func, coords, evaluation)
-
-        if integrand is None:
-            evaluation.message("inumer", func, domain)
-            return
-        results = []
-        for subdomain in product(*[axis[1] for axis in domain]):
-            # On each subdomain, check if the region is bounded.
-            # If not, implement a coordinate map
-            func2 = integrand
-            subdomain2 = []
-            coordtransform = []
-            nulldomain = False
-            for i, r in enumerate(subdomain):
-                a = r[0].evaluate(evaluation)
-                b = r[1].evaluate(evaluation)
-                if a == b:
-                    nulldomain = True
-                    break
-                elif a.get_head_name() == "System`DirectedInfinity":
-                    if b.get_head_name() == "System`DirectedInfinity":
-                        a = a.to_python()
-                        b = b.to_python()
-                        le = 1 - machine_epsilon
-                        if a == b:
-                            nulldomain = True
-                            break
-                        elif a < b:
-                            subdomain2.append([-le, le])
-                        else:
-                            subdomain2.append([le, -le])
-                        coordtransform.append(
-                            (np.arctanh, lambda u: 1.0 / (1.0 - u**2))
-                        )
-                    else:
-                        if not b.is_numeric(evaluation):
-                            evaluation.message("nlim", coords[i], b)
-                            return
-                        z = a.elements[0].value
-                        b = b.value
-                        subdomain2.append([machine_epsilon, 1.0])
-                        coordtransform.append(
-                            (lambda u: b - z + z / u, lambda u: -z * u ** (-2.0))
-                        )
-                elif b.get_head_name() == "System`DirectedInfinity":
-                    if not a.is_numeric(evaluation):
-                        evaluation.message("nlim", coords[i], a)
-                        return
-                    a = a.value
-                    z = b.elements[0].value
-                    subdomain2.append([machine_epsilon, 1.0])
-                    coordtransform.append(
-                        (lambda u: a - z + z / u, lambda u: z * u ** (-2.0))
-                    )
-                elif a.is_numeric(evaluation) and b.is_numeric(evaluation):
-                    a = eval_N(a, evaluation).value
-                    b = eval_N(b, evaluation).value
-                    subdomain2.append([a, b])
-                    coordtransform.append(None)
-                else:
-                    for x in (a, b):
-                        if not x.is_numeric(evaluation):
-                            evaluation.message("nlim", coords[i], x)
+            eq_list = [eqs]
+        sympy_eqs = []
+        sympy_denoms = []
+        for eq in eq_list:
+            if eq is SymbolTrue:
+                pass
+            elif eq is SymbolFalse:
+                return ListExpression()
+            elif not eq.has_form("Equal", 2):
+                return evaluation.message("Solve", "eqf", eqs)
+            else:
+                left, right = eq.elements
+                left = left.to_sympy()
+                right = right.to_sympy()
+                if left is None or right is None:
                     return
+                eq = left - right
+                eq = sympy.together(eq)
+                eq = sympy.cancel(eq)
+                sympy_eqs.append(eq)
+                numer, denom = eq.as_numer_denom()
+                sympy_denoms.append(denom)
 
-            if nulldomain:
-                continue
-            if any(coordtransform):
+        vars_sympy = [var.to_sympy() for var in vars]
+        if None in vars_sympy:
+            return
 
-                def func2_(*u):
-                    x_u = (
-                        x[0](u[i]) if x else u[i] for i, x in enumerate(coordtransform)
-                    )
-                    punctual_value = integrand(*x_u)
-                    jac_factors = tuple(
-                        jac[1](u[i]) for i, jac in enumerate(coordtransform) if jac
-                    )
-                    val_jac = np.prod(jac_factors)
-                    return punctual_value * val_jac
+        # delete unused variables to avoid SymPy's
+        # PolynomialError: Not a zero-dimensional system
+        # in e.g. Solve[x^2==1&&z^2==-1,{x,y,z}]
+        all_vars = vars[:]
+        all_vars_sympy = vars_sympy[:]
+        vars = []
+        vars_sympy = []
+        for var, var_sympy in zip(all_vars, all_vars_sympy):
+            pattern = Pattern.create(var)
+            if not eqs.is_free(pattern, evaluation):
+                vars.append(var)
+                vars_sympy.append(var_sympy)
 
-                func2 = func2_
-            opts = {
-                "acur": accuracy,
-                "tol": tolerance,
-                "maxrec": maxrecursion,
-            }
-            opts.update(method_options)
-            try:
-                if len(subdomain2) > 1:
-                    if is_multidimensional:
-                        nintegrate_method(func2, subdomain2, **opts)
-                    else:
-                        val = _fubini(
-                            func2, subdomain2, integrator=nintegrate_method, **opts
-                        )
+        def transform_dict(sols):
+            if not sols:
+                yield sols
+            for var, sol in sols.items():
+                rest = sols.copy()
+                del rest[var]
+                rest = transform_dict(rest)
+                if not isinstance(sol, (tuple, list)):
+                    sol = [sol]
+                if not sol:
+                    for r in rest:
+                        yield r
                 else:
-                    val = nintegrate_method(func2, *(subdomain2[0]), **opts)
-            except Exception:
-                val = None
+                    for r in rest:
+                        for item in sol:
+                            new_sols = r.copy()
+                            new_sols[var] = item
+                            yield new_sols
+                break
 
-            if val is None:
-                evaluation.message("NIntegrate", "mtdfail")
-                if len(subdomain2) > 1:
-                    val = _fubini(
-                        func2,
-                        subdomain2,
-                        integrator=_internal_adaptative_simpsons_rule,
-                        **opts,
+        def transform_solution(sol):
+            if not isinstance(sol, dict):
+                if not isinstance(sol, (list, tuple)):
+                    sol = [sol]
+                sol = dict(list(zip(vars_sympy, sol)))
+            return transform_dict(sol)
+
+        if not sympy_eqs:
+            sympy_eqs = True
+        elif len(sympy_eqs) == 1:
+            sympy_eqs = sympy_eqs[0]
+
+        try:
+            if isinstance(sympy_eqs, bool):
+                result = sympy_eqs
+            else:
+                result = sympy.solve(sympy_eqs, vars_sympy)
+            if not isinstance(result, list):
+                result = [result]
+            if isinstance(result, list) and len(result) == 1 and result[0] is True:
+                return ListExpression(ListExpression())
+            if result == [None]:
+                return ListExpression()
+            results = []
+            for sol in result:
+                results.extend(transform_solution(sol))
+            result = results
+            if any(
+                sol and any(var not in sol for var in all_vars_sympy) for sol in result
+            ):
+                evaluation.message("Solve", "svars")
+
+            # Filter out results for which denominator is 0
+            # (SymPy should actually do that itself, but it doesn't!)
+            result = [
+                sol
+                for sol in result
+                if all(sympy.simplify(denom.subs(sol)) != 0 for denom in sympy_denoms)
+            ]
+
+            return ListExpression(
+                *(
+                    ListExpression(
+                        *(
+                            Expression(SymbolRule, var, from_sympy(sol[var_sympy]))
+                            for var, var_sympy in zip(vars, vars_sympy)
+                            if var_sympy in sol
+                        ),
                     )
-                else:
-                    try:
-                        val = _internal_adaptative_simpsons_rule(
-                            func2, *(subdomain2[0]), **opts
-                        )
-                    except Exception:
-                        return None
-            results.append(val)
-
-        result = sum([r[0] for r in results])
-        # error = sum([r[1] for r in results]) -> use it when accuracy
-        #                                         be implemented...
-        return from_python(result)
-
-    def apply_D(self, func, domain, var, evaluation, options):
-        """D[%(name)s[func_, domain__, OptionsPattern[%(name)s]], var_Symbol]"""
-        return apply_D_to_Integral(
-            func, domain, var, evaluation, options, SymbolNIntegrate
-        )
+                    for sol in result
+                ),
+            )
+        except sympy.PolynomialError:
+            # raised for e.g. Solve[x^2==1&&z^2==-1,{x,y,z}] when not deleting
+            # unused variables beforehand
+            pass
+        except NotImplementedError:
+            pass
+        except TypeError as exc:
+            if str(exc).startswith("expected Symbol, Function or Derivative"):
+                evaluation.message("Solve", "ivar", vars_original)
 
 
 # Auxiliary routines. Maybe should be moved to another module.

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -448,7 +448,7 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def get_head(self) -> "Symbol":
         return Symbol("Symbol")
 
-    def get_head_name(self):
+    def get_head_name(self) -> str:
         return "System`Symbol"
 
     def get_option_values(self, evaluation, allow_symbols=False, stop_on_error=True):

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -126,3 +126,57 @@ def test_D(str_expr: str, str_expected: str, expected_messages):
         str_expected=str_expected,
         expected_messages=expected_messages,
     )
+
+
+@pytest.mark.parametrize(
+    "str_expr, str_expected, expected_messages",
+    [
+        (
+            "Solve[x^2 +1 == 0, x]",
+            "{{x -> -I}, {x -> I}}",
+            [],
+        ),
+        (
+            "Solve[x^5==x,x]",
+            "{{x -> -1}, {x -> 0}, {x -> 1}, {x -> -I}, {x -> I}}",
+            [],
+        ),
+        (
+            "Solve[g[x] == 0, x]",
+            "Solve[g[x] == 0, x]",
+            [],
+        ),
+        (
+            ## FIXME: should use inverse functions?
+            "Solve[g[x] + h[x] == 0, x]",
+            "Solve[g[x] + h[x] == 0, x]",
+            [],
+        ),
+        (
+            "Solve[Sin(x) == 1, x]",
+            "{{x -> 1 / Sin}}",
+            [],
+        ),
+        (
+            "Solve[E == 1, E]",
+            "Solve[False, E]",
+            ["E is not a valid variable."],
+        ),
+        (
+            "Solve[E == 1, E]",
+            "Solve[False, E]",
+            ["E is not a valid variable."],
+        ),
+        (
+            "Solve[False, Pi]",
+            "Solve[False, Pi]",
+            ["Pi is not a valid variable."],
+        ),
+    ],
+)
+def test_Solve(str_expr: str, str_expected: str, expected_messages):
+    check_evaluation(
+        str_expr=str_expr,
+        str_expected=str_expected,
+        expected_messages=expected_messages,
+    )


### PR DESCRIPTION
* Sort classes in calculus alphabetically
* add URL links to `Solve`
* remove variable type changing assignment in `Solve`
* note problem with filtering out domain in rule in `Solve`
* one small annotation addition
* Move `Solve` unit tests in docstring to unit tests
* move to flag-style attribute naming on `calculus.py`


<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/529"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

