### PR TITLE
Start to go over literals

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -368,12 +368,12 @@ class Plus(BinaryOperator, SympyFunction):
     def apply(self, items, evaluation):
         "Plus[items___]"
 
-        items = items.numerify(evaluation).get_sequence()
+        items_tuple = items.numerify(evaluation).get_sequence()
         elements = []
         last_item = last_count = None
 
-        prec = min_prec(*items)
-        is_machine_precision = any(item.is_machine_precision() for item in items)
+        prec = min_prec(*items_tuple)
+        is_machine_precision = any(item.is_machine_precision() for item in items_tuple)
         numbers = []
 
         def append_last():
@@ -392,7 +392,7 @@ class Plus(BinaryOperator, SympyFunction):
                             Expression(SymbolTimes, from_sympy(last_count), last_item)
                         )
 
-        for item in items:
+        for item in items_tuple:
             if isinstance(item, Number):
                 numbers.append(item)
             else:

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -82,7 +82,7 @@ from mathics.core.systemsymbols import (
 )
 
 
-@lru_cache(maxsize=1024)
+@lru_cache(maxsize=4096)
 def call_mpmath(mpmath_function, mpmath_args):
     try:
         return mpmath_function(*mpmath_args)
@@ -183,20 +183,6 @@ class _MPMathFunction(SympyFunction):
                 if isinstance(result, (mpmath.mpc, mpmath.mpf)):
                     result = from_mpmath(result, d)
         return result
-
-    def call_mpmath(self, mpmath_function, mpmath_args):
-        try:
-            return mpmath_function(*mpmath_args)
-        except ValueError as exc:
-            text = str(exc)
-            if text == "gamma function pole":
-                return SymbolComplexInfinity
-            else:
-                raise
-        except ZeroDivisionError:
-            return
-        except SpecialValueError as exc:
-            return Symbol(exc.name)
 
 
 class _MPMathMultiFunction(_MPMathFunction):

--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -13,10 +13,10 @@ Precision is not "guarded" through the evaluation process. Only integer precisio
 However, things like 'N[Pi, 100]' should work as expected.
 """
 
-import sympy
 import mpmath
-from functools import lru_cache
+import sympy
 
+from functools import lru_cache
 
 from mathics.builtin.base import Builtin, Predefined, Test
 
@@ -57,7 +57,7 @@ SymbolIntegerDigits = Symbol("IntegerDigits")
 SymbolIntegerExponent = Symbol("IntegerExponent")
 
 
-@lru_cache(maxsize=1024)
+@lru_cache()
 def log_n_b(py_n, py_b) -> int:
     return int(mpmath.ceil(mpmath.log(py_n, py_b))) if py_n != 0 and py_n != 1 else 1
 

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -586,7 +586,7 @@ class LetterNumber(Builtin):
             return
         # TODO: handle Uppercase
         if isinstance(chars, String):
-            py_chars = chars.get_string_value()
+            py_chars = chars.value
             if len(py_chars) == 1:
                 # FIXME generalize ord("a")
                 res = alphabet["Lowercase"].find(py_chars) + 1
@@ -615,7 +615,7 @@ class LetterNumber(Builtin):
 
         start_ord = ord("a") - 1
         if isinstance(chars, String):
-            py_chars = chars.get_string_value()
+            py_chars = chars.value
             if len(py_chars) == 1:
                 # FIXME generalize ord("a")
                 return letter_number([py_chars[0]], start_ord)[0]
@@ -765,11 +765,11 @@ class StringRepeat(Builtin):
 
     def apply(self, s, n, expression, evaluation):
         "StringRepeat[s_String, n_]"
-        py_n = n.get_int_value() if isinstance(n, Integer) else 0
+        py_n = n.value if isinstance(n, Integer) else 0
         if py_n < 1:
             evaluation.message("StringRepeat", "intp", 2, expression)
         else:
-            return String(s.get_string_value() * py_n)
+            return String(s.value * py_n)
 
     def apply_truncated(self, s, n, m, expression, evaluation):
         "StringRepeat[s_String, n_Integer, m_Integer]"
@@ -782,7 +782,7 @@ class StringRepeat(Builtin):
         elif py_m < 1:
             evaluation.message("StringRepeat", "intp", 3, expression)
         else:
-            py_s = s.get_string_value()
+            py_s = s.value
             py_n = min(1 + py_m // len(py_s), py_n)
 
             return String((py_s * py_n)[:py_m])
@@ -982,7 +982,7 @@ class ToExpression(Builtin):
             if isinstance(inp, String):
 
                 # TODO: turn the below up into a function and call that.
-                s = inp.get_string_value()
+                s = inp.value
                 short_s = s[:15] + "..." if len(s) > 16 else s
                 with io.StringIO(s) as f:
                     f.name = """ToExpression['%s']""" % short_s
@@ -1058,7 +1058,7 @@ class RemoveDiacritics(Builtin):
     def apply(self, s, evaluation):
         "RemoveDiacritics[s_String]"
         return String(
-            unicodedata.normalize("NFKD", s.get_string_value())
+            unicodedata.normalize("NFKD", s.value)
             .encode("ascii", "ignore")
             .decode("ascii")
         )
@@ -1095,7 +1095,7 @@ class Transliterate(Builtin):
         "Transliterate[s_String]"
         from unidecode import unidecode
 
-        return String(unidecode(s.get_string_value()))
+        return String(unidecode(s.value))
 
 
 def _pattern_search(name, string, patt, evaluation, options, matched):

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -718,7 +718,7 @@ class Symbol_(Builtin):
 
         from mathics.core.parser import is_symbol_name
 
-        text = string.get_string_value()
+        text = string.value
         if is_symbol_name(text):
             return Symbol(evaluation.definitions.lookup_name(string.value))
         else:

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -78,7 +78,7 @@ class Attributes(Builtin):
         "Attributes[expr_]"
 
         if isinstance(expr, String):
-            expr = Symbol(expr.get_string_value())
+            expr = Symbol(expr.value)
         name = expr.get_lookup_name()
 
         attributes = attributes_bitset_to_list(

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -20,7 +20,7 @@ from mathics.core.atoms import (
     String,
 )
 from mathics.core.attributes import protected, read_protected, no_attributes
-from mathics.core.convert.expression import to_expression
+from mathics.core.convert.expression import to_expression, to_numeric_sympy_args
 from mathics.core.convert.python import from_bool
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.definitions import Definition
@@ -654,18 +654,15 @@ class Test(Builtin):
 
 class SympyFunction(SympyObject):
     def apply(self, z, evaluation):
-        #
+        # Note: we omit a docstring here, so as not to confuse
+        # function signature collector ``contribute``.
+
         # Generic apply method that uses the class sympy_name.
         # to call the corresponding sympy function. Arguments are
         # converted to python and the result is converted from sympy
         #
         # "%(name)s[z__]"
-        if z.is_literal:
-            sympy_args = [z.value]
-        else:
-            args = z.numerify(evaluation).get_sequence()
-            sympy_args = [a.to_sympy() for a in args]
-
+        sympy_args = to_numeric_sympy_args(z, evaluation)
         sympy_fn = getattr(sympy, self.sympy_name)
         try:
             return from_sympy(sympy_fn(*sympy_args))

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -660,8 +660,12 @@ class SympyFunction(SympyObject):
         # converted to python and the result is converted from sympy
         #
         # "%(name)s[z__]"
-        args = z.numerify(evaluation).get_sequence()
-        sympy_args = [a.to_sympy() for a in args]
+        if z.is_literal:
+            sympy_args = [z.value]
+        else:
+            args = z.numerify(evaluation).get_sequence()
+            sympy_args = [a.to_sympy() for a in args]
+
         sympy_fn = getattr(sympy, self.sympy_name)
         try:
             return from_sympy(sympy_fn(*sympy_args))
@@ -727,6 +731,7 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
 
     def __new__(cls, *elements, **kwargs):
         instance = super().__new__(cls, *elements, **kwargs)
+        # This should not be here.
         article = (
             "an "
             if instance.get_name()[0].lower() in ("a", "e", "i", "o", "u")
@@ -741,8 +746,8 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
         if not instance.__doc__:
             instance.__doc__ = rf"""
             <dl>
