### PR TITLE
boxes_to_ -> boxes_to_format.  Improving support for encodings.

### DIFF
--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -839,6 +839,7 @@ class ToString(Builtin):
     >> ToString[Integrate[f[x],x], TeXForm]
      = \\int f\\left[x\\right] \\, dx
 
+    Ask for an specific encoding:
     >> ToString[\[Pi], CharacterEncoding->"ASCII"]
      = Pi
 

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -839,6 +839,9 @@ class ToString(Builtin):
     >> ToString[Integrate[f[x],x], TeXForm]
      = \\int f\\left[x\\right] \\, dx
 
+    >> ToString[\[Pi], CharacterEncoding->"ASCII"]
+     = Pi
+
     """
 
     options = {
@@ -858,18 +861,7 @@ class ToString(Builtin):
         return self.apply_form(value, SymbolOutputForm, evaluation, options)
 
     def apply_form(self, value, form, evaluation, options):
-        "ToString[value_, form_, OptionsPattern[ToString]]"
-
-        # For some reason, the rule for `apply_default` is never used.
-        # This handles the case where an options is placed instead
-        # of form.
-        if isinstance(form, Expression) and form.head in (
-            SymbolRule,
-            SymbolRuleDelayed,
-        ):
-            options[form.elements[0].name] = form.elements[1]
-            form = SymbolOutputForm
-
+        "ToString[value_, form_Symbol, OptionsPattern[ToString]]"
         # This handles the character encoding option. It is delegated
         # to the formatter.
         character_encoding = options["System`CharacterEncoding"]

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -42,8 +42,6 @@ from mathics.core.systemsymbols import (
     SymbolDirectedInfinity,
     SymbolInputForm,
     SymbolOutputForm,
-    SymbolRule,
-    SymbolRuleDelayed,
 )
 
 
@@ -816,7 +814,7 @@ class String_(Builtin):
 
 
 class ToString(Builtin):
-    """
+    r"""
     <dl>
       <dt>'ToString[$expr$]'
       <dd>returns a string representation of $expr$.
@@ -872,7 +870,7 @@ class ToString(Builtin):
             evaluation.message("$CharacterEncoding", "charcode", character_encoding)
             encoding = "Unicode"
 
-        if not encoding in _encodings:
+        if encoding not in _encodings:
             evaluation.message("$CharacterEncoding", "charcode", character_encoding)
             encoding = "Unicode"
 

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -835,7 +835,7 @@ class ToString(Builtin):
     >> "U" <> ToString[2]
      = U2
     >> ToString[Integrate[f[x],x], TeXForm]
-     = \\int f\\left[x\\right] \\, dx
+     = \int f\left[x\right] \, dx
 
     Ask for an specific encoding:
     >> ToString[\[Pi], CharacterEncoding->"ASCII"]

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -681,24 +681,6 @@ class GraphicsBox(BoxExpression):
 
         return ticks, ticks_small, origin_x
 
-    def _boxes_to_svg(self, elements=None, **options) -> str:
-        """This is the top-level function that converts a Mathics Expression
-        in to something suitable for SVG rendering.
-        """
-        if not elements:
-            elements = self._elements
-
-        elements, calc_dimensions = self._prepare_elements(
-            elements, options, neg_y=True
-        )
-        xmin, xmax, ymin, ymax, w, h, self.width, self.height = calc_dimensions()
-        data = (elements, xmin, xmax, ymin, ymax, w, h, self.width, self.height)
-        elements.view_width = w
-
-        format_fn = lookup_method(self, "svg")
-        svg_body = format_fn(self, elements, data=data, **options)
-        return svg_body
-
     def create_axes(self, elements, graphics_options, xmin, xmax, ymin, ymax):
         axes = graphics_options.get("System`Axes")
         if axes is SymbolTrue:

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -41,7 +41,7 @@ from mathics.core.atoms import (
 
 from mathics.core.attributes import hold_all, protected, read_protected
 from mathics.core.expression import Expression
-from mathics.core.formatter import format_element, lookup_method
+from mathics.core.formatter import boxes_to_format, format_element, lookup_method
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolTrue
 from mathics.core.systemsymbols import SymbolAutomatic, SymbolTraditionalForm
@@ -681,7 +681,7 @@ class GraphicsBox(BoxExpression):
 
         return ticks, ticks_small, origin_x
 
-    def boxes_to_svg(self, elements=None, **options) -> str:
+    def _boxes_to_svg(self, elements=None, **options) -> str:
         """This is the top-level function that converts a Mathics Expression
         in to something suitable for SVG rendering.
         """
@@ -983,8 +983,8 @@ class InsetBox(_GraphicsElementBox):
             self.content = self.content.atom_to_boxes(
                 SymbolStandardForm, evaluation=self.graphics.evaluation
             )
-        self.content_text = self.content.boxes_to_text(
-            evaluation=self.graphics.evaluation
+        self.content_text = boxes_to_format(
+            self.content, "text", evaluation=self.graphics.evaluation
         )
 
     def extent(self):

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -27,9 +27,10 @@ from mathics.builtin.drawing.graphics3d import (
 from mathics.builtin.drawing.graphics_internals import get_class
 
 
-from mathics.core.formatter import lookup_method
+
 from mathics.core.evaluators import eval_N
 from mathics.core.symbols import Symbol, SymbolTrue
+
 
 
 class Graphics3DBox(GraphicsBox):
@@ -337,11 +338,14 @@ class Graphics3DBox(GraphicsBox):
         """Turn the Graphics3DBox to into a something javascript-ish
         We include enclosing script tagging.
         """
-        json_repr = self.boxes_to_json(elements, **options)
+        if elements:
+            options["elements"] = elements
+
+        json_repr = boxes_to_format(self, "json", **options)
         js = f"<graphics3d data='{json_repr}'/>"
         return js
 
-    def boxes_to_json(self, elements=None, **options):
+    def __boxes_to_json(self, elements=None, **options):
         """Turn the Graphics3DBox to into a something JSON like.
         This can be used to embed in something else like MathML or Javascript.
 

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -334,17 +334,6 @@ class Graphics3DBox(GraphicsBox):
 
         return elements, axes, ticks, ticks_style, calc_dimensions, boxscale
 
