### PR TITLE
Implementing $PrintForms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Builtins
 #. ``SixJSymbol``
 #. ``Skewness``
 #. ``ThreeJSymbol``
+#. ``$PrintForms``
+
 
 Documentation
 +++++++++++++

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -532,7 +532,7 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
     if len(lhs.elements) == 2:
         form = lhs.elements[1]
         form_name = form.get_name()
-        if not form_names:
+        if not form_name:
             evaluation.message("Format", "fttp", lhs.elements[1])
             raise AssignmentException(lhs, None)
         # If the form is not in defs.printforms
@@ -558,7 +558,7 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
         if rejected_because_protected(self, lhs, tag, evaluation):
             continue
         count += 1
-        defs.add_format(tag, rule, form_names)
+        defs.add_format(tag, rule, form_name)
     return count > 0
 
 

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -531,7 +531,7 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
         raise AssignmentException(lhs, None)
     if len(lhs.elements) == 2:
         form = lhs.elements[1]
-        form_names = form.get_name()
+        form_name = form.get_name()
         if not form_names:
             evaluation.message("Format", "fttp", lhs.elements[1])
             raise AssignmentException(lhs, None)
@@ -541,7 +541,7 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
         if form not in print_forms:
             print_forms.append(form)
     else:
-        form_names = [
+        form_name = [
             "System`StandardForm",
             "System`TraditionalForm",
             "System`OutputForm",

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -530,19 +530,24 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
         evaluation.message_args("Format", len(lhs.elements), 1, 2)
         raise AssignmentException(lhs, None)
     if len(lhs.elements) == 2:
-        form = lhs.elements[1].get_name()
-        if not form:
+        form = lhs.elements[1]
+        form_names = form.get_name()
+        if not form_names:
             evaluation.message("Format", "fttp", lhs.elements[1])
             raise AssignmentException(lhs, None)
+        # If the form is not in defs.printforms
+        # add it.
+        print_forms = defs.printforms
+        if form not in print_forms:
+            print_forms.append(form)
     else:
-        form = system_symbols(
-            "StandardForm",
-            "TraditionalForm",
-            "OutputForm",
-            "TeXForm",
-            "MathMLForm",
-        )
-        form = [f.name for f in form]
+        form_names = [
+            "System`StandardForm",
+            "System`TraditionalForm",
+            "System`OutputForm",
+            "System`TeXForm",
+            "System`MathMLForm",
+        ]
     lhs = focus = lhs.elements[0]
     tags = process_tags_and_upset_dont_allow_custom(
         tags, upset, self, lhs, focus, evaluation
@@ -553,7 +558,7 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
         if rejected_because_protected(self, lhs, tag, evaluation):
             continue
         count += 1
-        defs.add_format(tag, rule, form)
+        defs.add_format(tag, rule, form_names)
     return count > 0
 
 

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -17,6 +17,11 @@ from mathics.builtin.makeboxes import MakeBoxes
 from mathics.builtin.tensors import get_dimensions
 
 from mathics.core.atoms import Integer, String, StringFromPython
+from mathics.core.attributes import (
+    no_attributes as A_NO_ATTRIBUTES,
+    locked as A_LOCKED,
+    protected as A_PROTECTED,
+)
 
 from mathics.core.element import EvalMixin
 from mathics.core.expression import Expression, BoxError
@@ -40,6 +45,37 @@ MULTI_NEWLINE_RE = re.compile(r"\n{2,}")
 SymbolNumberForm = Symbol("System`NumberForm")
 SymbolSuperscriptBox = Symbol("System`SuperscriptBox")
 SymbolTableDepth = Symbol("TableDepth")
+
+
+class PrintForms_(Predefined):
+    """
+    <dl>
+    <dt>'$PrintForms'
+    <dd>contains the list of basic print forms. It is updated automatically when new 'PrintForms' are defined by setting
+    format values
+    </dl>
+
+    >> $PrintForms
+     = ...
+
+    Suppose now that we want to add a new format `MyForm`. Initially, it does not belongs to $\$PrintForms$:
+    >> MemberQ[$PrintForms, MyForm]
+     = False
+    Now, let's define a format rule:
+    >> Format[MyForm[F[x_]]]:= "F<<" <> ToString[x] <> ">>"
+    >> Format[F[x_], MyForm]:= MyForm[F[x]]
+    Now, the new format belongs to the $\$PrintForms$ list
+    >> MemberQ[$PrintForms, MyForm]
+     = True
+
+    """
+
+    attributes = A_LOCKED | A_PROTECTED
+    name = "$PrintForms"
+    summary_text = "list the print formats"
+
+    def evaluate(self, evaluation):
+        return ListExpression(*evaluation.definitions.printforms)
 
 
 class TableForm(Builtin):
@@ -230,7 +266,7 @@ class Echo_(Predefined):
     </dl>
     """
 
-    attributes = 0
+    attributes = A_NO_ATTRIBUTES
     name = "$Echo"
     rules = {"$Echo": "{}"}
     summary_text = "files and pipes that echoes the input"

--- a/mathics/builtin/inout.py
+++ b/mathics/builtin/inout.py
@@ -50,9 +50,8 @@ SymbolTableDepth = Symbol("TableDepth")
 class PrintForms_(Predefined):
     """
     <dl>
-    <dt>'$PrintForms'
-    <dd>contains the list of basic print forms. It is updated automatically when new 'PrintForms' are defined by setting
-    format values
+      <dt>'$PrintForms'
+      <dd>contains the list of basic print forms. It is updated automatically when new 'PrintForms' are defined by setting format values.
     </dl>
 
     >> $PrintForms

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -19,6 +19,7 @@ from mathics.core.expression import Expression
 from mathics.core.symbols import (
     Atom,
     Symbol,
+    format_symbols,
     strip_context,
 )
 from mathics.core.systemsymbols import SymbolGet
@@ -106,6 +107,7 @@ class Definitions:
             "System`",
             "Global`",
         )
+        self.printforms = [f for f in format_symbols]
         self.trace_evaluation = False
         self.timing_trace_evaluation = False
 


### PR DESCRIPTION
In WMA, `$PrintForms` is a (not very well documented) variable that stores the possible formats in which an expression can be printed. This PR implements it in Mathics.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/565"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

