### PR TITLE
Fix RandomSample and add test cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Bugs
 ++++
 
 # ``0`` with a given precision (like in ```0`3```) is now parsed as ``0``, an integer number.
+#. ``RandomSample`` with one list argument now returns a random ordering of the list items. Previously it would return just one item.
 
 
 Enhancements

--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -745,7 +745,7 @@ class RandomSample(_RandomSelection):
      = {{1, 2}, {}, a}
     >> SeedRandom[42]
     >> RandomSample[Range[10]]
-     = {9, 2, 6, 1, 8, 3, 10, 5, 4, 7
+     = {9, 2, 6, 1, 8, 3, 10, 5, 4, 7}
     >> SeedRandom[42]
     >> RandomSample[Range[100], {2, 3}]
      = {{84, 54, 71}, {46, 45, 40}}

--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -253,7 +253,7 @@ class _RandomBase(Builtin):
         ),
     }
     rules = {
-        "%(name)s[spec_]": "%(name)s[spec, {Length[spec]}]",
+        "%(name)s[spec_]": "%(name)s[spec, {1}]",
         "%(name)s[spec_, n_Integer]": "%(name)s[spec, {n}]",
     }
 
@@ -753,6 +753,11 @@ class RandomSample(_RandomSelection):
     >> RandomSample[Range[100] -> Range[100], 5]
      = {62, 98, 86, 78, 40}
     """
+
+    rules = {
+        "%(name)s[spec_]": "%(name)s[spec, {Length[spec]}]",
+        "%(name)s[spec_, n_Integer]": "%(name)s[spec, {n}]",
+    }
 
     _replace = False
     summary_text = "pick a sample at random from a list"

--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -253,7 +253,7 @@ class _RandomBase(Builtin):
         ),
     }
     rules = {
-        "%(name)s[spec_]": "%(name)s[spec, {1}]",
+        "%(name)s[spec_]": "%(name)s[spec, {Length[spec]}]",
         "%(name)s[spec_, n_Integer]": "%(name)s[spec, {n}]",
     }
 
@@ -735,14 +735,17 @@ class RandomSample(_RandomSelection):
     </dl>
 
     >> SeedRandom[42]
-    >> RandomSample[{a, b, c}]
-     = {a}
+    >> RandomSample[{a, b, c, d}]
+     = {b, d, a, c}
     >> SeedRandom[42]
     >> RandomSample[{a, b, c, d, e, f, g, h}, 7]
      = {b, f, a, h, c, e, d}
     >> SeedRandom[42]
     >> RandomSample[{"a", {1, 2}, x, {}}, 3]
      = {{1, 2}, {}, a}
+    >> SeedRandom[42]
+    >> RandomSample[Range[10]]
+     = {9, 2, 6, 1, 8, 3, 10, 5, 4, 7
     >> SeedRandom[42]
     >> RandomSample[Range[100], {2, 3}]
      = {{84, 54, 71}, {46, 45, 40}}

--- a/test/builtin/numbers/test_randomnumbers.py
+++ b/test/builtin/numbers/test_randomnumbers.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtins.numbers.randomnumbers
+"""
+
+import pytest
+from test.helper import check_evaluation
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected"),
+    [
+        ("SeedRandom[42]; RandomSample[{a, b, c, d}]", "{b, d, a, c}"),
+        (
+            "SeedRandom[42]; RandomSample[{a, b, c, d, e, f, g, h}, 7]",
+            "{b, f, a, h, c, e, d}",
+        ),
+        ('SeedRandom[42]; RandomSample[{"a", {1, 2}, x, {}}, 3]', "{{1, 2}, {}, a}"),
+        (
+            "SeedRandom[42]; RandomSample[Range[100], {2, 3}]",
+            "{{84, 54, 71}, {46, 45, 40}}",
+        ),
+        (
+            "SeedRandom[42]; RandomSample[Range[100] -> Range[100], 5]",
+            "{62, 98, 86, 78, 40}",
+        ),
+        ("SeedRandom[42]; RandomSample[Range[10]]", "{9, 2, 6, 1, 8, 3, 10, 5, 4, 7}"),
+        (
+            "SeedRandom[42]; RandomSample[Range[10], {10}]",
+            "{9, 2, 6, 1, 8, 3, 10, 5, 4, 7}",
+        ),
+    ],
+)
+def test_random_sample(str_expr, str_expected):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+    )


### PR DESCRIPTION
Fixes #468
 
RandomSample with one list argument should return a random ordering of the items in the given list, not just one item from the list.

Before:
```Mathematica
In[1]:= SeedRandom[42]; RandomSample[Range[10]]
Out[1]= {9}
```

After:
```Mathematica
In[1]:= SeedRandom[42]; RandomSample[Range[10]]
Out[1]= {9, 2, 6, 1, 8, 3, 10, 5, 4, 7}
```