-    def boxes_to_js(self, elements=None, **options):
-        """Turn the Graphics3DBox to into a something javascript-ish
-        We include enclosing script tagging.
-        """
-        if elements:
-            options["elements"] = elements
-
-        json_repr = boxes_to_format(self, "json", **options)
-        js = f"<graphics3d data='{json_repr}'/>"
-        return js
-
     def create_axes(
         self, elements, graphics_options, xmin, xmax, ymin, ymax, zmin, zmax, boxscale
     ):

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -345,60 +345,6 @@ class Graphics3DBox(GraphicsBox):
         js = f"<graphics3d data='{json_repr}'/>"
         return js
 
-    def __boxes_to_json(self, elements=None, **options):
-        """Turn the Graphics3DBox to into a something JSON like.
-        This can be used to embed in something else like MathML or Javascript.
-
-        In contrast to to javascript or MathML, no enclosing tags are included.
-        the caller will do that if it is needed.
-        """
-        if not elements:
-            elements = self._elements
-
-        (
-            elements,
-            axes,
-            ticks,
-            ticks_style,
-            calc_dimensions,
-            boxscale,
-        ) = self._prepare_elements(elements, options)
-
-        js_ticks_style = [s.to_js() for s in ticks_style]
-
-        elements._apply_boxscaling(boxscale)
-
-        xmin, xmax, ymin, ymax, zmin, zmax, boxscale, w, h = calc_dimensions()
-        elements.view_width = w
-
-        # FIXME: json is the only thing we can convert MathML into.
-        # Handle other graphics formats.
-        format_fn = lookup_method(elements, "json")
-
-        json_repr = json.dumps(
-            {
-                "elements": format_fn(elements, **options),
-                "axes": {
-                    "hasaxes": axes,
-                    "ticks": ticks,
-                    "ticks_style": js_ticks_style,
-                },
-                "extent": {
-                    "xmin": xmin,
-                    "xmax": xmax,
-                    "ymin": ymin,
-                    "ymax": ymax,
-                    "zmin": zmin,
-                    "zmax": zmax,
-                },
-                "lighting": self.lighting,
-                "viewpoint": self.viewpoint,
-                "protocol": "1.1",
-            }
-        )
-
-        return json_repr
-
     def create_axes(
         self, elements, graphics_options, xmin, xmax, ymin, ymax, zmin, zmax, boxscale
     ):

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -3,7 +3,6 @@
 Boxing Routines for 3D Graphics
 """
 
-import json
 import numbers
 
 from mathics.builtin.exceptions import BoxExpressionError
@@ -27,10 +26,8 @@ from mathics.builtin.drawing.graphics3d import (
 from mathics.builtin.drawing.graphics_internals import get_class
 
 
-
 from mathics.core.evaluators import eval_N
 from mathics.core.symbols import Symbol, SymbolTrue
-
 
 
 class Graphics3DBox(GraphicsBox):

--- a/mathics/builtin/compress.py
+++ b/mathics/builtin/compress.py
@@ -6,6 +6,7 @@ import zlib
 
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import String
+from mathics.core.formatter import boxes_to_format
 
 
 class Compress(Builtin):
@@ -31,8 +32,8 @@ class Compress(Builtin):
             string = '"' + expr.value + '"'
         else:
             string = expr.format(evaluation, "System`FullForm")
-            string = string.boxes_to_text(
-                evaluation=evaluation, show_string_characters=True
+            string = boxes_to_format(
+                string, "text", evaluation=evaluation, show_string_characters=True
             )
         string = string.encode("utf-8")
 

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -29,7 +29,7 @@ from mathics.core.attributes import protected, read_protected
 from mathics.core.convert.expression import to_expression, to_mathics_list
 from mathics.core.convert.python import from_python
 from mathics.core.expression import BoxError, Expression
-from mathics.core.formatter import format_element, do_format
+from mathics.core.formatter import boxes_to_format, do_format, format_element
 from mathics.core.parser import MathicsFileLineFeeder, parse
 from mathics.core.read import (
     channel_to_stream,
@@ -1787,7 +1787,7 @@ class WriteString(Builtin):
         for expri in expr.get_sequence():
             result = format_element(expri, evaluation, SymbolOutputForm)
             try:
-                result = result.boxes_to_text(evaluation=evaluation)
+                result = boxes_to_format(result, "text", evaluation=evaluation)
             except BoxError:
                 return evaluation.message(
                     "General",

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -20,6 +20,7 @@ from mathics.core.atoms import Integer, String, StringFromPython
 
 from mathics.core.element import EvalMixin
 from mathics.core.expression import Expression, BoxError
+from mathics.core.formatter import boxes_to_format
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (
     Symbol,
@@ -392,7 +393,7 @@ class MathMLForm(Builtin):
 
         boxes = MakeBoxes(expr).evaluate(evaluation)
         try:
-            mathml = boxes.boxes_to_mathml(evaluation=evaluation)
+            mathml = boxes_to_format(boxes, "mathml", evaluation=evaluation)
         except BoxError:
             evaluation.message(
                 "General",
@@ -513,8 +514,8 @@ class TeXForm(Builtin):
             # Here we set ``show_string_characters`` to False, to reproduce
             # the standard behaviour in WMA. Remove this parameter to recover the
             # quotes in InputForm and FullForm
-            tex = boxes.boxes_to_tex(
-                show_string_characters=False, evaluation=evaluation
+            tex = boxes_to_format(
+                boxes, "latex", show_string_characters=False, evaluation=evaluation
             )
 
             # Replace multiple newlines by a single one e.g. between asy-blocks

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -40,7 +40,7 @@ from mathics.core.attributes import (
 )
 from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression, string_list
-from mathics.core.formatter import format_element
+from mathics.core.formatter import boxes_to_format, format_element
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (
     Symbol,
@@ -923,9 +923,11 @@ class StringRiffle(Builtin):
         # Getting all together
         result = left
         for i in range(len(liststr.elements)):
-            text = format_element(
-                liststr.elements[i], evaluation, SymbolOutputForm
-            ).boxes_to_text(evaluation=evaluation)
+            text = boxes_to_format(
+                format_element(liststr.elements[i], evaluation, SymbolOutputForm),
+                "text",
+                evaluation=evaluation,
+            )
             if i == len(liststr.elements) - 1:
                 result += text + right
             else:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -484,9 +484,21 @@ class BoxElementMixin(ImmutableValueMixin):
 
         return boxes_to_format(self, format, **options)
 
+    def boxes_to_js(self, **options: dict) -> str:
+        """For compatibility deprecated"""
+        return self.boxes_to_format("js", **options)
+
+    def boxes_to_json(self, **options: dict) -> str:
+        """For compatibility deprecated"""
+        return self.boxes_to_format("json", **options)
+
     def boxes_to_mathml(self, **options: dict) -> str:
         """For compatibility deprecated"""
         return self.boxes_to_format("mathml", **options)
+
+    def boxes_to_svg(self, **options: dict) -> str:
+        """For compatibility deprecated"""
+        return self.boxes_to_format("svg", **options)
 
     def boxes_to_tex(self, **options: dict) -> str:
         """For compatibility deprecated"""

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -131,8 +131,8 @@ def lookup_method(self, format: str) -> Callable:
         boxes_to_method = None
     if boxes_to_method:
 
-        def ret_fn(box, elements=None, **opts):
-            return boxes_to_method(elements, **opts)
+        def ret_fn(box, **opts):
+            return boxes_to_method(**opts)
 
         return ret_fn
 

--- a/mathics/format/js.py
+++ b/mathics/format/js.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Lower-level formatter of Mathics objects as js code.
+
+Right now this happens just for Graphics3DBox.
+"""
+
+
+from mathics.builtin.box.graphics3d import Graphics3DBox
+
+from mathics.core.element import BoxElementMixin
+from mathics.core.formatter import add_conversion_fn, boxes_to_format
+
+
+def generic(self, **options):
+    return boxes_to_format(self, "text", **options)
+
+
+add_conversion_fn(BoxElementMixin, generic)
+
+
+def graphics3d_box(self, elements=None, **options):
+    """Turn the Graphics3DBox to into a something javascript-ish
+    We include enclosing script tagging.
+    """
+    if elements:
+        options["elements"] = elements
+
+    json_repr = boxes_to_format(self, "json", **options)
+    js = f"<graphics3d data='{json_repr}'/>"
+    return js
+
+
+add_conversion_fn(Graphics3DBox, graphics3d_box)

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -27,6 +27,7 @@ from mathics.builtin.box.graphics3d import Graphics3DBox
 from mathics.core.atoms import String
 from mathics.core.element import BoxElementMixin
 from mathics.core.formatter import (
+    boxes_to_format,
     lookup_method as lookup_conversion_method,
     add_conversion_fn,
 )
