### PR TITLE
contributing builtin var

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Internals
 #. `from_mpmath` conversion supports a new parameter ``acc`` to set the accuracy of the number.
 #. Operator name to unicode or ASCII comes from Mathics scanner character tables.
 #. ``eval*`` methods in `Builtin` classes are considerer as synonyms of ``apply*`` methods.
-#. Modularize and improving the way in which `Builtin` classes are selected to have an associated `Definition`.
+#. Modularize and improve the way in which `Builtin` classes are selected to have an associated `Definition`.
 
    
 Bugs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,9 @@ Internals
 #. `from_mpmath` conversion supports a new parameter ``acc`` to set the accuracy of the number.
 #. Operator name to unicode or ASCII comes from Mathics scanner character tables.
 #. ``eval*`` methods in `Builtin` classes are considerer as synonyms of ``apply*`` methods.
+#. Modularize and improving the way in which `Builtin` classes are selected to have an associated `Definition`.
 
+   
 Bugs
 ++++
 

--- a/SYMBOLS_MANIFEST.txt
+++ b/SYMBOLS_MANIFEST.txt
@@ -52,6 +52,7 @@ System`$Post
 System`$Pre
 System`$PrePrint
 System`$PreRead
+System`$PrintForms
 System`$ProcessID
 System`$ProcessorType
 System`$RandomState
@@ -79,6 +80,7 @@ System`AbsoluteThickness
 System`AbsoluteTime
 System`AbsoluteTiming
 System`Accumulate
+System`Accuracy
 System`AddTo
 System`AiryAi
 System`AiryAiPrime
@@ -263,6 +265,7 @@ System`Csc
 System`CubeRoot
 System`Cuboid
 System`Cuboid3DBox
+System`Curl
 System`Cyan
 System`Cylinder
 System`Cylinder3DBox
@@ -546,6 +549,7 @@ System`Keys
 System`Khinchin
 System`KnownUnitQ
 System`KroneckerProduct
+System`Kurtosis
 System`LABColor
 System`LCHColor
 System`LCM
@@ -878,12 +882,14 @@ System`Sharpen
 System`ShearingTransform
 System`Shortest
 System`Show
