### PR TITLE
eval as a synonym of apply...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ Internals
 #. ``mathics.builtin.inout`` was splitted in several modules (``inout``, ``messages``, ``layout``, ``makeboxes``) in order to improve the documentation.
 #. `from_mpmath` conversion supports a new parameter ``acc`` to set the accuracy of the number.
 #. Operator name to unicode or ASCII comes from Mathics scanner character tables.
-
+#. ``eval*`` methods in `Builtin` classes are considerer as synonyms of ``apply*`` methods.
 
 Bugs
 ++++

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -119,7 +119,7 @@ class CubeRoot(Builtin):
 
     summary_text = "cubed root"
 
-    def apply(self, n, evaluation):
+    def eval(self, n, evaluation):
         "CubeRoot[n_Complex]"
 
         evaluation.message("CubeRoot", "preal", n)
@@ -237,7 +237,7 @@ class Minus(PrefixOperator):
 
     summary_text = "arithmetic negation"
 
-    def apply_int(self, x: Integer, evaluation):
+    def eval_int(self, x: Integer, evaluation):
         "Minus[x_Integer]"
         return Integer(-x.value)
 
@@ -366,7 +366,7 @@ class Plus(BinaryOperator, SympyFunction):
             SymbolLeft,
         )
 
-    def apply(self, items, evaluation):
+    def eval(self, items, evaluation):
         "Plus[items___]"
 
         items_tuple = items.numerify(evaluation).get_sequence()
@@ -584,7 +584,7 @@ class Power(BinaryOperator, _MPMathFunction):
 
     summary_text = "exponentiation"
 
-    def apply_check(self, x, y, evaluation):
+    def eval_check(self, x, y, evaluation):
         "Power[x_, y_]"
 
         # Power uses _MPMathFunction but does some error checking first
@@ -864,7 +864,7 @@ class Times(BinaryOperator, SympyFunction):
         "OutputForm: Times[items__]"
         return self.format_times(items, evaluation, op=" ")
 
-    def apply(self, items, evaluation):
+    def eval(self, items, evaluation):
         "Times[items___]"
         items = items.numerify(evaluation).get_sequence()
         elements = []

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -273,6 +273,12 @@ class Builtin:
             PyMathicsDefinitions() if is_pymodule else SystemDefinitions()
         )
 
+        for pattern, function in self.get_functions(
+            prefix="eval", is_pymodule=is_pymodule
+        ):
+            rules.append(
+                BuiltinRule(name, pattern, function, check_options, system=True)
+            )
         for pattern, function in self.get_functions(is_pymodule=is_pymodule):
             rules.append(
                 BuiltinRule(name, pattern, function, check_options, system=True)
@@ -546,7 +552,7 @@ class Operator(Builtin):
 class Predefined(Builtin):
     def get_functions(self, prefix="apply", is_pymodule=False) -> List[Callable]:
         functions = list(super().get_functions(prefix))
-        if prefix == "apply" and hasattr(self, "evaluate"):
+        if prefix in ("apply", "eval") and hasattr(self, "evaluate"):
             functions.append((Symbol(self.get_name()), self.evaluate))
         return functions
 


### PR DESCRIPTION
We have methods that start `apply_` that are really evaluation methods. This allows us to migrate the code to start using `eval_` like everyone else does.