### PR TITLE
Update 'attributes' for current standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ clean: clean-cython clean-cache
 
 #: Run py.test tests. Use environment variable "o" for pytest options
 pytest:
-	py.test $(PYTEST_WORKERS) test $o
+	$(PYTHON) -m pytest $(PYTEST_WORKERS) test $o
 
 
 #: Run a more extensive pattern-matching test

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
-r"""
+"""
 Attributes of Definitions
 
-While a definition like 'cube[$x_$] = $x$^3' gives a way to specify <em>values</em> of a function, <em>attributes</em> allow a way to specify general properties of functions and symbols. This is independent of the parameters they take and the values they produce.
+While a definition like 'cube[$x_$] = $x$^3' gives a way to specify \
+<em>values</em> of a function, <em>attributes</em> allow a way to \
+specify general properties of functions and symbols. This is \
+independent of the parameters they take and the values they produce.
 
-The builtin-attributes having a predefined meaning in \Mathics which are described below.
+The builtin-attributes having a predefined meaning in \Mathics which \
+are described below.
 
 However in contrast to \Mathematica, you can set any symbol as an attribute.
 """
@@ -33,6 +37,10 @@ SymbolProtected = Symbol("Protected")
 
 class Attributes(Builtin):
     """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/Attributes.html</url>
+
     <dl>
       <dt>'Attributes'[$symbol$]
       <dd>returns the attributes of $symbol$.
@@ -77,7 +85,7 @@ class Attributes(Builtin):
     }
     summary_text = "find the attributes of a symbol"
 
-    def apply(self, expr, evaluation):
+    def eval(self, expr, evaluation):
         "Attributes[expr_]"
 
         if isinstance(expr, String):
@@ -91,59 +99,12 @@ class Attributes(Builtin):
         return ListExpression(*attributes_symbols)
 
 