@@ -276,7 +277,9 @@ add_conversion_fn(StyleBox, stylebox)
 def graphicsbox(self, elements=None, **options) -> str:
     # FIXME: SVG is the only thing we can convert MathML into.
     # Handle other graphics formats.
-    svg_body = self.boxes_to_svg(elements, **options)
+    if elements:
+        options["elements"] = elements
+    svg_body = boxes_to_format(self, "svg", **options)
 
     # mglyph, which is what we have been using, is bad because MathML standard changed.
     # metext does not work because the way in which we produce the svg images is also based on this outdated mglyph behaviour.

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -118,11 +118,11 @@ def arcbox(self, **options) -> str:
         if closed:
             yield "Z"
 
-    l = self.style.get_line_width(face_element=self.face_element)
+    lw = self.style.get_line_width(face_element=self.face_element)
     style = create_css(
         self.edge_color,
         self.face_color,
-        stroke_width=l,
+        stroke_width=lw,
         edge_opacity=self.edge_opacity,
         face_opacity=self.face_opacity,
     )
@@ -267,8 +267,8 @@ def graphics_box(self, leaves=None, **options) -> str:
             ymax,
             self.boxwidth,
             self.boxheight,
-            width,
-            height,
+            self.width,
+            self.height,
         ) = data
     else:
         elements, calc_dimensions = self._prepare_elements(leaves, options, neg_y=True)
