### PR TITLE
moving method numerify to function in mathics.eval.numerify

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -11,13 +11,14 @@ import sympy
 import mpmath
 
 from mathics.builtin.arithmetic import _MPMathFunction, create_infix
-from mathics.eval.nevaluator import eval_N
 from mathics.builtin.base import (
     Builtin,
     BinaryOperator,
     PrefixOperator,
     SympyFunction,
 )
+
+
 from mathics.core.atoms import (
     Complex,
     Integer,
@@ -32,10 +33,23 @@ from mathics.core.atoms import (
     Real,
     String,
 )
+from mathics.core.attributes import (
+    A_FLAT,
+    A_LISTABLE,
+    A_NUMERIC_FUNCTION,
+    A_ONE_IDENTITY,
+    A_ORDERLESS,
+    A_PROTECTED,
+    A_READ_PROTECTED,
+)
+
 from mathics.core.convert.expression import to_expression
 from mathics.core.convert.mpmath import from_mpmath
+from mathics.core.convert.sympy import from_sympy
+
 from mathics.core.expression import ElementsProperties, Expression
 from mathics.core.list import ListExpression
+from mathics.core.number import min_prec, dps
 from mathics.core.symbols import (
     Symbol,
     SymbolDivide,
@@ -58,19 +72,10 @@ from mathics.core.systemsymbols import (
     SymbolPattern,
     SymbolSequence,
 )
-from mathics.core.number import min_prec, dps
 
-from mathics.core.convert.sympy import from_sympy
 
-from mathics.core.attributes import (
-    A_FLAT,
-    A_LISTABLE,
-    A_NUMERIC_FUNCTION,
-    A_ONE_IDENTITY,
-    A_ORDERLESS,
-    A_PROTECTED,
-    A_READ_PROTECTED,
-)
+from mathics.eval.nevaluator import eval_N
+from mathics.eval.numerify import numerify
 
 
 class CubeRoot(Builtin):
@@ -374,7 +379,7 @@ class Plus(BinaryOperator, SympyFunction):
     def eval(self, items, evaluation):
         "Plus[items___]"
 
-        items_tuple = items.numerify(evaluation).get_sequence()
+        items_tuple = numerify(items, evaluation).get_sequence()
         elements = []
         last_item = last_count = None
 
@@ -876,7 +881,7 @@ class Times(BinaryOperator, SympyFunction):
 
     def eval(self, items, evaluation):
         "Times[items___]"
-        items = items.numerify(evaluation).get_sequence()
+        items = numerify(items, evaluation).get_sequence()
         elements = []
         numbers = []
         infinity_factor = False

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -7,6 +7,8 @@ Mathematical Functions
 Basic arithmetic functions, including complex number arithmetic.
 """
 
+from mathics.eval.numerify import numerify
+
 # This tells documentation how to sort this module
 sort_order = "mathics.builtin.mathematical-functions"
 
@@ -123,7 +125,7 @@ class _MPMathFunction(SympyFunction):
     def apply(self, z, evaluation):
         "%(name)s[z__]"
 
-        args = z.numerify(evaluation).get_sequence()
+        args = numerify(z, evaluation).get_sequence()
         mpmath_function = self.get_mpmath_function(tuple(args))
         result = None
 

--- a/mathics/builtin/comparison.py
+++ b/mathics/builtin/comparison.py
@@ -56,6 +56,7 @@ from mathics.core.systemsymbols import (
     SymbolSign,
 )
 
+from mathics.eval.numerify import numerify
 
 operators = {
     "System`Less": (-1,),
@@ -682,7 +683,7 @@ class Inequality(Builtin):
     def apply(self, items, evaluation):
         "Inequality[items___]"
 
-        elements = items.numerify(evaluation).get_sequence()
+        elements = numerify(items, evaluation).get_sequence()
         count = len(elements)
         if count == 1:
             return SymbolTrue

--- a/mathics/builtin/lists.py
+++ b/mathics/builtin/lists.py
@@ -94,6 +94,9 @@ from mathics.core.systemsymbols import (
 
 from mathics.eval.nevaluator import eval_N
 
+from mathics.eval.nevaluator import eval_N
+from mathics.eval.numerify import numerify
+
 SymbolClusteringComponents = Symbol("ClusteringComponents")
 SymbolContainsOnly = Symbol("ContainsOnly")
 SymbolFindClusters = Symbol("FindClusters")
@@ -893,7 +896,7 @@ class _IterationFunction(Builtin):
 
         else:
             imax = imax.evaluate(evaluation)
-            imax = imax.numerify(evaluation)
+            imax = numerify(imax, evaluation)
             if isinstance(imax, Number):
                 imax = imax.round()
             py_max = imax.get_float_value()

--- a/mathics/builtin/specialfns/elliptic.py
+++ b/mathics/builtin/specialfns/elliptic.py
@@ -15,6 +15,8 @@ from mathics.core.atoms import Integer
 from mathics.core.convert.expression import to_numeric_sympy_args
 from mathics.core.convert.sympy import from_sympy
 
+from mathics.eval.numerify import numerify
+
 import sympy
 
 
@@ -53,7 +55,7 @@ class EllipticE(SympyFunction):
 
     def apply_m(self, m, evaluation):
         "%(name)s[m_]"
-        sympy_arg = m.numerify(evaluation).to_sympy()
+        sympy_arg = numerify(m, evaluation).to_sympy()
         try:
             return from_sympy(sympy.elliptic_e(sympy_arg))
         except:
@@ -61,7 +63,7 @@ class EllipticE(SympyFunction):
 
     def apply_phi_m(self, phi, m, evaluation):
         "%(name)s[phi_, m_]"
-        sympy_args = [a.numerify(evaluation).to_sympy() for a in (phi, m)]
+        sympy_args = [numerify(a, evaluation).to_sympy() for a in (phi, m)]
         try:
             return from_sympy(sympy.elliptic_e(*sympy_args))
         except:
@@ -97,7 +99,7 @@ class EllipticF(SympyFunction):
 
     def apply(self, phi, m, evaluation):
         "%(name)s[phi_, m_]"
-        sympy_args = [a.numerify(evaluation).to_sympy() for a in (phi, m)]
+        sympy_args = [numerify(a, evaluation).to_sympy() for a in (phi, m)]
         try:
             return from_sympy(sympy.elliptic_f(*sympy_args))
         except:
@@ -136,7 +138,7 @@ class EllipticK(SympyFunction):
 
     def apply(self, m, evaluation):
         "%(name)s[m_]"
-        args = m.numerify(evaluation).get_sequence()
+        args = numerify(m, evaluation).get_sequence()
         sympy_args = [a.to_sympy() for a in args]
         try:
             return from_sympy(sympy.elliptic_k(*sympy_args))

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -37,6 +37,8 @@ from mathics.core.systemsymbols import (
     SymbolIndeterminate,
 )
 
+from mathics.eval.numerify import numerify
+
 
 class Beta(_MPMathMultiFunction):
     """
@@ -98,11 +100,9 @@ class Beta(_MPMathMultiFunction):
         if not all(isinstance(q, Number) for q in (a, b, z)):
             return
 
-        args = (
-            Expression(SymbolSequence, a, b, Integer0, z)
-            .numerify(evaluation)
-            .get_sequence()
-        )
+        args = numerify(
+            Expression(SymbolSequence, a, b, Integer0, z), evaluation
+        ).get_sequence()
         mpmath_function = self.get_mpmath_function(tuple(args))
         if any(arg.is_machine_precision() for arg in args):
             # if any argument has machine precision then the entire calculation

--- a/mathics/builtin/statistics/orderstats.py
+++ b/mathics/builtin/statistics/orderstats.py
@@ -23,6 +23,8 @@ from mathics.core.symbols import (
 )
 from mathics.core.systemsymbols import SymbolSubtract
 
+from mathics.eval.numerify import numerify
+
 SymbolRankedMax = Symbol("RankedMax")
 SymbolRankedMin = Symbol("RankedMin")
 
@@ -86,7 +88,7 @@ class Quantile(Builtin):
         def ranked(i):
             return introselect(partially_sorted, min(max(0, i - 1), n - 1))
 
-        numeric_qs = qs.evaluate(evaluation).numerify(evaluation)
+        numeric_qs = numerify(qs.evaluate(evaluation), evaluation)
         results = []
 
         for q in numeric_qs.elements:
@@ -98,7 +100,7 @@ class Quantile(Builtin):
 
             x = (Integer(n) + b) * q + a
 
-            numeric_x = x.evaluate(evaluation).numerify(evaluation)
+            numeric_x = numerify(x.evaluate(evaluation), evaluation)
 
             if isinstance(numeric_x, Integer):
                 results.append(ranked(numeric_x.value))

--- a/mathics/core/convert/expression.py
+++ b/mathics/core/convert/expression.py
@@ -7,6 +7,8 @@ from mathics.core.expression import Expression, convert_expression_elements
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolList
 
+from mathics.eval.numerify import numerify
+
 
 def make_expression(head, *elements, **kwargs) -> Expression:
     """
@@ -94,7 +96,7 @@ def to_numeric_args(mathics_args: Type[BaseElement], evaluation) -> list:
     return (
         tuple(mathics_args.value)
         if mathics_args.is_literal
-        else mathics_args.numerify(evaluation).get_sequence()
+        else numerify(mathics_args, evaluation).get_sequence()
     )
 
 
@@ -109,7 +111,7 @@ def to_numeric_sympy_args(mathics_args: Type[BaseElement], evaluation) -> list:
     if mathics_args.is_literal:
         sympy_args = [mathics_args.value]
     else:
-        args = mathics_args.numerify(evaluation).get_sequence()
+        args = numerify(mathics_args, evaluation).get_sequence()
         sympy_args = [a.to_sympy() for a in args]
 
     return sympy_args

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Iterable, List, Optional, Tuple, Type
 from itertools import chain
 from bisect import bisect_left
 
-from mathics.core.atoms import Integer, Number, String
+from mathics.core.atoms import Integer, String
 
 # FIXME: adjust mathics.core.attributes to uppercase attribute names
 from mathics.core.attributes import (
@@ -30,7 +30,6 @@ from mathics.core.convert.python import from_python
 from mathics.core.element import ElementsProperties, EvalMixin, ensure_context
 from mathics.core.evaluation import Evaluation
 from mathics.core.interrupt import ReturnInterrupt
-from mathics.core.number import dps
 from mathics.core.structure import LinkedStructure
 from mathics.core.symbols import (
     Atom,
@@ -1717,55 +1716,6 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             return self._head in symbols_arithmetic_operations and all(
                 element.is_numeric() for element in self._elements
             )
-
-    def numerify(self, evaluation) -> "BaseElement":
-        """
-        Produces a new expression equivalent to the original,
-        s.t. inexact numeric elements are reduced to Real numbers with
-        the same precision.
-        This is used in arithmetic evaluations (like `Plus`, `Times`, and `Power` )
-        and in iterators.
-        """
-        _prec = None
-        for element in self._elements:
-            if element.is_inexact():
-                element_prec = element.get_precision()
-                if _prec is None or element_prec < _prec:
-                    _prec = element_prec
-        if _prec is not None:
-            new_elements = self.get_mutable_elements()
-            for index in range(len(new_elements)):
-                element = new_elements[index]
-                # Don't "numerify" numbers: they should be numerified
-                # automatically by the processing function,
-                # and we don't want to lose exactness in e.g. 1.0+I.
-                # Also, for compatibility with WMA, numerify just the elements
-                # s.t. ``NumericQ[element]==True``
-                if not isinstance(element, Number) and element.is_numeric(evaluation):
-                    n_expr = Expression(SymbolN, element, Integer(dps(_prec)))
-                    n_result = (
-                        n_expr.evaluate(evaluation)
-                        if isinstance(n_expr, EvalMixin)
-                        else n_expr
-                    )
-                    if isinstance(n_result, Number):
-                        new_elements[index] = n_result
-                        continue
-                    # If Nvalues are not available, just tries to do
-                    # a regular evaluation
-                    n_result = (
-                        element.evaluate(evaluation)
-                        if isinstance(element, EvalMixin)
-                        else element
-                    )
-                    if isinstance(n_result, Number):
-                        new_elements[index] = n_result
-            result = Expression(self._head)
-            result.elements = new_elements
-            return result
-
-        else:
-            return self
 
     def user_hash(self, update):
         update(("%s>%d>" % (self.get_head_name(), len(self._elements))).encode("utf8"))

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -323,9 +323,6 @@ class Atom(BaseElement):
         """
         return False
 
-    def numerify(self, evaluation) -> "Atom":
-        return self
-
     def replace_vars(self, vars, options=None, in_scoping=True) -> "Atom":
         return self
 

--- a/mathics/eval/__init__.py
+++ b/mathics/eval/__init__.py
@@ -6,6 +6,7 @@ This module contains routines that implement different kind of evaluations over 
 
   * eval_N
   * eval_makeboxes
+  * numerify
   * test helpers that check properties on expressions.
 
 """
@@ -13,6 +14,6 @@ This module contains routines that implement different kind of evaluations over 
 # Ideally, this module should depend on modules inside ``mathics.core`` but not in modules stored in ``mathics.builtin`` to avoid circular references.
 
 
-# ``numerify``, ``evaluation``, ``_rewrite_apply_eval_step``, ``set`` that in the current implementation
+# ``evaluation``, ``_rewrite_apply_eval_step``, ``set`` that in the current implementation
 # requires to introduce local imports.
 # This also would make easier to test and profile classes that store Expression-like objects and methods that produce the evaluation.

--- a/mathics/eval/numerify.py
+++ b/mathics/eval/numerify.py
@@ -1,0 +1,70 @@
+# cython: language_level=3
+# -*- coding: utf-8 -*-
+
+"""
+
+Produces a new expression equivalent to the original,
+s.t. inexact numeric elements are reduced to Real numbers with
+the same precision.
+This is used in arithmetic evaluations (like `Plus`, `Times`, and `Power` )
+and in iterators.
+
+"""
+
+from mathics.core.atoms import Integer, Number
+from mathics.core.element import BaseElement, EvalMixin
+from mathics.core.expression import Expression
+from mathics.core.evaluation import Evaluation
+from mathics.core.number import dps
+
+from mathics.eval.nevaluator import eval_N
+
+
+def numerify(self: BaseElement, evaluation: Evaluation) -> "BaseElement":
+    """
+    Produces a new expression with the inexact numeric elements reduced to Real
+    numbers with the same precision.
+    This is used in arithmetic evaluations (like `Plus`, `Times`, and `Power` )
+    and in iterators.
+    """
+    if not isinstance(self, Expression):
+        return self
+    _prec = None
+    for element in self._elements:
+        if element.is_inexact():
+            element_prec = element.get_precision()
+            if _prec is None or element_prec < _prec:
+                _prec = element_prec
+    if _prec is not None:
+        new_elements = self.get_mutable_elements()
+        for index in range(len(new_elements)):
+            element = new_elements[index]
+            # Don't "numerify" numbers: they should be numerified
+            # automatically by the processing function,
+            # and we don't want to lose exactness in e.g. 1.0+I.
+            # Also, for compatibility with WMA, numerify just the elements
+            # s.t. ``NumericQ[element]==True``
+            if not isinstance(element, Number) and element.is_numeric(evaluation):
+                n_result = (
+                    eval_N(element, evaluation, Integer(dps(_prec)))
+                    if isinstance(element, EvalMixin)
+                    else element
+                )
+                if isinstance(n_result, Number):
+                    new_elements[index] = n_result
+                    continue
+                # If Nvalues are not available, just tries to do
+                # a regular evaluation
+                n_result = (
+                    element.evaluate(evaluation)
+                    if isinstance(element, EvalMixin)
+                    else element
+                )
+                if isinstance(n_result, Number):
+                    new_elements[index] = n_result
+        result = Expression(self._head)
+        result.elements = new_elements
+        return result
+
+    else:
+        return self

--- a/test/test_evaluators.py
+++ b/test/test_evaluators.py
@@ -4,13 +4,14 @@ import pytest
 
 from mathics.session import MathicsSession
 from mathics.eval.nevaluator import eval_N, eval_nvalues
+from mathics.eval.numerify import numerify as eval_numerify
 
 session = MathicsSession()
 evaluation = session.evaluation
 
 
 def numerify(expr, evaluation):
-    return expr.numerify(evaluation)
+    return eval_numerify(expr, evaluation)
 
 
 def test_sameQ():


### PR DESCRIPTION
In this second round, the `numerify` method is converted in a non-member function, under  `mathics.eval.numerify`

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/632"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