+System`ShowStringCharacters
 System`Sign
 System`Simplify
 System`Sin
 System`SingularValueDecomposition
 System`Sinh
 System`SixJSymbol
+System`Skewness
 System`Skip
 System`Slot
 System`SlotSequence

--- a/admin-tools/build_and_check_manifest.py
+++ b/admin-tools/build_and_check_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from mathics.builtin import modules, is_builtin, Builtin
+from mathics.builtin import contributing_builtin_var, modules, is_builtin, Builtin
 import sys
 
 
@@ -10,15 +10,8 @@ def generate_avaliable_builtins_names():
     for module in modules:
         vars = dir(module)
         for name in vars:
-            var = getattr(module, name)
-            if (
-                hasattr(var, "__module__")
-                and var.__module__.startswith("mathics.builtin.")
-                and var.__module__ != "mathics.builtin.base"
-                and is_builtin(var)
-                and not name.startswith("_")
-                and var.__module__ == module.__name__
-            ):  # nopep8
+            var = contributing_builtin_var(module, name)
+            if var:  # nopep8
                 instance = var(expression=False)
                 if isinstance(instance, Builtin):
                     # This set the default context for symbols in mathics.builtins

--- a/admin-tools/build_and_check_manifest.py
+++ b/admin-tools/build_and_check_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from mathics.builtin import contributing_builtin_var, modules, is_builtin, Builtin
+from mathics.builtin import contributing_builtin_var, modules, Builtin
 import sys
 
 

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -38,14 +38,6 @@ from mathics.builtin.base import (
 )
 
 
-def is_builtin(var):
-    if var == Builtin:
-        return True
-    if hasattr(var, "__bases__"):
-        return any(is_builtin(base) for base in var.__bases__)
-    return False
-
-
 def contributing_builtin_var(module, name) -> Optional[type]:
     """
     Returns getattr(module, name) if it is a Builtin that
@@ -57,7 +49,7 @@ def contributing_builtin_var(module, name) -> Optional[type]:
 
     var = getattr(module, name)
 
-    if not hasattr(var, "__module__"):
+    if not (isinstance(var, type) and hasattr(var, "__module__")):
         return None
 
     # Skip those builtins defined in another module
@@ -73,7 +65,7 @@ def contributing_builtin_var(module, name) -> Optional[type]:
         return None
 
     # If it is not a subclass of Builtin, skip it
-    if not is_builtin(var):
+    if not issubclass(var, Builtin):
         return None
 
     # Skip it we explicitly set that we want to skip it:

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -166,7 +166,11 @@ class Definitions:
         from an external Python module in the pymathics module namespace.
         """
         import importlib
-        from mathics.builtin import is_builtin, builtins_by_module, Builtin
+        from mathics.builtin import (
+            contributing_builtin_var,
+            builtins_by_module,
+            Builtin,
+        )
 
         # Ensures that the pymathics module be reloaded
         import sys
@@ -187,14 +191,8 @@ class Definitions:
         if not ("pymathics_version_data" in vars):
             raise PyMathicsLoadException(module)
         for name in vars - set(("pymathics_version_data", "__version__")):
-            var = getattr(loaded_module, name)
-            if (
-                hasattr(var, "__module__")
-                and is_builtin(var)
-                and not name.startswith("_")
-                and var.__module__[: len(loaded_module.__name__)]
-                == loaded_module.__name__
-            ):  # nopep8
+            var = contributing_builtin_var(loaded_module, name)
+            if var:  # nopep8
                 instance = var(expression=False)
                 if isinstance(instance, Builtin):
                     if not var.context:

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -1071,19 +1071,12 @@ class PyMathicsDocumentation(Documentation):
 
         # Load the dictionary of mathics symbols defined in the module
         self.symbols = {}
-        from mathics.builtin import is_builtin, Builtin
+        from mathics.builtin import contributing_builtin_var, Builtin
 
         print("loading symbols")
         for name in dir(self.pymathicsmodule):
-            var = getattr(self.pymathicsmodule, name)
-            if (
-                hasattr(var, "__module__")
-                and var.__module__ != "mathics.builtin.base"
-                and is_builtin(var)
-                and not name.startswith("_")
-                and var.__module__[: len(self.pymathicsmodule.__name__)]
-                == self.pymathicsmodule.__name__
-            ):  # nopep8
+            var = contributing_builtin_var(self.pymathicsmodule, name)
+            if var:
                 instance = var(expression=False)
                 if isinstance(instance, Builtin):
                     self.symbols[instance.get_name()] = instance

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -6,7 +6,7 @@ had missing or duplicate build-in functions definitions.
 """
 import pytest
 import os
-from mathics.builtin import modules, is_builtin, Builtin
+from mathics.builtin import contributing_builtin_var, modules, is_builtin, Builtin
 
 
 @pytest.mark.skipif(
@@ -18,15 +18,8 @@ def test_check_duplicated():
     for module in modules:
         vars = dir(module)
         for name in vars:
-            var = getattr(module, name)
-            if (
-                hasattr(var, "__module__")
-                and var.__module__.startswith("mathics.builtin.")
-                and var.__module__ != "mathics.builtin.base"
-                and is_builtin(var)
-                and not name.startswith("_")
-                and var.__module__ == module.__name__
-            ):  # nopep8
+            var = contributing_builtin_var(module, name)
+            if var:
                 instance = var(expression=False)
                 if isinstance(instance, Builtin):
                     # This set the default context for symbols in mathics.builtins

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -6,7 +6,7 @@ had missing or duplicate build-in functions definitions.
 """
 import pytest
 import os
-from mathics.builtin import contributing_builtin_var, modules, is_builtin, Builtin
+from mathics.builtin import contributing_builtin_var, modules, Builtin
 
 
 @pytest.mark.skipif(

--- a/test/consistency-and-style/test_summary_text.py
+++ b/test/consistency-and-style/test_summary_text.py
@@ -7,7 +7,7 @@ import os
 import os.path as osp
 from mathics.version import __version__  # noqa used in loading to check consistency.
 
-
+from mathics.builtin import contributing_builtin_var
 from mathics.builtin.base import Builtin
 from mathics import __file__ as mathics_initfile_path
 
@@ -194,14 +194,12 @@ def test_summary_text_available(module_name):
     module = modules[module_name]
     vars = dir(module)
     for name in vars:
-        var = getattr(module, name)
+        var = contributing_builtin_var(module, name)
+        if var is None:
+            continue
         # skip if var is not a builtin that belongs to
         # this module
-        if (
-            name.startswith("_")
-            or (len(name) > 3 and name[-3:] == "Box")
-            or not (is_builtin(var) and var.__module__ == module.__name__)
-        ):
+        if len(name) > 3 and name[-3:] == "Box":
             continue
         instance = var(expression=False)
         if not isinstance(instance, Builtin):

--- a/test/consistency-and-style/test_summary_text.py
+++ b/test/consistency-and-style/test_summary_text.py
@@ -94,14 +94,6 @@ __py_files__ = [
 ]
 
 
-def _is_builtin(var):
-    if var == Builtin:
-        return True
-    if hasattr(var, "__bases__"):
-        return any(_is_builtin(base) for base in var.__bases__)
-    return False
-
-
 def import_module(module_name: str):
     try:
         module = importlib.import_module("mathics.builtin." + module_name)
@@ -167,15 +159,6 @@ def check_well_formatted_docstring(docstr: str, instance: Builtin, module_name: 
     assert (
         docstr.count("</dd>") == 0
     ), f"unnecesary </dd> field {instance.get_name()} from {module_name}"
-
-
-def is_builtin(var: object) -> bool:
-    return (
-        hasattr(var, "__module__")
-        and var.__module__.startswith("mathics.builtin.")
-        and var.__module__ != "mathics.builtin.base"
-        and _is_builtin(var)
-    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR improves the way in which we check if a Builtin class should contribute with a Definition. This makes the way in which this decision is made more modular, and allows marking certain base classes (as `FormBaseClass`) to be a public class but not a Definition. This is necessary for #576 to comply with all the requirements:
* To follow Python standards
* To follow Mathics naming pattern
* To avoid overpopulating `mathics.builtin.base`
*  To avoid adding unwanted base classes as a Definition.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/584"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

