### PR TITLE
More suggestions and fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ New Builtins
 #. ``Curl`` (2-D and 3-D vector forms only)
 #. ``Kurtosis``
 #. ``PauliMatrix``
+#. ``Remove``
 #. ``SixJSymbol``
 #. ``Skewness``
 #. ``ThreeJSymbol``

--- a/SYMBOLS_MANIFEST.txt
+++ b/SYMBOLS_MANIFEST.txt
@@ -831,6 +831,7 @@ System`RegularExpression
 System`RegularPolygon
 System`RegularPolygonBox
 System`ReleaseHold
+System`Remove
 System`RemoveDiacritics
 System`RenameDirectory
 System`RenameFile

--- a/mathics/autoload/forms/StandardForm.m
+++ b/mathics/autoload/forms/StandardForm.m
@@ -12,7 +12,7 @@ Begin["System`"]
    code. *)
 Attributes[CommonRadicalBox] = HoldAll;
 Attributes[RadBox] = HoldAll;
-CommonRadicalBox[expr_, form_] = RadBox[MakeBoxes[expr, form], 3];
+CommonRadicalBox[expr_, form_]:= RadBox[MakeBoxes[expr, form], 3];
 
 (******************************************************************************************)
 (* StandardForm Boxing Rules                                                               *)

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -170,8 +170,8 @@ class ClearAll(Clear):
 class Remove(Builtin):
     """
     <dl>
-    <dt>'Remove[$x$]'
-        <dd>removes the definition associated to $x$
+      <dt>'Remove[$x$]'
+      <dd>removes the definition associated to $x$.
     </dl>
     >> a := 2
     >> Names["Global`a"]
@@ -190,6 +190,8 @@ class Remove(Builtin):
         """Remove[symb_]"""
         if isinstance(symb, Symbol):
             evaluation.definitions.reset_user_definition(symb.name)
+        elif isinstance(symb, String):
+            evaluation.definitions.reset_user_definition(symb.value)
         else:
             evaluation.message(self.get_name(), "ssym", symb)
         return SymbolNull

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -167,6 +167,34 @@ class ClearAll(Clear):
         definition.defaultvalues = []
 
 
+class Remove(Builtin):
+    """
+    <dl>
+    <dt>'Remove[$x$]'
+        <dd>removes the definition associated to $x$
+    </dl>
+    >> a := 2
+    >> Names["Global`a"]
+     = {a}
+    >> Remove[a]
+    >> Names["Global`a"]
+     = {}
+    """
+
+    attributes = A_HOLD_ALL | A_LOCKED | A_PROTECTED
+    messages = {"ssym": "`1` is not a symbol."}
+    precedence = 670
+    summary_text = "remove the definition of a symbol"
+
+    def eval(self, symb, evaluation):
+        """Remove[symb_]"""
+        if isinstance(symb, Symbol):
+            evaluation.definitions.reset_user_definition(symb.name)
+        else:
+            evaluation.message(self.get_name(), "ssym", symb)
+        return SymbolNull
+
+
 class Unset(PostfixOperator):
     """
     <dl>

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -567,9 +567,9 @@ def process_assign_makeboxes(self, lhs, rhs, evaluation, tags, upset):
     #   MakeBoxes[CubeRoot, StandardForm] := RadicalBox[3, StandardForm]
     # rather than:
     #   MakeBoxes[CubeRoot, StandardForm] -> RadicalBox[3, StandardForm]
-    makeboxes_rule = Rule(lhs, rhs, system=True)
-    makeboxes_defs = evaluation.definitions.builtin["System`MakeBoxes"]
-    makeboxes_defs.add_rule(makeboxes_rule)
+    makeboxes_rule = Rule(lhs, rhs, system=False)
+    definitions = evaluation.definitions
+    definitions.add_rule("System`MakeBoxes", makeboxes_rule, "down")
     return True
 
 

--- a/mathics/builtin/assignments/internals.py
+++ b/mathics/builtin/assignments/internals.py
@@ -558,6 +558,21 @@ def process_assign_format(self, lhs, rhs, evaluation, tags, upset):
     return count > 0
 
 
+def process_assign_makeboxes(self, lhs, rhs, evaluation, tags, upset):
+    # FIXME: the below is a big hack.
+    # Currently MakeBoxes boxing is implemented as a bunch of rules.
+    # See mathics.builtin.base contribute().
+    # I think we want to change this so it works like normal SetDelayed
+    # That is:
+    #   MakeBoxes[CubeRoot, StandardForm] := RadicalBox[3, StandardForm]
+    # rather than:
+    #   MakeBoxes[CubeRoot, StandardForm] -> RadicalBox[3, StandardForm]
+    makeboxes_rule = Rule(lhs, rhs, system=True)
+    makeboxes_defs = evaluation.definitions.builtin["System`MakeBoxes"]
+    makeboxes_defs.add_rule(makeboxes_rule)
+    return True
+
+
 def process_assign_messagename(self, lhs, rhs, evaluation, tags, upset):
     lhs, condition = unroll_conditions(lhs)
     lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
