### PR TITLE
Two bugs found via another PR

### DIFF
--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -232,9 +232,9 @@ class BuiltinRule(BaseRule):
         return odict
 
     def __setstate__(self, dict):
-        from mathics.builtin import builtins
+        from mathics.builtin import _builtins
 
         self.__dict__.update(dict)  # update attributes
-        cls, name = dict["function_"]
+        class_name, name = dict["function_"]
 
-        self.function = getattr(builtins[cls], name)
+        self.function = getattr(_builtins[class_name], name)

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -1087,7 +1087,8 @@ class PyMathicsDocumentation(Documentation):
 
         # Load the dictionary of mathics symbols defined in the module
         self.symbols = {}
-        from mathics.builtin import Builtin, name_is_builtin_symbol
+        from mathics.builtin import name_is_builtin_symbol
+        from mathics.builtin.base import Builtin
 
         print("loading symbols")
         for name in dir(self.pymathicsmodule):

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -6,7 +6,8 @@ had missing or duplicate build-in functions definitions.
 """
 import pytest
 import os
-from mathics.builtin import name_is_builtin_symbol, modules, Builtin
+from mathics.builtin import name_is_builtin_symbol, modules
+from mathics.builtin.base import Builtin
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
`rules.py __setstate__()`:
   `mathics.builtin.builtins` was renamed to `mathics.builtin._builtins`
   I guess on the assumption it was private.

It turns out it wasn't. And we were using the older (more correct) name "builtins" instead of "_builtins". Use "_builtins" to make this work. `__setstate__` apparently isn't used right now, but would be if  we used `deepcopy()`. Note that in #635, this variable is renamed `system_builtins_dict`.

rest:
   Change imports of Builtin from `mathics.builtin` to  `mathics.builtin.base`. `mathics.builtin only accidentially imports `Builtin`.

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/636"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

