### PR TITLE
fix cleanup after loading autoload definitions

### DIFF
--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -171,8 +171,9 @@ class Definitions:
 
             # Move symbols defined in autoload modules
             # to Builtin definitions.
-            # This seems important for Export and Import...
-            # TODO: check why
+            # This is important to avoid that reset_user_definitions
+            # getting rid of the autoloaded definitions (including)
+            # the needed by Import/Export.
             for name in self.user:
                 self.builtin[name] = self.get_definition(name)
 

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -169,7 +169,13 @@ class Definitions:
                 if name.startswith("Global`"):
                     raise ValueError("autoload defined %s." % name)
 
-            self.builtin.update(self.user)
+            # Move symbols defined in autoload modules
+            # to Builtin definitions.
+            # This seems important for Export and Import...
+            # TODO: check why
+            for name in self.user:
+                self.builtin[name] = self.get_definition(name)
+
             self.user = {}
             self.clear_cache()
 


### PR DESCRIPTION
This is the part of #595 that avoids that definitions in autoload modules erase the builtin definitions.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/597"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

