### PR TITLE
Use ASCII to Unicode tables for Infix operators

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -22,9 +22,8 @@ jobs:
       run: |
         sudo apt update -qq && sudo apt install llvm-dev
         python -m pip install --upgrade pip
-        # Can remove after next Mathics-Scanner release
-        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
-    - name: Install Mathics with minimum dependencies
+        # Can comment out after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Math    - name: Install Mathics with minimum dependencies
       run: |
         make develop
     - name: Test Mathics Consistency and Style

--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -22,8 +22,9 @@ jobs:
       run: |
         sudo apt update -qq && sudo apt install llvm-dev
         python -m pip install --upgrade pip
-        # Can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Math    - name: Install Mathics with minimum dependencies
+        # We can comment out after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+    - name: Install Mathics with minimum dependencies
       run: |
         make develop
     - name: Test Mathics Consistency and Style

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -27,7 +27,7 @@ jobs:
         brew install llvm@11
         python -m pip install --upgrade pip
         LLVM_CONFIG=/usr/local/Cellar/llvm@11/11.1.0/bin/llvm-config pip install llvmlite
-        # Can comment out after next Mathics-Scanner release
+        # We can comment out after next Mathics-Scanner release
         python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -27,8 +27,8 @@ jobs:
         brew install llvm@11
         python -m pip install --upgrade pip
         LLVM_CONFIG=/usr/local/Cellar/llvm@11/11.1.0/bin/llvm-config pip install llvmlite
-        # Can remove after next Mathics-Scanner release
-        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        # Can comment out after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
-        # Can comment out after next Mathics-Scanner release
+        # We can comment out after next Mathics-Scanner release
         python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -24,8 +24,8 @@ jobs:
       run: |
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
-        # Can remove after next Mathics-Scanner release
-        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        # Can comment out after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full-cython

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
         # Can remove after next Mathics-Scanner release
-        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
-        # Can remove after next Mathics-Scanner release
+        # We can comment out after next Mathics-Scanner release
         python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,9 +25,8 @@ jobs:
         python -m pip install wheel
         choco install llvm
         set LLVM_DIR="C:\Program Files\LLVM"
-        # Can remove after next Mathics-Scanner release
-        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
-        pip install -e .
+        # Can comment out after next Mathics-Scanner release
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
     - name: Install Mathics
       run: |
         python setup.py install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,8 +25,9 @@ jobs:
         python -m pip install wheel
         choco install llvm
         set LLVM_DIR="C:\Program Files\LLVM"
-        # Can comment out after next Mathics-Scanner release
+        # We can comment out after next Mathics-Scanner release
         python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+        make develop
     - name: Install Mathics
       run: |
         python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 GIT2CL ?= admin-tools/git2cl
 PYTHON ?= python3
 PIP ?= pip3
+BASH ?= bash
 RM  ?= rm
 
 .PHONY: \
@@ -45,7 +46,7 @@ else
 endif
 
 #: Default target - same as "develop"
-all: develop
+all: develop mathics/data/op-tables.json
 
 #: build everything needed to install
 build:
@@ -107,6 +108,7 @@ clean: clean-cython clean-cache
 	   ($(MAKE) -C "$$dir" clean); \
 	done; \
 	rm -f factorials || true; \
+	rm -f mathics/data/op-tables || true; \
 	rm -rf build || true
 
 #: Run py.test tests. Use environment variable "o" for pytest options
@@ -125,11 +127,15 @@ doc-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/docu
 
 #: Run tests that appear in docstring in the code.
 doctest:
-	SANDBOX=$(SANDBOX) $(PYTHON) mathics/docpipeline.py $o
+	MATHICS_CHARACTER_ENCODING="ASCII" SANDBOX=$(SANDBOX) $(PYTHON) mathics/docpipeline.py $o
 
 #: Make Mathics PDF manual via Asymptote and LaTeX
 latexdoc texdoc doc:
 	(cd mathics/doc/latex && $(MAKE) doc)
+
+#: Build JSON ASCII to unicode opcode tables
+mathics/data/op-tables.json:
+	$(BASH) ./admin-tools/make-op-tables.sh
 
 #: Remove ChangeLog
 rmChangeLog:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ else
 endif
 
 #: Default target - same as "develop"
-all: develop mathics/data/op-tables.json
+all: develop
 
 #: build everything needed to install
 build:
@@ -56,17 +56,17 @@ build:
 # because pip install doesn't handle
 # INSTALL_REQUIRES properly
 #: Set up to run from the source tree
-develop:
+develop:  mathics/data/op-tables.json
 	$(PIP) install -e .[dev]
 
 # See note above on ./setup.py
 #: Set up to run from the source tree with full dependencies
-develop-full:
+develop-full:  mathics/data/op-tables.json
 	$(PIP) install -e .[dev,full]
 
 # See note above on ./setup.py
 #: Set up to run from the source tree with full dependencies and Cython
