### PR TITLE
add --show-cache-statistic option to docpipeline

### DIFF
--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -1,8 +1,8 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 
-# Note: docstring is flowed in documentation. Line breaks in the docstring will appear in the
-# printed output, so be carful not to add then mid-sentence.
+# Note: docstring is not flowed in documentation. Line breaks in the docstring will appear in the
+# printed output, so be careful not to add them mid-sentence.
 
 """
 Representation of Numbers

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -8,8 +8,8 @@ import re
 import sympy
 import typing
 
-from typing import Any, Optional
 from functools import lru_cache
+from typing import Any, Optional
 
 
 from mathics.core.element import ImmutableValueMixin, BoxElementMixin
@@ -98,6 +98,7 @@ class Integer(Number):
     value: int
     class_head_name = "System`Integer"
 
+    # Think about: Do we ever need this on a __new__ since that does the same thing?
     # We use __new__ here to unsure that two Integer's that have the same value
     # return the same object.
     def __new__(cls, value) -> "Integer":
@@ -232,6 +233,7 @@ IntegerM1 = Integer(-1)
 class Rational(Number):
     class_head_name = "System`Rational"
 
+    # Think about: Do we ever need this on a __new__ since that does the same thing?
     @lru_cache()
     def __new__(cls, numerator, denominator=1) -> "Rational":
         self = super().__new__(cls)

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -8,7 +8,6 @@ from mathics.core.atoms import (
     MachineReal,
     PrecisionReal,
 )
-from mathics.core.symbols import SymbolList
 
 
 @lru_cache(maxsize=1024)

--- a/mathics/core/convert/python.py
+++ b/mathics/core/convert/python.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+Conversions between Python and Mathics
+"""
+
 from typing import Any
 from mathics.core.number import get_type
 

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -28,6 +28,7 @@ from mathics.builtin import builtins_dict
 from mathics import version_string
 from mathics import settings
 from mathics.doc.common_doc import MathicsMainDocumentation
+from mathics.timing import show_lru_cache_statistics
 
 builtins = builtins_dict()
 
@@ -544,6 +545,11 @@ def main():
         default=MAX_TESTS,
         help="run only  N tests",
     )
+    parser.add_argument(
+        "--show-statistics",
+        action="store_true",
+        help="print cache statistics",
+    )
     # FIXME: there is some weird interacting going on with
     # mathics when tests in sorted order. Some of the Plot
     # show a noticeable 2 minute delay in processing.
@@ -618,6 +624,8 @@ def main():
             print("Tests took ", end_time - start_time)
     if logfile:
         logfile.close()
+    if args.show_statistics:
+        show_lru_cache_statistics()
 
 
 if __name__ == "__main__":

--- a/mathics/timing.py
+++ b/mathics/timing.py
@@ -59,3 +59,20 @@ class TimeitContextManager:
         elapsed = (te - self.ts) * 1000
         if elapsed > MIN_ELAPSE_REPORT:
             print("%r  %2.2f ms" % (self.name, elapsed))
+
+
+def show_lru_cache_statistics():
+    """
+    Print statistics from LRU caches (@lru_cache of functools)
+    """
+    from mathics.core.atoms import Integer, Rational
+    from mathics.builtin.arithmetic import call_mpmath, _MPMathFunction
+    from mathics.builtin.atomic.numbers import log_n_b
+    from mathics.core.convert.mpmath import from_mpmath
+
+    print(f"call_mpmath         {call_mpmath.cache_info()}")
+    print(f"log_n_b             {log_n_b.cache_info()}")
+    print(f"from_mpmath         {from_mpmath.cache_info()}")
+    print(f"get_mpmath_function {_MPMathFunction.get_mpmath_function.cache_info()}")
+    print(f"Integer             {Integer.__init__.cache_info()}")
+    print(f"Rational            {Rational.__new__.cache_info()}")


### PR DESCRIPTION
and mathics via a new function in mathics.timing.

TODO: add to mathicsscript and Django.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/538"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

