### PR TITLE
Infix formatting

### DIFF
--- a/admin-tools/make-op-tables.sh
+++ b/admin-tools/make-op-tables.sh
@@ -5,4 +5,10 @@ mydir=$(dirname $bs)
 PYTHON=${PYTHON:-python}
 
 cd $mydir/../mathics/data
-mathics-generate-json-table --field=ascii-operator-to-unicode --field=ascii-operator-to-wl-unicode -o op-tables.json
+mathics-generate-json-table \
+    --field=ascii-operator-to-symbol \
+    --field=ascii-operator-to-unicode \
+    --field=ascii-operator-to-wl-unicode \
+    --field=operator-to-ascii \
+    --field=operator-to-unicode \
+    -o op-tables.json

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -25,10 +25,12 @@ from mathics.core.atoms import (
     Integer1,
 )
 from mathics.core.attributes import listable, protected
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.convert.op import ascii_op_to_unicode
 from mathics.core.convert.python import from_bool
+from mathics.core.element import BaseElement
 from mathics.core.formatter import format_element
 from mathics.core.list import ListExpression
 from mathics.core.parser import MathicsFileLineFeeder, parse
@@ -330,66 +332,6 @@ def mathics_split(patt, string, flags):
     return [string[start:stop] for start, stop in indices]
 
 
