### PR TITLE
Use Integer 0 when we have a relative precision of the value 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,14 +23,14 @@ Documentation
 
 #. "Functional Programming" section split out.
 #. "Exponential Functional" split out from "Trigonometry Functions"
-
+#. A new section on "Accuracy and Precision" was included in the manual.
 
 Internals
 +++++++++
 
 #. ``boxes_to_`` methods are now optional for ``BoxElement`` subclasses. Most of the code is now moved to the ``mathics.format`` submodule, and implemented in a more scalable way.
 #. ``mathics.builtin.inout`` was splitted in several modules (``inout``, ``messages``, ``layout``, ``makeboxes``) in order to improve the documentation.
-
+# ``0`` with a given precision (like in ```0`3```) is now parsed as ``0``, an integer number. 
 
 
 Enhancements

--- a/mathics/core/parser/convert.py
+++ b/mathics/core/parser/convert.py
@@ -114,6 +114,9 @@ class GenericConverter:
                     prec10,
                 )
             else:
+                # "0`3"->0
+                if node.value == "0":
+                    return "Integer", 0
                 return (
                     "PrecisionReal",
                     ("DecimalString", str("-" + s if sign == -1 else s)),

--- a/mathics/core/parser/convert.py
+++ b/mathics/core/parser/convert.py
@@ -102,8 +102,13 @@ class GenericConverter:
             elif suffix == "":
                 return "MachineReal", sign * float(s)
             elif suffix.startswith("`"):
+                # A double Reversed Prime ("``") represents a fixed accuracy
+                # (absolute uncertainty).
                 acc = float(suffix[1:])
                 x = float(s)
+                # For 0, a finite absolute precision even if
+                # the number is an integer, it is stored as a
+                # PrecisionReal number.
                 if x == 0:
                     prec10 = acc
                 else:
@@ -114,7 +119,10 @@ class GenericConverter:
                     prec10,
                 )
             else:
-                # "0`3"->0
+                # A single Reversed Prime ("`") represents a fixed precision
+                # (relative uncertainty).
+                # For 0, a finite relative precision reduces to no uncertainty,
+                # so ``` 0`3 === 0 ``` and  ``` 0.`3 === 0.`4 ```
                 if node.value == "0":
                     return "Integer", 0
                 return (

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -194,6 +194,49 @@ The result of the previous query to \Mathics can be accessed by '%':
   ##
 </section>
 
+<section title="Precision and Accuracy">
+
+\Mathics handles relative ('Precision') and absolute ('Accuracy') uncertanties in numerical quantities. 'Precision' is set by adding a single reversed quote $`$
+and the numerical value of the precision right after the last digit of the mantissa. For example,
+
+  >> a = 3.1416`4
+   = 3.142
+
+set $a$ with a number having a relative uncertainty of $10^{-3}$, in a way that this number is numerically equivalent to $3.1413`4$:
+
+  >> a == 3.1413`4
+   = True
+
+We can recover the precision of the number by using  'Precision' 
+
+    >> Precision[a]
+     = 4.
+
+
+In a similar way, 'Accuracy' is set by adding a double reversed quote $``$
+and the numerical value of the accuracy right after the last digit of the mantissa. For example,
+
+  >> a = 13.1416``4
+   = 13.142
+
+set $a$ with a number having a absolute uncertainty of $10^{-4}$, in a way that this number is numerically equivalent to $13.1413``4$:
+
+  >> a == 13.1413``4
+   = True
+
+For $0$, 'Precision' is ignored, since corresponds to a zero uncertainty:
+
+  >> 0`4
+   = 0
+
+while 'Accuracy' is taken into account by storing the value as a fixed precision Real number:
+
+  >> 0``4
+   = 0.0000
+
+</section>
+
+
 <section title="Symbols and Assignments">
 Symbols need not be declared in \Mathics, they can just be entered and remain variable:
   >> x

--- a/test/core/parser/test_convert.py
+++ b/test/core/parser/test_convert.py
@@ -78,7 +78,10 @@ class ConvertTests(unittest.TestCase):
         self.check("1.5`", Real("1.5"))
         self.check("0.0", Real(0))
         self.check("-1.5`", Real("-1.5"))
-
+        self.check("0`3", Integer(0))
+        self.check("0``3", "0.000`3")
+        self.check("0.`3", "0.000`3")
+        self.check("0.``3", "0.000``3")
         self.check("0.00000000000000000", "0.")
         self.check("0.000000000000000000`", "0.")
         self.check("0.000000000000000000", "0.``18")


### PR DESCRIPTION
In WL, ```n`p``` represents a number `n` with precision  `p`, which means that the number is defined up to an error `dn ~ n * 10^-p`. In particular, in WMA and in Mathics,

```
In[1]:=0.`5
```
is parsed as ```Out[1]=0.x 10^-5```. On the other hand, in WMA,  ```0`5``` (without the decimal point) is parsed as `0` (an `Integer`), but in the current master of Mathics, it is parsed also as   `0. x 10^-5`. This PR changes this behavior to make it compatible with the expected in WMA. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/546"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

