### PR TITLE
Fixing a typo in scipy_utils/integrators.py. Improving checks.

### DIFF
--- a/mathics/builtin/scipy_utils/integrators.py
+++ b/mathics/builtin/scipy_utils/integrators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
-from mathics.builtin import check_requires_list
-from mathics.core.utils import IS_PYPY
+from mathics.builtin.base import check_requires_list
+from mathics.core.util import IS_PYPY
 
 if IS_PYPY or not check_requires_list(["scipy", "numpy"]):
     raise ImportError

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -64,8 +64,18 @@ if check_requires_list(["scipy", "scipy.integrate"]):
 
 else:
     tests_for_findminimum = [
-        (r"MatchQ[FindMinimum[Cos[x]^2, {x,1.}],{_Real,{x->_Real}}]", r"True", ""),
-        (r"MatchQ[FindMaximum[Cos[x]^2, {x,1.}], {_Real,{x->_Real}}]", r"True", ""),
+        (
+            r"MatchQ[FindMinimum[Cos[x]^2, {x,1.}],{_Real,{x->_Real}}]",
+            r"True",
+            "",
+            None,
+        ),
+        (
+            r"MatchQ[FindMaximum[Cos[x]^2, {x,1.}], {_Real,{x->_Real}}]",
+            r"True",
+            "",
+            None,
+        ),
     ]
     tests_for_findroot = [
         (r"MatchQ[FindRoot[Cos[x+1.5], {x,.1}], {x->_Real}]", r"True", ""),

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -9,6 +9,7 @@ FindRoot[], FindMinimum[], NFindMaximum[] tests
 
 """
 import pytest
+from typing import Optional
 from test.helper import evaluate, check_evaluation
 from mathics.builtin.base import check_requires_list
 
@@ -30,12 +31,21 @@ if check_requires_list(["scipy", "scipy.integrate"]):
     tests_for_findminimum = sum(
         [
             [
-                (tst[0].replace("{method}", "Method->" + method), tst[1], tst[2])
+                (tst[0].replace("{method}", "Method->" + method), tst[1], tst[2], None)
                 for tst in generic_tests_for_findminimum
             ]
             for method in methods_findminimum
         ],
-        [],
+        [
+            (
+                r"MatchQ[FindMaximum[Cos[x]^2, {x,1.}, Method->Newton], {_Real,{x->_Real}}]",
+                r"True",
+                r"check message",
+                [
+                    r"Encountered a gradient that is effectively zero. The result returned may not be a maximum; it may be a minimum or a saddle point."
+                ],
+            )
+        ],
     )
     methods_findroot = ["Automatic", "Newton", "Secant", "brenth"]
     generic_tests_for_findroot = [
@@ -69,17 +79,18 @@ tests_for_integrate = [
 
 
 @pytest.mark.parametrize(
-    "str_expr, str_expected, assert_fail_message", tests_for_findminimum
+    "str_expr, str_expected, assert_fail_message, expected_messages",
+    tests_for_findminimum,
 )
 def test_findminimum(
-    str_expr: str, str_expected: str, assert_fail_message: str, message=""
+    str_expr: str,
+    str_expected: str,
+    assert_fail_message: str,
+    expected_messages: Optional[list],
 ):
-    result = evaluate(str_expr)
-    expected = evaluate(str_expected)
-    if assert_fail_message:
-        assert result == expected, assert_fail_message
-    else:
-        assert result == expected
+    check_evaluation(
+        str_expr, str_expected, assert_fail_message, expected_messages=expected_messages
+    )
 
 
 @pytest.mark.parametrize(
@@ -88,24 +99,14 @@ def test_findminimum(
 def test_findroot(
     str_expr: str, str_expected: str, assert_fail_message: str, message=""
 ):
-    result = evaluate(str_expr)
-    expected = evaluate(str_expected)
-    if assert_fail_message:
-        assert result == expected, assert_fail_message
-    else:
-        assert result == expected
+    check_evaluation(str_expr, str_expected, assert_fail_message, expected_messages=[])
 
 
 @pytest.mark.parametrize(
     "str_expr, str_expected, assert_fail_message", tests_for_integrate
 )
 def test_integrate(str_expr: str, str_expected: str, assert_fail_message):
-    result = evaluate(str_expr)
-    expected = evaluate(str_expected)
-    if assert_fail_message:
-        assert result == expected, assert_fail_message
-    else:
-        assert result == expected
+    check_evaluation(str_expr, str_expected, assert_fail_message, expected_messages=[])
 
 
 @pytest.mark.parametrize(

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -5,11 +5,13 @@ Unit tests for mathics.buitin.numbers.nintegrate
 NIntegrate[] tests
 
 """
-from test.helper import evaluate
+from test.helper import check_evaluation
+from typing import Optional
 
 import pytest
 
 from mathics.builtin.base import check_requires_list
+
 
 if check_requires_list(["scipy", "scipy.integrate"]):
     methods = ["Automatic", "Romberg", "Internal", "NQuadrature"]
@@ -28,12 +30,21 @@ if check_requires_list(["scipy", "scipy.integrate"]):
     tests_for_nintegrate = sum(
         [
             [
-                (tst[0].replace("{method}", "Method->" + method), tst[1], tst[2])
+                (tst[0].replace("{method}", "Method->" + method), tst[1], tst[2], [])
                 for tst in generic_tests_for_nintegrate
             ]
             for method in methods
         ],
-        [],
+        [
+            (
+                r'NIntegrate[1., {x,0,1}, Method->"NotAMethod"]',
+                "1.",
+                None,
+                [
+                    r"The Method option should be a built-in method name in {`Automatic`, `Internal`, `Simpson`}. Using `Automatic`"
+                ],
+            )
+        ],
     )
 else:
     tests_for_nintegrate = [
@@ -41,14 +52,21 @@ else:
         (r"NIntegrate[x^2 y^2, {y,0,1}, {x,0,1}]", r"1/9.", ""),
         # FIXME: this can integrate to Infinity
         # (r"NIntegrate[x^2 y^(-.5), {x,0,1},{y,0,1}]", r"1.", ""),
+        (
+            r'NIntegrate[1., {x,0,1}, Method->"NotAMethod"]',
+            "1.",
+            None,
+            [
+                r"The Method option should be a built-in method name in {`Automatic`, `Internal`, `Simpson`}. Using `Automatic`"
+            ],
+        ),
     ]
 
 
-@pytest.mark.parametrize("str_expr, str_expected, msg", tests_for_nintegrate)
-def test_nintegrate(str_expr: str, str_expected: str, msg: str, message=""):
-    result = evaluate(str_expr)
-    expected = evaluate(str_expected)
-    if msg:
-        assert result == expected, msg
-    else:
-        assert result == expected
+@pytest.mark.parametrize("str_expr, str_expected, msg, messages", tests_for_nintegrate)
+def test_nintegrate(
+    str_expr: str, str_expected: str, msg: str, messages: Optional[list]
+):
+    check_evaluation(
+        str_expr, str_expected, failure_message=msg, expected_messages=messages
+    )

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -30,20 +30,26 @@ if check_requires_list(["scipy", "scipy.integrate"]):
     tests_for_nintegrate = sum(
         [
             [
-                (tst[0].replace("{method}", "Method->" + method), tst[1], tst[2], [])
+                (tst[0].replace("{method}", "Method->" + method), tst[1], tst[2], None)
                 for tst in generic_tests_for_nintegrate
             ]
             for method in methods
         ],
         [
             (
+                r'NIntegrate[1., {x,0,1}, Method->"Quadrature"]',
+                "1.",
+                "Check that the library is already loaded.",
+                [],
+            ),
+            (
                 r'NIntegrate[1., {x,0,1}, Method->"NotAMethod"]',
                 "1.",
                 None,
                 [
-                    r"The Method option should be a built-in method name in {`Automatic`, `Internal`, `Simpson`}. Using `Automatic`"
+                    r"The Method option should be a built-in method name in {`Automatic`, `Internal`, `Simpson`, `NQuadrature`, `Quadrature`, `Romberg`}. Using `Automatic`"
                 ],
-            )
+            ),
         ],
     )
 else:

--- a/test/builtin/numbers/test_nintegrate.py
+++ b/test/builtin/numbers/test_nintegrate.py
@@ -54,8 +54,8 @@ if check_requires_list(["scipy", "scipy.integrate"]):
     )
 else:
     tests_for_nintegrate = [
-        (r"NIntegrate[x^2, {x,0,1}]", r"1/3.", ""),
-        (r"NIntegrate[x^2 y^2, {y,0,1}, {x,0,1}]", r"1/9.", ""),
+        (r"NIntegrate[x^2, {x,0,1}]", r"1/3.", "", None),
+        (r"NIntegrate[x^2 y^2, {y,0,1}, {x,0,1}]", r"1/9.", "", None),
         # FIXME: this can integrate to Infinity
         # (r"NIntegrate[x^2 y^(-.5), {x,0,1},{y,0,1}]", r"1.", ""),
         (

--- a/test/helper.py
+++ b/test/helper.py
@@ -97,7 +97,9 @@ def check_evaluation(
         msgs = list(expected_messages)
         expected_len = len(msgs)
         got_len = len(outs)
-        assert expected_len == got_len, f"expected {expected_len}; got {got_len}"
+        assert (
+            expected_len == got_len
+        ), f"expected {expected_len}; got {got_len}. Messages: {outs}"
         for (out, msg) in zip(outs, msgs):
             if out != msg:
                 print(f"out:<<{out}>>")


### PR DESCRIPTION
During some checks I did yesterday, I found a typo that made that the scipy integrators were not loaded even if the scipy library is available. This PR fixes it, and adds some tests to detect this kind of bug.

* Fixing a typo that prevented that scipy integrators were loaded.
* Improving test_nintegrators and test_calculus.
* Improving test/helper.py to show the evaluation messages in case they are not expected.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/560"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