@@ -279,8 +279,8 @@ def graphics_box(self, leaves=None, **options) -> str:
             ymax,
             self.boxwidth,
             self.boxheight,
-            width,
-            height,
+            self.width,
+            self.height,
         ) = calc_dimensions()
 
     elements.view_width = self.boxwidth

--- a/test/builtin/atomic/test_strings.py
+++ b/test/builtin/atomic/test_strings.py
@@ -29,3 +29,56 @@ def test_alphabet(str_expr, str_expected, fail_msg, warnings):
     check_evaluation(
         str_expr, str_expected, failure_message="", expected_messages=warnings
     )
+
+
+"""
+    The following test would fail because the following two pending issues:
+    * boxes_to_form(self, "text", options) should handle
+    * the ``encoding`` parameter using the corresponding
+      dictionary in mathics_scanner.
+    *  "\\[Integral]" is parsed as "\u222b" instead of "\[Integral]"
+        (
+            r'ToString["\[Integral]", CharacterEncoding->"ASCII"]',
+            r'"\\[Integral]"',
+            None,
+            None),
+"""
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "fail_msg", "warnings"),
+    [
+        (r'ToString["\[Integral]", CharacterEncoding->"Unicode"]', r'"∫"', None, None),
+        (
+            r'ToString["\[Integral]", CharacterEncoding->"No"]',
+            r'"∫"',
+            None,
+            [
+                "The character encoding No is not supported. Use $CharacterEncodings to list supported encodings."
+            ],
+        ),
+        (
+            r'ToString["\[Integral]", CharacterEncoding->"3"]',
+            r'"∫"',
+            None,
+            [
+                "The character encoding 3 is not supported. Use $CharacterEncodings to list supported encodings."
+            ],
+        ),
+        (
+            r'ToString["\[Integral]", TeXForm]',
+            r'"\\text{∫}"',  # Should be '\\int'
+            None,
+            None,
+        ),
+    ],
+)
+def test_tostring(str_expr, str_expected, fail_msg, warnings):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        failure_message="",
+        expected_messages=warnings,
+        to_string_expr=False,
+        to_string_expected=False,
+    )

