### PR TITLE
earlier load of formatters

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -108,6 +108,12 @@ class Definitions:
         )
         self.trace_evaluation = False
         self.timing_trace_evaluation = False
+
+        # This loads all the formatting functions.
+        # Needs to be early because it can be used in
+        # messages during the builtins loading.
+        import mathics.format
+
         if add_builtin:
             from mathics.builtin import modules, contribute
             from mathics.settings import ROOT_DIR
@@ -151,14 +157,6 @@ class Definitions:
             self.builtin.update(self.user)
             self.user = {}
             self.clear_cache()
-
-        # This loads all the formatting functions
-        import mathics.format
-
-        # FIXME load dynamically as we do other things
-        # import mathics.format.asy  # noqa
-        # import mathics.format.json  # noqa
-        # import mathics.format.svg  # noqa
 
     def load_pymathics_module(self, module, remove_on_quit=True):
         """

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -341,10 +341,6 @@ class BaseElement(KeyComparable):
         """Convert's a Mathics Sequence into a Python's list of elements"""
         from mathics.core.symbols import SymbolSequence
 
-        # FIXME: using the below test causes:
-        # TypeError: boxes_to_text() takes 1 positional argument but 2 were given
-        # Why?
-        # if hasattr(self, "element"):
         if self.get_head() is SymbolSequence:
             return self.elements
         else:


### PR DESCRIPTION
This PR moves the loading of formatter functions at an early position in the `mathics.core.definitions` module. This fixes the issue mentioned in https://github.com/Mathics3/mathics-core/blob/2a716c9f332555032fc7aafc3855dcfc9b6a809f/mathics/core/element.py#L344

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/548"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

