### PR TITLE
Move more eval functions from mathics.builtin to mathics.eval

### DIFF
--- a/SYMBOLS_MANIFEST.txt
+++ b/SYMBOLS_MANIFEST.txt
@@ -462,7 +462,7 @@ System`Hash
 System`Haversine
 System`Head
 System`HermiteH
-System`HexidecimalCharacter
+System`HexadecimalCharacter
 System`Histogram
 System`Hold
 System`HoldAll

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -440,7 +440,7 @@ class Alphabet(Builtin):
 
     summary_text = "lowercase letters in an alphabet"
 
-    def apply(self, alpha, evaluation):
+    def eval(self, alpha, evaluation):
         """Alphabet[alpha_String]"""
         alphakey = alpha.value
         alphakey = alphabet_alias.get(alphakey, alphakey)
@@ -539,7 +539,7 @@ class InterpretedBox(PrefixOperator):
     precedence = 670
     summary_text = "interpret boxes as an expression"
 
-    def apply_dummy(self, boxes, evaluation: Evaluation):
+    def eval_dummy(self, boxes, evaluation: Evaluation):
         """InterpretedBox[boxes_]"""
         # TODO: the following is a very raw and dummy way to
         # handle these expressions.
@@ -604,7 +604,7 @@ class LetterNumber(Builtin):
 
     summary_text = "position of a letter in an alphabet"
 
-    def apply_alpha_str(self, chars: List[Any], alpha: String, evaluation):
+    def eval_alpha_str(self, chars: List[Any], alpha: String, evaluation):
         "LetterNumber[chars_, alpha_String]"
         alphakey = alpha.value
         alphakey = alphabet_alias.get(alphakey, alphakey)
@@ -643,7 +643,7 @@ class LetterNumber(Builtin):
             return evaluation.message(self.__class__.__name__, "nas", chars)
         return None
 
-    def apply(self, chars: List[Any], evaluation):
+    def eval(self, chars: List[Any], evaluation):
         "LetterNumber[chars_]"
 
         start_ord = ord("a") - 1
@@ -661,7 +661,7 @@ class LetterNumber(Builtin):
         elif chars.has_form("List", 1, None):
             result = []
             for element in chars.elements:
-                result.append(self.apply(element, evaluation))
+                result.append(self.eval(element, evaluation))
             return ListExpression(*result)
         else:
             return evaluation.message(self.__class__.__name__, "nas", chars)
@@ -710,7 +710,7 @@ class RemoveDiacritics(Builtin):
 
     summary_text = "remove diacritics"
 
-    def apply(self, s, evaluation: Evaluation):
+    def eval(self, s, evaluation: Evaluation):
         "RemoveDiacritics[s_String]"
         return String(
             unicodedata.normalize("NFKD", s.value)
@@ -928,7 +928,7 @@ class StringContainsQ(Builtin):
 
     summary_text = "test whether a pattern matches with a substring"
 
-    def apply(self, string, patt, evaluation, options):
+    def eval(self, string, patt, evaluation, options):
         "StringContainsQ[string_, patt_, OptionsPattern[%(name)s]]"
         return _pattern_search(
             self.__class__.__name__, string, patt, evaluation, options, True
@@ -990,7 +990,7 @@ class StringRepeat(Builtin):
 
     summary_text = "build a string by concatenating repetitions"
 
-    def apply(self, s, n, expression, evaluation):
+    def eval(self, s, n, expression, evaluation):
         "StringRepeat[s_String, n_]"
         py_n = n.value if isinstance(n, Integer) else 0
         if py_n < 1:
@@ -998,7 +998,7 @@ class StringRepeat(Builtin):
         else:
             return String(s.value * py_n)
 
-    def apply_truncated(self, s, n, m, expression, evaluation):
+    def eval_truncated(self, s, n, m, expression, evaluation):
         "StringRepeat[s_String, n_Integer, m_Integer]"
         # The above rule insures that n and m are boht Integer type
         py_n = n.value
@@ -1107,7 +1107,7 @@ class ToExpression(Builtin):
     }
     summary_text = "build an expression from formatted text"
 
-    def apply(self, seq, evaluation: Evaluation):
+    def eval(self, seq, evaluation: Evaluation):
         "ToExpression[seq__]"
 
         # Organise Arguments
@@ -1163,7 +1163,7 @@ class ToExpression(Builtin):
 
         return result
 
-    def apply_empty(self, evaluation: Evaluation):
+    def eval_empty(self, evaluation: Evaluation):
         "ToExpression[]"
         evaluation.message(
             "ToExpression", "argb", "ToExpression", Integer0, Integer1, Integer(3)
@@ -1212,11 +1212,11 @@ class ToString(Builtin):
 
     summary_text = "format an expression and produce a string"
 
-    def apply_default(self, value, evaluation, options):
+    def eval_default(self, value, evaluation, options):
         "ToString[value_, OptionsPattern[ToString]]"
-        return self.apply_form(value, SymbolOutputForm, evaluation, options)
+        return self.eval_form(value, SymbolOutputForm, evaluation, options)
 
-    def apply_form(self, expr, form, evaluation, options):
+    def eval_form(self, expr, form, evaluation, options):
         "ToString[expr_, form_, OptionsPattern[ToString]]"
         encoding = options["System`CharacterEncoding"]
         return eval_ToString(expr, form, encoding.value, evaluation)