-class AsciiOpToString(Builtin):
-    """
-    <dl>
-      <dt>'AsciiOpToString[$operator$]'
-      <dd>returns a unicode (string)representation of ASCII string operator $op$ .
-      <dd>returns a unicode (string)representation of ASCII string operator $op$ .
-    </dl>
-    This is a Mathics-specific function which is used in operation output rendering.
-
-
-    >> AsciiOpToString[">="]
-     = ...
-    """
-
-    options = {
-        "CharacterEncoding": '"Unicode"',
-    }
-    summary_text = "convert ASCII operator to unicode"
-
-    def apply(self, operator, evaluation, options):
-        "AsciiOpToString[operator_String, OptionsPattern[AsciiOpToString]]"
-        encoding = options["System`CharacterEncoding"]
-        return String(ascii_op_to_unicode(operator.value, encoding.value))
-
-
-class SystemCharacterEncoding(Predefined):
-    """
-    <dl>
-      <dt>$SystemCharacterEncoding
-      <dd>gives the default character encoding of the system.
-    </dl>
-    """
-
-    name = "$SystemCharacterEncoding"
-
-    rules = {
-        "$SystemCharacterEncoding": '"' + SYSTEM_CHARACTER_ENCODING + '"',
-    }
-
-    summary_text = "system's character enconding"
-
-
-class CharacterEncoding(Predefined):
-    """
-    <dl>
-    <dt>'CharacterEncoding'
-        <dd>specifies the default character encoding to use if no other encoding is
-        specified.
-    </dl>
-    """
-
-    name = "$CharacterEncoding"
-    value = '"UTF-8"'
-    rules = {
-        "$CharacterEncoding": value,
-    }
-
-    summary_text = "default character encoding"
-
-
 _encodings = {
     # see https://docs.python.org/2/library/codecs.html#standard-encodings
     "ASCII": "ascii",
@@ -437,6 +379,23 @@ _encodings = {
 
 def to_python_encoding(encoding):
     return _encodings.get(encoding)
+
+
+class CharacterEncoding(Predefined):
+    """
+    <dl>
+    <dt>'CharacterEncoding'
+        <dd>specifies the default character encoding to use if no other encoding is specified.
+    </dl>
+    """
+
+    name = "$CharacterEncoding"
+    value = f'"{SYSTEM_CHARACTER_ENCODING}"'
+    rules = {
+        "$CharacterEncoding": value,
+    }
+
+    summary_text = "default character encoding"
 
 
 class CharacterEncodings(Predefined):
@@ -839,6 +798,14 @@ class String_(Builtin):
     summary_text = "head for strings"
 
 
+def eval_ToString(
+    expr: BaseElement, form: Symbol, encoding: String, evaluation: Evaluation
+) -> String:
+    boxes = format_element(expr, evaluation, form, encoding=encoding)
+    text = boxes.boxes_to_text(evaluation=evaluation)
+    return String(text)
+
+
 class ToString(Builtin):
     """
     <dl>
@@ -881,12 +848,10 @@ class ToString(Builtin):
         "ToString[value_, OptionsPattern[ToString]]"
         return self.apply_form(value, SymbolOutputForm, evaluation, options)
 
-    def apply_form(self, value, form, evaluation, options):
-        "ToString[value_, form_, OptionsPattern[ToString]]"
+    def apply_form(self, expr, form, evaluation, options):
+        "ToString[expr_, form_, OptionsPattern[ToString]]"
         encoding = options["System`CharacterEncoding"]
-        text = format_element(value, evaluation, form, encoding=encoding)
-        text = text.boxes_to_text(evaluation=evaluation)
-        return String(text)
+        return eval_ToString(expr, form, encoding.value, evaluation)
 
 
 # This isn't your normal Box class. We'll keep this here rather than
@@ -906,7 +871,7 @@ class InterpretedBox(PrefixOperator):
     precedence = 670
     summary_text = "interpret boxes as an expression"
 
-    def apply_dummy(self, boxes, evaluation):
+    def apply_dummy(self, boxes, evaluation: Evaluation):
         """InterpretedBox[boxes_]"""
         # TODO: the following is a very raw and dummy way to
         # handle these expressions.
@@ -980,7 +945,7 @@ class ToExpression(Builtin):
     }
     summary_text = "build an expression from formatted text"
 
-    def apply(self, seq, evaluation):
+    def apply(self, seq, evaluation: Evaluation):
         "ToExpression[seq__]"
 
         # Organise Arguments
@@ -1036,7 +1001,7 @@ class ToExpression(Builtin):
 
         return result
 
-    def apply_empty(self, evaluation):
+    def apply_empty(self, evaluation: Evaluation):
         "ToExpression[]"
         evaluation.message(
             "ToExpression", "argb", "ToExpression", Integer0, Integer1, Integer(3)
@@ -1081,7 +1046,7 @@ class RemoveDiacritics(Builtin):
 
     summary_text = "remove diacritics"
 
-    def apply(self, s, evaluation):
+    def apply(self, s, evaluation: Evaluation):
         "RemoveDiacritics[s_String]"
         return String(
             unicodedata.normalize("NFKD", s.value)
@@ -1117,7 +1082,7 @@ class Transliterate(Builtin):
     requires = ("unidecode",)
     summary_text = "transliterate an UTF string in different alphabets to ASCII"
 
-    def apply(self, s, evaluation):
+    def apply(self, s, evaluation: Evaluation):
         "Transliterate[s_String]"
         from unidecode import unidecode
 
@@ -1258,3 +1223,20 @@ class StringContainsQ(Builtin):
         return _pattern_search(
             self.__class__.__name__, string, patt, evaluation, options, True
         )
+
+
+class SystemCharacterEncoding(Predefined):
+    """
+    <dl>
+      <dt>$SystemCharacterEncoding
+      <dd>gives the default character encoding of the system.
+    </dl>
+    """
+
+    name = "$SystemCharacterEncoding"
+
+    rules = {
+        "$SystemCharacterEncoding": '"' + SYSTEM_CHARACTER_ENCODING + '"',
+    }
+
+    summary_text = "system's character enconding"

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -22,7 +22,7 @@ from mathics.core.atoms import (
 )
 from mathics.core.attributes import protected, read_protected, no_attributes
 from mathics.core.convert.expression import to_expression, to_numeric_sympy_args
-from mathics.core.convert.op import ascii_op_to_unicode
+from mathics.core.convert.op import ascii_operator_to_symbol
 from mathics.core.convert.python import from_bool
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.definitions import Definition
@@ -40,7 +40,6 @@ from mathics.core.symbols import (
     strip_context,
 )
 from mathics.core.systemsymbols import SymbolMessageName, SymbolRule
-from mathics.settings import SYSTEM_CHARACTER_ENCODING
 
 
 def check_requires_list(requires: list) -> bool:
@@ -622,17 +621,11 @@ class BinaryOperator(Operator):
             op_pattern = "%s[x_, y_]" % name
             replace_items = "x, y"
 
+        operator = ascii_operator_to_symbol.get(self.operator, self.__class__.__name__)
         if self.default_formats:
-            operator = self.get_operator_display()
-            formatted = 'MakeBoxes[Infix[{%s},"%s",%d,%s], form]' % (
+            formatted = "MakeBoxes[Infix[{%s}, %s, %d,%s], form]" % (
                 replace_items,
-                ascii_op_to_unicode(operator, SYSTEM_CHARACTER_ENCODING),
-                self.precedence,
-                self.grouping,
-            )
-            formatted_output = 'MakeBoxes[Infix[{%s}," %s ",%d,%s], form]' % (
-                replace_items,
-                ascii_op_to_unicode(operator, SYSTEM_CHARACTER_ENCODING),
+                operator,
                 self.precedence,
                 self.grouping,
             )
@@ -642,7 +635,7 @@ class BinaryOperator(Operator):
                 ): formatted,
                 "MakeBoxes[{0}, form:InputForm|OutputForm]".format(
                     op_pattern
-                ): formatted_output,
+                ): formatted,
             }
             default_rules.update(self.rules)
             self.rules = default_rules

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -2251,7 +2251,7 @@ if "Pyston" not in sys.version:
           <dd>Gives a word cloud with the words weighted using the given weights.
         </dl>
 
-        >> WordCloud[StringSplit[Import["ExampleData/EinsteinSzilLetter.txt"]]]
+        >> WordCloud[StringSplit[Import["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"]]]
          = -Image-
 
         >> WordCloud[Range[50] -> ToString /@ Range[50]]

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -164,7 +164,7 @@ class _OpenAction(Builtin):
             opener = MathicsOpen(
                 path_string,
                 mode=mode,
-                encoding=encoding.get_string_value(),
+                encoding=encoding.value,
                 is_temporary_file=is_temporary_file,
             )
             opener.__enter__(is_temporary_file=is_temporary_file)
@@ -503,7 +503,7 @@ class OpenRead(_OpenAction):
       <dd>opens a file and returns an 'InputStream'.
     </dl>
 
-    >> OpenRead["ExampleData/EinsteinSzilLetter.txt"]
+    >> OpenRead["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"]
      = InputStream[...]
     #> Close[%];
 
@@ -525,7 +525,7 @@ class OpenRead(_OpenAction):
      : Cannot open MathicsNonExampleFile.
      = OpenRead[MathicsNonExampleFile]
 
-    #> OpenRead["ExampleData/EinsteinSzilLetter.txt", BinaryFormat -> True]
+    #> OpenRead["ExampleData/EinsteinSzilLetter.txt", BinaryFormat -> True, CharacterEncoding->"UTF8"]
      = InputStream[...]
     #> Close[%];
     """
@@ -1484,7 +1484,7 @@ class Find(Read):
       <dd>find the first line in $stream$ that contains $text$.
     </dl>
 
-    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt"];
+    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"];
     >> Find[stream, "uranium"]
      = in manuscript, leads me to expect that the element uranium may be turned into
     >> Find[stream, "uranium"]
@@ -1492,7 +1492,7 @@ class Find(Read):
     >> Close[stream]
      = ...
 
-    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt"];
+    >> stream = OpenRead["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"];
     >> Find[stream, {"energy", "power"} ]
      = a new and important source of energy in the immediate future. Certain aspects
     >> Find[stream, {"energy", "power"} ]

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -2,7 +2,7 @@
 
 """
 This module contains symbols used to define the high level layout for
-expression formatting. 
+expression formatting.
 
 For instance, to represent a set of consecutive expressions in a row,
 we can use ``Row``
@@ -254,8 +254,7 @@ class Infix(Builtin):
     """
     <dl>
       <dt>'Infix[$expr$, $oper$, $prec$, $assoc$]'
-      <dd>displays $expr$ with the infix operator $oper$, with
-        precedence $prec$ and associativity $assoc$.
+      <dd>displays $expr$ with the infix operator $oper$, with precedence $prec$ and associativity $assoc$.
     </dl>
 
     'Infix' can be used with 'Format' to display certain forms with
@@ -294,8 +293,7 @@ class NonAssociative(Builtin):
     """
     <dl>
       <dt>'NonAssociative'
-      <dd>is used with operator formatting constructs to specify a
-        non-associative operator.
+      <dd>is used with operator formatting constructs to specify a non-associative operator.
     </dl>
     """
 
@@ -306,8 +304,7 @@ class Left(Builtin):
     """
     <dl>
       <dt>'Left'
-      <dd>is used with operator formatting constructs to specify a
-        left-associative operator.
+      <dd>is used with operator formatting constructs to specify a left-associative operator.
     </dl>
     """
 
@@ -318,8 +315,7 @@ class Right(Builtin):
     """
     <dl>
       <dt>'Right'
-      <dd>is used with operator formatting constructs to specify a
-        right-associative operator.
+      <dd>is used with operator formatting constructs to specify a right-associative operator.
     </dl>
     """
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -5,11 +5,13 @@
 Low level Format definitions
 """
 
+from typing import Union
 import mpmath
 
 
 from mathics.builtin.base import Builtin, Predefined
 from mathics.builtin.box.layout import _boxed_string, RowBox, to_boxes
+from mathics.core.convert.op import operator_to_unicode, operator_to_ascii
 from mathics.core.atoms import (
     Integer,
     Integer1,
@@ -44,6 +46,7 @@ from mathics.core.symbols import (
 from mathics.core.systemsymbols import (
     SymbolAutomatic,
     SymbolInfinity,
+    SymbolInputForm,
     SymbolMakeBoxes,
     SymbolOutputForm,
     SymbolRowBox,
@@ -80,11 +83,17 @@ def parenthesize(precedence, element, element_boxes, when_equal):
     return element_boxes
 
 
-def make_boxes_infix(elements, ops, precedence, grouping, form):
+# FIXME: op should be a string, so remove the Union.
+def make_boxes_infix(
+    elements, op: Union[str, list], precedence: int, grouping, form: Symbol
+):
     result = []
     for index, element in enumerate(elements):
         if index > 0:
-            result.append(ops[index - 1])
+            if isinstance(op, list):
+                result.append(op[index - 1])
+            else:
+                result.append(op)
         parenthesized = False
         if grouping == "System`NonAssociative":
             parenthesized = True
@@ -474,26 +483,26 @@ class MakeBoxes(Builtin):
         else:
             return MakeBoxes(expr, f).evaluate(evaluation)
 
-    def apply_infix(self, expr, h, prec, grouping, f, evaluation):
-        """MakeBoxes[Infix[expr_, h_, prec_:None, grouping_:None],
-        f:StandardForm|TraditionalForm|OutputForm|InputForm]"""
+    def apply_infix(self, expr, operator, prec, grouping, form: Symbol, evaluation):
+        """MakeBoxes[Infix[expr_, operator_, prec_:None, grouping_:None],
+        form:StandardForm|TraditionalForm|OutputForm|InputForm]"""
 
         def get_op(op):
             if not isinstance(op, String):
-                op = MakeBoxes(op, f)
+                op = MakeBoxes(op, form)
             else:
                 op_value = op.get_string_value()
-                if f.get_name() == "System`InputForm" and op_value in ["*", "^"]:
+                if form.get_name() == "System`InputForm" and op_value in ["*", "^"]:
                     pass
                 elif (
-                    f.get_name() in ("System`InputForm", "System`OutputForm")
+                    form in (SymbolInputForm, SymbolOutputForm)
                     and not op_value.startswith(" ")
                     and not op_value.endswith(" ")
                 ):
                     op = String(" " + op_value + " ")
             return op
 
-        precedence = prec.get_int_value()
+        precedence = prec.value
         grouping = grouping.get_name()
 
         if isinstance(expr, Atom):
@@ -502,15 +511,31 @@ class MakeBoxes(Builtin):
 
         elements = expr.elements
         if len(elements) > 1:
-            if h.has_form("List", len(elements) - 1):
-                ops = [get_op(op) for op in h.elements]
+            if operator.has_form("List", len(elements) - 1):
+                operator = [get_op(op) for op in operator.elements]
+                return make_boxes_infix(elements, operator, precedence, grouping, form)
+            elif isinstance(operator, String):
+                op_str = operator.value
             else:
-                ops = [get_op(h)] * (len(elements) - 1)
-            return make_boxes_infix(elements, ops, precedence, grouping, f)
+                encoding = evaluation.definitions.get_ownvalue(
+                    "$CharacterEncoding"
+                ).replace.value
+                if encoding == "ASCII":
+                    op_str = operator_to_ascii[operator.short_name]
+                else:
+                    op_str = operator_to_unicode[operator.short_name]
+
+            if form in (SymbolInputForm, SymbolOutputForm) and op_str != " ":
+                op_str = f" {op_str} "
+
+            return make_boxes_infix(
+                elements, String(op_str), precedence, grouping, form
+            )
+
         elif len(elements) == 1:
-            return MakeBoxes(elements[0], f)
+            return MakeBoxes(elements[0], form)
         else:
-            return MakeBoxes(expr, f)
+            return MakeBoxes(expr, form)
 
 
 class ToBoxes(Builtin):

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -98,6 +98,10 @@ from mathics.core.systemsymbols import (
 
 import sympy
 
+# These should be used in lower-level formatting
+SymbolDifferentialD = Symbol("System`DifferentialD")
+SymbolIntegral = Symbol("System`Integral")
+
 
 class D(SympyFunction):
     """

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -534,7 +534,7 @@ class StringPosition(Builtin):
      = {{4, 6}, {9, 11}}
 
     'StringPosition' can be useful for searching through text.
-    >> data = Import["ExampleData/EinsteinSzilLetter.txt"];
+    >> data = Import["ExampleData/EinsteinSzilLetter.txt", CharacterEncoding->"UTF8"];
     >> StringPosition[data, "uranium"]
      = {{299, 305}, {870, 876}, {1538, 1544}, {1671, 1677}, {2300, 2306}, {2784, 2790}, {3093, 3099}}
 

--- a/mathics/core/convert/op.py
+++ b/mathics/core/convert/op.py
@@ -22,6 +22,10 @@ assert osp.exists(
 with open(characters_path, "r") as f:
     op_data = ujson.load(f)
 
+ascii_operator_to_symbol = op_data["ascii-operator-to-symbol"]
+operator_to_unicode = op_data["operator-to-unicode"]
+operator_to_ascii = op_data["operator-to-ascii"]
+
 
 @lru_cache(maxsize=1024)
 def ascii_op_to_unicode(ascii_op: str, encoding: str) -> str:

--- a/mathics/core/formatter.py
+++ b/mathics/core/formatter.py
@@ -215,7 +215,7 @@ def do_format_element(
     evaluation.inc_recursion_depth()
     try:
         expr = element
-        head = element.get_head()
+        head = element.get_head()  # use element.head
         elements = element.get_elements()
         include_form = False
         # If the expression is enclosed by a Format

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -405,6 +405,8 @@ class Symbol(Atom, NumericOperators, EvalMixin):
             # code to see even what type of value should be expected
             # for it.
             self.value = value
+            self._short_name = name.split("`")[-1]
+
             cls.defined_symbols[name] = self
         return self
 
@@ -555,9 +557,6 @@ class Symbol(Atom, NumericOperators, EvalMixin):
                 1,
             )
 
-    def user_hash(self, update) -> None:
-        update(b"System`Symbol>" + self.name.encode("utf8"))
-
     def replace_vars(self, vars, options={}, in_scoping=True):
         assert all(fully_qualified_symbol_name(v) for v in vars)
         var = vars.get(self.name, None)
@@ -569,6 +568,14 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def sameQ(self, rhs: Any) -> bool:
         """Mathics SameQ"""
         return self is rhs
+
+    @property
+    def short_name(self) -> str:
+        """The symbol name with its context stripped off"""
+        return self._short_name
+
+    def user_hash(self, update) -> None:
+        update(b"System`Symbol>" + self.name.encode("utf8"))
 
     def to_python(self, *args, python_form: bool = False, **kwargs):
         if self is SymbolTrue:

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -405,7 +405,7 @@ class Symbol(Atom, NumericOperators, EvalMixin):
             # code to see even what type of value should be expected
             # for it.
             self.value = value
-            self._short_name = name.split("`")[-1]
+            self._short_name = strip_context(name)
 
             cls.defined_symbols[name] = self
         return self

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -373,16 +373,20 @@ all_test = {
     },
     # Here I use Integrate to simplify the input.
     "Integrate[F[x], {x, a, g[b]}]": {
-        "msg": "Non trivial SubsuperscriptBox",
+        "msg": "Nontrivial SubsuperscriptBox",
         "text": {
-            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\U0001D451x",
-            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\U0001D451x",
+            # FIXME: The next to are use the wrong DifferentialD due to hard-coding
+            # in Integrate[] MakeBox rules.
+            "System`StandardForm": "Subsuperscript[∫, a, g[b]]\u2062F[x]\u2062\uf74cx",
+            "System`TraditionalForm": "Subsuperscript[∫, a, g(b)]\u2062F(x)\u2062\uf74cx",
             "System`InputForm": "Integrate[F[x], {x, a, g[b]}]",
             "System`OutputForm": "Integrate[F[x], {x, a, g[b]}]",
         },
         "mathml": {
-            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\U0001D451</mtext> <mi>x</mi></mrow></mrow>',
-            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\U0001D451</mtext> <mi>x</mi></mrow></mrow>',
+            # FIXME: The next to are use the wrong DifferentialD due to hard-coding
+            # in Integrate[] MakeBox rules.
+            "System`StandardForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
+            "System`TraditionalForm": '<mrow><msubsup><mo>∫</mo> <mi>a</mi> <mrow><mi>g</mi> <mo>(</mo> <mi>b</mi> <mo>)</mo></mrow></msubsup> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mi>F</mi> <mo>(</mo> <mi>x</mi> <mo>)</mo></mrow> <mo form="prefix" lspace="0" rspace="0.2em">\u2062</mo> <mrow><mtext>\uf74c</mtext> <mi>x</mi></mrow></mrow>',
             "System`InputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
             "System`OutputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
         },


### PR DESCRIPTION
This revises the work done in the `ascii-op-to-Unicode` branch. 

I had a hard time understanding the flow of what's going on, and this process was both painful and made me a bit annoyed. 

I was pleased though at @mmatera start to move the makeboxes into its own module, and we have a _little_ bit of segregating boxing routines, so that I suppose helps a little.

It is not that the code isn't sophisticated or complicated. It is just that it is not organized and changes haven't been coordinated. 

Let me describe a little of the history around this PR and the code I see, and reflect. The aim show of this reflection shows how the code has become of poorer quality, is in constant need of serious refactoring, and can get worse with uncoordinated bug fixes or feature improvements. Functionally the code does a quite a bit; but it is at the cost of lots of code with undue complexity. I assume that much of the complicated code is to ensure correct behavior.

However, where we find that the code is not correct or lacking, we have a hard time figuring out where to go and what to change that isn't going to impact a lot of other things.

mmatera notes a problem with infix operator behavior in the `ascii-op-to-Unicode` branch. I had sort of seen this when I wrote that branch initially. One thing that I noticed that was was wrong in my PR is that the place where the change occurs felt wrong: it is code inside a "MakeBox" _rule_. But this rule is defined on class creation or registering each of the infix operators. These rules are is never changed. Something like `$CharacterEncoding` can change at will, so this location is too static.

Therefore I had to give up (temporarily) on making this work for `$CharacterEncoding`. Instead, I used the less dynamic `$SystemCharacterEncoding` instead.

Looking over this in a second pass, I see now that  a  rule like this is boneheaded:


```
formatted_output = 'MakeBoxes[Infix[{%s}," %s ",%d,%s], form]' % (
                replace_items,
                operator,
                self.precedence,
                self.grouping,
            )
default_rules = {
  # ...
  "MakeBoxes[{0}, form:InputForm|OutputForm]".format(op_pattern):
  formatted_output
}
```

Do you see why? ...

Hint: it is in the `" %s "` part.

This is supposed to be a rule that is called when boxing infix operators. And already it is deciding that operators should be surrounded by spaces for "InputForm" and "OutputForm".
In other words, right here in part which dictates rules to Box Infix expressions, we are already making decisions about the low-level formatting: that there should be spaces around the operator and what characters to use to represent the operator.

And when we actually get to the low-level format to final string, we have lost structure. Basically we have violated the principle that you evaluate to get an M-expression, then you Box the result, and then after Boxing then a low-level formatting is done.

If we want to write dozens more forms, the above isn't scalable. And we make high-quality formatting harder. 

At some level this was probably noticed, at least implicitly; when there are such few comments it is hard to know what was noticed and what was just random programming by reacting to problems that come up.
Since everything can't be done by MakeBox rules, we have `do_format_xxx` routines in `mathics-core/mathics/core/formatter.py` as well as special routines in `builtin/arithfns/basic.py`, `builtin/pympler/asizeof.py`, some that are done on inside `MakeBox()` internal functions.

In short, since principles if they were decided or defined, they were not communicated anywhere I can tell; so naturally formatting codes is scattering  at many of places in the code at several conceptual levels. Possibly some of the code is redundant or worse, works cross purposes.

If discussion of high-level principle were lacking, so are basic description code. Things like docstrings on functions. Or making an effort to _name_ what a function does. For example take the `get_op()` an interanal function inside _evaluation_ method `apply_infix()` leaving aside the missing `apply_` prefix that I have mentioned many times before.

What is `get_op()` "getting"? You already pass it some sort of operator. If you look at the function you realize it is not getting or accessing something, but rather converiting or _formatting_. 

And then once you realize that you are then in a position to ask _why_ is this routine formatting inside a Boxing routine? In the overall architecture isn't a separate step. Or should low-level formatting routines, be put  together?

Vagueness in code, lack of description and discussion around the code has led to very haphazard code that, in the end result, does not seem fully thought out.

With all the effort spent in just figuring out what he code _does_; by the time I understand that, I am exhausted and often not in a mood to think about how it should be designed or whether it follows a design or how to best write this.

Let me come back to adding spaces around the operator and losing the operator structure (the `" %s "` part) one more time. Because of this, the "remedy" was put in place that makes things worse. A routine was added that scans strings and unconditionally changes some strings (e.g. ASCII-formatted operators) into Unicode characters. I doesn't  matter if this was done by ignorance, willful frustration: in the end, it makes the code a bigger mess.

It is, as I say, like trying to solve a Rubik's cube by getting adjacent faces in line one at a time. In the beginning there is a certain satisfaction because you can "make progress". However getting to the end this way is much harder than understanding what is going on performing operations that work in conjunction with the principles and groups of the Rubik's cube.

Given all this, my inclination right now is to hold off on adding new Forms, or correcting the existing ones to be more correct. Instead if we just make things work they do but in a logical sensible and extensible way, I think this would buy us the most to then correct the existing behavior to match the specifications more closely and to add more Forms.






<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/569"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

