### PR TITLE
moving pending doctests in MakeBoxes to pytests

### DIFF
--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -309,7 +309,7 @@ def number_form(expr, n, f, evaluation, options):
 
 # TODO: Differently from the current implementation, MakeBoxes should only
 # accept as its format field the symbols in `$BoxForms`. This is something to
-# fix in a following step.
+# fix in a following step, changing the way in which Format and MakeBoxes work.
 
 
 class BoxForms_(Predefined):
@@ -374,91 +374,6 @@ class MakeBoxes(Builtin):
      = (a <> b)[x]
     """
 
-    # TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
-    """
-    >> \\(a + b\\)
-     = RowBox[{a, +, b}]
-
-    >> \\(TraditionalForm \\` a + b\\)
-     = FormBox[RowBox[{a, +, b}], TraditionalForm]
-
-    >> \\(x \\/ \\(y + z\\)\\)
-     =  FractionBox[x, RowBox[{y, +, z}]]
-    """
-
-    # TODO: Constructing boxes from Real
-    """
-    ## Test Real MakeBoxes
-    #> MakeBoxes[1.4]
-     = 1.4`
-    #> MakeBoxes[1.4`]
-     = 1.4`
-    #> MakeBoxes[1.5`20]
-     = 1.5`20.
-    #> MakeBoxes[1.4`20]
-     = 1.4`20.
-    #> MakeBoxes[1.5``20]
-     = 1.5`20.1760912591
-    #> MakeBoxes[-1.4]
-     = RowBox[{-, 1.4`}]
-    #> MakeBoxes[34.*^3]
-     = 34000.`
-
-    #> MakeBoxes[0`]
-     = 0.`
-    #> MakeBoxes[0`3]
-     = 0
-    #> MakeBoxes[0``30]
-     = 0.``30.
-    #> MakeBoxes[0.`]
-     = 0.`
-    #> MakeBoxes[0.`3]
-     = 0.`
-    #> MakeBoxes[0.``30]
-     = 0.``30.
-
-    #> MakeBoxes[14]
-     = 14
-    #> MakeBoxes[-14]
-     = RowBox[{-, 14}]
-    """
-
-    # TODO: Correct precedence
-    """
-    >> \\(x \\/ y + z\\)
-     = RowBox[{FractionBox[x, y], +, z}]
-    >> \\(x \\/ (y + z)\\)
-     = FractionBox[x, RowBox[{(, RowBox[{y, +, z}], )}]]
-
-    #> \\( \\@ a + b \\)
-     = RowBox[{SqrtBox[a], +, b}]
-    """
-
-    # FIXME: Don't insert spaces with brackets
-    """
-    #> \\(c (1 + x)\\)
-     = RowBox[{c, RowBox[{(, RowBox[{1, +, x}], )}]}]
-    """
-
-    # TODO: Required MakeExpression
-    """
-    #> \\!\\(x \\^ 2\\)
-     = x ^ 2
-    #> FullForm[%]
-     = Power[x, 2]
-    """
-
-    # TODO: Fix Infix operators
-    """
-    >> MakeBoxes[1 + 1]
-     = RowBox[{1, +, 1}]
-    """
-
-    # TODO: Parsing of special characters (like commas)
-    """
-    >> \\( a, b \\)
-     = RowBox[{a, ,, b}]
-    """
     attributes = A_HOLD_ALL_COMPLETE
 
     rules = {

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -3,6 +3,29 @@ import pytest
 from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
+
+# 15 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"MakeBoxes[0`3]", r"0", None),
+        (r"MakeBoxes[14]", r"14", None),
+    ],
+)
+def test_makeboxes_real(str_expr, str_expected, msg):
+    """
+    # TODO: Constructing boxes from Real
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
 # 15 tests
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
@@ -12,20 +35,18 @@ from mathics_scanner.errors import IncompleteSyntaxError
         (r"MakeBoxes[1.5`20]", r"1.5`20.", None),
         (r"MakeBoxes[1.4`20]", r"1.4`20.", None),
         (r"MakeBoxes[1.5``20]", r"1.5`20.1760912591", None),
-        (r"MakeBoxes[-1.4]", r'RowBox[{"-", 1.4`}]', None),
+        (r"MakeBoxes[-1.4]", r"RowBox[{-, 1.4`}]", None),
         (r"MakeBoxes[34.*^3]", r"34000.`", None),
         (r"MakeBoxes[0`]", r"0.`", None),
-        (r"MakeBoxes[0`3]", r"0", None),
         (r"MakeBoxes[0``30]", r"0.``30.", None),
         (r"MakeBoxes[0.`]", r"0.`", None),
         (r"MakeBoxes[0.`3]", r"0.`", None),
         (r"MakeBoxes[0.``30]", r"0.``30.", None),
-        (r"MakeBoxes[14]", r"14", None),
-        (r"MakeBoxes[-14]", r'RowBox[{"-", 14}]', None),
+        (r"MakeBoxes[-14]", r"RowBox[{-, 14}]", None),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_real(str_expr, str_expected, msg):
+def test_makeboxes_real_fail(str_expr, str_expected, msg):
     """
     # TODO: Constructing boxes from Real
     """
@@ -43,17 +64,35 @@ def test_makeboxes_real(str_expr, str_expected, msg):
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        (r"\(x \/ y + z\)", r'RowBox[{FractionBox["x", "y"], "+", "z"}]', None),
+        (r"\(x \/ y + z\)", r"RowBox[{FractionBox[x, y], +, z}]", None),
+        (r"\( \@ a + b \)", r"RowBox[{SqrtBox[a], +, b}]", None),
+    ],
+)
+def test_makeboxes_precedence(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 2 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
         (
             r"\(x \/ (y + z)\)",
-            r'FractionBox["x", RowBox[{"(", RowBox[{"y", "+", "z"}], ")"}]]',
+            r"FractionBox[x, RowBox[{(, RowBox[{y, +, z}], )}]]",
             None,
         ),
-        (r"\( \@ a + b \)", r'RowBox[{SqrtBox["a"], "+", "b"}]', None),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_precedence(str_expr, str_expected, msg):
+def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
     """ """
     check_evaluation(
         str_expr,
@@ -70,17 +109,59 @@ def test_makeboxes_precedence(str_expr, str_expected, msg):
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        (r"\(a + b\)", r'RowBox[{"a", "+", "b"}]', None),
+        (r"\(a + b\)", r"RowBox[{a, +, b}]", None),
+        (r"\(x \/ \(y + z\)\)", r"FractionBox[x, RowBox[{y, +, z}]]", None),
+    ],
+)
+def test_makeboxes_representation(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 3 tests
+# TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
         (
             r"\(TraditionalForm \` a + b\)",
-            r'FormBox[RowBox[{"a", "+", "b"}], TraditionalForm]',
+            r"FormBox[RowBox[{a, +, b}], TraditionalForm]",
             None,
         ),
-        (r"\(x \/ \(y + z\)\)", r'FractionBox["x", RowBox[{"y", "+", "z"}]]', None),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_representation(str_expr, str_expected, msg):
+def test_makeboxes_representation_fail(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+#  5 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r"\( a, b \)",
+            r"RowBox[{a, ,, b}]",
+            "TODO: Parsing of special characters (like commas)",
+        ),
+    ],
+)
+def test_makeboxes_others(str_expr, str_expected, msg):
     """ """
     check_evaluation(
         str_expr,
@@ -98,24 +179,18 @@ def test_makeboxes_representation(str_expr, str_expected, msg):
     [
         (
             r"\(c (1 + x)\)",
-            r'RowBox[{"c", RowBox[{"(", RowBox[{"1", "+", "x"}], ")"}]}]',
+            r"RowBox[{c, RowBox[{(, RowBox[{1, +, x}], )}]}]",
             r"FIXME: Don't insert spaces with brackets",
         ),
         (r"\!\(x \^ 2\)", r"x ^ 2", "Required MakeExpression"),
         #
-        (r"FullForm[%]", r'Power["x", "2"]', "Required MakeExpression"),
+        (r"FullForm[%]", r"Power[x, 2]", "Required MakeExpression"),
         #
-        (r"MakeBoxes[1 + 1]", r'RowBox[{"1", "+", "1"}]', "TODO: Fix Infix operators"),
-        #
-        (
-            r"\( a, b \)",
-            r'RowBox[{"a", ",", "b"}]',
-            "TODO: Parsing of special characters (like commas)",
-        ),
+        (r"MakeBoxes[1 + 1]", r"RowBox[{1, +, 1}]", "TODO: Fix Infix operators"),
     ],
 )
 @pytest.mark.xfail
-def test_makeboxes_others(str_expr, str_expected, msg):
+def test_makeboxes_others_fail(str_expr, str_expected, msg):
     """ """
     check_evaluation(
         str_expr,

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+import pytest
+from test.helper import check_evaluation, session
+from mathics_scanner.errors import IncompleteSyntaxError
+
+# 15 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"MakeBoxes[1.4]", r"1.4`", None),
+        (r"MakeBoxes[1.4`]", r"1.4`", None),
+        (r"MakeBoxes[1.5`20]", r"1.5`20.", None),
+        (r"MakeBoxes[1.4`20]", r"1.4`20.", None),
+        (r"MakeBoxes[1.5``20]", r"1.5`20.1760912591", None),
+        (r"MakeBoxes[-1.4]", r'RowBox[{"-", 1.4`}]', None),
+        (r"MakeBoxes[34.*^3]", r"34000.`", None),
+        (r"MakeBoxes[0`]", r"0.`", None),
+        (r"MakeBoxes[0`3]", r"0", None),
+        (r"MakeBoxes[0``30]", r"0.``30.", None),
+        (r"MakeBoxes[0.`]", r"0.`", None),
+        (r"MakeBoxes[0.`3]", r"0.`", None),
+        (r"MakeBoxes[0.``30]", r"0.``30.", None),
+        (r"MakeBoxes[14]", r"14", None),
+        (r"MakeBoxes[-14]", r'RowBox[{"-", 14}]', None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_real(str_expr, str_expected, msg):
+    """
+    # TODO: Constructing boxes from Real
+    """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 3 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"\(x \/ y + z\)", r'RowBox[{FractionBox["x", "y"], "+", "z"}]', None),
+        (
+            r"\(x \/ (y + z)\)",
+            r'FractionBox["x", RowBox[{"(", RowBox[{"y", "+", "z"}], ")"}]]',
+            None,
+        ),
+        (r"\( \@ a + b \)", r'RowBox[{SqrtBox["a"], "+", "b"}]', None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_precedence(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+# 3 tests
+# TODO: Convert operators to appropriate representations e.g. 'Plus' to '+'
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (r"\(a + b\)", r'RowBox[{"a", "+", "b"}]', None),
+        (
+            r"\(TraditionalForm \` a + b\)",
+            r'FormBox[RowBox[{"a", "+", "b"}], TraditionalForm]',
+            None,
+        ),
+        (r"\(x \/ \(y + z\)\)", r'FractionBox["x", RowBox[{"y", "+", "z"}]]', None),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_representation(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )
+
+
+#  5 tests
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            r"\(c (1 + x)\)",
+            r'RowBox[{"c", RowBox[{"(", RowBox[{"1", "+", "x"}], ")"}]}]',
+            r"FIXME: Don't insert spaces with brackets",
+        ),
+        (r"\!\(x \^ 2\)", r"x ^ 2", "Required MakeExpression"),
+        #
+        (r"FullForm[%]", r'Power["x", "2"]', "Required MakeExpression"),
+        #
+        (r"MakeBoxes[1 + 1]", r'RowBox[{"1", "+", "1"}]', "TODO: Fix Infix operators"),
+        #
+        (
+            r"\( a, b \)",
+            r'RowBox[{"a", ",", "b"}]',
+            "TODO: Parsing of special characters (like commas)",
+        ),
+    ],
+)
+@pytest.mark.xfail
+def test_makeboxes_others(str_expr, str_expected, msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
+import os
 import pytest
 from test.helper import check_evaluation, session
 from mathics_scanner.errors import IncompleteSyntaxError
 
+
+DEBUG = int(os.environ.get("DEBUG", "0")) == 1  # To set to True, set ENV var to "1"
+
+if DEBUG:
+    skip_or_fail = pytest.mark.xfail
+else:
+    skip_or_fail = pytest.mark.skip
 
 # 15 tests
 @pytest.mark.parametrize(
@@ -14,7 +22,7 @@ from mathics_scanner.errors import IncompleteSyntaxError
 )
 def test_makeboxes_real(str_expr, str_expected, msg):
     """
