### PR TITLE
fix and test expressions of the form BoxExpression[[...]]

### DIFF
--- a/mathics/builtin/box/layout.py
+++ b/mathics/builtin/box/layout.py
@@ -305,6 +305,13 @@ class RowBox(BoxExpression):
         result = RowBox(*items)
         return result
 
+    @property
+    def elements(self):
+        return self.to_expression().elements
+
+    def get_head(self):
+        return SymbolRowBox
+
     def init(self, *items, **kwargs):
         # TODO: check that each element is an string or a BoxElementMixin
         self.box_options = {}
@@ -352,8 +359,8 @@ class RowBox(BoxExpression):
                 for item in self.items
             )
 
-            self._elements = Expression(SymbolRowBox, ListExpression(*items))
-        return self._elements
+            self._elements = ListExpression(*items)
+        return Expression(SymbolRowBox, self._elements)
 
 
 class ShowStringCharacters(Builtin):

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -12,6 +12,40 @@ if DEBUG:
 else:
     skip_or_fail = pytest.mark.skip
 
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "fail_msg", "msgs"),
+    [
+        ('rb=RowBox[{"a", "b"}]; rb[[1]]', "{a, b}", None, []),
+        ("rb[[0]]", "RowBox", None, []),
+        (
+            "rb[[2]]",
+            "RowBox[{a, b}][[2]]",
+            None,
+            ["Part 2 of RowBox[{a, b}] does not exist."],
+        ),
+        ('fb=FractionBox["1", "2"]; fb[[0]]', "FractionBox", None, []),
+        ("fb[[1]]", "1", None, []),
+        ('sb=StyleBox["string", "Section"]; sb[[0]]', "StyleBox", None, []),
+        ("sb[[1]]", "string", None, []),
+        # FIXME: <<RowBox object does not have the attribute "restructure">>
+        # ('rb[[All, 1]]', "{a, b}", "\"a\"", []),
+        # ('fb[[All]][[1]]','1', None, []),
+        # ('sb[[All]][[1]]','string', None, []),
+    ],
+)
+def test_part_boxes(str_expr, str_expected, fail_msg, msgs):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=fail_msg,
+        expected_messages=msgs,
+    )
+
+
 # 15 tests
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),


### PR DESCRIPTION
Another small fix to something that I found working on MakeBoxes. When a ```BoxExpression``` is passed as the first element to ```Part```, since it does not have in general an attribute `_elements`, the evaluation ends with an unhandled exception. In particular, this happens to `RowBox`. This PR fixes it by providing an implementation for that method. 