### PR TITLE
Improving the way in which outputs are presented in the interpreter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ Enhancements
 #. Better handling of comparisons with finite precision numbers.
 #. Improved implementation for  ``Precision``.
 #. Infix operators, like ``->`` render with their Unicode symbol when ``$CharacterEncoding`` is not "ASCII".
+#. In the command line interface, outputs with non-default formats are now printed as``Out[`lineno`]//`form`= `result```.
 
 
 5.0.2

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -129,11 +129,11 @@ class TerminalShell(MathicsLineFeeder):
     def get_out_prompt(self, format=None):
         line_number = self.get_last_line_number()
         if format:
-            return "{2}Out[{3}{0}{4}]//{1}= {5}".format(
+            return "{2}Out[{3}{0}{2}]{4}//{1}= {5}".format(
                 line_number, format, *self.outcolors
             )
         else:
-            return "{1}Out[{2}{0}{3}]= {4}".format(line_number, *self.outcolors)
+            return "{1}Out[{2}{0}{1}]{3}= {4}".format(line_number, *self.outcolors)
 
     def to_output(self, text):
         line_number = self.get_last_line_number()


### PR DESCRIPTION
This PR modifies the interpreter to show (like in WMA) the output of formatted expressions like

```
In[1]:=InputForm[expr]
Out[1]//InputForm = expr
```



<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/575"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