-            <dt>'{instance.get_name()}'
-            <dd> box structure.
+              <dt>'{instance.get_name()}'
+              <dd> box structure.
             </dl>
             """
 
@@ -763,10 +768,8 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
         depend on definition bindings. That is why, in contrast to
         `is_uncertain_final_definitions()` we don't need a `definitions`
         parameter.
-
-        Think about: We will say that a BoxExpression can't change.
         """
-        return True
+        return False
 
     @property
     def elements(self):

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -34,14 +34,14 @@ from mathics.core.atoms import (
     String,
 )
 from mathics.core.attributes import (
-    flat,
-    listable,
-    numeric_function,
-    one_identity,
-    orderless,
-    protected,
+    flat as A_FLAT,
+    listable as A_LISTABLE,
+    numeric_function as A_NUMERIC_FUNCTION,
+    one_identity as A_ONE_IDENTITY,
+    orderless as A_ORDERLESS,
+    protected as A_PROTECTED,
 )
-from mathics.core.convert.expression import to_expression
+from mathics.core.convert.expression import to_expression, to_numeric_args
 from mathics.core.evaluators import eval_N
 from mathics.core.expression import Expression
 from mathics.core.number import dps
@@ -94,7 +94,7 @@ class _InequalityOperator(BinaryOperator):
                 n_items.append(item)
             items = n_items
         else:
-            items = items.numerify(evaluation).get_sequence()
+            items = to_numeric_args(items, evaluation)
         return items
 
 
@@ -904,7 +904,7 @@ class Positive(Builtin):
      = {False, True}
     """
 
-    attributes = listable | protected
+    attributes = A_LISTABLE | A_PROTECTED
 
     rules = {
         "Positive[x_?NumericQ]": "If[x > 0, True, False, False]",
@@ -934,7 +934,7 @@ class Negative(Builtin):
      = {True, False}
     """
 