@@ -1252,7 +1252,7 @@ class Transliterate(Builtin):
     requires = ("unidecode",)
     summary_text = "transliterate an UTF string in different alphabets to ASCII"
 
-    def apply(self, s, evaluation: Evaluation):
+    def eval(self, s, evaluation: Evaluation):
         "Transliterate[s_String]"
         from unidecode import unidecode
 

--- a/mathics/builtin/matrices/constrmatrix.py
+++ b/mathics/builtin/matrices/constrmatrix.py
@@ -8,7 +8,6 @@ Methods for constructing Matrices.
 
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import Integer0
-from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 
 

--- a/mathics/builtin/vectors/math_ops.py
+++ b/mathics/builtin/vectors/math_ops.py
@@ -4,62 +4,12 @@
 Mathematical Operations
 """
 
-from typing import Optional
 import sympy
 
 from mathics.builtin.base import Builtin, SympyFunction
-from mathics.core.atoms import Integer, Real, String
 from mathics.core.attributes import A_PROTECTED
-from mathics.core.evaluation import Evaluation
-from mathics.core.expression import Expression
-
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
-from mathics.core.symbols import Symbol
-
-
-def eval_2_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
-    """
-    2-Norm[] evaluation function
-    """
-    sympy_m = to_sympy_matrix(m)
-    if sympy_m is None:
-        return evaluation.message("Norm", "nvm")
-
-    return from_sympy(sympy_m.norm())
-
-
-def eval_p_norm(
-    m: Expression, p: Expression, evaluation: Evaluation
-) -> Optional[Expression]:
-    """
-    p2-Norm[] evaluation function
-    """
-    if isinstance(p, Symbol):
-        sympy_p = p.to_sympy()
-    elif isinstance(p, String):
-        sympy_p = p.value
-        if sympy_p == "Frobenius":
-            sympy_p = "fro"
-    elif isinstance(p, (Real, Integer)) and p.to_python() >= 1:
-        sympy_p = p.to_sympy()
-    else:
-        return evaluation.message("Norm", "ptype", p)
-
-    if sympy_p is None:
-        return
-    matrix = to_sympy_matrix(m)
-
-    if matrix is None:
-        return evaluation.message("Norm", "nvm")
-    if len(matrix) == 0:
-        return
-
-    try:
-        res = matrix.norm(sympy_p)
-    except NotImplementedError:
-        return evaluation.message("Norm", "normnotimplemented")
-
-    return from_sympy(res)
+from mathics.eval.math_ops import eval_2_Norm, eval_p_norm
 
 
 class Cross(Builtin):

--- a/mathics/builtin/vectors/math_ops.py
+++ b/mathics/builtin/vectors/math_ops.py
@@ -14,7 +14,13 @@ from mathics.eval.math_ops import eval_2_Norm, eval_p_norm
 
 class Cross(Builtin):
     """
-    <url>:Cross product: https://en.wikipedia.org/wiki/Cross_product</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/physics/vector/api/functions.html#sympy.physics.vector.functions.cross</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Cross.html</url>)
+    <url>
+    :Cross product:
+    https://en.wikipedia.org/wiki/Cross_product</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/physics/vector/api/functions.html#sympy.physics.vector.functions.cross</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Cross.html</url>)
 
     <dl>
       <dt>'Cross[$a$, $b$]'
@@ -57,7 +63,7 @@ class Cross(Builtin):
     rules = {"Cross[{x_, y_}]": "{-y, x}"}
     summary_text = "vector cross product"
 
-    def apply(self, a, b, evaluation):
+    def eval(self, a, b, evaluation):
         "Cross[a_, b_]"
         a = to_sympy_matrix(a)
         b = to_sympy_matrix(b)
