### PR TITLE
using a private symbol to store the state.

### DIFF
--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -30,6 +30,7 @@ from mathics.core.atoms import (
     StringFromPython,
 )
 
+from mathics.core.attributes import A_LOCKED, A_PROTECTED
 from mathics.core.expression import Expression, BoxError
 from mathics.core.formatter import format_element
 from mathics.core.list import ListExpression
@@ -194,7 +195,7 @@ class DisplayForm(FormBaseClass):
         try:
             result = MakeBoxes(expr, f).evaluate(evaluation)
         except Exception:
-            return
+            result = None
         evaluation.definitions.set_ownvalue(
             SYMBOL_FORMATBOXES.name, old_value_in_display_form
         )
@@ -1141,9 +1142,10 @@ class PrivateSymbolThatControlsTheStateOfDisplayForm(Builtin):
     </dl>
     """
 
-    name = "PrivateSymbolThatControlsTheStateOfDisplayForm"
+    attributes = A_LOCKED | A_PROTECTED
     context = "System`Private`MakeBoxes`"
-    summary_text = "control if boxes are reevaluated."
+    name = "PrivateSymbolThatControlsTheStateOfDisplayForm"
     rules = {
         "System`Private`MakeBoxes`PrivateSymbolThatControlsTheStateOfDisplayForm": "False",
     }
+    summary_text = "control if boxes are reevaluated."

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -37,12 +37,19 @@ from mathics.core.number import dps
 from mathics.core.symbols import (
     Atom,
     Symbol,
+    SymbolTrue,
 )
 
 from mathics.core.systemsymbols import (
     SymbolInputForm,
     SymbolOutputForm,
     SymbolRowBox,
+)
+
+
+# Afterwards, we can find a better name
+SYMBOL_FORMATBOXES = Symbol(
+    "System`Private`MakeBoxes`PrivateSymbolThatControlsTheStateOfDisplayForm"
 )
 
 
@@ -396,7 +403,7 @@ class MakeBoxes(Builtin):
         if isinstance(expr, BoxElementMixin):
             # If we are inside a DisplayForm block,
             # BoxElementMixin are not processed.
-            if evaluation.in_display_form:
+            if SYMBOL_FORMATBOXES.evaluate(evaluation) is SymbolTrue:
                 return expr
             expr = expr.to_expression()
         if isinstance(expr, Atom):

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -257,8 +257,6 @@ class Evaluation:
         self.quiet_all = False
         self.format = format
 
-        # See comment in mathics.builtin.makeboxes.DisplayForm
-        self.in_display_form = False
         self.catch_interrupt = catch_interrupt
         self.SymbolNull = SymbolNull
 


### PR DESCRIPTION
This is the alternative version. This makes the control variable "hackable" from inside the mathics session (we can read it) but avoids that the user overwrite the value (because it is protected and locked). 