-    attributes = listable | protected
+    attributes = A_LISTABLE | A_PROTECTED
 
     rules = {
         "Negative[x_?NumericQ]": "If[x < 0, True, False, False]",
@@ -953,7 +953,7 @@ class NonNegative(Builtin):
      = {False, True}
     """
 
-    attributes = listable | protected
+    attributes = A_LISTABLE | A_PROTECTED
 
     rules = {
         "NonNegative[x_?NumericQ]": "If[x >= 0, True, False, False]",
@@ -972,7 +972,7 @@ class NonPositive(Builtin):
      = {False, True}
     """
 
-    attributes = listable | protected
+    attributes = A_LISTABLE | A_PROTECTED
 
     rules = {
         "NonPositive[x_?NumericQ]": "If[x <= 0, True, False, False]",
@@ -1000,7 +1000,9 @@ def expr_min(elements):
 
 class _MinMax(Builtin):
 
-    attributes = flat | numeric_function | one_identity | orderless | protected
+    attributes = (
+        A_FLAT | A_NUMERIC_FUNCTION | A_ONE_IDENTITY | A_ORDERLESS | A_PROTECTED
+    )
 
     def apply(self, items, evaluation):
         "%(name)s[items___]"

--- a/mathics/builtin/specialfns/elliptic.py
+++ b/mathics/builtin/specialfns/elliptic.py
@@ -12,6 +12,7 @@ from mathics.core.attributes import (
 )
 from mathics.builtin.base import SympyFunction
 from mathics.core.atoms import Integer
+from mathics.core.convert.expression import to_numeric_sympy_args
 from mathics.core.convert.sympy import from_sympy
 
 import sympy
@@ -172,18 +173,18 @@ class EllipticPi(SympyFunction):
 
     def apply_n_m(self, n, m, evaluation):
         "%(name)s[n_, m_]"
-        sympy_n = m.numerify(evaluation).to_sympy()
-        sympy_m = n.numerify(evaluation).to_sympy()
+        sympy_m = to_numeric_sympy_args(m, evaluation)[0]
+        sympy_n = to_numeric_sympy_args(n, evaluation)[0]
         try:
-            return from_sympy(sympy.elliptic_pi(sympy_n, sympy_m))
+            return from_sympy(sympy.elliptic_pi(sympy_m, sympy_n))
         except:
             return
 
     def apply_n_phi_m(self, n, phi, m, evaluation):
         "%(name)s[n_, phi_, m_]"
-        sympy_n = m.numerify(evaluation).to_sympy()
-        sympy_phi = m.numerify(evaluation).to_sympy()
-        sympy_m = n.numerify(evaluation).to_sympy()
+        sympy_n = to_numeric_sympy_args(n, evaluation)[0]
+        sympy_phi = to_numeric_sympy_args(m, evaluation)[0]
+        sympy_m = to_numeric_sympy_args(m, evaluation)[0]
         try:
             result = from_sympy(sympy.elliptic_pi(sympy_n, sympy_phi, sympy_m))
             return result

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -150,7 +150,7 @@ class Integer(Number):
     def abs(self) -> "Integer":
         return -self if self < Integer0 else self
 
-    @lru_cache()
+    @lru_cache(maxsize=1024)
     def __init__(self, value):
         super().__init__()
 
@@ -232,7 +232,7 @@ class Rational(Number):
     class_head_name = "System`Rational"
 
     # Think about: Do we ever need this on a __new__ since that does the same thing?
-    @lru_cache()
+    @lru_cache(maxsize=1024)
     def __new__(cls, numerator, denominator=1) -> "Rational":
         self = super().__new__(cls)
         self.value = sympy.Rational(numerator, denominator)

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -96,7 +96,6 @@ class Integer(Number):
     value: int
     class_head_name = "System`Integer"
 
-    # Think about: Do we ever need this on a __new__ since that does the same thing?
     # We use __new__ here to unsure that two Integer's that have the same value
     # return the same object.
     def __new__(cls, value) -> "Integer":

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -6,11 +6,9 @@ import math
 import mpmath
 import re
 import sympy
-import typing
 
 from functools import lru_cache
-from typing import Any, Optional
-
+from typing import Optional, Type, Union
 
 from mathics.core.element import ImmutableValueMixin, BoxElementMixin
 from mathics.core.number import (
@@ -178,7 +176,7 @@ class Integer(Number):
     def to_python(self, *args, **kwargs):
         return self.value
 
-    def round(self, d=None) -> typing.Union["MachineReal", "PrecisionReal"]:
+    def round(self, d=None) -> Union["MachineReal", "PrecisionReal"]:
         if d is None:
             d = self.value.bit_length()
             if d <= machine_precision:
@@ -254,7 +252,7 @@ class Rational(Number):
     def to_python(self, *args, **kwargs) -> float:
         return float(self.value)
 
-    def round(self, d=None) -> typing.Union["MachineReal", "PrecisionReal"]:
+    def round(self, d=None) -> Union["MachineReal", "PrecisionReal"]:
         if d is None:
             return MachineReal(float(self.value))
         else:
@@ -309,6 +307,7 @@ class Rational(Number):
 RationalOneHalf = Rational(1, 2)
 
 
+# This has to come before Complex
 class Real(Number):
     class_head_name = "System`Real"
 
@@ -381,6 +380,7 @@ class Real(Number):
         update(b"System`Real>" + str(self.to_sympy().n(dps(_prec))).encode("utf8"))
 
 
+# Has to come before PrecisionReal
 class MachineReal(Real):
     """
     Machine precision real number.
@@ -388,14 +388,20 @@ class MachineReal(Real):
     Stored internally as a python float.
     """
 
-    value: float
-
     def __new__(cls, value) -> "MachineReal":
         self = Number.__new__(cls)
         self.value = float(value)
         if math.isinf(self.value) or math.isnan(self.value):
             raise OverflowError
         return self
+
+    @property
+    def is_literal(self) -> bool:
+        """For a Real, the value can't change and has a Python representation,
+        i.e. a value is set and it does not depend on definition
+        bindings. So we say it is a literal.
+        """
+        return True
 
     def to_python(self, *args, **kwargs) -> float:
         return self.value
@@ -489,16 +495,19 @@ class PrecisionReal(Real):
         self.value = sympy.Float(value)
         return self
 
-    def to_python(self, *args, **kwargs):
-        return float(self.value)
+    @property
+    def is_literal(self) -> bool:
+        """For a PrecisionReal, the value can't change and has a Python representation,
+        i.e. a value is set and it does not depend on definition
+        bindings. So we say it is a literal.
+        """
+        return True
 
-    def to_sympy(self, *args, **kwargs):
-        return self.value
+    @property
+    def is_zero(self) -> bool:
+        return self.value == 0.0
 
-    def to_mpmath(self):
-        return mpmath.mpf(self.value)
-
-    def round(self, d=None) -> typing.Union["MachineReal", "PrecisionReal"]:
+    def round(self, d=None) -> Union[MachineReal, "PrecisionReal"]:
         if d is None:
             return MachineReal(float(self.value))
         else:
@@ -545,9 +554,91 @@ class PrecisionReal(Real):
     def __neg__(self) -> "PrecisionReal":
         return PrecisionReal(-self.value)
 
+    def to_python(self, *args, **kwargs):
+        return float(self.value)
+
+    def to_sympy(self, *args, **kwargs):
+        return self.value
+
+    def to_mpmath(self):
+        return mpmath.mpf(self.value)
+
+
+class ByteArrayAtom(Atom, ImmutableValueMixin):
+    value: str
+    class_head_name = "System`ByteArrayAtom"
+
+    # We use __new__ here to unsure that two ByteArrayAtom's that have the same value
+    # return the same object.
+    def __new__(cls, value):
+        self = super().__new__(cls)
+        if type(value) in (bytes, bytearray):
+            self.value = value
+        elif type(value) is list:
+            self.value = bytearray(list)
+        elif type(value) is str:
+            self.value = base64.b64decode(value)
+        else:
+            raise Exception("value does not belongs to a valid type")
+        return self
+
+    def __str__(self) -> str:
+        return base64.b64encode(self.value).decode("utf8")
+
+    def atom_to_boxes(self, f, evaluation) -> "String":
+        res = String('""' + self.__str__() + '""')
+        return res
+
+    def do_copy(self) -> "ByteArrayAtom":
+        return ByteArrayAtom(self.value)
+
+    def default_format(self, evaluation, form) -> str:
+        value = self.value
+        return '"' + value.__str__() + '"'
+
+    def get_sort_key(self, pattern_sort=False) -> tuple:
+        if pattern_sort:
+            return super().get_sort_key(True)
+        else:
+            return (0, 1, self.value, 0, 1)
+
     @property
-    def is_zero(self) -> bool:
-        return self.value == 0.0
+    def is_literal(self) -> bool:
+        """For an ByteArrayAtom, the value can't change and has a Python representation,
+        i.e. a value is set and it does not depend on definition
+        bindings. So we say it is a literal.
+        """
+        return True
+
+    def sameQ(self, other) -> bool:
+        """Mathics SameQ"""
+        # FIX: check
+        if isinstance(other, ByteArrayAtom):
+            return self.value == other.value
+        return False
+
+    def get_string_value(self) -> Optional[str]:
+        try:
+            return self.value.decode("utf-8")
+        except Exception:
+            return None
+
+    def to_sympy(self, **kwargs):
+        return None
+
+    def to_python(self, *args, **kwargs) -> str:
+        return self.value
+
+    def __hash__(self):
+        return hash(("ByteArrayAtom", self.value))
+
+    def user_hash(self, update):
+        # hashing a String is the one case where the user gets the untampered
+        # hash value of the string's text. this corresponds to MMA behavior.
+        update(self.value)
+
+    def __getnewargs__(self):
+        return (self.value,)
 
 
 class Complex(Number):
@@ -556,8 +647,8 @@ class Complex(Number):
     """
 
     class_head_name = "System`Complex"
-    real: Any
-    imag: Any
+    real: Type[Number]
+    imag: Type[Number]
 
     def __new__(cls, real, imag):
         self = super().__new__(cls)
@@ -693,6 +784,227 @@ class Complex(Number):
         return real_zero and imag_zero
 
 
+class Integer(Number):
+    value: int
+    class_head_name = "System`Integer"
+
+    # We use __new__ here to unsure that two Integer's that have the same value
+    # return the same object.
+    def __new__(cls, value) -> "Integer":
+        n = int(value)
+        self = super(Integer, cls).__new__(cls)
+        self.value = n
+        return self
+
+    def __eq__(self, other) -> bool:
+        return (
+            self.value == other.value
+            if isinstance(other, Integer)
+            else super().__eq__(other)
+        )
+
+    def __le__(self, other) -> bool:
+        return (
+            self.value <= other.value
+            if isinstance(other, Integer)
+            else super().__le__(other)
+        )
+
+    def __lt__(self, other) -> bool:
+        return (
+            self.value < other.value
+            if isinstance(other, Integer)
+            else super().__lt__(other)
+        )
+
+    def __ge__(self, other) -> bool:
+        return (
+            self.value >= other.value
+            if isinstance(other, Integer)
+            else super().__ge__(other)
+        )
+
+    def __gt__(self, other) -> bool:
+        return (
+            self.value > other.value
+            if isinstance(other, Integer)
+            else super().__gt__(other)
+        )
+
+    def __ne__(self, other) -> bool:
+        return (
+            self.value != other.value
+            if isinstance(other, Integer)
+            else super().__ne__(other)
+        )
+
+    def abs(self) -> "Integer":
+        return -self if self < Integer0 else self
+
+    @lru_cache()
+    def __init__(self, value):
+        super().__init__()
+
+    def atom_to_boxes(self, f, evaluation):
+        return self.make_boxes(f.get_name())
+
+    def default_format(self, evaluation, form) -> str:
+        return str(self.value)
+
+    @property
+    def is_literal(self) -> bool:
+        """For an Integer, the value can't change and has a Python representation,
+        i.e. a value is set and it does not depend on definition
+        bindings. So we say it is a literal.
+        """
+        return True
+
+    def make_boxes(self, form) -> "String":
+        from mathics.builtin.box.layout import _boxed_string
+
+        if form in ("System`InputForm", "System`FullForm"):
+            return _boxed_string(str(self.value), number_as_text=True)
+        return String(str(self.value))
+
+    def to_sympy(self, **kwargs):
+        return sympy.Integer(self.value)
+
+    def to_mpmath(self):
+        return mpmath.mpf(self.value)
+
+    def to_python(self, *args, **kwargs):
+        return self.value
+
+    def round(self, d=None) -> Union["MachineReal", "PrecisionReal"]:
+        if d is None:
+            d = self.value.bit_length()
+            if d <= machine_precision:
+                return MachineReal(float(self.value))
+            else:
+                # machine_precision / log_2(10) + 1
+                d = machine_digits
+        return PrecisionReal(sympy.Float(self.value, d))
+
+    def get_int_value(self) -> int:
+        return self.value
+
+    def sameQ(self, other) -> bool:
+        """Mathics SameQ"""
+        return isinstance(other, Integer) and self.value == other.value
+
+    def get_sort_key(self, pattern_sort=False) -> tuple:
+        if pattern_sort:
+            return super().get_sort_key(True)
+        else:
+            return (0, 0, self.value, 0, 1)
+
+    def do_copy(self) -> "Integer":
+        return Integer(self.value)
+
+    def __hash__(self):
+        return hash(("Integer", self.value))
+
+    def user_hash(self, update):
+        update(b"System`Integer>" + str(self.value).encode("utf8"))
+
+    def __getnewargs__(self):
+        return (self.value,)
+
+    def __neg__(self) -> "Integer":
+        return Integer(-self.value)
+
+    @property
+    def is_zero(self) -> bool:
+        return self.value == 0
+
+
+Integer0 = Integer(0)
+Integer1 = Integer(1)
+Integer2 = Integer(2)
+Integer3 = Integer(3)
+Integer310 = Integer(310)
+Integer10 = Integer(10)
+IntegerM1 = Integer(-1)
+
+
+class Rational(Number):
+    class_head_name = "System`Rational"
+
+    @lru_cache()
+    def __new__(cls, numerator, denominator=1) -> "Rational":
+        self = super().__new__(cls)
+        self.value = sympy.Rational(numerator, denominator)
+        return self
+
+    def atom_to_boxes(self, f, evaluation):
+        from mathics.core.formatter import format_element
+
+        return format_element(self, evaluation, f)
+
+    def to_sympy(self, **kwargs):
+        return self.value
+
+    def to_mpmath(self):
+        return mpmath.mpf(self.value)
+
+    def to_python(self, *args, **kwargs) -> float:
+        return float(self.value)
+
+    def round(self, d=None) -> Union["MachineReal", "PrecisionReal"]:
+        if d is None:
+            return MachineReal(float(self.value))
+        else:
+            return PrecisionReal(self.value.n(d))
+
+    def sameQ(self, other) -> bool:
+        """Mathics SameQ"""
+        return isinstance(other, Rational) and self.value == other.value
+
+    def numerator(self) -> "Integer":
+        return Integer(self.value.as_numer_denom()[0])
+
+    def denominator(self) -> "Integer":
+        return Integer(self.value.as_numer_denom()[1])
+
+    def default_format(self, evaluation, form) -> str:
+        return "Rational[%s, %s]" % self.value.as_numer_denom()
+
+    def get_sort_key(self, pattern_sort=False) -> tuple:
+        if pattern_sort:
+            return super().get_sort_key(True)
+        else:
+            # HACK: otherwise "Bus error" when comparing 1==1.
+            return (0, 0, sympy.Float(self.value), 0, 1)
+
+    def do_copy(self) -> "Rational":
+        return Rational(self.value)
+
+    def __hash__(self):
+        return hash(("Rational", self.value))
+
+    def user_hash(self, update) -> None:
+        update(
+            b"System`Rational>" + ("%s>%s" % self.value.as_numer_denom()).encode("utf8")
+        )
+
+    def __getnewargs__(self):
+        return (self.numerator().get_int_value(), self.denominator().get_int_value())
+
+    def __neg__(self) -> "Rational":
+        return Rational(
+            -self.numerator().get_int_value(), self.denominator().get_int_value()
+        )
+
+    @property
+    def is_zero(self) -> bool:
+        return (
+            self.numerator().is_zero
+        )  # (implicit) and not (self.denominator().is_zero)
+
+
+RationalOneHalf = Rational(1, 2)
+
+
 class String(Atom, BoxElementMixin):
     value: str
     class_head_name = "System`String"
@@ -728,12 +1040,20 @@ class String(Atom, BoxElementMixin):
         else:
             return (0, 1, self.value, 0, 1)
 
+    def get_string_value(self) -> str:
+        return self.value
+
+    @property
+    def is_literal(self) -> bool:
+        """For a String, the value can't change and has a Python representation,
+        i.e. a value is set and it does not depend on definition
+        bindings. So we say it is a literal.
+        """
+        return True
+
     def sameQ(self, other) -> bool:
         """Mathics SameQ"""
         return isinstance(other, String) and self.value == other.value
-
-    def get_string_value(self) -> str:
-        return self.value
 
     def to_expression(self):
         return self
@@ -754,75 +1074,6 @@ class String(Atom, BoxElementMixin):
         # hashing a String is the one case where the user gets the untampered
         # hash value of the string's text. this corresponds to MMA behavior.
         update(self.value.encode("utf8"))
-
-    def __getnewargs__(self):
-        return (self.value,)
-
-
-class ByteArrayAtom(Atom, ImmutableValueMixin):
-    value: str
-    class_head_name = "System`ByteArrayAtom"
-
-    # We use __new__ here to unsure that two ByteArrayAtom's that have the same value
-    # return the same object.
-    def __new__(cls, value):
-        self = super().__new__(cls)
-        if type(value) in (bytes, bytearray):
-            self.value = value
-        elif type(value) is list:
-            self.value = bytearray(list)
-        elif type(value) is str:
-            self.value = base64.b64decode(value)
-        else:
-            raise Exception("value does not belongs to a valid type")
-        return self
-
-    def __str__(self) -> str:
-        return base64.b64encode(self.value).decode("utf8")
-
-    def atom_to_boxes(self, f, evaluation) -> "String":
-        res = String('""' + self.__str__() + '""')
-        return res
-
-    def do_copy(self) -> "ByteArrayAtom":
-        return ByteArrayAtom(self.value)
-
-    def default_format(self, evaluation, form) -> str:
-        value = self.value
-        return '"' + value.__str__() + '"'
-
-    def get_sort_key(self, pattern_sort=False) -> tuple:
-        if pattern_sort:
-            return super().get_sort_key(True)
-        else:
-            return (0, 1, self.value, 0, 1)
-
-    def sameQ(self, other) -> bool:
-        """Mathics SameQ"""
-        # FIX: check
-        if isinstance(other, ByteArrayAtom):
-            return self.value == other.value
-        return False
-
-    def get_string_value(self) -> Optional[str]:
-        try:
-            return self.value.decode("utf-8")
-        except Exception:
-            return None
-
-    def to_sympy(self, **kwargs):
-        return None
-
-    def to_python(self, *args, **kwargs) -> str:
-        return self.value
-
-    def __hash__(self):
-        return hash(("ByteArrayAtom", self.value))
-
-    def user_hash(self, update):
-        # hashing a String is the one case where the user gets the untampered
-        # hash value of the string's text. this corresponds to MMA behavior.
-        update(self.value)
 
     def __getnewargs__(self):
         return (self.value,)

--- a/mathics/core/convert/expression.py
+++ b/mathics/core/convert/expression.py
@@ -26,11 +26,16 @@ def to_expression(
     #    from mathics.core.convert.expression import to_mathics_list
     #    return to_mathics_list(elements)
 
-    elements_tuple, elements_properties = convert_expression_elements(
+    elements_tuple, elements_properties, literal_values = convert_expression_elements(
         elements, elements_conversion_fn
     )
 
-    return Expression(head, *elements_tuple, elements_properties=elements_properties)
+    return Expression(
+        head,
+        *elements_tuple,
+        elements_properties=elements_properties,
+        literal_values=literal_values
+    )
 
 
 def to_expression_with_specialization(
@@ -57,14 +62,14 @@ def to_mathics_list(
        to_mathics_list(1, 2, 3)
        to_mathics_list(1, 2, 3, elements_conversion_fn=Integer, is_literal=True)
     """
-    elements_tuple, elements_properties = convert_expression_elements(
+    elements_tuple, elements_properties, values = convert_expression_elements(
         elements, elements_conversion_fn
     )
     list_expression = ListExpression(
         *elements_tuple, elements_properties=elements_properties
     )
     if is_literal:
-        list_expression.python_list = elements
+        list_expression.value = elements
     return list_expression
 
 

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -337,7 +337,7 @@ class BaseElement(KeyComparable):
             rules.append(rule)
         return rules
 
-    def get_sequence(self):
+    def get_sequence(self) -> list:
         """Convert's a Mathics Sequence into a Python's list of elements"""
         from mathics.core.symbols import SymbolSequence
 

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -6,7 +6,7 @@ Here we have the base class and related function for element inside an Expressio
 """
 
 
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Union
 
 from mathics.core.attributes import no_attributes
 
@@ -337,10 +337,16 @@ class BaseElement(KeyComparable):
             rules.append(rule)
         return rules
 
-    def get_sequence(self) -> list:
-        """Convert's a Mathics Sequence into a Python's list of elements"""
+    def get_sequence(self) -> Union[tuple, list]:
+        """If self has return that, otherwise turn self into a
+        tuple() and return that"""
+
         from mathics.core.symbols import SymbolSequence
 
+        # FIXME: using the below test causes:
+        # TypeError: boxes_to_text() takes 1 positional argument but 2 were given
+        # Why?
+        # if hasattr(self, "element"):
         if self.get_head() is SymbolSequence:
             return self.elements
         else:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -184,6 +184,9 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
     positional Arguments:
         - head -- The head of the M-Expression
         - *elements - optional: the remaining elements
+        - *literal_values - optional: if this is not None, then all elements
+                            are (Python) literal values and literal_values
+                            contains these literals.
 
     Keyword Arguments:
         - elements_properties -- properties of the collection of elements
@@ -201,21 +204,23 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         self,
         head: BaseElement,
         *elements: Tuple[BaseElement],
-        elements_properties: Optional[ElementsProperties] = None
+        elements_properties: Optional[ElementsProperties] = None,
+        literal_values: Optional[tuple] = None,
     ):
         self.options = None
         self.pattern_sequence = False
+
+        # # Uncomment to check for errors:
         # assert isinstance(head, BaseElement)
         # assert isinstance(elements, tuple)
         # assert all(isinstance(e, BaseElement) for e in elements)
-        # if head is SymbolList:
-        #     from trepan.api import debug; debug()
+        # assert head is BaseElement
 
         self._head = head
         self._elements = elements
         self.elements_properties = elements_properties
-        #        if elements_properties is None:
-        #            self._build_elements_properties()
+        self.value = literal_values
+        self._is_literal = None if literal_values is None else True
 
         self._sequences = None
         self._cache = None
@@ -254,9 +259,12 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         self.elements_properties = ElementsProperties(True, True, True)
 
         last_element = None
+        values = []
         for element in self._elements:
             # Test for the three properties mentioned above.
-            if not element.is_literal:
+            if element.is_literal:
+                values.append(element.value)
+            else:
                 self.elements_properties.elements_fully_evaluated = False
             if isinstance(element, Expression):
                 self.elements_properties.is_flat = False
@@ -278,6 +286,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
         if self.is_literal:
             assert self.elements_properties.elements_fully_evaluated
+            self.value = tuple(values)
 
     def _flatten_sequence(self, sequence, evaluation) -> "Expression":
         indices = self.sequences()
@@ -1571,7 +1580,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             *[
                 element.replace_vars(vars, options=options, in_scoping=in_scoping)
                 for element in elements
-            ]
+            ],
         )
 
     def replace_slots(self, slots, evaluation):
@@ -1602,7 +1611,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             return self
         return Expression(
             self._head.replace_slots(slots, evaluation),
-            *[element.replace_slots(slots, evaluation) for element in self._elements]
+            *[element.replace_slots(slots, evaluation) for element in self._elements],
         )
 
     def thread(self, evaluation, head=None) -> Tuple[bool, "Expression"]:
@@ -1866,25 +1875,35 @@ def atom_list_constructor(evaluation, head, *atom_names):
 # Note: this function is called a *lot* so it needs to be fast.
 def convert_expression_elements(
     elements: Iterable, conversion_fn: Callable = from_python
-) -> Tuple[tuple, ElementsProperties]:
+) -> Tuple[tuple, ElementsProperties, Optional[tuple]]:
     """
-    Convert and return tuple of Elements from the Python-like items in `elements`,
-    along with elements properties of the elements tuple.
+    Convert and return tuple of Elements from the Python-like items in
+    `elements`, along with elements properties of the elements tuple,
+    and a tuple of literal values if it elements are all literal
+    otherwise, None.
 
     The return information is suitable for use to the Expression() constructor.
+
     """
 
     # All of the properties start out optimistic (True) and are reset when that proves wrong.
     elements_properties = ElementsProperties(True, True, True)
+
+    is_literal = True
+    values = []  # If is_literal, "values" contains the (Python) literal values
 
     result = []
     last_converted_elt = None
     for element in elements:
         converted_elt = conversion_fn(element)
 
-        # Test for the three properties mentioned above.
-        if not converted_elt.is_literal:
+        # Test for the three properties mentioned above and literalness.
+        if is_literal and converted_elt.is_literal:
+            values.append(converted_elt.value)
+        else:
             elements_properties.elements_fully_evaluated = False
+            is_literal = False
+
         if isinstance(converted_elt, Expression):
             elements_properties.is_flat = False
             if converted_elt.elements_properties is None:
@@ -1903,7 +1922,8 @@ def convert_expression_elements(
         last_converted_elt = converted_elt
         result.append(converted_elt)
 
-    return tuple(result), elements_properties
+    final_values = tuple(values) if is_literal else None
+    return tuple(result), elements_properties, final_values
 
 
 def string_list(head, elements, evaluation):

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -296,11 +296,11 @@ class Atom(BaseElement):
 
     @property
     def is_literal(self) -> bool:
-        """
-        True if the value can't change, i.e. a value is set and it does not
-        depend on definition bindings. That is why, in contrast to
-        `is_uncertain_final_definitions()` we don't need a `definitions`
-        parameter.
+        """True if the value can't change and has a Python representation,
+        i.e. a value is set and it does not depend on definition
+        bindings. That is why, in contrast to
+        `is_uncertain_final_definitions()` we don't need a
+        `definitions` parameter.
 
         Most Atoms, like Numbers and Strings, do not need evaluation
         or reevaluation. However some kinds of Atoms like Symbols do
@@ -309,7 +309,7 @@ class Atom(BaseElement):
         it might is literal in general.
 
         """
-        return True
+        return False
 
     def is_uncertain_final_definitions(self, definitions) -> bool:
         """
@@ -369,7 +369,7 @@ class Symbol(Atom, NumericOperators, EvalMixin):
 
     # __new__ instead of __init__ is used here because we want
     # to return the same object for a given "name" value.
-    def __new__(cls, name, sympy_dummy=None):
+    def __new__(cls, name, sympy_dummy=None, value=None):
         """
         Allocate an object ensuring that for a given `name` we get back the same object.
         """
@@ -379,6 +379,7 @@ class Symbol(Atom, NumericOperators, EvalMixin):
             self = super(Symbol, cls).__new__(cls)
             self.name = name
             self.sympy_dummy = sympy_dummy
+            self.value = value
             cls.defined_symbols[name] = self
         return self
 
@@ -473,12 +474,13 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     @property
     def is_literal(self) -> bool:
         """
-        True if the value can't change, i.e. a value is set and it does not
-        depend on definition bindings. That is why, in contrast to
-        `is_uncertain_final_definitions()` we don't need a `definitions`
-        parameter.
+        In general, for Atoms its value can change and might not have a Python
+        representation. Symbol is an example of this.
 
-        Here, we have to be pessimistic and return False.
+        So Here, we have to be pessimistic and return False. A number of
+        subclasses, like Integer, Real, String, change the value returned
+        to True.
+
         """
         return False
 
@@ -656,9 +658,9 @@ format_symbols = system_symbols(
 # more of the below and in systemsymbols
 # PredefineSymbol.
 
-SymbolFalse = PredefinedSymbol("System`False")
+SymbolFalse = PredefinedSymbol("System`False", value=False)
 SymbolList = PredefinedSymbol("System`List")
-SymbolTrue = PredefinedSymbol("System`True")
+SymbolTrue = PredefinedSymbol("System`True", value=True)
 
 SymbolAbs = Symbol("Abs")
 SymbolDivide = Symbol("Divide")

--- a/mathics/timing.py
+++ b/mathics/timing.py
@@ -68,11 +68,14 @@ def show_lru_cache_statistics():
     from mathics.core.atoms import Integer, Rational
     from mathics.builtin.arithmetic import call_mpmath, _MPMathFunction
     from mathics.builtin.atomic.numbers import log_n_b
+    from mathics.builtin.base import run_sympy
     from mathics.core.convert.mpmath import from_mpmath
 
+    print(f"Integer             {Integer.__init__.cache_info()}")
+    print(f"Rational            {Rational.__new__.cache_info()}")
     print(f"call_mpmath         {call_mpmath.cache_info()}")
     print(f"log_n_b             {log_n_b.cache_info()}")
     print(f"from_mpmath         {from_mpmath.cache_info()}")
     print(f"get_mpmath_function {_MPMathFunction.get_mpmath_function.cache_info()}")
-    print(f"Integer             {Integer.__init__.cache_info()}")
-    print(f"Rational            {Rational.__new__.cache_info()}")
+
+    print(f"run_sympy           {run_sympy.cache_info()}")

--- a/test/core/test_expression_constructor.py
+++ b/test/core/test_expression_constructor.py
@@ -12,14 +12,14 @@ def test_expression_constructor():
 
     # The below will convert 1 Integer(1) multiple times
     # and discover that the arguments are flat, fully evaluated, and ordered.
-    ones = [1] * 50
+    ones = [1] * 20
     e1 = to_expression(SymbolPlus, *ones)
     attribute_check(e1, "e1")
 
     e1a = to_expression("Plus", *ones)
     attribute_check(e1a, "e1a")
 
-    integer_ones = [Integer1] * 50
+    integer_ones = [Integer1] * 20
     e2 = Expression(SymbolPlus, *integer_ones)
     e2._build_elements_properties()
     attribute_check(e2, "e2")

--- a/test/core/test_is_literal.py
+++ b/test/core/test_is_literal.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+Test mathics.core property on BaseElement is_literal.
+"""
+
+from mathics.core.parser import MathicsSingleLineFeeder
+from mathics.core.parser.convert import convert
+from mathics.core.parser.parser import Parser
+from mathics.session import MathicsSession
+
+session = MathicsSession(add_builtin=False, catch_interrupt=True)
+parser = Parser()
+
+
+def test_is_literal():
+    """
+    Tests properties literalness of expressions
+    coming out of initial conversion are set accurately.
+    """
+
+    for str_expression, is_literal, assert_msg in [
+        # fmt: off
+        # expr                  is_literal? assert message
+        ("5",                   True,       "an atomic Integer is a literals"),
+        ('"5"',                 True,       "an atomic String is a literal"),
+        ("1/2",                 False,      "a ratio is not a literal"),
+        ("X",                   False,      "a variable symbol is not a literal"),
+        ("{1, 2, 3}",           True,       "a list of Integers is a literal"),
+        ("{1, 2, Pi}",          False,      "a list with a symbolic constant is not a literal"),
+        ('{"x", 2, 3.0}',       True,       "a list of literals is a literal"),
+        ('{"x", {2, 3, {}}}',   True,       "a nested list of literals is a literal"),
+        ('{"x", {2, 3}, 1/2}',  False,      "a nested list containing a ratio is not a literal "),
+    ]:
+        # fmt: on
+        session.evaluation.out.clear()
+        feeder = MathicsSingleLineFeeder(str_expression)
+        ast = parser.parse(feeder)
+
+        # convert() creates the initial Expression. In that various properties should
+        # be set.
+        expr = convert(ast, session.definitions)
+        assert expr.is_literal == is_literal, assert_msg


### PR DESCRIPTION
Although there may be benefit in noting literals that do not have direct
Python representations like Complex (as it currently is implemented) or
Boxes, the vast majority of literals that we can make immediate use of
is where there is a direct Python representation, e.g. Integers, Reals,
Strings, and ListExpressions (of literals).

Also go over some types and remove some string.get_string_value()

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/537"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