-    # TODO: Constructing boxes from Real
+    # Constructing boxes from Real
     """
     check_evaluation(
         str_expr,
@@ -45,10 +53,10 @@ def test_makeboxes_real(str_expr, str_expected, msg):
         (r"MakeBoxes[-14]", r"RowBox[{-, 14}]", None),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_real_fail(str_expr, str_expected, msg):
     """
-    # TODO: Constructing boxes from Real
+    # TODO: Constructing boxes from Real which are currently failing
     """
     check_evaluation(
         str_expr,
@@ -69,7 +77,7 @@ def test_makeboxes_real_fail(str_expr, str_expected, msg):
     ],
 )
 def test_makeboxes_precedence(str_expr, str_expected, msg):
-    """ """
+    """Test precedence in string-like boxes"""
     check_evaluation(
         str_expr,
         str_expected,
@@ -91,9 +99,9 @@ def test_makeboxes_precedence(str_expr, str_expected, msg):
         ),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
-    """ """
+    """TODO: fix the parsing for testing precedence in string-like boxes ("""
     check_evaluation(
         str_expr,
         str_expected,
@@ -114,7 +122,6 @@ def test_makeboxes_precedence_fail(str_expr, str_expected, msg):
     ],
 )
 def test_makeboxes_representation(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,
@@ -137,9 +144,8 @@ def test_makeboxes_representation(str_expr, str_expected, msg):
         ),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_representation_fail(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,
@@ -162,7 +168,6 @@ def test_makeboxes_representation_fail(str_expr, str_expected, msg):
     ],
 )
 def test_makeboxes_others(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,
@@ -183,15 +188,12 @@ def test_makeboxes_others(str_expr, str_expected, msg):
             r"FIXME: Don't insert spaces with brackets",
         ),
         (r"\!\(x \^ 2\)", r"x ^ 2", "Required MakeExpression"),
-        #
         (r"FullForm[%]", r"Power[x, 2]", "Required MakeExpression"),
-        #
         (r"MakeBoxes[1 + 1]", r"RowBox[{1, +, 1}]", "TODO: Fix Infix operators"),
     ],
 )
-@pytest.mark.xfail
+@skip_or_fail
 def test_makeboxes_others_fail(str_expr, str_expected, msg):
-    """ """
     check_evaluation(
         str_expr,
         str_expected,


### PR DESCRIPTION
This PR moves several doctests (mostly about broken behavior) associated to MakeBoxes to (xfailed) pytest tests.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/558"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

