### PR TITLE
Go back to using master branch in scanner

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt update -qq && sudo apt install llvm-dev
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with minimum dependencies
       run: |
         make develop

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         LLVM_CONFIG=/usr/local/Cellar/llvm@11/11.1.0/bin/llvm-config pip install llvmlite
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full-cython

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt-get update -qq && sudo apt-get install -qq liblapack-dev llvm-dev
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Install Mathics with full dependencies
       run: |
         make develop-full

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
         choco install llvm
         set LLVM_DIR="C:\Program Files\LLVM"
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@ascii-op-to-unicode#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         make develop
     - name: Install Mathics
       run: |


### PR DESCRIPTION
We needed to use a branch of mathics-scanner in workflows CI. That branch now is in master, so we can simplify things a little in workflows testing.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/571"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