-develop-full-cython:
+develop-full-cython: mathics/data/op-tables.json
 	$(PIP) install -e .[dev,full,cython]
 
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ install:
 #: Run the most extensive set of tests
 check: pytest gstest doctest
 
-
 #: Build and check manifest of Builtins
 check-builtin-manifest:
 	$(PYTHON) admin-tools/build_and_check_manifest.py

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ gstest:
 
 #: Create data that is used to in Django docs and to build LaTeX PDF
 doc-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/documentation/images/*
-	$(PYTHON) mathics/docpipeline.py --output --keep-going
+	MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) mathics/docpipeline.py --output --keep-going
 
 #: Run tests that appear in docstring in the code.
 doctest:

--- a/admin-tools/make-op-tables.sh
+++ b/admin-tools/make-op-tables.sh
@@ -5,4 +5,10 @@ mydir=$(dirname $bs)
 PYTHON=${PYTHON:-python}
 
 cd $mydir/../mathics/data
-mathics-generate-json-table --field=ascii-operator-to-unicode --field=ascii-operator-to-wl-unicode -o op-tables.json
+mathics-generate-json-table \
+    --field=ascii-operator-to-symbol \
+    --field=ascii-operator-to-unicode \
+    --field=ascii-operator-to-wl-unicode \
+    --field=operator-to-ascii \
+    --field=operator-to-unicode \
+    -o op-tables.json

--- a/admin-tools/make-op-tables.sh
+++ b/admin-tools/make-op-tables.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Create ASCII operator to Unicode tables
+bs=${BASH_SOURCE[0]}
+mydir=$(dirname $bs)
+PYTHON=${PYTHON:-python}
+
+cd $mydir/../mathics/data
+mathics-generate-json-table --field=ascii-operator-to-unicode --field=ascii-operator-to-wl-unicode -o op-tables.json

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -27,6 +27,7 @@ from mathics.core.atoms import (
 from mathics.core.attributes import listable, protected
 from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.op import ascii_op_to_unicode
 from mathics.core.convert.python import from_bool
 from mathics.core.formatter import format_element
 from mathics.core.list import ListExpression
@@ -327,6 +328,31 @@ def mathics_split(patt, string, flags):
 
     # slice up the string
     return [string[start:stop] for start, stop in indices]
+
+
+class AsciiOpToString(Builtin):
+    """
+    <dl>
+      <dt>'AsciiOpToString[$operator$]'
+      <dd>returns a unicode (string)representation of ASCII string operator $op$ .
+      <dd>returns a unicode (string)representation of ASCII string operator $op$ .
+    </dl>
+    This is a Mathics-specific function which is used in operation output rendering.
+
+
+    >> AsciiOpToString[">="]
+     = ...
+    """
+
+    options = {
+        "CharacterEncoding": '"Unicode"',
+    }
+    summary_text = "convert ASCII operator to unicode"
+
+    def apply(self, operator, evaluation, options):
+        "AsciiOpToString[operator_String, OptionsPattern[AsciiOpToString]]"
+        encoding = options["System`CharacterEncoding"]
+        return String(ascii_op_to_unicode(operator.value, encoding.value))
 
 
 class SystemCharacterEncoding(Predefined):

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -25,10 +25,12 @@ from mathics.core.atoms import (
     Integer1,
 )
 from mathics.core.attributes import listable, protected
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.convert.op import ascii_op_to_unicode
 from mathics.core.convert.python import from_bool
+from mathics.core.element import BaseElement
 from mathics.core.formatter import format_element
 from mathics.core.list import ListExpression
 from mathics.core.parser import MathicsFileLineFeeder, parse
@@ -330,66 +332,6 @@ def mathics_split(patt, string, flags):
     return [string[start:stop] for start, stop in indices]
 
 
-class AsciiOpToString(Builtin):
-    """
-    <dl>
-      <dt>'AsciiOpToString[$operator$]'
-      <dd>returns a unicode (string)representation of ASCII string operator $op$ .
-      <dd>returns a unicode (string)representation of ASCII string operator $op$ .
-    </dl>
-    This is a Mathics-specific function which is used in operation output rendering.
-
-
-    >> AsciiOpToString[">="]
-     = ...
-    """
-
-    options = {
-        "CharacterEncoding": '"Unicode"',
-    }
-    summary_text = "convert ASCII operator to unicode"
-
-    def apply(self, operator, evaluation, options):
-        "AsciiOpToString[operator_String, OptionsPattern[AsciiOpToString]]"
-        encoding = options["System`CharacterEncoding"]
-        return String(ascii_op_to_unicode(operator.value, encoding.value))
-
-
-class SystemCharacterEncoding(Predefined):
-    """
-    <dl>
-      <dt>$SystemCharacterEncoding
-      <dd>gives the default character encoding of the system.
-    </dl>
-    """
-
-    name = "$SystemCharacterEncoding"
-
-    rules = {
-        "$SystemCharacterEncoding": '"' + SYSTEM_CHARACTER_ENCODING + '"',
-    }
-
-    summary_text = "system's character enconding"
-
-
-class CharacterEncoding(Predefined):
-    """
-    <dl>
-    <dt>'CharacterEncoding'
-        <dd>specifies the default character encoding to use if no other encoding is
-        specified.
-    </dl>
-    """
-
-    name = "$CharacterEncoding"
-    value = '"UTF-8"'
-    rules = {
-        "$CharacterEncoding": value,
-    }
-
-    summary_text = "default character encoding"
-
-
 _encodings = {
     # see https://docs.python.org/2/library/codecs.html#standard-encodings
     "ASCII": "ascii",
@@ -437,6 +379,23 @@ _encodings = {
 
 def to_python_encoding(encoding):
     return _encodings.get(encoding)
+
+
+class CharacterEncoding(Predefined):
+    """
+    <dl>
+    <dt>'CharacterEncoding'
+        <dd>specifies the default character encoding to use if no other encoding is specified.
+    </dl>
+    """
+
+    name = "$CharacterEncoding"
+    value = f'"{SYSTEM_CHARACTER_ENCODING}"'
+    rules = {
+        "$CharacterEncoding": value,
+    }
+
+    summary_text = "default character encoding"
 
 
 class CharacterEncodings(Predefined):
@@ -839,6 +798,14 @@ class String_(Builtin):
     summary_text = "head for strings"
 
 
+def eval_ToString(
+    expr: BaseElement, form: Symbol, encoding: String, evaluation: Evaluation
+) -> String:
+    boxes = format_element(expr, evaluation, form, encoding=encoding)
+    text = boxes.boxes_to_text(evaluation=evaluation)
+    return String(text)
+
+
 class ToString(Builtin):
     """
     <dl>
@@ -881,12 +848,10 @@ class ToString(Builtin):
         "ToString[value_, OptionsPattern[ToString]]"
         return self.apply_form(value, SymbolOutputForm, evaluation, options)
 
-    def apply_form(self, value, form, evaluation, options):
-        "ToString[value_, form_, OptionsPattern[ToString]]"
+    def apply_form(self, expr, form, evaluation, options):
+        "ToString[expr_, form_, OptionsPattern[ToString]]"
         encoding = options["System`CharacterEncoding"]
-        text = format_element(value, evaluation, form, encoding=encoding)
-        text = text.boxes_to_text(evaluation=evaluation)
-        return String(text)
+        return eval_ToString(expr, form, encoding.value, evaluation)
 
 
 # This isn't your normal Box class. We'll keep this here rather than
@@ -906,7 +871,7 @@ class InterpretedBox(PrefixOperator):
     precedence = 670
     summary_text = "interpret boxes as an expression"
 
-    def apply_dummy(self, boxes, evaluation):
+    def apply_dummy(self, boxes, evaluation: Evaluation):
         """InterpretedBox[boxes_]"""
         # TODO: the following is a very raw and dummy way to
         # handle these expressions.
@@ -980,7 +945,7 @@ class ToExpression(Builtin):
     }
     summary_text = "build an expression from formatted text"
 
-    def apply(self, seq, evaluation):
+    def apply(self, seq, evaluation: Evaluation):
         "ToExpression[seq__]"
 
         # Organise Arguments
@@ -1036,7 +1001,7 @@ class ToExpression(Builtin):
 
         return result
 
-    def apply_empty(self, evaluation):
+    def apply_empty(self, evaluation: Evaluation):
         "ToExpression[]"
         evaluation.message(
             "ToExpression", "argb", "ToExpression", Integer0, Integer1, Integer(3)
@@ -1081,7 +1046,7 @@ class RemoveDiacritics(Builtin):
 
     summary_text = "remove diacritics"
 
-    def apply(self, s, evaluation):
+    def apply(self, s, evaluation: Evaluation):
         "RemoveDiacritics[s_String]"
         return String(
             unicodedata.normalize("NFKD", s.value)
@@ -1117,7 +1082,7 @@ class Transliterate(Builtin):
     requires = ("unidecode",)
     summary_text = "transliterate an UTF string in different alphabets to ASCII"
 
-    def apply(self, s, evaluation):
+    def apply(self, s, evaluation: Evaluation):
         "Transliterate[s_String]"
         from unidecode import unidecode
 
@@ -1258,3 +1223,20 @@ class StringContainsQ(Builtin):
         return _pattern_search(
             self.__class__.__name__, string, patt, evaluation, options, True
         )
+
+
+class SystemCharacterEncoding(Predefined):
+    """
+    <dl>
+      <dt>$SystemCharacterEncoding
+      <dd>gives the default character encoding of the system.
+    </dl>
+    """
+
+    name = "$SystemCharacterEncoding"
+
+    rules = {
+        "$SystemCharacterEncoding": '"' + SYSTEM_CHARACTER_ENCODING + '"',
+    }
+
+    summary_text = "system's character enconding"

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -22,6 +22,7 @@ from mathics.core.atoms import (
 )
 from mathics.core.attributes import protected, read_protected, no_attributes
 from mathics.core.convert.expression import to_expression, to_numeric_sympy_args
+from mathics.core.convert.op import ascii_op_to_unicode
 from mathics.core.convert.python import from_bool
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.definitions import Definition
@@ -39,6 +40,7 @@ from mathics.core.symbols import (
     strip_context,
 )
 from mathics.core.systemsymbols import SymbolMessageName, SymbolRule
+from mathics.settings import SYSTEM_CHARACTER_ENCODING
 
 
 def check_requires_list(requires: list) -> bool:
@@ -624,13 +626,13 @@ class BinaryOperator(Operator):
             operator = self.get_operator_display()
             formatted = 'MakeBoxes[Infix[{%s},"%s",%d,%s], form]' % (
                 replace_items,
-                operator,
+                ascii_op_to_unicode(operator, SYSTEM_CHARACTER_ENCODING),
                 self.precedence,
                 self.grouping,
             )
             formatted_output = 'MakeBoxes[Infix[{%s}," %s ",%d,%s], form]' % (
                 replace_items,
-                operator,
+                ascii_op_to_unicode(operator, SYSTEM_CHARACTER_ENCODING),
                 self.precedence,
                 self.grouping,
             )

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -22,7 +22,7 @@ from mathics.core.atoms import (
 )
 from mathics.core.attributes import protected, read_protected, no_attributes
 from mathics.core.convert.expression import to_expression, to_numeric_sympy_args
-from mathics.core.convert.op import ascii_op_to_unicode
+from mathics.core.convert.op import ascii_operator_to_symbol
 from mathics.core.convert.python import from_bool
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.definitions import Definition
@@ -40,7 +40,6 @@ from mathics.core.symbols import (
     strip_context,
 )
 from mathics.core.systemsymbols import SymbolMessageName, SymbolRule
-from mathics.settings import SYSTEM_CHARACTER_ENCODING
 
 
 def check_requires_list(requires: list) -> bool:
@@ -622,17 +621,11 @@ class BinaryOperator(Operator):
             op_pattern = "%s[x_, y_]" % name
             replace_items = "x, y"
 
+        operator = ascii_operator_to_symbol.get(self.operator, self.__class__.__name__)
         if self.default_formats:
-            operator = self.get_operator_display()
-            formatted = 'MakeBoxes[Infix[{%s},"%s",%d,%s], form]' % (
+            formatted = "MakeBoxes[Infix[{%s}, %s, %d,%s], form]" % (
                 replace_items,
-                ascii_op_to_unicode(operator, SYSTEM_CHARACTER_ENCODING),
-                self.precedence,
-                self.grouping,
-            )
-            formatted_output = 'MakeBoxes[Infix[{%s}," %s ",%d,%s], form]' % (
-                replace_items,
-                ascii_op_to_unicode(operator, SYSTEM_CHARACTER_ENCODING),
+                operator,
                 self.precedence,
                 self.grouping,
             )
@@ -642,7 +635,7 @@ class BinaryOperator(Operator):
                 ): formatted,
                 "MakeBoxes[{0}, form:InputForm|OutputForm]".format(
                     op_pattern
-                ): formatted_output,
+                ): formatted,
             }
             default_rules.update(self.rules)
             self.rules = default_rules

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -2251,7 +2251,7 @@ if "Pyston" not in sys.version:
           <dd>Gives a word cloud with the words weighted using the given weights.
         </dl>
 
-        >> WordCloud[StringSplit[Import["ExampleData/EinsteinSzilLetter.txt"]]]
+        >> WordCloud[StringSplit[Import["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"]]]
          = -Image-
 
         >> WordCloud[Range[50] -> ToString /@ Range[50]]

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -164,7 +164,7 @@ class _OpenAction(Builtin):
             opener = MathicsOpen(
                 path_string,
                 mode=mode,
-                encoding=encoding.get_string_value(),
+                encoding=encoding.value,
                 is_temporary_file=is_temporary_file,
             )
             opener.__enter__(is_temporary_file=is_temporary_file)
@@ -503,7 +503,7 @@ class OpenRead(_OpenAction):
       <dd>opens a file and returns an 'InputStream'.
     </dl>
 
-    >> OpenRead["ExampleData/EinsteinSzilLetter.txt"]
+    >> OpenRead["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"]
      = InputStream[...]
     #> Close[%];
 
@@ -525,7 +525,7 @@ class OpenRead(_OpenAction):
      : Cannot open MathicsNonExampleFile.
      = OpenRead[MathicsNonExampleFile]
 
-    #> OpenRead["ExampleData/EinsteinSzilLetter.txt", BinaryFormat -> True]
+    #> OpenRead["ExampleData/EinsteinSzilLetter.txt", BinaryFormat -> True, CharacterEncoding->"UTF8"]
      = InputStream[...]
     #> Close[%];
     """
@@ -1484,7 +1484,7 @@ class Find(Read):
       <dd>find the first line in $stream$ that contains $text$.
     </dl>
 
-    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt"];
+    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"];
     >> Find[stream, "uranium"]
      = in manuscript, leads me to expect that the element uranium may be turned into
     >> Find[stream, "uranium"]
@@ -1492,7 +1492,7 @@ class Find(Read):
     >> Close[stream]
      = ...
 
-    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt"];
+    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"];
     >> Find[stream, {"energy", "power"} ]
      = a new and important source of energy in the immediate future. Certain aspects
     >> Find[stream, {"energy", "power"} ]

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -2,7 +2,7 @@
 
 """
 This module contains symbols used to define the high level layout for
-expression formatting. 
+expression formatting.
 
 For instance, to represent a set of consecutive expressions in a row,
 we can use ``Row``
@@ -254,8 +254,7 @@ class Infix(Builtin):
     """
     <dl>
       <dt>'Infix[$expr$, $oper$, $prec$, $assoc$]'
-      <dd>displays $expr$ with the infix operator $oper$, with
-        precedence $prec$ and associativity $assoc$.
+      <dd>displays $expr$ with the infix operator $oper$, with precedence $prec$ and associativity $assoc$.
     </dl>
 
     'Infix' can be used with 'Format' to display certain forms with
@@ -294,8 +293,7 @@ class NonAssociative(Builtin):
     """
     <dl>
       <dt>'NonAssociative'
-      <dd>is used with operator formatting constructs to specify a
-        non-associative operator.
+      <dd>is used with operator formatting constructs to specify a non-associative operator.
     </dl>
     """
 
@@ -306,8 +304,7 @@ class Left(Builtin):
     """
     <dl>
       <dt>'Left'
-      <dd>is used with operator formatting constructs to specify a
-        left-associative operator.
+      <dd>is used with operator formatting constructs to specify a left-associative operator.
     </dl>
     """
 
@@ -318,8 +315,7 @@ class Right(Builtin):
     """
     <dl>
       <dt>'Right'
-      <dd>is used with operator formatting constructs to specify a
-        right-associative operator.
+      <dd>is used with operator formatting constructs to specify a right-associative operator.
     </dl>
     """
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -5,11 +5,13 @@
 Low level Format definitions
 """
 
+from typing import Union
 import mpmath
 
 
 from mathics.builtin.base import Builtin, Predefined
 from mathics.builtin.box.layout import _boxed_string, RowBox, to_boxes
+from mathics.core.convert.op import operator_to_unicode, operator_to_ascii
 from mathics.core.atoms import (
     Integer,
     Integer1,
@@ -23,7 +25,7 @@ from mathics.core.attributes import (
     hold_all_complete as A_HOLD_ALL_COMPLETE,
     read_protected as A_READ_PROTECTED,
 )
-from mathics.core.element import BoxElementMixin
+from mathics.core.element import BaseElement, BoxElementMixin
 from mathics.core.expression import Expression
 from mathics.core.formatter import format_element
 from mathics.core.list import ListExpression
@@ -44,6 +46,7 @@ from mathics.core.symbols import (
 from mathics.core.systemsymbols import (
     SymbolAutomatic,
     SymbolInfinity,
+    SymbolInputForm,
     SymbolMakeBoxes,
     SymbolOutputForm,
     SymbolRowBox,
@@ -80,11 +83,17 @@ def parenthesize(precedence, element, element_boxes, when_equal):
     return element_boxes
 
 
-def make_boxes_infix(elements, ops, precedence, grouping, form):
+# FIXME: op should be a string, so remove the Union.
+def make_boxes_infix(
+    elements, op: Union[String, list], precedence: int, grouping, form: Symbol
+):
     result = []
     for index, element in enumerate(elements):
         if index > 0:
-            result.append(ops[index - 1])
+            if isinstance(op, list):
+                result.append(op[index - 1])
+            else:
+                result.append(op)
         parenthesized = False
         if grouping == "System`NonAssociative":
             parenthesized = True
@@ -474,26 +483,41 @@ class MakeBoxes(Builtin):
         else:
             return MakeBoxes(expr, f).evaluate(evaluation)
 
-    def apply_infix(self, expr, h, prec, grouping, f, evaluation):
-        """MakeBoxes[Infix[expr_, h_, prec_:None, grouping_:None],
-        f:StandardForm|TraditionalForm|OutputForm|InputForm]"""
+    def apply_infix(
+        self, expr, operator, prec: Integer, grouping, form: Symbol, evaluation
+    ):
+        """MakeBoxes[Infix[expr_, operator_, prec_:None, grouping_:None],
+        form:StandardForm|TraditionalForm|OutputForm|InputForm]"""
 
-        def get_op(op):
-            if not isinstance(op, String):
-                op = MakeBoxes(op, f)
-            else:
-                op_value = op.get_string_value()
-                if f.get_name() == "System`InputForm" and op_value in ["*", "^"]:
-                    pass
-                elif (
-                    f.get_name() in ("System`InputForm", "System`OutputForm")
-                    and not op_value.startswith(" ")
-                    and not op_value.endswith(" ")
-                ):
-                    op = String(" " + op_value + " ")
-            return op
+        ## FIXME: this should go into a some formatter.
+        def format_operator(operator) -> Union[String, BaseElement]:
+            """
+            Format infix operator `operator`. To do this outside parameter form is used.
+            Sometimes no changes are made and operator is returned unchanged.
 
-        precedence = prec.get_int_value()
+            This function probably should be rewritten be more scalable across other forms
+            and moved to a module that contiaing similar formatting routines.
+            """
+            if not isinstance(operator, String):
+                return MakeBoxes(operator, form)
+
+            op_str = operator.value
+
+            # FIXME: performing a check using the operator symbol representation feels a bit
+            # fragile. The operator name seems more straightforward and more robust.
+            if form == SymbolInputForm and op_str in ["*", "^", " "]:
+                return operator
+            elif (
+                form in (SymbolInputForm, SymbolOutputForm)
+                and not op_str.startswith(" ")
+                and not op_str.endswith(" ")
+            ):
+                # FIXME: Again, testing on specific forms is fragile and not scalable.
+                op = String(" " + op_str + " ")
+                return op
+            return operator
+
+        precedence = prec.value
         grouping = grouping.get_name()
 
         if isinstance(expr, Atom):
@@ -502,15 +526,36 @@ class MakeBoxes(Builtin):
 
         elements = expr.elements
         if len(elements) > 1:
-            if h.has_form("List", len(elements) - 1):
-                ops = [get_op(op) for op in h.elements]
+            if operator.has_form("List", len(elements) - 1):
+                operator = [format_operator(op) for op in operator.elements]
+                return make_boxes_infix(elements, operator, precedence, grouping, form)
             else:
-                ops = [get_op(h)] * (len(elements) - 1)
-            return make_boxes_infix(elements, ops, precedence, grouping, f)
+                encoding_rule = evaluation.definitions.get_ownvalue(
+                    "$CharacterEncoding"
+                )
+                encoding = (
+                    "UTF8" if encoding_rule is None else encoding_rule.replace.value
+                )
+                op_str = (
+                    operator.value
+                    if isinstance(operator, String)
+                    else operator.short_name
+                )
+                if encoding == "ASCII":
+                    operator = format_operator(
+                        String(operator_to_ascii.get(op_str, op_str))
+                    )
+                else:
+                    operator = format_operator(
+                        String(operator_to_unicode.get(op_str, op_str))
+                    )
+
+            return make_boxes_infix(elements, operator, precedence, grouping, form)
+
         elif len(elements) == 1:
-            return MakeBoxes(elements[0], f)
+            return MakeBoxes(elements[0], form)
         else:
-            return MakeBoxes(expr, f)
+            return MakeBoxes(expr, form)
 
 
 class ToBoxes(Builtin):

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -98,6 +98,10 @@ from mathics.core.systemsymbols import (
 
 import sympy
 
+# These should be used in lower-level formatting
+SymbolDifferentialD = Symbol("System`DifferentialD")
+SymbolIntegral = Symbol("System`Integral")
+
 
 class D(SympyFunction):
     """

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -534,7 +534,7 @@ class StringPosition(Builtin):
      = {{4, 6}, {9, 11}}
 
     'StringPosition' can be useful for searching through text.
-    >> data = Import["ExampleData/EinsteinSzilLetter.txt"];
+    >> data = Import["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"];
     >> StringPosition[data, "uranium"]
      = {{299, 305}, {870, 876}, {1538, 1544}, {1671, 1677}, {2300, 2306}, {2784, 2790}, {3093, 3099}}
 

--- a/mathics/core/convert/op.py
+++ b/mathics/core/convert/op.py
@@ -22,6 +22,10 @@ assert osp.exists(
 with open(characters_path, "r") as f:
     op_data = ujson.load(f)
 
+ascii_operator_to_symbol = op_data["ascii-operator-to-symbol"]
+operator_to_unicode = op_data["operator-to-unicode"]
+operator_to_ascii = op_data["operator-to-ascii"]
+
 
 @lru_cache(maxsize=1024)
 def ascii_op_to_unicode(ascii_op: str, encoding: str) -> str:

--- a/mathics/core/convert/op.py
+++ b/mathics/core/convert/op.py
@@ -16,7 +16,9 @@ ROOT_DIR = pkg_resources.resource_filename("mathics", "")
 
 # Load the conversion tables from disk
 characters_path = osp.join(ROOT_DIR, "data", "op-tables.json")
-assert osp.exists(characters_path), "ASCII operator to Unicode tables are missing"
+assert osp.exists(
+    characters_path
+), f"ASCII operator to Unicode tables are missing from {characters_path}"
 with open(characters_path, "r") as f:
     op_data = ujson.load(f)
 

--- a/mathics/core/convert/op.py
+++ b/mathics/core/convert/op.py
@@ -1,0 +1,35 @@
+"""
+Conversions from the ASCII representation of Mathics operators to their Unicode equivalent
+"""
+
+import os.path as osp
+import pkg_resources
+
+from functools import lru_cache
+
+try:
+    import ujson
+except ImportError:
+    import json as ujson
+
+ROOT_DIR = pkg_resources.resource_filename("mathics", "")
+
+# Load the conversion tables from disk
+characters_path = osp.join(ROOT_DIR, "data", "op-tables.json")
+assert osp.exists(characters_path), "ASCII operator to Unicode tables are missing"
+with open(characters_path, "r") as f:
+    op_data = ujson.load(f)
+
+
+@lru_cache(maxsize=1024)
+def ascii_op_to_unicode(ascii_op: str, encoding: str) -> str:
+    """
+    Convert an ASCII representation of a Mathics operator into its
+    Unicode equivalent based on encoding (in Mathics, $CharacterEncoding).
+    If we can't come up with a unicode equivalent, just return "ascii_op".
+    """
+    if encoding in ("UTF-8", "utf-8", "Unicode"):
+        return op_data["ascii-operator-to-unicode"].get(ascii_op, ascii_op)
+    if encoding in ("WMA",):
+        return op_data["ascii-operator-to-wl-unicode"].get(ascii_op, ascii_op)
+    return ascii_op

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -215,7 +215,7 @@ def do_format_element(
     evaluation.inc_recursion_depth()
     try:
         expr = element
-        head = element.get_head()
+        head = element.get_head()  # use element.head
         elements = element.get_elements()
         include_form = False
         # If the expression is enclosed by a Format

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -405,6 +405,8 @@ class Symbol(Atom, NumericOperators, EvalMixin):
             # code to see even what type of value should be expected
             # for it.
             self.value = value
+            self._short_name = strip_context(name)
+
             cls.defined_symbols[name] = self
         return self
 
@@ -555,9 +557,6 @@ class Symbol(Atom, NumericOperators, EvalMixin):
                 1,
             )
 
-    def user_hash(self, update) -> None:
-        update(b"System`Symbol>" + self.name.encode("utf8"))
-
     def replace_vars(self, vars, options={}, in_scoping=True):
         assert all(fully_qualified_symbol_name(v) for v in vars)
         var = vars.get(self.name, None)
@@ -569,6 +568,14 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def sameQ(self, rhs: Any) -> bool:
         """Mathics SameQ"""
         return self is rhs
+
+    @property
+    def short_name(self) -> str:
+        """The symbol name with its context stripped off"""
+        return self._short_name
+
+    def user_hash(self, update) -> None:
+        update(b"System`Symbol>" + self.name.encode("utf8"))
 
     def to_python(self, *args, python_form: bool = False, **kwargs):
         if self is SymbolTrue:

--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -13,7 +13,7 @@ all doc texdoc: mathics.pdf
 
 #: Create internal Document Data from .mdoc and Python builtin module docstrings
 doc-data $(DOC_TEX_DATA_PCL):
-	(cd ../.. && $(PYTHON) docpipeline.py --output --keep-going --want-sorting)
+	(cd ../.. && MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) docpipeline.py --output --keep-going --want-sorting)
 
 #: Build mathics PDF
 mathics.pdf: mathics.tex documentation.tex logo-text-nodrop.pdf logo-heptatom.pdf version-info.tex $(DOC_TEX_DATA_PCL)

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -19,6 +19,7 @@ from argparse import ArgumentParser
 from datetime import datetime
 
 import mathics
+import mathics.settings
 
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
@@ -171,6 +172,11 @@ def test_tests(
     max_tests=MAX_TESTS,
     excludes=[],
 ):
+
+    # For consistency set the character encoding ASCII which is
+    # the lowest common denominator available on all systems.
+    mathics.settings.SYSTEM_CHARACTER_ENCODING = "ASCII"
+
     definitions.reset_user_definitions()
     total = failed = skipped = 0
     failed_symbols = set()

--- a/mathics/session.py
+++ b/mathics/session.py
@@ -10,10 +10,13 @@ In particular we provide:
 """
 
 import os.path as osp
+from typing import Optional
+
 from mathics.core.definitions import autoload_files
 from mathics.core.parser import parse, MathicsSingleLineFeeder
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
+import mathics.settings
 
 
 def load_default_settings_files(
@@ -53,7 +56,15 @@ class MathicsSession:
     it and evaluating it in the context of the current session.
     """
 
-    def __init__(self, add_builtin=True, catch_interrupt=False, form="InputForm"):
+    def __init__(
+        self,
+        add_builtin=True,
+        catch_interrupt=False,
+        form="InputForm",
+        character_encoding=Optional[str],
+    ):
+        if character_encoding is not None:
+            mathics.settings.SYSTEM_CHARACTER_ENCODING = character_encoding
         self.form = form
         self.reset(add_builtin, catch_interrupt)
 

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -69,7 +69,10 @@ ENABLE_FILES_MODULE = True
 # whatever it is that setting this thing did.
 default_pymathics_modules = []
 
-SYSTEM_CHARACTER_ENCODING = "UTF-8" if sys.getdefaultencoding() == "utf-8" else "ASCII"
+character_encoding = os.environ.get(
+    "MATHICS_CHARACTER_ENCODING", sys.getdefaultencoding()
+)
+SYSTEM_CHARACTER_ENCODING = "UTF-8" if character_encoding == "utf-8" else "ASCII"
 
 
 def get_doc_tex_data_path(should_be_readable=False, create_parent=False) -> str:

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,6 @@ else:
 
 # General Requirements
 INSTALL_REQUIRES += [
-    "Mathics_Scanner>=1.2.1,<1.3.0",
     "mpmath>=1.2.0",
     "palettable",
     "pint",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from setuptools import setup, Extension
 
 is_PyPy = platform.python_implementation() == "PyPy"
 
-INSTALL_REQUIRES = ["Mathics-Scanner >= 1.2.1,<1.3.0"]
+INSTALL_REQUIRES = ["Mathics-Scanner >= 1.3.0.dev0"]
 
 # Ensure user has the correct Python version
 # Address specific package dependencies based on Python version

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -373,16 +373,20 @@ all_test = {
     },
     # Here I use Integrate to simplify the input.
     "Integrate[F[x], {x, a, g[b]}]": {
-        "msg": "Non trivial SubsuperscriptBox",
+        "msg": "Nontrivial SubsuperscriptBox",
         "text": {
-            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\U0001D451x",
-            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\U0001D451x",
+            # FIXME: The next to are use the wrong DifferentialD due to hard-coding
+            # in Integrate[] MakeBox rules.
+            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
+            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\uf74cx",
             "System`InputForm": "Integrate[F[x], {x, a, g[b]}]",
             "System`OutputForm": "Integrate[F[x], {x, a, g[b]}]",
         },
         "mathml": {
-            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\U0001D451</mtext> <mi>x</mi></mrow></mrow>',
-            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\U0001D451</mtext> <mi>x</mi></mrow></mrow>',
+            # FIXME: The next to are use the wrong DifferentialD due to hard-coding
+            # in Integrate[] MakeBox rules.
+            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
+            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
             "System`InputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
             "System`OutputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
         },

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -377,16 +377,16 @@ all_test = {
         "text": {
             # FIXME: The next to are use the wrong DifferentialD due to hard-coding
             # in Integrate[] MakeBox rules.
-            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
-            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\uf74cx",
-            "System`InputForm": "Integrate[F[x], {x, a, g[b]}]",
+            # "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
+            # "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\uf74cx",
+            # "System`InputForm": "Integrate[F[x], {x, a, g[b]}]",
             "System`OutputForm": "Integrate[F[x], {x, a, g[b]}]",
         },
         "mathml": {
             # FIXME: The next to are use the wrong DifferentialD due to hard-coding
             # in Integrate[] MakeBox rules.
-            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
-            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
+            # "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
+            # "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
             "System`InputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
             "System`OutputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
         },

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -375,14 +375,14 @@ all_test = {
     "Integrate[F[x], {x, a, g[b]}]": {
         "msg": "Non trivial SubsuperscriptBox",
         "text": {
-            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
-            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\uf74cx",
+            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\U0001D451x",
+            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\U0001D451x",
             "System`InputForm": "Integrate[F[x], {x, a, g[b]}]",
             "System`OutputForm": "Integrate[F[x], {x, a, g[b]}]",
         },
         "mathml": {
-            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
-            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
+            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\U0001D451</mtext> <mi>x</mi></mrow></mrow>',
+            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\U0001D451</mtext> <mi>x</mi></mrow></mrow>',
             "System`InputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
             "System`OutputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
         },

--- a/test/helper.py
+++ b/test/helper.py
@@ -3,7 +3,10 @@ import time
 from mathics.session import MathicsSession
 from typing import Optional
 
-session = MathicsSession()
+# Set up a Mathics session with definitions.
+# For consistency set the character encoding ASCII which is
+# the lowest common denominator available on all systems.
+session = MathicsSession(character_encoding="ASCII")
 
 
 def reset_session(add_builtin=True, catch_interrupt=False):


### PR DESCRIPTION
./admin-tools/make-op-tables.sh builds the JSON tables.

Also, environment variable MATHICS_CHARACTER_ENCODING can be used to set SYSTEM_CHARACTER_ENCODING

Some adjustments to tests with DifferentialD were made so we use standard Unicode symbols not WMA unicode.

There was a bug in gstest from a prior commit in mathics-scanner where the "pre-scanner()" was replacing strings starting with "|".


<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/567"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