@@ -685,23 +700,24 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
 
 class _SetOperator:
     special_cases = {
-        "System`OwnValues": process_assign_definition_values,
-        "System`DownValues": process_assign_definition_values,
-        "System`SubValues": process_assign_definition_values,
-        "System`UpValues": process_assign_definition_values,
-        "System`NValues": process_assign_definition_values,
-        "System`DefaultValues": process_assign_definition_values,
-        "System`Messages": process_assign_definition_values,
-        "System`Attributes": process_assign_attributes,
-        "System`Options": process_assign_options,
-        "System`$RandomState": process_assign_random_state,
         "System`$Context": process_assign_context,
         "System`$ContextPath": process_assign_context_path,
-        "System`N": process_assign_n,
-        "System`NumericQ": process_assign_numericq,
-        "System`MessageName": process_assign_messagename,
+        "System`$RandomState": process_assign_random_state,
+        "System`Attributes": process_assign_attributes,
         "System`Default": process_assign_default,
+        "System`DefaultValues": process_assign_definition_values,
+        "System`DownValues": process_assign_definition_values,
         "System`Format": process_assign_format,
+        "System`MakeBoxes": process_assign_makeboxes,
+        "System`MessageName": process_assign_messagename,
+        "System`Messages": process_assign_definition_values,
+        "System`N": process_assign_n,
+        "System`NValues": process_assign_definition_values,
+        "System`NumericQ": process_assign_numericq,
+        "System`Options": process_assign_options,
+        "System`OwnValues": process_assign_definition_values,
+        "System`SubValues": process_assign_definition_values,
+        "System`UpValues": process_assign_definition_values,
     }
 
     def assign_elementary(self, lhs, rhs, evaluation, tags=None, upset=False):
@@ -755,21 +771,5 @@ class _SetOperator:
                 return False
             indices = lhs.elements[1:]
             return walk_parts([rule.replace], indices, evaluation, rhs)
-
-        # FIXME: the below is a big hack.
-        # Currently MakeBoxes boxing is implemented as a bunch of rules.
-        # See mathics.builtin.base contribute().
-        # I think we want to change this so it works like normal SetDelayed
-        # That is:
-        #   MakeBoxes[CubeRoot, StandardForm] := RadicalBox[3, StandardForm]
-        # rather than:
-        #   MakeBoxes[CubeRoot, StandardForm] -> RadicalBox[3, StandardForm]
-        elif lhs.get_head_name() == "System`MakeBoxes":
-            makeboxes_rule = Rule(lhs, rhs, system=True)
-            makeboxes_defs = defs.builtin["System`MakeBoxes"]
-            makeboxes_defs.add_rule(makeboxes_rule)
-            # FIXME: what should be the result?
-            return makeboxes_rule
-
         else:
             return self.assign_elementary(lhs, rhs, evaluation)

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -283,15 +283,13 @@ class Builtin:
             rules.append(
                 BuiltinRule(name, pattern, function, check_options, system=True)
             )
-        for pattern, replace in self.rules.items():
-            # FIXME: sometimes pattern is a string and sometimes a BaseElement?
-            # This seems wrong.
-            if not isinstance(pattern, BaseElement):
-                pattern = pattern % {"name": name}
-                pattern = parse_builtin_rule(pattern, definition_class)
-            replace = replace % {"name": name}
-            # FIXME: Should system=True be system=not is_pymodule ?
-            rules.append(Rule(pattern, parse_builtin_rule(replace), system=True))
+        for pattern_str, replace_str in self.rules.items():
+            pattern_str = pattern_str % {"name": name}
+            pattern = parse_builtin_rule(pattern_str, definition_class)
+            replace_str = replace_str % {"name": name}
+            rules.append(
+                Rule(pattern, parse_builtin_rule(replace_str), system=not is_pymodule)
+            )
 
         box_rules = []
         # FIXME: Why a special case for System`MakeBoxes? Remove this

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -169,7 +169,14 @@ class Definitions:
                 if name.startswith("Global`"):
                     raise ValueError("autoload defined %s." % name)
 
-            self.builtin.update(self.user)
+            # The idea here is that all the symbols loaded in
+            # autoload become converted in builtin.
+            # For some reason, if we do not do this here,
+            # `Export` and `Import` fails.
+            # TODO: investigate why.
+            for name in self.user:
+                self.builtin[name] = self.get_definition(name)
+
             self.user = {}
             self.clear_cache()
 


### PR DESCRIPTION
In this PR
* the assignment to `MakeBoxes` is rewritten following the pattern of the other special cases.
* The last step of cleaning up in the load of `Definitions` is fixed, to avoid get ride of the builtin definitions for symbols that are overloaded in  the `autoload` step.
* the builtin `Remove`  is added.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/595"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

