### PR TITLE
Go over doc for CharacterEncoding functions ...

### DIFF
--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -341,6 +341,15 @@ class BaseElement(KeyComparable):
         """Convert's a Mathics Sequence into a Python's list of elements"""
         from mathics.core.symbols import SymbolSequence
 
+        # Below, we special-case for SymbolSequence. Here is an example to suggest why.
+        # Suppose we have this evaluation method:
+        #
+        # def apply(x, evaluation):
+        #     """F[x__]"""
+        #     args = x.get_sequence()
+        #
+        # For the expression "F[a,b]", this function is expected to return [Symbol(a), Symbol(b)], while
+        # for the expression "F[{a,b}]" this function is expected to return ListExpression[Symbol(a), Symbol(b)].
         if self.get_head() is SymbolSequence:
             return self.elements
         else:


### PR DESCRIPTION
and add mmatera's explanation in for a `get_sequence()` behavior. See https://github.com/Mathics3/mathics-core/pull/548#issuecomment-1243089289

It is always useful to provide at least one example for each Built-in function

Put builtin methods in alphabetic order in `builtin/atomic/strings.py` and use newer form of attribute symbols

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/572"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

