### PR TITLE
Separate pytest consistency checks ...

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -1,4 +1,4 @@
-name: Mathics (ubuntu)
+name: Mathics (Consistency Checks)
 
 on:
   push:
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.10']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,13 +20,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
+        sudo apt update -qq && sudo apt install llvm-dev
         python -m pip install --upgrade pip
         # Can remove after next Mathics-Scanner release
         # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
-    - name: Install Mathics with full dependencies
+    - name: Install Mathics with minimum dependencies
       run: |
-        make develop-full
-    - name: Test Mathics
+        make develop
+    - name: Test Mathics Consistency and Style
       run: |
-        make -j3 check
+        make check-consistency-and-style

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,30 @@ PYTHON ?= python3
 PIP ?= pip3
 RM  ?= rm
 
-.PHONY: all build \
-   check clean clean-cython \
-   develop dist doctest doc-data djangotest \
-   gstest pytest \
+.PHONY: \
+   all \
+   build \
+   check \
+   check-builtin-manifest \
+   check-consistency-and-style \
+   check-full \
+   clean \
+   clean-cache \
+   clean-cython \
+   develop \
+   develop-full \
+   develop-full-cython \
+   dist \
+   doc \
+   doctest \
+   doc-data \
+   djangotest \
+   gstest \
+   latexdoc \
+   pytest \
    rmChangeLog \
-   test
+   test \
+   texdoc
 
 SANDBOX	?=
 ifeq ($(OS),Windows_NT)
@@ -59,14 +77,19 @@ dist:
 install:
 	$(PYTHON) setup.py install
 
+#: Run the most extensive set of tests
 check: pytest gstest doctest
 
 
-# Check manifest, lint, etc
-check-lint:
+#: Build and check manifest of Builtins
+check-builtin-manifest:
 	$(PYTHON) admin-tools/build_and_check_manifest.py
 
-check-full: check-lint check
+#: Run pytest consistency and style checks
+check-consistency-and-style:
+	MATHICS_LINT=t $(PYTHON) -m pytest test/consistency-and-style
+
+check-full: check-builtin-manifest check-builtin-manifest check
 
 #: Remove Cython-derived files
 clean-cython:
@@ -99,11 +122,6 @@ gstest:
 #: Create data that is used to in Django docs and to build LaTeX PDF
 doc-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/documentation/images/*
 	$(PYTHON) mathics/docpipeline.py --output --keep-going
-
-#: Run tests that appear in docstring in the code.
-doctest-workaround:
-	SANDBOX=$(SANDBOX) $(PYTHON) mathics/docpipeline.py --exclude=NIntegrate,MaxRecursion
-	SANDBOX=$(SANDBOX) $(PYTHON) mathics/docpipeline.py --sections=NIntegrate,MaxRecursion
 
 #: Run tests that appear in docstring in the code.
 doctest:

--- a/admin-tools/build_and_check_manifest.py
+++ b/admin-tools/build_and_check_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from mathics.builtin import modules, sanity_check, is_builtin, Builtin
+from mathics.builtin import modules, is_builtin, Builtin
 import sys
 
 

--- a/admin-tools/normalize_docstrings.py
+++ b/admin-tools/normalize_docstrings.py
@@ -2,16 +2,21 @@
 
 
 """
-This program ensures the indentation inside docstrings.
+This program ensures a consistent indentation <dd>, and <dt> inside <dl> in docstrings.
 """
 
+import filecmp
+import os
 import re
 import sys
-import os
-import shutil
 
 
-def process_file(filename: str) -> int:
+def rewrite_dl_tags(filename: str) -> int:
+    """
+    Look for <dl>, <dd>, and <dt> tags and rewrite them
+    using a consistent set of indentation.
+    0 is returned there was no error.
+    """
     new_lines = []
     with open(filename, "r") as f_in:
         for line in f_in.readlines():
@@ -21,20 +26,26 @@ def process_file(filename: str) -> int:
             line = re.sub(r"^[ ]*[<]dd[>]", r"      <dd>", line)
             new_lines.append(line)
 
-    # backup the file
-    shutil.copyfile(filename, filename + "~")
-    with open(filename, "w") as f_out:
+    rewritten_file = filename + ".rewritten"
+    with open(rewritten_file, "w") as f_out:
         for line in new_lines:
             f_out.write(line)
+        if filecmp.cmp(rewritten_file, filename):
+            print(f"No change; removing temporary {rewritten_file}")
+        else:
+            backup_file = filename + "~"
+            print(f"File changed, backing up {filename} to {backup_file}")
+            os.rename(filename, backup_file)
+            os.rename(rewritten_file, filename)
     return 0
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("This tool applies basic rules to normalize the format of docstrings")
+        print(__doc__)
         print("usage:")
-        print("clean_docstring  [filename]")
-        exit(-1)
+        print(f"  {__file__} [Mathics-module-containing-builtins]")
+        quit(-1)
     filename = sys.argv[1]
-    print(f"normalizing {filename}. Backup in {filename}~")
-    process_file(filename)
+    print(f"Checking <dl>, <dd>, and <dt> indentation on {filename}.")
+    quit(rewrite_dl_tags(filename))

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -1,10 +1,16 @@
+"""
+Checks that builtin functions do not get redefined.
+
+In the past when reorganizing builtin functions we sometimes
+had missing or duplicate build-in functions definitions.
+"""
 import pytest
 import os
-from mathics.builtin import modules, sanity_check, is_builtin, Builtin
+from mathics.builtin import modules, is_builtin, Builtin
 
 
 @pytest.mark.skipif(
-    not os.environ.get("LINT"), reason="Lint checking done only when specified"
+    not os.environ.get("MATHICS_LINT"), reason="Lint checking done only when specified"
 )
 def test_check_duplicated():
     msg = ""

--- a/test/consistency-and-style/test_summary_text.py
+++ b/test/consistency-and-style/test_summary_text.py
@@ -1,19 +1,18 @@
 import pytest
 
-from mathics.doc.common_doc import MathicsMainDocumentation, XMLDoc
-
 import glob
 import importlib
 import pkgutil
+import os
 import os.path as osp
 from mathics.version import __version__  # noqa used in loading to check consistency.
 
 
 from mathics.builtin.base import Builtin
-
 from mathics import __file__ as mathics_initfile_path
 
-mathics_path = mathics_initfile_path[:-12]
+# Get file system path name for mathics.builtin
+mathics_path = osp.dirname(mathics_initfile_path)
 mathics_builtins_path = mathics_path + "/builtin"
 
 CHECK_GRAMMAR = False
@@ -179,11 +178,14 @@ def is_builtin(var: object) -> bool:
     )
 
 
+@pytest.mark.skipif(
+    not os.environ.get("MATHICS_LINT"),
+    reason="Checking done only when MATHICS_LINT=t specified",
+)
 @pytest.mark.parametrize(
     ("module_name",),
     [(module_name,) for module_name in modules],
 )
-# @pytest.mark.xfail
 def test_summary_text_available(module_name):
     """
     Checks that each Builtin has its summary_text property.

--- a/test/test_help.py
+++ b/test/test_help.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from .helper import check_evaluation, evaluate
+from .helper import check_evaluation
 from mathics.builtin.base import Builtin
-from mathics.core.atoms import Integer0
 
 
 class Builtin1(Builtin):


### PR DESCRIPTION
Makefile:
* Add targets `check_consistency-and-style`, and `check-builtin-manifest`
* Go over PHONY targets

Add workflow for running consistency checks only. This doesn't need optional packages installed, and it doesn't need to be run by all Pythons.

Move consistency checks to test/consistency-and_style directory
Prefix environment variable LINT with MATHICS_
Lint a test file or two

normalize_docstrings.py:
If no changes were needed: 
* do not change timestamp on file
* do not create backup of unchanged file

 remove magic constant -11. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/536"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