--- a/test/builtin/atomic/test_strings.py
+++ b/test/builtin/atomic/test_strings.py
@@ -66,8 +66,8 @@ def test_alphabet(str_expr, str_expected, fail_msg, warnings):
             ],
         ),
         (
-            r'ToString["\[Integral]", TeXForm]',
-            r'"\\text{∫}"',  # Should be '\\int'
+            r'ToString["\[Integral] f(x) \[DifferentialD]x", TeXForm]',
+            r'"\\text{$\int$  f(x) \, dx}"',
             None,
             None,
         ),

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -451,7 +451,7 @@ def test_makeboxes_custom(str_expr, str_expected, msg):
         ),
         #
         (
-            r'MakeBoxes[InputForm[G[F[1., "l"]], .2], StandardForm]',
+            r'MakeBoxes[InputForm[G[F[1., "l"], .2]], StandardForm]',
             (
                 r'InterpretationBox[StyleBox["{\"In\", GG[{F[1.], \"In\"}, 0.2]}", '
                 r"ShowStringCharacters->True, NumberMarks->True], "
@@ -459,6 +459,15 @@ def test_makeboxes_custom(str_expr, str_expected, msg):
                 r"AutoDelete->True]"
             ),
             "MakeBoxes, InputForm",
+        ),
+        #
+        (
+            r'MakeBoxes[OutputForm[G[F[1., "l"], .2]], StandardForm]',
+            (
+                r'InterpretationBox[PaneBox["\"{Out, GG[{F[1.], Out}, 0.2]}\""],'
+                r'OutputForm[G[F[1.`, "l"], 0.2`]], Editable->False]'
+            ),
+            "MakeBoxes, OutputForm",
         ),
         #
         (

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -4,13 +4,54 @@ import pytest
 from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
+# To check the progress in the improvement of formatting routines, set this variable to 1.
+# Otherwise, the tests are going to be skipped.
+DEBUGMAKEBOXES = int(os.environ.get("DEBUGMAKEBOXES", "0")) == 1
 
-DEBUG = int(os.environ.get("DEBUG", "0")) == 1  # To set to True, set ENV var to "1"
-
-if DEBUG:
+if DEBUGMAKEBOXES:
     skip_or_fail = pytest.mark.xfail
 else:
     skip_or_fail = pytest.mark.skip
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "fail_msg", "msgs"),
+    [
+        ('rb=RowBox[{"a", "b"}]; rb[[1]]', "{a, b}", None, []),
+        ("rb[[0]]", "RowBox", None, []),
+        (
+            "rb[[2]]",
+            "RowBox[{a, b}][[2]]",
+            None,
+            ["Part 2 of RowBox[{a, b}] does not exist."],
+        ),
+        ('fb=FractionBox["1", "2"]; fb[[0]]', "FractionBox", None, []),
+        ("fb[[1]]", "1", None, []),
+        ('sb=StyleBox["string", "Section"]; sb[[0]]', "StyleBox", None, []),
+        ("sb[[1]]", "string", None, []),
+        # FIXME: <<RowBox object does not have the attribute "restructure">>
+        # ('rb[[All, 1]]', "{a, b}", "\"a\"", []),
+        # ('fb[[All]][[1]]','1', None, []),
+        # ('sb[[All]][[1]]','string', None, []),
+    ],
+)
+@skip_or_fail
+def test_part_boxes(str_expr, str_expected, fail_msg, msgs):
+    """
+    This unit test checks that certain typical box structures
+    work together with `Part`. In the current master,
+    these expressions crashes the interpreter.
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=fail_msg,
+        expected_messages=msgs,
+    )
+
 
 # 15 tests
 @pytest.mark.parametrize(
@@ -200,5 +241,308 @@ def test_makeboxes_others_fail(str_expr, str_expected, msg):
         to_string_expr=True,
         to_string_expected=True,
         hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# Fixme: "2." should be "2.`"
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r"MakeBoxes[G[F[2.]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"F","[","2.","]"}],"]"}]',
+            "Standard bahaviour",
+        ),
+        (
+            r'MakeBoxes[F[x_], fmt_] := "F[" <> ToString[x] <> "]";MakeBoxes[G[F[3.002]], StandardForm]',
+            r'RowBox[{"G","[","F[3.002]","]"}]',
+            "Checking the rule over regular (Standard)",
+        ),
+        (
+            r"MakeBoxes[OutputForm[G[F[3.002]]], StandardForm]",
+            # We do not use InterpretationBox   = InterpretationBox[PaneBox["\"G[F[3.002]]\""], OutputForm[G[F[3.002`]]], Rule[Editable, False]]
+            r'RowBox[{"G","[","F[3.002]","]"}]',
+            "Checking the rule over OutputForm",
+        ),
+        (
+            r'Format[F[x_]] := {"Formatted f", {x}, "Standard"};',
+            r"System`Null",
+            "Adding a generic format",
+        ),
+        (
+            r"MakeBoxes[G[F[3.002]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",",", RowBox[{"{","3.002","}"}],"," ,"\"Standard\""}],"}"}],"]"}]',
+            "Checking again, with the defined StandardForm format",
+        ),
+        # InterpretationBox is not used in Mathics  = InterpretationBox[PaneBox["\"G[{Formatted f, {3.002}, Standard}]\""], OutputForm[G[F[3.002`]]], Rule[Editable, False]]
+        (
+            r"MakeBoxes[OutputForm[G[F[3.002]]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",", ", RowBox[{"{","3.002","}"}],", ","\"Standard\""}],"}"}],"]"}]',
+            "Checking again, with the defined StandardForm OutputForm",
+        ),
+        (
+            r'Format[F[x_], StandardForm] :=  {"Formatted f", {x}, "Standard"};Format[F[x_], OutputForm] :=  {"Formatted f", {x}, "Output"};',
+            r"Null",
+            "Defining now specific formats",
+        ),
+        (
+            r"MakeBoxes[G[F[3.002]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",",",RowBox[{"{","3.002","}"}],",","\"Standard\""}],"}"}],"]"}]',
+            "Test Custom StandardForm",
+        ),
+        # InterpretationBox is now used here... = InterpretationBox[PaneBox["\"G[{Formatted f, {3.002}, Output}]\""], OutputForm[G[F[3.002`]]], Rule[Editable, False]]
+        (
+            r"MakeBoxes[OutputForm[G[F[3.002]]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",", ",RowBox[{"{","3.002","}"}],", ","\"Standard\""}],"}"}],"]"}]',
+            "Test Custom OutputForm",
+        ),
+        (
+            r"ClearAll[F]; MakeBoxes[G[F[2.]], StandardForm]",
+            r'RowBox[{"G","[","F[2.]","]"}]',
+            "Clear Formats",
+        ),
+        (
+            r"MakeBoxes[F[x_], fmt_]=.; MakeBoxes[G[F[2.]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"F","[","2.","]"}],"]"}]',
+            "Clear MakeBoxes rule",
+        ),
+    ],
+)
+@skip_or_fail
+def test_makeboxes_custom(str_expr, str_expected, msg):
+    """
+    These tests checks the behaviour of MakeBoxes.
+    Most of them are broken, because our implementation
+    is different that the WMA.
+
+    In WMA, MakeBoxes[...] is not evaluated as
+    other expressions, but behaves like `Format[]`:
+    Format rules (and MakeBoxes) are not taken into
+    account in the regular evaluation.
+    When a MakeBoxes expression is found, then
+    the kernel applies first the format rules,
+    and then the MakeBoxes rules
+
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=False,
+        to_string_expected=False,
+        hold_expected=False,
+        to_python_expected=False,
+        failure_message=msg,
+    )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r'MakeBoxes[F[x__], fmt_] :=  RowBox[{"F", "<~", RowBox[MakeBoxes[#1, fmt] & /@ List[x]], "~>"}]',
+            "Null",
+            "MakeBoxes rule for F",
+        ),
+        #
+        (
+            r'MakeBoxes[G[x___], fmt_] := RowBox[{"G", "<", RowBox[MakeBoxes[#1, fmt] & /@ List[x]], ">"}]',
+            "Null",
+            "MakeBoxes rule for G",
+        ),
+        #
+        (
+            r'MakeBoxes[GG[x___], fmt_] := RowBox[{"GG", "<<", RowBox[MakeBoxes[#1, fmt] & /@ List[x]], ">>"}]',
+            "Null",
+            "MakeBoxes rule for GG",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], StandardForm] := {F[x], "Standard"}',
+            "Null",
+            "Format rule for F, StandardForm",
+        ),
+        #
+        (
+            r'Format[G[x___], StandardForm] :=  {"Standard", GG[x]}',
+            "Null",
+            "Format rule for G, StandardForm",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r"{Standard, GG << {F<~1.`~>, Standard} 0.2` >>}",
+            None,
+        ),
+        #
+        (r'ToString[FullForm[G[F[1., "l"], .2]]]', r'G[F[1.`, "l"], 0.2`]', "FullForm"),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"G[F[1.`, \"l\"], 0.2`]"',
+            "InputForm - no format defined",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"G[F[1.`, l], 0.2`]"',
+            "OutputForm - no format defined",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], InputForm] := {F[x], "In"}',
+            "Null",
+            "Format rule for F, InputForm",
+        ),
+        #
+        (
+            r'Format[G[x___], InputForm] :=  {"In", GG[x]}',
+            "Null",
+            "Format rule for G, OutputForm",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], OutputForm] := {F[x], "Out"}',
+            "Null",
+            "Format rule for F, InputForm",
+        ),
+        #
+        (
+            r'Format[G[x___], OutputForm] :=  {"Out", GG[x]}',
+            "Null",
+            "Format rule for G, OutputForm",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], FullForm] := {F[x], "full"}',
+            "Null",
+            "Format for FullForm. (never used)",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r'"{Standard, GG << {F<~1.`~>, Standard} 0.2` >>}"',
+            "StandardForm - formats defined",
+        ),
+        #
+        (r'ToString[FullForm[G[F[1., "l"], .2]]]', r'"G[F[1.`, \"l\"], 0.2`]"', None),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"{\"In\", GG[{F[1.], \"In\"}, 0.2]}"',
+            "FullForm - formats defined",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"{Out, GG[{F[1.], Out}, 0.2]}"',
+            None,
+        ),
+        #
+        (
+            r'MakeBoxes[G[F[1., "l"], .2], StandardForm]',
+            (
+                r'RowBox[{"{", RowBox[{"\"Standard\"", ",",'
+                r'RowBox[{"GG", "<<", RowBox[{RowBox[{"{",'
+                r'RowBox[{RowBox[{"F", "<~", RowBox[{"1.`"}], "~>"}],'
+                r'",", "\"Standard\""}], "}"}], "0.2`"}], ">>"}]}], "}"}]'
+            ),
+            "MakeBoxes, StandardForm",
+        ),
+        #
+        (
+            r'MakeBoxes[InputForm[G[F[1., "l"]], .2], StandardForm]',
+            (
+                r'InterpretationBox[StyleBox["{\"In\", GG[{F[1.], \"In\"}, 0.2]}", '
+                r"ShowStringCharacters->True, NumberMarks->True], "
+                r'InputForm[G[F[1.`, "l"], 0.2`]], Editable-> True, '
+                r"AutoDelete->True]"
+            ),
+            "MakeBoxes, InputForm",
+        ),
+        #
+        (
+            r'ToString[TeXForm[G[F[1., "l"], .2]]]',
+            r'"G<F<\sim 1.\text{l}\sim >0.2>"',
+            "TeXForm - format defined",
+        ),
+        #
+        (
+            r'ToString[TeXForm[InputForm[G[F[1., "l"], .2]]]]',
+            r'"\text{$\{$In, GG[$\{$F[1.], In$\}$, 0.2]$\}$}"',
+            "TeXForm - InputForm - format defined",
+        ),
+        #
+        (r"ClearAll[F, G, GG]", "Null", "Clear Format rules"),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r'"G < F<~1.`l~>0.2` >"',
+            "StandardForm - formats clear",
+        ),
+        #
+        (
+            r'ToString[FullForm[G[F[1., "l"], .2]]]',
+            r'"G[F[1., \"l\"], 0.2`]"',
+            "FullForm - formats clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"G[F[1., \"l\"], 0.2]"',
+            "InputForm - formats clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"G[F[1., l], 0.2]"',
+            "OutputForm - formats clear",
+        ),
+        #
+        (r"MakeBoxes[F[x__], fmt_]=.", "Null", "Clear MakeBoxes rule for F"),
+        #
+        (r"MakeBoxes[G[x___], fmt_]=.", "Null", "Clear MakeBoxes rule for G"),
+        #
+        (r"MakeBoxes[GG[x___], fmt_]=.", "Null", "Clear MakeBoxes rule for GG"),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r'"G[F[1.`, l], 0.2`]"',
+            "StandardForm - Boxes clear",
+        ),
+        #
+        (
+            r'ToString[FullForm[G[F[1., "l"], .2]]]',
+            r'"G[F[1.`, \"l\"], 0.2`]"',
+            "FullForm - Boxes clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"G[F[1., \"l\"], 0.2]"',
+            "InputForm - Boxes clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"G[F[1., l], 0.2]"',
+            "OutputForm - Boxes clear",
+        ),
+    ],
+)
+@skip_or_fail
+def test_makeboxes_custom2(str_expr, str_expected, msg):
+    """
+    These tests checks the behaviour of MakeBoxes.
+    Most of them are broken, because our implementation
+    is different that the WMA.
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=False,
+        to_string_expected=False,
+        hold_expected=False,
+        to_python_expected=False,
         failure_message=msg,
     )


### PR DESCRIPTION
This PR continues the refactor of the formatting methods, with some of the changes proposed here: https://github.com/Mathics3/mathics-core/discussions/317#discussioncomment-3450105

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/539"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