-class SetAttributes(Builtin):
-    """
-    <dl>
-      <dt>'SetAttributes'[$symbol$, $attrib$]
-      <dd>adds $attrib$ to the list of $symbol$'s attributes.
-    </dl>
-
-    >> SetAttributes[f, Flat]
-    >> Attributes[f]
-     = {Flat}
-
-    Multiple attributes can be set at the same time using lists:
-    >> SetAttributes[{f, g}, {Flat, Orderless}]
-    >> Attributes[g]
-     = {Flat, Orderless}
-    """
-
-    attributes = A_HOLD_FIRST | A_PROTECTED
-
-    messages = {
-        "unknownattr": f"`1` should be one of {', '.join(attribute_string_to_number.keys())}"
-    }
-    summary_text = "set attributes for a symbol"
-
-    def apply(self, symbols, attributes, evaluation):
-        "SetAttributes[symbols_, attributes_]"
-
-        symbols = get_symbol_list(
-            symbols, lambda item: evaluation.message("SetAttributes", "sym", item, 1)
-        )
-        if symbols is None:
-            return
-        values = get_symbol_list(
-            attributes, lambda item: evaluation.message("SetAttributes", "sym", item, 2)
-        )
-        if values is None:
-            return
-        for symbol in symbols:
-            if A_LOCKED & evaluation.definitions.get_attributes(symbol):
-                evaluation.message("SetAttributes", "locked", Symbol(symbol))
-            else:
-                for value in values:
-                    try:
-                        evaluation.definitions.set_attribute(
-                            symbol, attribute_string_to_number[value]
-                        )
-                    except KeyError:
-                        evaluation.message("Attributes", "attnf", Symbol(value))
-        return SymbolNull
-
-
 class ClearAttributes(Builtin):
     """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/ClearAttributes.html</url>
+
     <dl>
       <dt>'ClearAttributes'[$symbol$, $attrib$]
       <dd>removes $attrib$ from $symbol$'s attributes.
@@ -164,7 +125,7 @@ class ClearAttributes(Builtin):
     attributes = A_HOLD_FIRST | A_PROTECTED
     summary_text = "clear the attributes of a symbol"
 
-    def apply(self, symbols, attributes, evaluation):
+    def eval(self, symbols, attributes, evaluation):
         "ClearAttributes[symbols_, attributes_]"
 
         symbols = get_symbol_list(
@@ -192,8 +153,370 @@ class ClearAttributes(Builtin):
         return SymbolNull
 
 
+class Constant(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Constant.html</url>
+
+    <dl>
+      <dt>'Constant'
+      <dd>is an attribute that indicates that a symbol is a constant.
+    </dl>
+
+    Mathematical constants like 'E' have attribute 'Constant':
+    >> Attributes[E]
+     = {Constant, Protected, ReadProtected}
+
+    Constant symbols cannot be used as variables in 'Solve' and
+    related functions:
+    >> Solve[x + E == 0, E]
+     : E is not a valid variable.
+     = Solve[x + E == 0, E]
+    """
+
+    summary_text = "treat as a constant in differentiation, etc"
+
+
+class Flat(Predefined):
+    """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/Flat.html</url>
+
+    <dl>
+      <dt>'Flat'
+      <dd>is an attribute that specifies that nested occurrences of \
+        a function should be automatically flattened.
+    </dl>
+
+    A symbol with the 'Flat' attribute represents an associative \
+    mathematical operation:
+
+    >> SetAttributes[f, Flat]
+    >> f[a, f[b, c]]
+     = f[a, b, c]
+
+    'Flat' is taken into account in pattern matching:
+    >> f[a, b, c] /. f[a, b] -> d
+     = f[d, c]
+
+    #> SetAttributes[{u, v}, Flat]
+    #> u[x_] := {x}
+    #> u[]
+     = u[]
+    #> u[a]
+     = {a}
+    #> u[a, b]
+     : Iteration limit of 1000 exceeded.
+     = $Aborted
+    #> u[a, b, c]
+     : Iteration limit of 1000 exceeded.
+     = $Aborted
+    #> v[x_] := x
+    #> v[]
+     = v[]
+    #> v[a]
+     = a
+    #> v[a, b] (* in Mathematica: Iteration limit of 4096 exceeded. *)
+     = v[a, b]
+    #> v[a, b, c] (* in Mathematica: Iteration limit of 4096 exceeded. *)
+     : Iteration limit of 1000 exceeded.
+     = $Aborted
+    """
+
+    summary_text = "attribute for associative symbols"
+
+
+class HoldAll(Predefined):
+    """
+    <url>
+     :WMA link:
+      https://reference.wolfram.com/language/ref/HoldAll.html</url>
+
+    <dl>
+      <dt>'HoldAll'
+      <dd>is an attribute specifying that all arguments of a \
+        function should be left unevaluated.
+    </dl>
+
+    >> Attributes[Function]
+     = {HoldAll, Protected}
+    """
+
+    summary_text = "attribute for symbols that keep unevaluated all their elements"
+
+
+class HoldAllComplete(Predefined):
+    """
+    <url>
+    :WMA link:
+      https://reference.wolfram.com/language/ref/HoldAllComplete.html</url>
+
+    <dl>
+      <dt>'HoldAllComplete'
+      <dd>is an attribute that includes the effects of 'HoldAll' and \
+        'SequenceHold', and also protects the function from being \
+        affected by the upvalues of any arguments.
+    </dl>
+
+    'HoldAllComplete' even prevents upvalues from being used, and \
+    includes 'SequenceHold'.
+
+    >> SetAttributes[f, HoldAllComplete]
+    >> f[a] ^= 3;
+    >> f[a]
+     = f[a]
+    >> f[Sequence[a, b]]
+     = f[Sequence[a, b]]
+    """
+
+    summary_text = "attribute for symbols that keep unevaluated all their elements, and discards upvalues"
+
+
+class HoldFirst(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/HoldFirst.html</url>
+
+    <dl>
+      <dt>'HoldFirst'
+      <dd>is an attribute specifying that the first argument of a \
+        function should be left unevaluated.
+    </dl>
+
+    >> Attributes[Set]
+     = {HoldFirst, Protected, SequenceHold}
+    """
+
+    summary_text = "attribute for symbols that keep unevaluated their first element"
+
+
+class HoldRest(Predefined):
+    """
+      <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/HoldRest.html</url>
+
+    <dl>
+      <dt>'HoldRest'
+      <dd>is an attribute specifying that all but the first argument \
+          of a function should be left unevaluated.
+    </dl>
+
+    >> Attributes[If]
+     = {HoldRest, Protected}
+    """
+
+    summary_text = (
+        "attribute for symbols that keep unevaluated all but their first element"
+    )
+
+
+class Listable(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Listable.html</url>
+
+    <dl>
+      <dt>'Listable'
+      <dd>is an attribute specifying that a function should be \
+        automatically applied to each element of a list.
+    </dl>
+
+    >> SetAttributes[f, Listable]
+    >> f[{1, 2, 3}, {4, 5, 6}]
+     = {f[1, 4], f[2, 5], f[3, 6]}
+    >> f[{1, 2, 3}, 4]
+     = {f[1, 4], f[2, 4], f[3, 4]}
+    >> {{1, 2}, {3, 4}} + {5, 6}
+     = {{6, 7}, {9, 10}}
+    """
+
+    summary_text = "automatically thread over lists appearing in arguments"
+
+
+class Locked(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Locked.html</url>
+
+    <dl>
+      <dt>'Locked'
+      <dd>is an attribute that prevents attributes on a symbol from \
+        being modified.
+    </dl>
+
+    The attributes of 'Locked' symbols cannot be modified:
+    >> Attributes[lock] = {Flat, Locked};
+    >> SetAttributes[lock, {}]
+     : Symbol lock is locked.
+    >> ClearAttributes[lock, Flat]
+     : Symbol lock is locked.
+    >> Attributes[lock] = {}
+     : Symbol lock is locked.
+     = {}
+    >> Attributes[lock]
+     = {Flat, Locked}
+
+    However, their values might be modified (as long as they are not 'Protected' too):
+    >> lock = 3
+     = 3
+    """
+
+    summary_text = "keep all attributes locked (settable but not clearable)"
+
+
+class NHoldAll(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/NHoldAll.html</url>
+
+    <dl>
+      <dt>'NHoldAll'
+      <dd>is an attribute that protects all arguments of a \
+        function from numeric evaluation.
+    </dl>
+
+    >> N[f[2, 3]]
+     = f[2., 3.]
+    >> SetAttributes[f, NHoldAll]
+    >> N[f[2, 3]]
+     = f[2, 3]
+    """
+
+    summary_text = "prevent numerical evaluation of elements"
+
+
+class NHoldFirst(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/NHoldFirst.html</url>
+
+    <dl>
+      <dt>'NHoldFirst'
+      <dd>is an attribute that protects the first argument of a \
+        function from numeric evaluation.
+    </dl>
+    """
+
+    summary_text = "prevent numerical evaluation of the first element"
+
+
+class NHoldRest(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/NHoldRest.html</url>
+
+    <dl>
+      <dt>'NHoldRest'
+      <dd>is an attribute that protects all but the first argument
+        of a function from numeric evaluation.
+    </dl>
+    """
+
+    summary_text = "prevent numerical evaluation of all but the first element"
+
+
+class NumericFunction(Predefined):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/NumericFunction.html</url>
+
+    <dl>
+      <dt>'NumericFunction'
+      <dd>is an attribute that indicates that a symbol is the head of a numeric function.
+    </dl>
+
+    Mathematical functions like 'Sqrt' have attribute 'NumericFunction':
+    >> Attributes[Sqrt]
+     = {Listable, NumericFunction, Protected}
+
+    Expressions with a head having this attribute, and with all the elements \
+    being numeric expressions, are considered numeric expressions:
+    >> NumericQ[Sqrt[1]]
+     = True
+    >> NumericQ[a]=True; NumericQ[Sqrt[a]]
+     = True
+    >> NumericQ[a]=False; NumericQ[Sqrt[a]]
+     = False
+    """
+
+    summary_text = "treat as a numeric function"
+
+
+class OneIdentity(Predefined):
+    """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/OneIdentity.html</url>
+
+    <dl>
+      <dt>'OneIdentity'
+      <dd>is an attribute specifying that '$f$[$x$]' should be treated \
+        as equivalent to $x$ in pattern matching.
+    </dl>
+
+    'OneIdentity' affects pattern matching:
+    >> SetAttributes[f, OneIdentity]
+    >> a /. f[args___] -> {args}
+     = {a}
+    It does not affect evaluation:
+    >> f[a]
+     = f[a]
+    """
+
+    summary_text = "attribute for idempotent symbols"
+
+
+class Orderless(Predefined):
+    """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/Orderless.html</url>
+
+    <dl>
+      <dt>'Orderless'
+      <dd>is an attribute that can be assigned to a symbol $f$ to \
+        indicate that the elements $ei$ in expressions of the form \
+        $f$[$e1$, $e2$, ...] should automatically be sorted into \
+        canonical order. This property is accounted for in pattern \
+        matching.
+    </dl>
+
+    The elements of an 'Orderless' function are automatically sorted:
+    >> SetAttributes[f, Orderless]
+    >> f[c, a, b, a + b, 3, 1.0]
+     = f[1., 3, a, b, c, a + b]
+
+    A symbol with the 'Orderless' attribute represents a commutative \
+    mathematical operation.
+    >> f[a, b] == f[b, a]
+     = True
+
+    'Orderless' affects pattern matching:
+    >> SetAttributes[f, Flat]
+    >> f[a, b, c] /. f[a, c] -> d
+     = f[b, d]
+
+    """
+
+    summary_text = "attribute for commutative symbols"
+
+
 class Protect(Builtin):
     """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Protect.html</url>
+
     <dl>
       <dt>'Protect'[$s1$, $s2$, ...]
       <dd>sets the attribute 'Protected' for the symbols $si$.
@@ -213,7 +536,7 @@ class Protect(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "protect a symbol against redefinitions"
 
-    def apply(self, symbols, evaluation):
+    def eval(self, symbols, evaluation):
         "Protect[symbols___]"
         protected = SymbolProtected
         items = []
@@ -252,60 +575,12 @@ class Protect(Builtin):
         return SymbolNull
 
 
-class Unprotect(Builtin):
-    """
-    <dl>
-      <dt>'Unprotect'[$s1$, $s2$, ...]
-      <dd>removes the attribute 'Protected' for the symbols $si$.
-
-      <dt>'Unprotect'[$str$]
-      <dd>unprotects symbols whose names textually match $str$.
-    </dl>
-    """
-
-    attributes = A_HOLD_ALL | A_PROTECTED
-    summary_text = "remove protection against redefinitions"
-
-    def apply(self, symbols, evaluation):
-        "Unprotect[symbols___]"
-        protected = SymbolProtected
-        items = []
-        if isinstance(symbols, Symbol):
-            symbols = [symbols]
-        elif isinstance(symbols, Expression):
-            symbols = symbols.elements
-        elif isinstance(symbols, String):
-            symbols = [symbols]
-        else:
-            symbols = symbols.get_sequence()
-
-        for symbol in symbols:
-            if isinstance(symbol, Symbol):
-                items.append(symbol)
-            else:
-                pattern = symbol.get_string_value()
-                if not pattern or pattern == "":
-                    evaluation.message("Unprotect", "ssym", symbol)
-                    continue
-
-                if pattern[0] == "`":
-                    pattern = evaluation.definitions.get_current_context() + pattern[1:]
-                names = evaluation.definitions.get_matching_names(pattern)
-                for defn in names:
-                    symbol = Symbol(defn)
-                    if not A_LOCKED & evaluation.definitions.get_attributes(defn):
-                        items.append(symbol)
-
-        Expression(
-            SymbolClearAttributes,
-            ListExpression(*items),
-            protected,
-        ).evaluate(evaluation)
-        return SymbolNull
-
-
 class Protected(Predefined):
     """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Protected.html</url>
+
     <dl>
       <dt>'Protected'
       <dd>is an attribute that prevents values on a symbol from
@@ -349,14 +624,19 @@ class Protected(Predefined):
 
 class ReadProtected(Predefined):
     """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/ReadProtected.html</url>
+
     <dl>
       <dt>'ReadProtected'
-      <dd>is an attribute that prevents values on a symbol from
-        being read.
+      <dd>is an attribute that prevents values on a symbol from \
+          being read.
     </dl>
 
-    Values associated with 'ReadProtected' symbols cannot be seen in
+    Values associated with 'ReadProtected' symbols cannot be seen in \
     'Definition':
+
     >> ClearAll[p]
     >> p = 3;
     >> Definition[p]
@@ -369,138 +649,20 @@ class ReadProtected(Predefined):
     summary_text = "attribute of symbols with hidden definitions"
 
 
-class Locked(Predefined):
-    """
-    <dl>
-      <dt>'Locked'
-      <dd>is an attribute that prevents attributes on a symbol from
-        being modified.
-    </dl>
-
-    The attributes of 'Locked' symbols cannot be modified:
-    >> Attributes[lock] = {Flat, Locked};
-    >> SetAttributes[lock, {}]
-     : Symbol lock is locked.
-    >> ClearAttributes[lock, Flat]
-     : Symbol lock is locked.
-    >> Attributes[lock] = {}
-     : Symbol lock is locked.
-     = {}
-    >> Attributes[lock]
-     = {Flat, Locked}
-
-    However, their values might be modified (as long as they are not 'Protected' too):
-    >> lock = 3
-     = 3
-    """
-
-    summary_text = "keep all attributes locked (settable but not clearable)"
-
-
-class Flat(Predefined):
-    """
-    <dl>
-      <dt>'Flat'
-      <dd>is an attribute that specifies that nested occurrences of
-        a function should be automatically flattened.
-    </dl>
-
-    A symbol with the 'Flat' attribute represents an associative
-    mathematical operation:
-    >> SetAttributes[f, Flat]
-    >> f[a, f[b, c]]
-     = f[a, b, c]
-
-    'Flat' is taken into account in pattern matching:
-    >> f[a, b, c] /. f[a, b] -> d
-     = f[d, c]
-
-    #> SetAttributes[{u, v}, Flat]
-    #> u[x_] := {x}
-    #> u[]
-     = u[]
-    #> u[a]
-     = {a}
-    #> u[a, b]
-     : Iteration limit of 1000 exceeded.
-     = $Aborted
-    #> u[a, b, c]
-     : Iteration limit of 1000 exceeded.
-     = $Aborted
-    #> v[x_] := x
-    #> v[]
-     = v[]
-    #> v[a]
-     = a
-    #> v[a, b] (* in Mathematica: Iteration limit of 4096 exceeded. *)
-     = v[a, b]
-    #> v[a, b, c] (* in Mathematica: Iteration limit of 4096 exceeded. *)
-     : Iteration limit of 1000 exceeded.
-     = $Aborted
-    """
-
-    summary_text = "attribute for associative symbols"
-
-
-class Orderless(Predefined):
-    """<dl>
-      <dt>'Orderless'
-      <dd>is an attribute that can be assigned to a symbol $f$ to
-        indicate that the elements $ei$ in expressions of the form
-        $f$[$e1$, $e2$, ...] should automatically be sorted into
-        canonical order. This property is accounted for in pattern
-        matching.
-    </dl>
-
-    The leaves of an 'Orderless' function are automatically sorted:
-    >> SetAttributes[f, Orderless]
-    >> f[c, a, b, a + b, 3, 1.0]
-     = f[1., 3, a, b, c, a + b]
-
-    A symbol with the 'Orderless' attribute represents a commutative
-    mathematical operation.
-    >> f[a, b] == f[b, a]
-     = True
-
-    'Orderless' affects pattern matching:
-    >> SetAttributes[f, Flat]
-    >> f[a, b, c] /. f[a, c] -> d
-     = f[b, d]
-
-    """
-
-    summary_text = "attribute for commutative symbols"
-
-
-class OneIdentity(Predefined):
-    """
-    <dl>
-      <dt>'OneIdentity'
-      <dd>is an attribute specifying that '$f$[$x$]' should be treated
-        as equivalent to $x$ in pattern matching.
-    </dl>
-
-    'OneIdentity' affects pattern matching:
-    >> SetAttributes[f, OneIdentity]
-    >> a /. f[args___] -> {args}
-     = {a}
-    It does not affect evaluation:
-    >> f[a]
-     = f[a]
-    """
-
-    summary_text = "attribute for idempotent symbols"
-
-
 class SequenceHold(Predefined):
     """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/SequenceHold.html</url>
+
     <dl>
       <dt>'SequenceHold'
-      <dd>is an attribute that prevents 'Sequence' objects from being
+      <dd>is an attribute that prevents 'Sequence' objects from being \
         spliced into a function's arguments.
     </dl>
 
     Normally, 'Sequence' will be spliced into a function:
+
     >> f[Sequence[a, b]]
      = f[a, b]
     It does not for 'SequenceHold' functions:
@@ -509,6 +671,7 @@ class SequenceHold(Predefined):
      = f[Sequence[a, b]]
 
     E.g., 'Set' has attribute 'SequenceHold' to allow assignment of sequences to variables:
+
     >> s = Sequence[a, b];
     >> s
      = Sequence[a, b]
@@ -519,177 +682,112 @@ class SequenceHold(Predefined):
     summary_text = "attribute for symbols that do not expand sequences"
 
 
-class HoldFirst(Predefined):
+class SetAttributes(Builtin):
     """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/SetAttributes.html</url>
+
     <dl>
-      <dt>'HoldFirst'
-      <dd>is an attribute specifying that the first argument of a
-        function should be left unevaluated.
+      <dt>'SetAttributes'[$symbol$, $attrib$]
+      <dd>adds $attrib$ to the list of $symbol$'s attributes.
     </dl>
 
-    >> Attributes[Set]
-     = {HoldFirst, Protected, SequenceHold}
+    >> SetAttributes[f, Flat]
+    >> Attributes[f]
+     = {Flat}
+
+    Multiple attributes can be set at the same time using lists:
+    >> SetAttributes[{f, g}, {Flat, Orderless}]
+    >> Attributes[g]
+     = {Flat, Orderless}
     """
 
-    summary_text = "attribute for symbols that keep unevaluated their first element"
+    attributes = A_HOLD_FIRST | A_PROTECTED
+
+    messages = {
+        "unknownattr": f"`1` should be one of {', '.join(attribute_string_to_number.keys())}"
+    }
+    summary_text = "set attributes for a symbol"
+
+    def eval(self, symbols, attributes, evaluation):
+        "SetAttributes[symbols_, attributes_]"
+
+        symbols = get_symbol_list(
+            symbols, lambda item: evaluation.message("SetAttributes", "sym", item, 1)
+        )
+        if symbols is None:
+            return
+        values = get_symbol_list(
+            attributes, lambda item: evaluation.message("SetAttributes", "sym", item, 2)
+        )
+        if values is None:
+            return
+        for symbol in symbols:
+            if A_LOCKED & evaluation.definitions.get_attributes(symbol):
+                evaluation.message("SetAttributes", "locked", Symbol(symbol))
+            else:
+                for value in values:
+                    try:
+                        evaluation.definitions.set_attribute(
+                            symbol, attribute_string_to_number[value]
+                        )
+                    except KeyError:
+                        evaluation.message("Attributes", "attnf", Symbol(value))
+        return SymbolNull
 
 
-class HoldRest(Predefined):
+class Unprotect(Builtin):
     """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Unprotect.html</url>
+
     <dl>
-      <dt>'HoldRest'
-      <dd>is an attribute specifying that all but the first argument
-        of a function should be left unevaluated.
-    </dl>
+      <dt>'Unprotect'[$s1$, $s2$, ...]
+      <dd>removes the attribute 'Protected' for the symbols $si$.
 
-    >> Attributes[If]
-     = {HoldRest, Protected}
-    """
-
-    summary_text = (
-        "attribute for symbols that keep unevaluated all but their first element"
-    )
-
-
-class HoldAll(Predefined):
-    """
-    <dl>
-      <dt>'HoldAll'
-      <dd>is an attribute specifying that all arguments of a
-        function should be left unevaluated.
-    </dl>
-
-    >> Attributes[Function]
-     = {HoldAll, Protected}
-    """
-
-    summary_text = "attribute for symbols that keep unevaluated all their elements"
-
-
-class HoldAllComplete(Predefined):
-    """
-    <dl>
-      <dt>'HoldAllComplete'
-      <dd>is an attribute that includes the effects of 'HoldAll' and
-        'SequenceHold', and also protects the function from being
-        affected by the upvalues of any arguments.
-    </dl>
-
-    'HoldAllComplete' even prevents upvalues from being used, and
-    includes 'SequenceHold'.
-    >> SetAttributes[f, HoldAllComplete]
-    >> f[a] ^= 3;
-    >> f[a]
-     = f[a]
-    >> f[Sequence[a, b]]
-     = f[Sequence[a, b]]
-    """
-
-    summary_text = "attribute for symbols that keep unevaluated all their elements, and discards upvalues"
-
-
-class NHoldAll(Predefined):
-    """
-    <dl>
-      <dt>'NHoldAll'
-      <dd>is an attribute that protects all arguments of a
-        function from numeric evaluation.
-    </dl>
-
-    >> N[f[2, 3]]
-     = f[2., 3.]
-    >> SetAttributes[f, NHoldAll]
-    >> N[f[2, 3]]
-     = f[2, 3]
-    """
-
-    summary_text = "prevent numerical evaluation of elements"
-
-
-class NHoldFirst(Predefined):
-    """
-    <dl>
-      <dt>'NHoldFirst'
-      <dd>is an attribute that protects the first argument of a
-        function from numeric evaluation.
+      <dt>'Unprotect'[$str$]
+      <dd>unprotects symbols whose names textually match $str$.
     </dl>
     """
 
-    summary_text = "prevent numerical evaluation of the first element"
+    attributes = A_HOLD_ALL | A_PROTECTED
+    summary_text = "remove protection against redefinitions"
 
+    def eval(self, symbols, evaluation):
+        "Unprotect[symbols___]"
+        protected = SymbolProtected
+        items = []
+        if isinstance(symbols, Symbol):
+            symbols = [symbols]
+        elif isinstance(symbols, Expression):
+            symbols = symbols.elements
+        elif isinstance(symbols, String):
+            symbols = [symbols]
+        else:
+            symbols = symbols.get_sequence()
 
-class NHoldRest(Predefined):
-    """
-    <dl>
-      <dt>'NHoldRest'
-      <dd>is an attribute that protects all but the first argument
-        of a function from numeric evaluation.
-    </dl>
-    """
+        for symbol in symbols:
+            if isinstance(symbol, Symbol):
+                items.append(symbol)
+            else:
+                pattern = symbol.get_string_value()
+                if not pattern or pattern == "":
+                    evaluation.message("Unprotect", "ssym", symbol)
+                    continue
 
-    summary_text = "prevent numerical evaluation of all but the first element"
+                if pattern[0] == "`":
+                    pattern = evaluation.definitions.get_current_context() + pattern[1:]
+                names = evaluation.definitions.get_matching_names(pattern)
+                for defn in names:
+                    symbol = Symbol(defn)
+                    if not A_LOCKED & evaluation.definitions.get_attributes(defn):
+                        items.append(symbol)
 
-
-class Listable(Predefined):
-    """
-    <dl>
-      <dt>'Listable'
-      <dd>is an attribute specifying that a function should be
-        automatically applied to each element of a list.
-    </dl>
-
-    >> SetAttributes[f, Listable]
-    >> f[{1, 2, 3}, {4, 5, 6}]
-     = {f[1, 4], f[2, 5], f[3, 6]}
-    >> f[{1, 2, 3}, 4]
-     = {f[1, 4], f[2, 4], f[3, 4]}
-    >> {{1, 2}, {3, 4}} + {5, 6}
-     = {{6, 7}, {9, 10}}
-    """
-
-    summary_text = "automatically thread over lists appearing in arguments"
-
-
-class Constant(Predefined):
-    """
-    <dl>
-      <dt>'Constant'
-      <dd>is an attribute that indicates that a symbol is a constant.
-    </dl>
-
-    Mathematical constants like 'E' have attribute 'Constant':
-    >> Attributes[E]
-     = {Constant, Protected, ReadProtected}
-
-    Constant symbols cannot be used as variables in 'Solve' and
-    related functions:
-    >> Solve[x + E == 0, E]
-     : E is not a valid variable.
-     = Solve[x + E == 0, E]
-    """
-
-    summary_text = "treat as a constant in differentiation, etc"
-
-
-class NumericFunction(Predefined):
-    """
-    <dl>
-      <dt>'NumericFunction'
-      <dd>is an attribute that indicates that a symbol is the head of a numeric function.
-    </dl>
-
-    Mathematical functions like 'Sqrt' have attribute 'NumericFunction':
-    >> Attributes[Sqrt]
-     = {Listable, NumericFunction, Protected}
-
-    Expressions with a head having this attribute, and with all the leaves
-    being numeric expressions, are considered numeric expressions:
-    >> NumericQ[Sqrt[1]]
-     = True
-    >> NumericQ[a]=True; NumericQ[Sqrt[a]]
-     = True
-    >> NumericQ[a]=False; NumericQ[Sqrt[a]]
-     = False
-    """
-
-    summary_text = "treat as a numeric function"
+        Expression(
+            SymbolClearAttributes,
+            ListExpression(*items),
+            protected,
+        ).evaluate(evaluation)
+        return SymbolNull

--- a/mathics/core/attributes.py
+++ b/mathics/core/attributes.py
@@ -9,37 +9,73 @@
 # (the most of the cases).
 
 # To check if a builtin has an attribute, you do:
-# ATTRIBUTE_NAME & attributes
+#   ATTRIBUTE_NAME & attributes
+#
 # To set all the attributes of a builtin you do:
-# attributes = ATTRIBUTE1 | ATTRIBUTE2 | ATTRIBUTE3 | ...
+#   attributes = ATTRIBUTE1 | ATTRIBUTE2 | ATTRIBUTE3 | ...
+#
 # To add an attribute to a builtin you do:
-# attributes = ATTRIBUTE_NAME | attributes
+#   attributes = ATTRIBUTE_NAME | attributes
+#
 # To remove an attribute you do:
-# attributes = ~ATTRIBUTE_NAME & attributes
+#   attributes = ~ATTRIBUTE_NAME & attributes
 
 from typing import Dict, Generator
 
 # fmt: off
 A_NO_ATTRIBUTES     = 0b0000000000000000
 
-# FIXME: remove lowercase after thes are no longer imported
-# alphabetical order
+# Symbol is a constant.
 A_CONSTANT          = 0b00000000000000001
+
+# Nested occurrences of a function should be automatically flattened.
 A_FLAT              = 0b00000000000000010
+
+# All arguments of a function should be left unevaluated.
 A_HOLD_ALL          = 0b00000000000000100
+
+# Includes the effects of 'HoldAll' and 'SequenceHold', and also
+# protects the function from being affected by the upvalues of any
+# arguments.
 A_HOLD_ALL_COMPLETE = 0b00000000000001000
+
+# First argument of a function should be left unevaluated.
 A_HOLD_FIRST        = 0b00000000000010000
+
+# All but the first argument of a function should be left unevaluated.
 A_HOLD_REST         = 0b00000000000100000
+
+# Function should be automatically applied to each element of a list.
 A_LISTABLE          = 0b00000000001000000
+
+# prevents attributes on a symbol from being modified.
 A_LOCKED            = 0b00000000010000000
+
+# Protects all arguments of a function from numeric evaluation
 A_N_HOLD_ALL        = 0b00000000100000000
+
+# Protects the first argument of a function from numeric evaluation.
 A_N_HOLD_FIRST      = 0b00000001000000000
+
+# Protects all but the first argument of a function from numeric evaluation.
 A_N_HOLD_REST       = 0b00000010000000000
+
+# Symbol is the head of a numeric function.
 A_NUMERIC_FUNCTION  = 0b00000100000000000
+
+# '$f$[$x$]' should be treated as equivalent to $x$ in pattern matching.
 A_ONE_IDENTITY      = 0b00001000000000000
+
+# elements should automatically be sorted into canonical order
 A_ORDERLESS         = 0b00010000000000000
+
+# Prevents values on a symbol from being modified.
 A_PROTECTED         = 0b00100000000000000
+
+# Prevents values on a symbol from being read.
 A_READ_PROTECTED    = 0b01000000000000000
+
+# prevents 'Sequence' objects from being spliced into a function's arguments
 A_SEQUENCE_HOLD     = 0b10000000000000000
 
 attribute_number_to_string: Dict[int, str] = {


### PR DESCRIPTION
`mathics.builtin.attributes`:

* `def apply(` -> `def eval(`
* Add WMA links 
* Class names ordered alphabetically
* Hard breaks in docstring removed
* Some incorrect references to "leaves" changed to "attributes"

`mathics.core.attributes`:

* Add short comments above flag value

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/607"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

