### PR TITLE
Removing the n_evaluation parameter from the `to_python` method

### DIFF
--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -25,8 +25,11 @@ from mathics.builtin.drawing.graphics3d import (
 )
 
 from mathics.builtin.drawing.graphics_internals import get_class
-from mathics.core.symbols import Symbol, SymbolTrue
+
+
 from mathics.core.formatter import lookup_method
+from mathics.core.evaluators import eval_N
+from mathics.core.symbols import Symbol, SymbolTrue
 
 
 class Graphics3DBox(GraphicsBox):
@@ -182,7 +185,7 @@ class Graphics3DBox(GraphicsBox):
 
         # ViewPoint Option
         viewpoint_option = self.graphics_options["System`ViewPoint"]
-        viewpoint = viewpoint_option.to_python(n_evaluation=evaluation)
+        viewpoint = eval_N(viewpoint_option, evaluation).to_python()
 
         if isinstance(viewpoint, list) and len(viewpoint) == 3:
             if all(isinstance(x, numbers.Real) for x in viewpoint):

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -464,7 +464,7 @@ class _Plot(Builtin):
             return False
 
         plotrange_option = self.get_option(options, "PlotRange", evaluation)
-        plotrange = plotrange_option.to_python(n_evaluation=evaluation)
+        plotrange = eval_N(plotrange_option, evaluation).to_python()
         x_range, y_range = self.get_plotrange(plotrange, start, stop)
         if not check_range(x_range) or not check_range(y_range):
             evaluation.message(self.get_name(), "prng", plotrange_option)
@@ -531,7 +531,7 @@ class _Plot(Builtin):
             return True
 
         exclusions_option = self.get_option(options, "Exclusions", evaluation)
-        exclusions = exclusions_option.to_python(n_evaluation=evaluation)
+        exclusions = eval_N(exclusions_option, evaluation).to_python()
         # TODO Turn expressions into points E.g. Sin[x] == 0 becomes 0, 2 Pi...
 
         if exclusions in ["System`None", ["System`None"]]:
@@ -1479,7 +1479,7 @@ class _ListPlot(Builtin):
         "%(name)s[points_, OptionsPattern[%(name)s]]"
 
         plot_name = self.get_name()
-        all_points = points.to_python(n_evaluation=evaluation)
+        all_points = eval_N(points, evaluation).to_python()
         # FIXME: arrange forself to have a .symbolname property or attribute
         expr = Expression(Symbol(self.get_name()), points, *options_to_rules(options))
 
@@ -1495,7 +1495,7 @@ class _ListPlot(Builtin):
             return False
 
         plotrange_option = self.get_option(options, "PlotRange", evaluation)
-        plotrange = plotrange_option.to_python(n_evaluation=evaluation)
+        plotrange = eval_N(plotrange_option, evaluation).to_python()
         if plotrange == "System`All":
             plotrange = ["System`All", "System`All"]
         elif plotrange == "System`Automatic":
@@ -1522,7 +1522,7 @@ class _ListPlot(Builtin):
         # Filling option
         # TODO: Fill between corresponding points in two datasets:
         filling_option = self.get_option(options, "Filling", evaluation)
-        filling = filling_option.to_python(n_evaluation=evaluation)
+        filling = eval_N(filling_option, evaluation).to_python()
         if filling in [
             "System`Top",
             "System`Bottom",

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -28,6 +28,7 @@ from mathics.core.attributes import (
 )
 from mathics.core.convert.expression import to_expression, to_mathics_list
 from mathics.core.convert.python import from_python
+from mathics.core.evaluators import eval_N
 from mathics.core.expression import Expression
 from mathics.core.streams import (
     HOME_DIR,
@@ -830,9 +831,10 @@ class FileDate(Builtin):
             return
 
         # Offset for system epoch
-        epochtime = Expression(
+        epochtime_expr = Expression(
             SymbolAbsoluteTime, String(time.strftime("%Y-%m-%d %H:%M", time.gmtime(0)))
-        ).to_python(n_evaluation=evaluation)
+        )
+        epochtime = eval_N(epochtime_expr, evaluation).to_python()
         result += epochtime
 
         return to_expression("DateList", Real(result))
@@ -2149,7 +2151,7 @@ class SetFileDate(Builtin):
         )
 
         stattime = to_expression("AbsoluteTime", from_python(py_datelist))
-        stattime = stattime.to_python(n_evaluation=evaluation)
+        stattime = eval_N(stattime, evaluation).to_python()
 
         stattime -= epochtime
 

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -494,8 +494,23 @@ class NextPrime(Builtin):
 
     def apply(self, n, k, evaluation):
         "NextPrime[n_?NumberQ, k_Integer]"
-        py_k = k.to_python(n_evaluation=evaluation)
-        py_n = n.to_python(n_evaluation=evaluation)
+
+        def to_int_value(x):
+            if isinstance(x, Integer):
+                return x.value
+            x = eval_N(x, evaluation)
+            if isinstance(x, Integer):
+                return x.value
+            elif isinstance(x, Real):
+                return round(x.value)
+            else:
+                return None
+
+        py_k = to_int_value(k)
+        if py_k is None:
+            return None
+
+        py_n = n.value
 
         if py_k >= 0:
             return Integer(sympy.ntheory.nextprime(py_n, py_k))
@@ -606,7 +621,7 @@ class PrimePi(SympyFunction):
 
     def apply(self, n, evaluation):
         "PrimePi[n_?NumericQ]"
-        result = sympy.ntheory.primepi(n.to_python(n_evaluation=evaluation))
+        result = sympy.ntheory.primepi(eval_N(n, evaluation).to_python())
         return Integer(result)
 
 

--- a/mathics/core/convert/function.py
+++ b/mathics/core/convert/function.py
@@ -74,7 +74,7 @@ def expression_to_callable(
                 vars = dict(list(zip([a.name for a in args], x_mathics)))
                 pyexpr = expr.replace_vars(vars)
                 pyexpr = eval_N(pyexpr, inner_evaluation)
-                res = pyexpr.to_python(n_evaluation=inner_evaluation)
+                res = pyexpr.to_python()
                 return res
 
             # TODO: check if we can use numba to compile this...

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -422,10 +422,26 @@ class BaseElement(KeyComparable):
         # __hash__ might only hash a sample of the data available.
         raise NotImplementedError
 
-    def to_sympy(self, **kwargs):
+    def to_python(self, *args, python_form: bool = False, **kwargs):
+        # Returns a native builtin Python object
+        # something in (int, float, complex, str, tuple, list or dict.).
+        # (See discussions in
+        #  https://github.com/Mathics3/mathics-core/discussions/550
+        # and
+        # https://github.com/Mathics3/mathics-core/pull/551
+        #
+        #
+        # if n_evaluation is an Evaluation object, then the expression
+        # is passed by an eval_N().
+        # If python_form is True, the standard behaviour is changed,
+        # and it seems to behave like to_sympy....
+
         raise NotImplementedError
 
     def to_mpmath(self):
+        raise NotImplementedError
+
+    def to_sympy(self, **kwargs):
         raise NotImplementedError
 
 


### PR DESCRIPTION
Following the line of attempts to clarify, document, and remove flaky practices from the code, I collected in this PR the part of #551 in which @rocky seems to agree.

* adding the prototype of `to_python` in `BaseElement`.
* adding type annotations to its parameters.
* removing the use of the parameter n_evaluation in ``expr.to_python(n_evaluation=evaluation)`` in favor of ``eval_N(expr, evaluation).to_python()``.
* in the modified functions, make changes to avoid the same variable to represent objects of different classes from one line to the next one.
* adding several comments.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/552"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

