### PR TITLE
Changes suggested in PR review

### DIFF
--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -6,23 +6,10 @@ Forms of Assignment
 
 from mathics.builtin.base import BinaryOperator, Builtin
 from mathics.core.assignment import (
+    ASSIGNMENT_FUNCTION_MAP,
     AssignmentException,
     assign_store_rules_by_tag,
     normalize_lhs,
-    process_assign_attributes,
-    process_assign_context,
-    process_assign_context_path,
-    process_assign_default,
-    process_assign_definition_values,
-    process_assign_format,
-    process_assign_list,
-    process_assign_makeboxes,
-    process_assign_messagename,
-    process_assign_n,
-    process_assign_numericq,
-    process_assign_options,
-    process_assign_random_state,
-    process_assign_part,
 )
 
 from mathics.core.attributes import (
@@ -43,49 +30,26 @@ class _SetOperator:
 
     Special cases are determined by the head of the expression. Then
     they are processed by specific routines, which are poke from
-    the `special_cases` dict.
+    the ``ASSIGNMENT_FUNCTION_MAP`` dict.
     """
 
     # FIXME:
     # Assigment is determined by the LHS.
-    # Is there a larger patterns or natural grouping that we are missing?
-    # For example it might be that
-    # there are some attributes or other properties of of the
-    # LHS of a builtin that we should be targetting.
+    # Are there a larger patterns or natural groupings that we are missing?
+    # For example, it might be that it
+    # we can key off of some attributes or other properties of the
+    # LHS of a builtin, instead of listing all of the builtins in that class
+    # (which may miss some).
     # Below, we key on a string, but Symbol is more correct.
-    #
-
-    special_cases = {
-        "System`$Context": process_assign_context,
-        "System`$ContextPath": process_assign_context_path,
-        "System`$RandomState": process_assign_random_state,
-        "System`Attributes": process_assign_attributes,
-        "System`Default": process_assign_default,
-        "System`DefaultValues": process_assign_definition_values,
-        "System`DownValues": process_assign_definition_values,
-        "System`Format": process_assign_format,
-        "System`List": process_assign_list,
-        "System`MakeBoxes": process_assign_makeboxes,
-        "System`MessageName": process_assign_messagename,
-        "System`Messages": process_assign_definition_values,
-        "System`N": process_assign_n,
-        "System`NValues": process_assign_definition_values,
-        "System`NumericQ": process_assign_numericq,
-        "System`Options": process_assign_options,
-        "System`OwnValues": process_assign_definition_values,
-        "System`Part": process_assign_part,
-        "System`SubValues": process_assign_definition_values,
-        "System`UpValues": process_assign_definition_values,
-    }
 
     def assign(self, lhs, rhs, evaluation, tags=None, upset=False):
         lhs, lookup_name = normalize_lhs(lhs, evaluation)
         try:
-            # Deal with direct assignation to properties of
-            # the definition object
-            func = self.special_cases.get(lookup_name, None)
-            if func:
-                return func(self, lhs, rhs, evaluation, tags, upset)
+            # Using a builtin name, find which assignment procedure to perform,
+            # and then call that function.
+            assignment_func = ASSIGNMENT_FUNCTION_MAP.get(lookup_name, None)
+            if assignment_func:
+                return assignment_func(self, lhs, rhs, evaluation, tags, upset)
 
             return assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset)
         except AssignmentException:

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -38,9 +38,8 @@ from mathics.core.systemsymbols import (
     SymbolUpValues,
 )
 
+from mathics.core.assignment import is_protected
 from mathics.core.atoms import String
-
-from mathics.builtin.assignments.internals import is_protected
 
 
 class Clear(Builtin):

--- a/mathics/builtin/assignments/types.py
+++ b/mathics/builtin/assignments/types.py
@@ -8,8 +8,7 @@ Types of Values
 
 from mathics.builtin.base import Builtin
 
-from mathics.builtin.assignments.internals import get_symbol_values
-
+from mathics.core.assignment import get_symbol_values
 from mathics.core.attributes import A_HOLD_ALL, A_PROTECTED
 
 

--- a/mathics/builtin/assignments/upvalues.py
+++ b/mathics/builtin/assignments/upvalues.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from mathics.builtin.assignments.internals import _SetOperator
+from mathics.builtin.assignments.assignment import _SetOperator
 from mathics.builtin.base import BinaryOperator
 from mathics.core.attributes import (
     A_HOLD_ALL,

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -7,7 +7,6 @@ Symbolic data. Every symbol has a unique name, exists in a certain context or na
 
 import re
 
-from mathics.builtin.assignments.internals import get_symbol_values
 from mathics.builtin.base import (
     Builtin,
     PrefixOperator,
@@ -16,6 +15,7 @@ from mathics.builtin.base import (
 
 from mathics.builtin.atomic.strings import to_regex
 
+from mathics.core.assignment import get_symbol_values
 from mathics.core.atoms import String
 
 from mathics.core.attributes import (

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -15,7 +15,7 @@ However in contrast to \Mathematica, you can set any symbol as an attribute.
 
 
 from mathics.builtin.base import Predefined, Builtin
-from mathics.builtin.assignments.internals import get_symbol_list
+from mathics.core.assignment import get_symbol_list
 from mathics.core.atoms import String
 from mathics.core.attributes import (
     attributes_bitset_to_list,

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -4,13 +4,13 @@ Scoping Constructs
 """
 
 
-from mathics.builtin.assignments.internals import get_symbol_list
 from mathics.core.attributes import (
     A_HOLD_ALL,
     A_PROTECTED,
     attribute_string_to_number,
 )
 from mathics.builtin.base import Builtin, Predefined
+from mathics.core.assignment import get_symbol_list
 from mathics.core.atoms import (
     String,
     Integer,

--- a/mathics/core/assignment.py
+++ b/mathics/core/assignment.py
@@ -814,3 +814,28 @@ def process_tags_and_upset_allow_custom(tags, upset, self, lhs, evaluation):
                 raise AssignmentException(lhs, None)
 
     return tags, focus
+
+
+# Below is a mapping from a string Symbol name into an assignment function
+ASSIGNMENT_FUNCTION_MAP = {
+    "System`$Context": process_assign_context,
+    "System`$ContextPath": process_assign_context_path,
+    "System`$RandomState": process_assign_random_state,
+    "System`Attributes": process_assign_attributes,
+    "System`Default": process_assign_default,
+    "System`DefaultValues": process_assign_definition_values,
+    "System`DownValues": process_assign_definition_values,
+    "System`Format": process_assign_format,
+    "System`List": process_assign_list,
+    "System`MakeBoxes": process_assign_makeboxes,
+    "System`MessageName": process_assign_messagename,
+    "System`Messages": process_assign_definition_values,
+    "System`N": process_assign_n,
+    "System`NValues": process_assign_definition_values,
+    "System`NumericQ": process_assign_numericq,
+    "System`Options": process_assign_options,
+    "System`OwnValues": process_assign_definition_values,
+    "System`Part": process_assign_part,
+    "System`SubValues": process_assign_definition_values,
+    "System`UpValues": process_assign_definition_values,
+}

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -4,6 +4,7 @@ import reprlib
 from typing import Optional, Tuple
 
 from mathics.core.element import ElementsProperties
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.symbols import EvalMixin, Symbol, SymbolList
 
@@ -85,7 +86,7 @@ class ListExpression(Expression):
         return f"<ListExpression: {self._elements}>"
 
     # @timeit
-    def evaluate_elements(self, evaluation):
+    def evaluate_elements(self, evaluation: Evaluation) -> Expression:
         """
         return a new expression with the same head, and the
         evaluable elements evaluated.

--- a/test/builtin/test_assignment.py
+++ b/test/builtin/test_assignment.py
@@ -174,25 +174,25 @@ def test_setdelayed_oneidentity():
         (
             "F[x_]:=G[x]; H[F[y_]]:=Q[y]; ClearAll[F]; {H[G[5]],H[F[5]]}",
             "{Q[5], H[F[5]]}",
-            "The arguments on the LHS are evaluated before the assignment",
+            "Arguments on the LHS are evaluated before the assignment in := after F reset",
         ),
         (None, None, None),
         (
             "F[x_]:=G[x]; H[F[y_]]^:=Q[y]; ClearAll[F]; {H[G[5]],H[F[5]]}",
             "{Q[5], H[F[5]]}",
-            "The arguments on the LHS are evaluated before the assignment",
+            "Arguments on the LHS are evaluated before the assignment in ^:= after F reset",
         ),
         (None, None, None),
         (
             "F[x_]:=G[x]; H[F[y_]]:=Q[y]; ClearAll[G]; {H[G[5]],H[F[5]]}",
             "{Q[5], Q[5]}",
-            "The arguments on the LHS are evaluated before the assignment",
+            "The arguments on the LHS are evaluated before the assignment in := after G reset",
         ),
         (None, None, None),
         (
             "F[x_]:=G[x]; H[F[y_]]^:=Q[y]; ClearAll[G]; {H[G[5]],H[F[5]]}",
             "{H[G[5]], H[G[5]]}",
-            "The arguments on the LHS are evaluated before the assignment",
+            "The arguments on the LHS are evaluated before the assignment in ^:= after G reset",
         ),
         (None, None, None),
         (


### PR DESCRIPTION
Move core-like assignment interals out of builtins and into core. (We may want to split up core more in the future though)

Better sort long list of assignment methods alphabetically

Some small RsT tagging in a docstring

Remove nonexistent word "evaluable"

Add yet another type annotation to a signature

Make test assert failure messages unique

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/622"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

