### PR TITLE
Fixing parsing for FormBox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,8 +34,8 @@ Internals
 Bugs
 ++++
 
-# ``0`` with a given precision (like in ```0`3```) is now parsed as ``0``, an integer number.
-
+#. ``0`` with a given precision (like in ```0`3```) is now parsed as ``0``, an integer number.
+#. Improving parsing ``RowBox`` expressions including ``FormBox`` tags (``` \` ```) inside. 
 
 Enhancements
 ++++++++++++

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -369,13 +369,10 @@ class MakeBoxes(Builtin):
     #> (a <> b)[x]
      : String expected.
      = (a <> b)[x]
-    """
-
-    # TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
-    """
     >> \\(a + b\\)
      = RowBox[{a, +, b}]
 
+    This fails because is not properly parsed. Check in Mathics-scanner.
     >> \\(TraditionalForm \\` a + b\\)
      = FormBox[RowBox[{a, +, b}], TraditionalForm]
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -372,7 +372,6 @@ class MakeBoxes(Builtin):
     >> \\(a + b\\)
      = RowBox[{a, +, b}]
 
-    This fails because is not properly parsed. Check in Mathics-scanner.
     >> \\(TraditionalForm \\` a + b\\)
      = FormBox[RowBox[{a, +, b}], TraditionalForm]
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -327,38 +327,38 @@ class BoxForms_(Predefined):
 
 
 class MakeBoxes(Builtin):
-    """
+    r"""
     <dl>
       <dt>'MakeBoxes[$expr$]'
-      <dd>is a low-level formatting primitive that converts $expr$
-        to box form, without evaluating it.
-      <dt>'\\( ... \\)'
+      <dd>is a low-level formatting primitive that converts $expr$ to box form, without evaluating it.
+
+      <dt>'\( ... \)'
       <dd>directly inputs box objects.
     </dl>
 
     String representation of boxes
-    >> \\(x \\^ 2\\)
+    >> \(x \^ 2\)
      = SuperscriptBox[x, 2]
 
-    >> \\(x \\_ 2\\)
+    >> \(x \_ 2\)
      = SubscriptBox[x, 2]
 
-    >> \\( a \\+ b \\% c\\)
+    >> \( a \+ b \% c\)
      = UnderoverscriptBox[a, b, c]
 
-    >> \\( a \\& b \\% c\\)
+    >> \( a \& b \% c\)
      = UnderoverscriptBox[a, c, b]
 
-    #> \\( \\@ 5 \\)
+    #> \( \@ 5 \)
      = SqrtBox[5]
 
-    >> \\(x \\& y \\)
+    >> \(x \& y \)
      = OverscriptBox[x, y]
 
-    >> \\(x \\+ y \\)
+    >> \(x \+ y \)
      = UnderscriptBox[x, y]
 
-    #> \\( x \\^ 2 \\_ 4 \\)
+    #> \( x \^ 2 \_ 4 \)
      = SuperscriptBox[x, SubscriptBox[2, 4]]
 
     ## Tests for issue 151 (infix operators in heads)
@@ -369,13 +369,13 @@ class MakeBoxes(Builtin):
     #> (a <> b)[x]
      : String expected.
      = (a <> b)[x]
-    >> \\(a + b\\)
+    >> \(a + b\)
      = RowBox[{a, +, b}]
 