@@ -74,7 +80,11 @@ class Cross(Builtin):
 
 class Curl(SympyFunction):
     """
-    <url>:Curl: https://en.wikipedia.org/wiki/Curl_(mathematics)</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/vector/api/vectorfunctions.html#sympy.vector.curl</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Curl.html</url>)
+    <url>
+    :Curl:
+    https://en.wikipedia.org/wiki/Curl_(mathematics)</url> (<url>
+    :SymPy: https://docs.sympy.org/latest/modules/vector/api/vectorfunctions.html#sympy.vector.curl</url>, <url>
+    :WMA: https://reference.wolfram.com/language/ref/Curl.html</url>)
 
     <dl>
       <dt>'Curl[{$f1$, $f2$}, {$x1$, $x2$}]'
@@ -115,7 +125,12 @@ class Curl(SympyFunction):
 
 class Norm(Builtin):
     """
-    <url>:Matrix norms induced by vector p-norms: https://en.wikipedia.org/wiki/Matrix_norm#Matrix_norms_induced_by_vector_p-norms</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/matrices/matrices.html#sympy.matrices.matrices.MatrixBase.norm</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Norm.html</url>)
+    <url>
+    :Matrix norms induced by vector p-norms: https://en.wikipedia.org/wiki/Matrix_norm#Matrix_norms_induced_by_vector_p-norms</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/matrices/matrices.html#sympy.matrices.matrices.MatrixBase.norm</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Norm.html</url>)
 
     <dl>
       <dt>'Norm[$m$, $p$]'
@@ -171,11 +186,11 @@ class Norm(Builtin):
     }
     summary_text = "norm of a vector or matrix"
 
-    def apply_two_norm(self, m, evaluation):
+    def eval_two_norm(self, m, evaluation):
         "Norm[m_]"
         return eval_2_Norm(m, evaluation)
 
-    def apply_p_norm(self, m, p, evaluation):
+    def eval_p_norm(self, m, p, evaluation):
         "Norm[m_, p_]"
         return eval_p_norm(m, p, evaluation)
 

--- a/mathics/data/.gitignore
+++ b/mathics/data/.gitignore
@@ -1,1 +1,2 @@
 /doc_tex_data.pcl
+/op-tables.json

--- a/mathics/eval/math_ops.py
+++ b/mathics/eval/math_ops.py
@@ -1,0 +1,52 @@
+from typing import Optional
+
+from mathics.core.atoms import Integer, Real, String
+from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
+from mathics.core.evaluation import Evaluation
+from mathics.core.expression import Expression
+from mathics.core.symbols import Symbol
+
+
+def eval_2_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
+    """
+    2-Norm[] evaluation function
+    """
+    sympy_m = to_sympy_matrix(m)
+    if sympy_m is None:
+        return evaluation.message("Norm", "nvm")
+
+    return from_sympy(sympy_m.norm())
+
+
+def eval_p_norm(
+    m: Expression, p: Expression, evaluation: Evaluation
+) -> Optional[Expression]:
+    """
+    p2-Norm[] evaluation function
+    """
+    if isinstance(p, Symbol):
+        sympy_p = p.to_sympy()
+    elif isinstance(p, String):
+        sympy_p = p.value
+        if sympy_p == "Frobenius":
+            sympy_p = "fro"
+    elif isinstance(p, (Real, Integer)) and p.to_python() >= 1:
+        sympy_p = p.to_sympy()
+    else:
+        return evaluation.message("Norm", "ptype", p)
+
+    if sympy_p is None:
+        return
+    matrix = to_sympy_matrix(m)
+
+    if matrix is None:
+        return evaluation.message("Norm", "nvm")
+    if len(matrix) == 0:
+        return
+
+    try:
+        res = matrix.norm(sympy_p)
+    except NotImplementedError:
+        return evaluation.message("Norm", "normnotimplemented")
+
+    return from_sympy(res)

--- a/mathics/eval/strings.py
+++ b/mathics/eval/strings.py
@@ -1,0 +1,13 @@
+from mathics.core.atoms import String
+from mathics.core.element import BaseElement
+from mathics.core.evaluation import Evaluation
+from mathics.core.symbols import Symbol
+from mathics.eval.makeboxes import format_element
+
+
+def eval_ToString(
+    expr: BaseElement, form: Symbol, encoding: String, evaluation: Evaluation
+) -> String:
+    boxes = format_element(expr, evaluation, form, encoding=encoding)
+    text = boxes.boxes_to_text(evaluation=evaluation)
+    return String(text)


### PR DESCRIPTION
Move some eval functions to `mathics.core.eval` go over the changed modules for apply->eval, <dd> tags, and WMA links and shorten some lines with <url>s in them. 

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/645"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Hexidecimal -> Hexadecimals

isort imports of changed modules
