### PR TITLE
List to python+roundtrip quotes

### DIFF
--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -338,9 +338,7 @@ class BaseElement(KeyComparable):
         return rules
 
     def get_sequence(self) -> Union[tuple, list]:
-        """If self has return that, otherwise turn self into a
-        tuple() and return that"""
-
+        """Convert's a Mathics Sequence into a Python's list of elements"""
         from mathics.core.symbols import SymbolSequence
 
         # FIXME: using the below test causes:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -261,9 +261,12 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         last_element = None
         values = []
         for element in self._elements:
-            # Test for the three properties mentioned above.
+            # Test for the literalness, and the three properties mentioned above
+            if element.is_literal:
+                values.append(element.value)
+            else:
+                self.elements_properties.elements_fully_evaluated = False
 
-            # First we test for not flatness, and elements_fully_evaluated
             if isinstance(element, Expression):
 
                 # "self" can't be flat.


### PR DESCRIPTION
In the Mathics python code, there are a number of places where we need to strip off double quotes. This should have been a red flag that something was wrong in the design of Mathics. Around Mathics 2.2.0, we added a "string_quotes" parameter to `to_python()` so that we could specify the behavior. 

However, more recently in getting rid of `get_string_value()` and replacing it with `value`, I see that `.get_string_value()`/ `.value` is another way that could have been used to not add quotes around the string in many of the offending cases that this occurs.

Note that  still need `to_python()`  when there are things like lists (or other composite structures) of strings and you want to specify whether or not to include quotes. 

This PR, simplifies string quote removal which is most noticeable in Mathics Builtins involving filesystem operations. It does this by simply using `.value` in place of `.to_python()`. 

The other thing it does, make from LIstExpressions  of literals have a round-trip behavior:  

```python
x = ['a', 'b', 'c']
assert to_mathics_list(*x).value == x
```

--- 

A long while ago I had said that we shouldn't worry about using `to_python()` over `get_string_value()` or `get_int_value()` and let Python figure that out. 

Here, I realize I have to amend that. Especially in light of unifying the `get_...value()` routines. (This PR adds `.value` on list expression literals). 

What I hadn't realized before is that `to_python()` is not invertible unless you specify `string_quotes=False` and there may be other situations like this.  Also `.value` is a common interpreter idiom.  And third (but in my mind _least_ important) is that fact that yes, it is faster too.  

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/544"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