-    >> \\(TraditionalForm \\` a + b\\)
+    >> \(TraditionalForm \` a + b\)
      = FormBox[RowBox[{a, +, b}], TraditionalForm]
 
-    >> \\(x \\/ \\(y + z\\)\\)
+    >> \(x \/ \(y + z\)\)
      =  FractionBox[x, RowBox[{y, +, z}]]
     """
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -309,7 +309,7 @@ def number_form(expr, n, f, evaluation, options):
 
 # TODO: Differently from the current implementation, MakeBoxes should only
 # accept as its format field the symbols in `$BoxForms`. This is something to
-# fix in a following step.
+# fix in a following step, changing the way in which Format and MakeBoxes work.
 
 
 class BoxForms_(Predefined):
@@ -374,91 +374,6 @@ class MakeBoxes(Builtin):
      = (a <> b)[x]
     """
 
-    # TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
-    """
-    >> \\(a + b\\)
-     = RowBox[{a, +, b}]
-
-    >> \\(TraditionalForm \\` a + b\\)
-     = FormBox[RowBox[{a, +, b}], TraditionalForm]
-
-    >> \\(x \\/ \\(y + z\\)\\)
-     =  FractionBox[x, RowBox[{y, +, z}]]
-    """
-
-    # TODO: Constructing boxes from Real
-    """
-    ## Test Real MakeBoxes
-    #> MakeBoxes[1.4]
-     = 1.4`
-    #> MakeBoxes[1.4`]
-     = 1.4`
-    #> MakeBoxes[1.5`20]
-     = 1.5`20.
-    #> MakeBoxes[1.4`20]
-     = 1.4`20.
-    #> MakeBoxes[1.5``20]
-     = 1.5`20.1760912591
-    #> MakeBoxes[-1.4]
-     = RowBox[{-, 1.4`}]
-    #> MakeBoxes[34.*^3]
-     = 34000.`
-
-    #> MakeBoxes[0`]
-     = 0.`
-    #> MakeBoxes[0`3]
-     = 0
-    #> MakeBoxes[0``30]
-     = 0.``30.
-    #> MakeBoxes[0.`]
-     = 0.`
-    #> MakeBoxes[0.`3]
-     = 0.`
-    #> MakeBoxes[0.``30]
-     = 0.``30.
-
-    #> MakeBoxes[14]
-     = 14
-    #> MakeBoxes[-14]
-     = RowBox[{-, 14}]
-    """
-
-    # TODO: Correct precedence
-    """
-    >> \\(x \\/ y + z\\)
-     = RowBox[{FractionBox[x, y], +, z}]
-    >> \\(x \\/ (y + z)\\)
-     = FractionBox[x, RowBox[{(, RowBox[{y, +, z}], )}]]
-
-    #> \\( \\@ a + b \\)
-     = RowBox[{SqrtBox[a], +, b}]
-    """
-
-    # FIXME: Don't insert spaces with brackets
-    """
-    #> \\(c (1 + x)\\)
-     = RowBox[{c, RowBox[{(, RowBox[{1, +, x}], )}]}]
-    """
-
-    # TODO: Required MakeExpression
-    """
-    #> \\!\\(x \\^ 2\\)
-     = x ^ 2
-    #> FullForm[%]
-     = Power[x, 2]
-    """
-
-    # TODO: Fix Infix operators
-    """
-    >> MakeBoxes[1 + 1]
-     = RowBox[{1, +, 1}]
-    """
-
-    # TODO: Parsing of special characters (like commas)
-    """
-    >> \\( a, b \\)
-     = RowBox[{a, ,, b}]
-    """
     attributes = A_HOLD_ALL_COMPLETE
 
     rules = {

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -315,9 +315,7 @@ class Parser:
             self.bracket_depth += 1
 
         token = self.next()
-        while token.tag not in ("RightRowBox", "OtherscriptBox"):
-            if token.tag in "FormBox":
-                break
+        while token.tag not in ("RightRowBox", "OtherscriptBox", "FormBox"):
             newnode = self.parse_box(0)
             children.append(newnode)
             token = self.next()

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -7,7 +7,6 @@ from mathics_scanner import (
     InvalidSyntaxError,
     Tokeniser,
     TranslateError,
-    is_symbol_name,
 )
 
 from mathics.core.parser.ast import Node, Number, Symbol, String, Filename
@@ -308,13 +307,29 @@ class Parser:
     def p_LeftRowBox(self, token):
         self.consume()
         children = []
-        self.box_depth += 1
-        self.bracket_depth += 1
+        # If this does not happend, it would be because
+        # it was called when a `FormBox` was found.
+        if token.tag == "LeftRowBox":
+            self.box_depth += 1
+            self.bracket_depth += 1
+
         token = self.next()
         while token.tag not in ("RightRowBox", "OtherscriptBox"):
+            if token.tag in "FormBox":
+                break
             newnode = self.parse_box(0)
             children.append(newnode)
             token = self.next()
+
+        if token.tag == "FormBox":
+            if len(children) == 0:
+                fmt = Symbol("StandardForm")
+            elif len(children) == 1:
+                fmt = children[0]
+            else:
+                fmt = Node("RowBox", Node("List", *children))
+            rest = self.p_LeftRowBox(token)
+            return Node("FormBox", rest, fmt)
         if len(children) == 0:
             result = String("")
         elif len(children) == 1:
@@ -839,20 +854,6 @@ class Parser:
         self.consume()
         box2 = self.parse_box(q + 1)
         return Node("FractionBox", box1, box2)
-
-    def b_FormBox(self, box1, token, p):
-        q = misc_ops["FormBox"]
-        if q < p:
-            return None
-        if box1 is None:
-            box1 = Symbol("StandardForm")  # RawForm
-        elif is_symbol_name(box1.value):
-            box1 = Symbol(box1.value, context=None)
-        else:
-            box1 = Node("Removed", String("$$Failure"))
-        self.consume()
-        box2 = self.parse_box(q)
-        return Node("FormBox", box2, box1)
 
     def b_OverscriptBox(self, box1, token, p):
         q = misc_ops["OverscriptBox"]

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -308,9 +308,14 @@ class Parser:
     def p_LeftRowBox(self, token):
         self.consume()
         children = []
-        # If this does not happend, it would be because
-        # it was called when a `FormBox` was found.
-        if token.tag == "LeftRowBox":
+        # If this does not happen, it would be because
+        # it was called when a `FormBox` (or any other)
+        # was found. More generally, we could use
+        # ``token.tag == "LeftRowBox"
+        # if there were other Tokens with a
+        # similar behaviour (see bellow).
+
+        if token.tag != "FormBox":
             self.box_depth += 1
             self.bracket_depth += 1
 
@@ -320,6 +325,21 @@ class Parser:
             children.append(newnode)
             token = self.next()
 
+        # FormBox token has a particular behaviour: if it is found inside
+        # a RowBox, it splits the Rowbox in two pieces: the part at the
+        # left is taken as a "Format" and the part at the right is parsed
+        # as the Box to be formatted, in a way that
+        # \(a_1, a_2 ... \` b_1 b_2 ... \) is parsed as
+        # FormBox[RowBox[{b_1, b_2,...}], RowBox[a_1, a_2, ...]]
+        # This kind of parsing is not supported by the standard mechanism,
+        # so we need to processing it here instead of using a p_FormBox
+        # method.
+        # The strategy to deal with is that, when a "FormBox" tag is found,
+        # the collected elements are used to build the second argument of the
+        # output, and then the method is called again to parse the rest of the
+        # box as it had started at the "FormBox" tag. In this new call,
+        # neither `self.box_depth` or `self.bracket_depth` are going to be
+        # incremented, but are decremented at the end of the child expression.
         if token.tag == "FormBox":
             if len(children) == 0:
                 fmt = Symbol("StandardForm")
@@ -330,7 +350,7 @@ class Parser:
                     if is_symbol_name(fmt_name):
                         fmt = Symbol(fmt_name)
                     else:
-                        fmt = Node("Removed", Symbol("$$Failure"))
+                        fmt = Node("Removed", String("$$Failure"))
             else:
                 fmt = Node("RowBox", Node("List", *children))
             rest = self.p_LeftRowBox(token)

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -7,6 +7,7 @@ from mathics_scanner import (
     InvalidSyntaxError,
     Tokeniser,
     TranslateError,
+    is_symbol_name,
 )
 
 from mathics.core.parser.ast import Node, Number, Symbol, String, Filename
@@ -326,6 +327,12 @@ class Parser:
                 fmt = Symbol("StandardForm")
             elif len(children) == 1:
                 fmt = children[0]
+                if type(fmt) is String:
+                    fmt_name = fmt.value
+                    if is_symbol_name(fmt_name):
+                        fmt = Symbol(fmt_name)
+                    else:
+                        fmt = Node("Removed", Symbol("$$Failure"))
             else:
                 fmt = Node("RowBox", Node("List", *children))
             rest = self.p_LeftRowBox(token)

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -3,6 +3,29 @@ import pytest
 from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
+
+# 15 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"MakeBoxes[0`3]", r"0", None),
+        (r"MakeBoxes[14]", r"14", None),
+    ],
+)
+def test_makeboxes_real(str_expr, str_expected, msg):
+    """
+    # TODO: Constructing boxes from Real
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
 # 15 tests
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
@@ -12,20 +35,18 @@ from mathics_scanner.errors import IncompleteSyntaxError
         (r"MakeBoxes[1.5`20]", r"1.5`20.", None),
         (r"MakeBoxes[1.4`20]", r"1.4`20.", None),
         (r"MakeBoxes[1.5``20]", r"1.5`20.1760912591", None),
-        (r"MakeBoxes[-1.4]", r'RowBox[{"-", 1.4`}]', None),
+        (r"MakeBoxes[-1.4]", r"RowBox[{-, 1.4`}]", None),
         (r"MakeBoxes[34.*^3]", r"34000.`", None),
         (r"MakeBoxes[0`]", r"0.`", None),
-        (r"MakeBoxes[0`3]", r"0", None),
         (r"MakeBoxes[0``30]", r"0.``30.", None),
         (r"MakeBoxes[0.`]", r"0.`", None),
         (r"MakeBoxes[0.`3]", r"0.`", None),
         (r"MakeBoxes[0.``30]", r"0.``30.", None),
-        (r"MakeBoxes[14]", r"14", None),
-        (r"MakeBoxes[-14]", r'RowBox[{"-", 14}]', None),
+        (r"MakeBoxes[-14]", r"RowBox[{-, 14}]", None),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_real(str_expr, str_expected, msg):
+def test_makeboxes_real_fail(str_expr, str_expected, msg):
     """
     # TODO: Constructing boxes from Real
     """
@@ -43,17 +64,35 @@ def test_makeboxes_real(str_expr, str_expected, msg):
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        (r"\(x \/ y + z\)", r'RowBox[{FractionBox["x", "y"], "+", "z"}]', None),
+        (r"\(x \/ y + z\)", r"RowBox[{FractionBox[x, y], +, z}]", None),
+        (r"\( \@ a + b \)", r"RowBox[{SqrtBox[a], +, b}]", None),
+    ],
+)
+def test_makeboxes_precedence(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 2 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
         (
             r"\(x \/ (y + z)\)",
-            r'FractionBox["x", RowBox[{"(", RowBox[{"y", "+", "z"}], ")"}]]',
+            r"FractionBox[x, RowBox[{(, RowBox[{y, +, z}], )}]]",
             None,
         ),
-        (r"\( \@ a + b \)", r'RowBox[{SqrtBox["a"], "+", "b"}]', None),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_precedence(str_expr, str_expected, msg):
+def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
     """ """
     check_evaluation(
         str_expr,
@@ -70,17 +109,59 @@ def test_makeboxes_precedence(str_expr, str_expected, msg):
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        (r"\(a + b\)", r'RowBox[{"a", "+", "b"}]', None),
+        (r"\(a + b\)", r"RowBox[{a, +, b}]", None),
+        (r"\(x \/ \(y + z\)\)", r"FractionBox[x, RowBox[{y, +, z}]]", None),
+    ],
+)
+def test_makeboxes_representation(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 3 tests
+# TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
         (
             r"\(TraditionalForm \` a + b\)",
-            r'FormBox[RowBox[{"a", "+", "b"}], TraditionalForm]',
+            r"FormBox[RowBox[{a, +, b}], TraditionalForm]",
             None,
         ),
-        (r"\(x \/ \(y + z\)\)", r'FractionBox["x", RowBox[{"y", "+", "z"}]]', None),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_representation(str_expr, str_expected, msg):
+def test_makeboxes_representation_fail(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+#  5 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r"\( a, b \)",
+            r"RowBox[{a, ,, b}]",
+            "TODO: Parsing of special characters (like commas)",
+        ),
+    ],
+)
+def test_makeboxes_others(str_expr, str_expected, msg):
     """ """
     check_evaluation(
         str_expr,
@@ -98,24 +179,18 @@ def test_makeboxes_representation(str_expr, str_expected, msg):
     [
         (
             r"\(c (1 + x)\)",
-            r'RowBox[{"c", RowBox[{"(", RowBox[{"1", "+", "x"}], ")"}]}]',
+            r"RowBox[{c, RowBox[{(, RowBox[{1, +, x}], )}]}]",
             r"FIXME: Don't insert spaces with brackets",
         ),
         (r"\!\(x \^ 2\)", r"x ^ 2", "Required MakeExpression"),
         #
-        (r"FullForm[%]", r'Power["x", "2"]', "Required MakeExpression"),
+        (r"FullForm[%]", r"Power[x, 2]", "Required MakeExpression"),
         #
-        (r"MakeBoxes[1 + 1]", r'RowBox[{"1", "+", "1"}]', "TODO: Fix Infix operators"),
-        #
-        (
-            r"\( a, b \)",
-            r'RowBox[{"a", ",", "b"}]',
-            "TODO: Parsing of special characters (like commas)",
-        ),
+        (r"MakeBoxes[1 + 1]", r"RowBox[{1, +, 1}]", "TODO: Fix Infix operators"),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_others(str_expr, str_expected, msg):
+def test_makeboxes_others_fail(str_expr, str_expected, msg):
     """ """
     check_evaluation(
         str_expr,

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -119,24 +119,6 @@ def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
     [
         (r"\(a + b\)", r"RowBox[{a, +, b}]", None),
         (r"\(x \/ \(y + z\)\)", r"FractionBox[x, RowBox[{y, +, z}]]", None),
-    ],
-)
-def test_makeboxes_representation(str_expr, str_expected, msg):
-    check_evaluation(
-        str_expr,
-        str_expected,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=msg,
-    )
-
-
-# 3 tests
-# TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
-@pytest.mark.parametrize(
-    ("str_expr", "str_expected", "msg"),
-    [
         (
             r"\(TraditionalForm \` a + b\)",
             r"FormBox[RowBox[{a, +, b}], TraditionalForm]",
@@ -144,8 +126,7 @@ def test_makeboxes_representation(str_expr, str_expected, msg):
         ),
     ],
 )
-@skip_or_fail
-def test_makeboxes_representation_fail(str_expr, str_expected, msg):
+def test_makeboxes_representation(str_expr, str_expected, msg):
     check_evaluation(
         str_expr,
         str_expected,

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -451,7 +451,7 @@ def test_makeboxes_custom(str_expr, str_expected, msg):
         ),
         #
         (
-            r'MakeBoxes[InputForm[G[F[1., "l"]], .2], StandardForm]',
+            r'MakeBoxes[InputForm[G[F[1., "l"], .2]], StandardForm]',
             (
                 r'InterpretationBox[StyleBox["{\"In\", GG[{F[1.], \"In\"}, 0.2]}", '
                 r"ShowStringCharacters->True, NumberMarks->True], "
@@ -459,6 +459,15 @@ def test_makeboxes_custom(str_expr, str_expected, msg):
                 r"AutoDelete->True]"
             ),
             "MakeBoxes, InputForm",
+        ),
+        #
+        (
+            r'MakeBoxes[OutputForm[G[F[1., "l"], .2]], StandardForm]',
+            (
+                r'InterpretationBox[PaneBox["\"{Out, GG[{F[1.], Out}, 0.2]}\""],'
+                r'OutputForm[G[F[1.`, "l"], 0.2`]], Editable->False]'
+            ),
+            "MakeBoxes, OutputForm",
         ),
         #
         (

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+import pytest
+from test.helper import check_evaluation, session
+from mathics_scanner.errors import IncompleteSyntaxError
+
+# 15 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"MakeBoxes[1.4]", r"1.4`", None),
+        (r"MakeBoxes[1.4`]", r"1.4`", None),
+        (r"MakeBoxes[1.5`20]", r"1.5`20.", None),
+        (r"MakeBoxes[1.4`20]", r"1.4`20.", None),
+        (r"MakeBoxes[1.5``20]", r"1.5`20.1760912591", None),
+        (r"MakeBoxes[-1.4]", r'RowBox[{"-", 1.4`}]', None),
+        (r"MakeBoxes[34.*^3]", r"34000.`", None),
+        (r"MakeBoxes[0`]", r"0.`", None),
+        (r"MakeBoxes[0`3]", r"0", None),
+        (r"MakeBoxes[0``30]", r"0.``30.", None),
+        (r"MakeBoxes[0.`]", r"0.`", None),
+        (r"MakeBoxes[0.`3]", r"0.`", None),
+        (r"MakeBoxes[0.``30]", r"0.``30.", None),
+        (r"MakeBoxes[14]", r"14", None),
+        (r"MakeBoxes[-14]", r'RowBox[{"-", 14}]', None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_real(str_expr, str_expected, msg):
+    """
+    # TODO: Constructing boxes from Real
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 3 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"\(x \/ y + z\)", r'RowBox[{FractionBox["x", "y"], "+", "z"}]', None),
+        (
+            r"\(x \/ (y + z)\)",
+            r'FractionBox["x", RowBox[{"(", RowBox[{"y", "+", "z"}], ")"}]]',
+            None,
+        ),
+        (r"\( \@ a + b \)", r'RowBox[{SqrtBox["a"], "+", "b"}]', None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_precedence(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 3 tests
+# TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"\(a + b\)", r'RowBox[{"a", "+", "b"}]', None),
+        (
+            r"\(TraditionalForm \` a + b\)",
+            r'FormBox[RowBox[{"a", "+", "b"}], TraditionalForm]',
+            None,
+        ),
+        (r"\(x \/ \(y + z\)\)", r'FractionBox["x", RowBox[{"y", "+", "z"}]]', None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_representation(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+#  5 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r"\(c (1 + x)\)",
+            r'RowBox[{"c", RowBox[{"(", RowBox[{"1", "+", "x"}], ")"}]}]',
+            r"FIXME: Don't insert spaces with brackets",
+        ),
+        (r"\!\(x \^ 2\)", r"x ^ 2", "Required MakeExpression"),
+        #
+        (r"FullForm[%]", r'Power["x", "2"]', "Required MakeExpression"),
+        #
+        (r"MakeBoxes[1 + 1]", r'RowBox[{"1", "+", "1"}]', "TODO: Fix Infix operators"),
+        #
+        (
+            r"\( a, b \)",
+            r'RowBox[{"a", ",", "b"}]',
+            "TODO: Parsing of special characters (like commas)",
+        ),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_others(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
+import os
 import pytest
 from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
+
+DEBUG = int(os.environ.get("DEBUG", "0")) == 1  # To set to True, set ENV var to "1"
+
+if DEBUG:
+    skip_or_fail = pytest.mark.xfail
+else:
+    skip_or_fail = pytest.mark.skip
 
 # 15 tests
 @pytest.mark.parametrize(
@@ -14,7 +22,7 @@ from mathics_scanner.errors import IncompleteSyntaxError
 )
 def test_makeboxes_real(str_expr, str_expected, msg):
     """
-    # TODO: Constructing boxes from Real
+    # Constructing boxes from Real
     """
     check_evaluation(
         str_expr,
@@ -45,10 +53,10 @@ def test_makeboxes_real(str_expr, str_expected, msg):
         (r"MakeBoxes[-14]", r"RowBox[{-, 14}]", None),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_real_fail(str_expr, str_expected, msg):
     """
-    # TODO: Constructing boxes from Real
+    # TODO: Constructing boxes from Real which are currently failing
     """
     check_evaluation(
         str_expr,
@@ -69,7 +77,7 @@ def test_makeboxes_real_fail(str_expr, str_expected, msg):
     ],
 )
 def test_makeboxes_precedence(str_expr, str_expected, msg):
-    """ """
+    """Test precedence in string-like boxes"""
     check_evaluation(
         str_expr,
         str_expected,
@@ -91,9 +99,9 @@ def test_makeboxes_precedence(str_expr, str_expected, msg):
         ),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
-    """ """
+    """TODO: fix the parsing for testing precedence in string-like boxes ("""
     check_evaluation(
         str_expr,
         str_expected,
@@ -114,7 +122,6 @@ def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
     ],
 )
 def test_makeboxes_representation(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,
@@ -137,9 +144,8 @@ def test_makeboxes_representation(str_expr, str_expected, msg):
         ),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_representation_fail(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,
@@ -162,7 +168,6 @@ def test_makeboxes_representation_fail(str_expr, str_expected, msg):
     ],
 )
 def test_makeboxes_others(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,
@@ -183,15 +188,12 @@ def test_makeboxes_others(str_expr, str_expected, msg):
             r"FIXME: Don't insert spaces with brackets",
         ),
         (r"\!\(x \^ 2\)", r"x ^ 2", "Required MakeExpression"),
-        #
         (r"FullForm[%]", r"Power[x, 2]", "Required MakeExpression"),
-        #
         (r"MakeBoxes[1 + 1]", r"RowBox[{1, +, 1}]", "TODO: Fix Infix operators"),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_others_fail(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -4,13 +4,54 @@ import pytest
 from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
+# To check the progress in the improvement of formatting routines, set this variable to 1.
+# Otherwise, the tests are going to be skipped.
+DEBUGMAKEBOXES = int(os.environ.get("DEBUGMAKEBOXES", "0")) == 1
 
-DEBUG = int(os.environ.get("DEBUG", "0")) == 1  # To set to True, set ENV var to "1"
-
-if DEBUG:
+if DEBUGMAKEBOXES:
     skip_or_fail = pytest.mark.xfail
 else:
     skip_or_fail = pytest.mark.skip
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "fail_msg", "msgs"),
+    [
+        ('rb=RowBox[{"a", "b"}]; rb[[1]]', "{a, b}", None, []),
+        ("rb[[0]]", "RowBox", None, []),
+        (
+            "rb[[2]]",
+            "RowBox[{a, b}][[2]]",
+            None,
+            ["Part 2 of RowBox[{a, b}] does not exist."],
+        ),
+        ('fb=FractionBox["1", "2"]; fb[[0]]', "FractionBox", None, []),
+        ("fb[[1]]", "1", None, []),
+        ('sb=StyleBox["string", "Section"]; sb[[0]]', "StyleBox", None, []),
+        ("sb[[1]]", "string", None, []),
+        # FIXME: <<RowBox object does not have the attribute "restructure">>
+        # ('rb[[All, 1]]', "{a, b}", "\"a\"", []),
+        # ('fb[[All]][[1]]','1', None, []),
+        # ('sb[[All]][[1]]','string', None, []),
+    ],
+)
+@skip_or_fail
+def test_part_boxes(str_expr, str_expected, fail_msg, msgs):
+    """
+    This unit test checks that certain typical box structures
+    work together with `Part`. In the current master,
+    these expressions crashes the interpreter.
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=fail_msg,
+        expected_messages=msgs,
+    )
+
 
 # 15 tests
 @pytest.mark.parametrize(
@@ -200,5 +241,308 @@ def test_makeboxes_others_fail(str_expr, str_expected, msg):
         to_string_expr=True,
         to_string_expected=True,
         hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# Fixme: "2." should be "2.`"
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r"MakeBoxes[G[F[2.]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"F","[","2.","]"}],"]"}]',
+            "Standard bahaviour",
+        ),
+        (
+            r'MakeBoxes[F[x_], fmt_] := "F[" <> ToString[x] <> "]";MakeBoxes[G[F[3.002]], StandardForm]',
+            r'RowBox[{"G","[","F[3.002]","]"}]',
+            "Checking the rule over regular (Standard)",
+        ),
+        (
+            r"MakeBoxes[OutputForm[G[F[3.002]]], StandardForm]",
+            # We do not use InterpretationBox   = InterpretationBox[PaneBox["\"G[F[3.002]]\""], OutputForm[G[F[3.002`]]], Rule[Editable, False]]
+            r'RowBox[{"G","[","F[3.002]","]"}]',
+            "Checking the rule over OutputForm",
+        ),
+        (
+            r'Format[F[x_]] := {"Formatted f", {x}, "Standard"};',
+            r"System`Null",
+            "Adding a generic format",
+        ),
+        (
+            r"MakeBoxes[G[F[3.002]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",",", RowBox[{"{","3.002","}"}],"," ,"\"Standard\""}],"}"}],"]"}]',
+            "Checking again, with the defined StandardForm format",
+        ),
+        # InterpretationBox is not used in Mathics  = InterpretationBox[PaneBox["\"G[{Formatted f, {3.002}, Standard}]\""], OutputForm[G[F[3.002`]]], Rule[Editable, False]]
+        (
+            r"MakeBoxes[OutputForm[G[F[3.002]]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",", ", RowBox[{"{","3.002","}"}],", ","\"Standard\""}],"}"}],"]"}]',
+            "Checking again, with the defined StandardForm OutputForm",
+        ),
+        (
+            r'Format[F[x_], StandardForm] :=  {"Formatted f", {x}, "Standard"};Format[F[x_], OutputForm] :=  {"Formatted f", {x}, "Output"};',
+            r"Null",
+            "Defining now specific formats",
+        ),
+        (
+            r"MakeBoxes[G[F[3.002]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",",",RowBox[{"{","3.002","}"}],",","\"Standard\""}],"}"}],"]"}]',
+            "Test Custom StandardForm",
+        ),
+        # InterpretationBox is now used here... = InterpretationBox[PaneBox["\"G[{Formatted f, {3.002}, Output}]\""], OutputForm[G[F[3.002`]]], Rule[Editable, False]]
+        (
+            r"MakeBoxes[OutputForm[G[F[3.002]]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"{",RowBox[{"\"Formatted f\"",", ",RowBox[{"{","3.002","}"}],", ","\"Standard\""}],"}"}],"]"}]',
+            "Test Custom OutputForm",
+        ),
+        (
+            r"ClearAll[F]; MakeBoxes[G[F[2.]], StandardForm]",
+            r'RowBox[{"G","[","F[2.]","]"}]',
+            "Clear Formats",
+        ),
+        (
+            r"MakeBoxes[F[x_], fmt_]=.; MakeBoxes[G[F[2.]], StandardForm]",
+            r'RowBox[{"G","[",RowBox[{"F","[","2.","]"}],"]"}]',
+            "Clear MakeBoxes rule",
+        ),
+    ],
+)
+@skip_or_fail
+def test_makeboxes_custom(str_expr, str_expected, msg):
+    """
+    These tests checks the behaviour of MakeBoxes.
+    Most of them are broken, because our implementation
+    is different that the WMA.
+
+    In WMA, MakeBoxes[...] is not evaluated as
+    other expressions, but behaves like `Format[]`:
+    Format rules (and MakeBoxes) are not taken into
+    account in the regular evaluation.
+    When a MakeBoxes expression is found, then
+    the kernel applies first the format rules,
+    and then the MakeBoxes rules
+
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=False,
+        to_string_expected=False,
+        hold_expected=False,
+        to_python_expected=False,
+        failure_message=msg,
+    )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r'MakeBoxes[F[x__], fmt_] :=  RowBox[{"F", "<~", RowBox[MakeBoxes[#1, fmt] & /@ List[x]], "~>"}]',
+            "Null",
+            "MakeBoxes rule for F",
+        ),
+        #
+        (
+            r'MakeBoxes[G[x___], fmt_] := RowBox[{"G", "<", RowBox[MakeBoxes[#1, fmt] & /@ List[x]], ">"}]',
+            "Null",
+            "MakeBoxes rule for G",
+        ),
+        #
+        (
+            r'MakeBoxes[GG[x___], fmt_] := RowBox[{"GG", "<<", RowBox[MakeBoxes[#1, fmt] & /@ List[x]], ">>"}]',
+            "Null",
+            "MakeBoxes rule for GG",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], StandardForm] := {F[x], "Standard"}',
+            "Null",
+            "Format rule for F, StandardForm",
+        ),
+        #
+        (
+            r'Format[G[x___], StandardForm] :=  {"Standard", GG[x]}',
+            "Null",
+            "Format rule for G, StandardForm",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r"{Standard, GG << {F<~1.`~>, Standard} 0.2` >>}",
+            None,
+        ),
+        #
+        (r'ToString[FullForm[G[F[1., "l"], .2]]]', r'G[F[1.`, "l"], 0.2`]', "FullForm"),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"G[F[1.`, \"l\"], 0.2`]"',
+            "InputForm - no format defined",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"G[F[1.`, l], 0.2`]"',
+            "OutputForm - no format defined",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], InputForm] := {F[x], "In"}',
+            "Null",
+            "Format rule for F, InputForm",
+        ),
+        #
+        (
+            r'Format[G[x___], InputForm] :=  {"In", GG[x]}',
+            "Null",
+            "Format rule for G, OutputForm",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], OutputForm] := {F[x], "Out"}',
+            "Null",
+            "Format rule for F, InputForm",
+        ),
+        #
+        (
+            r'Format[G[x___], OutputForm] :=  {"Out", GG[x]}',
+            "Null",
+            "Format rule for G, OutputForm",
+        ),
+        #
+        (
+            r'Format[F[x_, y_], FullForm] := {F[x], "full"}',
+            "Null",
+            "Format for FullForm. (never used)",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r'"{Standard, GG << {F<~1.`~>, Standard} 0.2` >>}"',
+            "StandardForm - formats defined",
+        ),
+        #
+        (r'ToString[FullForm[G[F[1., "l"], .2]]]', r'"G[F[1.`, \"l\"], 0.2`]"', None),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"{\"In\", GG[{F[1.], \"In\"}, 0.2]}"',
+            "FullForm - formats defined",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"{Out, GG[{F[1.], Out}, 0.2]}"',
+            None,
+        ),
+        #
+        (
+            r'MakeBoxes[G[F[1., "l"], .2], StandardForm]',
+            (
+                r'RowBox[{"{", RowBox[{"\"Standard\"", ",",'
+                r'RowBox[{"GG", "<<", RowBox[{RowBox[{"{",'
+                r'RowBox[{RowBox[{"F", "<~", RowBox[{"1.`"}], "~>"}],'
+                r'",", "\"Standard\""}], "}"}], "0.2`"}], ">>"}]}], "}"}]'
+            ),
+            "MakeBoxes, StandardForm",
+        ),
+        #
+        (
+            r'MakeBoxes[InputForm[G[F[1., "l"]], .2], StandardForm]',
+            (
+                r'InterpretationBox[StyleBox["{\"In\", GG[{F[1.], \"In\"}, 0.2]}", '
+                r"ShowStringCharacters->True, NumberMarks->True], "
+                r'InputForm[G[F[1.`, "l"], 0.2`]], Editable-> True, '
+                r"AutoDelete->True]"
+            ),
+            "MakeBoxes, InputForm",
+        ),
+        #
+        (
+            r'ToString[TeXForm[G[F[1., "l"], .2]]]',
+            r'"G<F<\sim 1.\text{l}\sim >0.2>"',
+            "TeXForm - format defined",
+        ),
+        #
+        (
+            r'ToString[TeXForm[InputForm[G[F[1., "l"], .2]]]]',
+            r'"\text{$\{$In, GG[$\{$F[1.], In$\}$, 0.2]$\}$}"',
+            "TeXForm - InputForm - format defined",
+        ),
+        #
+        (r"ClearAll[F, G, GG]", "Null", "Clear Format rules"),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r'"G < F<~1.`l~>0.2` >"',
+            "StandardForm - formats clear",
+        ),
+        #
+        (
+            r'ToString[FullForm[G[F[1., "l"], .2]]]',
+            r'"G[F[1., \"l\"], 0.2`]"',
+            "FullForm - formats clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"G[F[1., \"l\"], 0.2]"',
+            "InputForm - formats clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"G[F[1., l], 0.2]"',
+            "OutputForm - formats clear",
+        ),
+        #
+        (r"MakeBoxes[F[x__], fmt_]=.", "Null", "Clear MakeBoxes rule for F"),
+        #
+        (r"MakeBoxes[G[x___], fmt_]=.", "Null", "Clear MakeBoxes rule for G"),
+        #
+        (r"MakeBoxes[GG[x___], fmt_]=.", "Null", "Clear MakeBoxes rule for GG"),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], StandardForm]',
+            r'"G[F[1.`, l], 0.2`]"',
+            "StandardForm - Boxes clear",
+        ),
+        #
+        (
+            r'ToString[FullForm[G[F[1., "l"], .2]]]',
+            r'"G[F[1.`, \"l\"], 0.2`]"',
+            "FullForm - Boxes clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], InputForm]',
+            r'"G[F[1., \"l\"], 0.2]"',
+            "InputForm - Boxes clear",
+        ),
+        #
+        (
+            r'ToString[G[F[1., "l"], .2], OutputForm]',
+            r'"G[F[1., l], 0.2]"',
+            "OutputForm - Boxes clear",
+        ),
+    ],
+)
+@skip_or_fail
+def test_makeboxes_custom2(str_expr, str_expected, msg):
+    """
+    These tests checks the behaviour of MakeBoxes.
+    Most of them are broken, because our implementation
+    is different that the WMA.
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=False,
+        to_string_expected=False,
+        hold_expected=False,
+        to_python_expected=False,
         failure_message=msg,
     )

--- a/test/core/parser/test_parser.py
+++ b/test/core/parser/test_parser.py
@@ -694,14 +694,14 @@ class BoxTests(ParserTests):
         self.check("\\(   \\/   \\)", 'FractionBox["", ""]')
 
     def testFormBox(self):
-        self.check("\\( \\` b \\)", 'FormBox["b", StandardForm]')
-        self.check("\\( a \\` b \\)", 'FormBox["b", a]')
-        self.check("\\( a \\` \\)", 'FormBox["", a]')
-        self.check("\\( a \\` b + c \\)", 'FormBox[RowBox[{"b", "+", "c"}], a]')
-        self.check("\\( a \\` b \\` c \\)", 'FormBox[FormBox["c", b], a]')
-        self.check('\\( "a" \\` b \\)', 'FormBox["b", Removed[$$Failure]]')
-        self.check("\\( 3.2 \\` b \\)", 'FormBox["b", Removed[$$Failure]]')
-        self.check("\\( 3.2 + a \\` b \\)", 'FormBox["b", RowBox[{"3.2", "+", "a"}]]')
+        self.check(r"\( \` b \)", 'FormBox["b", StandardForm]')
+        self.check(r"\( a \` b \)", 'FormBox["b", a]')
+        self.check(r"\( a \` \)", 'FormBox["", a]')
+        self.check(r"\( a \` b + c \)", 'FormBox[RowBox[{"b", "+", "c"}], a]')
+        self.check(r"\( a \` b \` c \)", 'FormBox[FormBox["c", b], a]')
+        self.check(r'\( "a" \` b \)', 'FormBox["b", Removed["$$Failure"]]')
+        self.check(r"\( 3.2 \` b \)", 'FormBox["b", Removed["$$Failure"]]')
+        self.check(r"\( 3.2 + a \` b \)", 'FormBox["b", RowBox[{"3.2", "+", "a"}]]')
 
     def testRow(self):
         self.check("\\( \\)", String(""))

--- a/test/core/parser/test_parser.py
+++ b/test/core/parser/test_parser.py
@@ -694,10 +694,14 @@ class BoxTests(ParserTests):
         self.check("\\(   \\/   \\)", 'FractionBox["", ""]')
 
     def testFormBox(self):
-        self.check("\\( 1 \\` b \\)", 'FormBox["b", Removed["$$Failure"]]')
         self.check("\\( \\` b \\)", 'FormBox["b", StandardForm]')
         self.check("\\( a \\` b \\)", 'FormBox["b", a]')
         self.check("\\( a \\` \\)", 'FormBox["", a]')
+        self.check("\\( a \\` b + c \\)", 'FormBox[RowBox[{"b", "+", "c"}], a]')
+        self.check("\\( a \\` b \\` c \\)", 'FormBox[FormBox["c", b], a]')
+        self.check('\\( "a" \\` b \\)', 'FormBox["b", Removed[$$Failure]]')
+        self.check("\\( 3.2 \\` b \\)", 'FormBox["b", Removed[$$Failure]]')
+        self.check("\\( 3.2 + a \\` b \\)", 'FormBox["b", RowBox[{"3.2", "+", "a"}]]')
 
     def testRow(self):
         self.check("\\( \\)", String(""))


### PR DESCRIPTION
This PR starts to fix the issues enumerated (right after) the docstring of `MakeBoxes` (https://github.com/Mathics3/mathics-core/blob/a90d0ad493c7324f2c797b811e7375e802609220/mathics/builtin/makeboxes.py#L374)

In this first round, the behavior of `FormBox` is fixed in a way to  make it closer to the WL expected behavior:

* ``\(a_(String|Real|Integer) ` b_ \)`` is parsed as `FormBox[ToBoxes[b], Removed[$$Failure]]` (notice that the argument of `Removed` is a `Symbol` not a `String`).
* ``\(a_Symbol \` b_ \)`` is parsed as `FormBox[ToBoxes[b], a]`
* Otherwise, ``\(a_ \` b_ \)`` is parsed as `FormBox[b, ToBoxes[a]]`

Tests were adjusted  accordingly.






<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/545"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

