### PR TITLE
Revise for current standards ...

### DIFF
--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -11,29 +11,16 @@ sort_order = "mathics.builtin.mathematical-constants"
 
 
 import math
+
 import mpmath
 import numpy
 import sympy
 
-
 from mathics.builtin.base import Builtin, Predefined, SympyObject
-
-from mathics.core.atoms import (
-    MachineReal,
-    PrecisionReal,
-)
-from mathics.core.attributes import (
-    A_CONSTANT,
-    A_PROTECTED,
-    A_READ_PROTECTED,
-)
-
-from mathics.core.number import get_precision, PrecisionValueError, machine_precision
-from mathics.core.symbols import (
-    Atom,
-    Symbol,
-    strip_context,
-)
+from mathics.core.atoms import MachineReal, PrecisionReal
+from mathics.core.attributes import A_CONSTANT, A_PROTECTED, A_READ_PROTECTED
+from mathics.core.number import PrecisionValueError, get_precision, machine_precision
+from mathics.core.symbols import Atom, Symbol, strip_context
 from mathics.core.systemsymbols import SymbolIndeterminate
 
 
@@ -84,7 +71,7 @@ class _Constant_Common(Predefined):
     nargs = {0}
     options = {"Method": "Automatic"}
 
-    def apply_N(self, precision, evaluation):
+    def eval_N(self, precision, evaluation):
         "N[%(name)s, precision_?NumericQ]"
         return self.get_constant(precision, evaluation)
 
@@ -208,7 +195,12 @@ class _SympyConstant(_Constant_Common, SympyObject):
 
 class Catalan(_MPMathConstant, _SympyConstant):
     """
-    <url>:Catalan's constant: https://en.wikipedia.org/wiki/Catalan%27s_constant</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.Catalan</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Catalan.html</url>)
+    <url>
+    :Catalan's constant:
+    https://en.wikipedia.org/wiki/Catalan%27s_constant</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.Catalan</url>, <url>
+    :WMA: https://reference.wolfram.com/language/ref/Catalan.html</url>)
 
     <dl>
       <dt>'Catalan'
@@ -230,7 +222,14 @@ class Catalan(_MPMathConstant, _SympyConstant):
 
 class ComplexInfinity(_SympyConstant):
     """
-    <url>:Complex Infinity: https://en.wikipedia.org/wiki/Infinity#Complex_analysis</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html?highlight=zoo#complexinfinity</url>, <url>:WMA: https://reference.wolfram.com/language/ref/ComplexInfinity.html</url>)
+    <url>
+    :Complex Infinity:
+    https://en.wikipedia.org/wiki/Infinity#Complex_analysis</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/core.html?highlight=zoo#complexinfinity</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/ComplexInfinity.html</url>)
+
     <dl>
       <dt>'ComplexInfinity'
       <dd>represents an infinite complex quantity of undetermined direction.
@@ -262,7 +261,11 @@ class ComplexInfinity(_SympyConstant):
 
 class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
     """
-    <url>:Degree (angle): https://en.wikipedia.org/wiki/Degree_(angle)</url> (<url>:WMA: https://reference.wolfram.com/language/ref/Degree.html</url>)
+    <url>
+    :Degree (angle):
+    https://en.wikipedia.org/wiki/Degree_(angle)</url> (<url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Degree.html</url>)
 
     <dl>
       <dt>'Degree'
@@ -301,7 +304,7 @@ class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
             # return mpmath.degree
             return numpy.pi / 180
 
-    def apply_N(self, precision, evaluation):
+    def eval_N(self, precision, evaluation):
         "N[Degree, precision_]"
         try:
             if precision:
@@ -325,7 +328,13 @@ class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
 
 class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
     """
-    <url>:Euler's number: https://en.wikipedia.org/wiki/E_(mathematical_constant)</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html#exp1</url>, <url>:WMA: https://reference.wolfram.com/language/ref/E.html</url>)
+    <url>
+    :Euler's number:
+    https://en.wikipedia.org/wiki/E_(mathematical_constant)</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/core.html#exp1</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/E.html</url>)
 
     <dl>
       <dt>'E'
@@ -346,14 +355,18 @@ class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
     numpy_name = "e"
     sympy_name = "E"
 
-    def apply_N(self, precision, evaluation):
+    def eval_N(self, precision, evaluation):
         "N[E, precision_]"
         return self.get_constant(precision, evaluation)
 
 
 class EulerGamma(_MPMathConstant, _NumpyConstant, _SympyConstant):
     """
-    <url>:Euler's constant: https://en.wikipedia.org/wiki/Euler%27s_constant</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.EulerGamma</url>, <url>:WMA: https://reference.wolfram.com/language/ref/EulerGamma.html</url>)
+    <url>
+    :Euler's constant:
+    https://en.wikipedia.org/wiki/Euler%27s_constant</url> (<url>
+    :SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.EulerGamma</url>, <url>
+    :WMA: https://reference.wolfram.com/language/ref/EulerGamma.html</url>)
 
     <dl>
       <dt>'EulerGamma'
@@ -375,7 +388,13 @@ class EulerGamma(_MPMathConstant, _NumpyConstant, _SympyConstant):
 
 class Glaisher(_MPMathConstant):
     """
-    <url>:Glaisher–Kinkelin constant: https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/constants.html#glaisher-s-constant-glaisher</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Glaisher.html</url>)
+    <url>
+    :Glaisher–Kinkelin constant:
+    https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant</url> (<url>
+    :mpmath:
+    https://mpmath.org/doc/current/functions/constants.html#glaisher-s-constant-glaisher</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Glaisher.html</url>)
     <dl>
       <dt>'Glaisher'
       <dd>is Glaisher's constant, with numerical value \u2243 1.28243.
@@ -394,7 +413,13 @@ class Glaisher(_MPMathConstant):
 
 class GoldenRatio(_MPMathConstant, _SympyConstant):
     """
-    <url>:Golden ratio: https://en.wikipedia.org/wiki/Golden_ratio</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/constants.html#golden-ratio-phi</url>, <url>:WMA: https://reference.wolfram.com/language/ref/GoldenRatio.html</url>)
+    <url>
+    :Golden ratio:
+    https://en.wikipedia.org/wiki/Golden_ratio</url> (<url>
+    :mpmath:
+    https://mpmath.org/doc/current/functions/constants.html#golden-ratio-phi</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/GoldenRatio.html</url>)
 
     <dl>
       <dt>'GoldenRatio'
@@ -414,7 +439,13 @@ class GoldenRatio(_MPMathConstant, _SympyConstant):
 
 class Indeterminate(_SympyConstant):
     """
-    <url>:Indeterminate form: https://en.wikipedia.org/wiki/Indeterminate_form</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.NaN</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Indeterminate.html</url>)
+    <url>
+    :Indeterminate form:
+    https://en.wikipedia.org/wiki/Indeterminate_form</url> (<url>
+    :SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.NaN</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Indeterminate.html</url>)
+
     <dl>
       <dt>'Indeterminate'
       <dd>represents an indeterminate result.
@@ -431,14 +462,20 @@ class Indeterminate(_SympyConstant):
     summary_text = "indeterminate value"
     sympy_name = "nan"
 
-    def apply_N(self, precision, evaluation, options={}):
+    def eval_N(self, precision, evaluation, options={}):
         "N[%(name)s, precision_?NumericQ, OptionsPattern[%(name)s]]"
         return SymbolIndeterminate
 
 
 class Infinity(_SympyConstant):
     """
-    <url>:Infinity: https://en.wikipedia.org/wiki/Infinity</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.Infinity</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Infinity.html</url>)
+    <url>:
+    Infinity:
+    https://en.wikipedia.org/wiki/Infinity</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.Infinity</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Infinity.html</url>)
 
     <dl>
       <dt>'Infinity'
@@ -478,7 +515,14 @@ class Infinity(_SympyConstant):
 
 class Khinchin(_MPMathConstant):
     """
-    <url>:Khinchin's constant: https://en.wikipedia.org/wiki/Khinchin%27s_constant</url> (<url>:mpmath: https://mpmath.org/doc/current/functions/constants.html#mpmath.mp.khinchin</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Khinchin.html</url>)
+    <url>
+    :Khinchin's constant:
+    https://en.wikipedia.org/wiki/Khinchin%27s_constant</url> (<url>
+    :mpmath:
+    https://mpmath.org/doc/current/functions/constants.html#mpmath.mp.khinchin</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Khinchin.html</url>)
+
     <dl>
       <dt>'Khinchin'
       <dd>is Khinchin's constant, with numerical value \u2243 2.68545.
@@ -497,7 +541,14 @@ class Khinchin(_MPMathConstant):
 
 class Overflow(Builtin):
     """
-    Overflow (<url>:WMA: https://reference.wolfram.com/language/ref/Overflow.html</url>)
+    Numeric Overflow (<url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Overflow.html
+    </url>)
+
+    See also <url>
+    :Integer Overflow:
+    <https://en.wikipedia.org/wiki/Integer_overflow></url>.
 
     <dl>
       <dt>'Overflow[]'
@@ -522,7 +573,12 @@ class Overflow(Builtin):
 
 class Pi(_MPMathConstant, _SympyConstant):
     """
-    <url>:Pi, \u03c0: https://en.wikipedia.org/wiki/Pi</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.Pi</url>, <url>:WMA: https://reference.wolfram.com/language/ref/Pi.html</url>)
+    <url>
+    :Pi, \u03c0: https://en.wikipedia.org/wiki/Pi</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/core.html#sympy.core.numbers.Pi</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Pi.html</url>)
 
     <dl>
       <dt>'Pi'
@@ -557,7 +613,9 @@ class Pi(_MPMathConstant, _SympyConstant):
 
 class Undefined(Builtin):
     """
-    Undefined symbol/value (<url>:WMA: https://reference.wolfram.com/language/ref/Undefined.html</url>)
+    Undefined symbol/value (<url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/Undefined.html</url>)
 
     <dl>
       <dt>'Undefined'
@@ -576,7 +634,9 @@ class Undefined(Builtin):
 
 class Underflow(Builtin):
     """
-    <url>:Arithmetic underflow: https://en.wikipedia.org/wiki/Arithmetic_underflow</url> (<url>:WMA: https://reference.wolfram.com/language/ref/Underflow.html</url>)
+    <url>:Arithmetic underflow:
+    https://en.wikipedia.org/wiki/Arithmetic_underflow</url> (<url>
+    :WMA: https://reference.wolfram.com/language/ref/Underflow.html</url>)
 
     <dl>
       <dt>'Overflow[]'

--- a/mathics/builtin/vectors/vector_space_operations.py
+++ b/mathics/builtin/vectors/vector_space_operations.py
@@ -8,23 +8,29 @@ from sympy.physics.quantum import TensorProduct
 
 from mathics.builtin.base import Builtin, SympyFunction
 from mathics.core.atoms import Complex, Integer, Integer0, Integer1, Real
-from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
-from mathics.core.evaluation import Evaluation
-from mathics.core.expression import Expression
-from mathics.core.list import ListExpression
-from mathics.core.symbols import Symbol
-from mathics.core.systemsymbols import SymbolDot, SymbolConjugate
 from mathics.core.attributes import (
     # A_LISTABLE,
     # A_NUMERIC_FUNCTION,
     A_PROTECTED,
     A_READ_PROTECTED,
 )
+from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
+from mathics.core.evaluation import Evaluation
+from mathics.core.expression import Expression
+from mathics.core.list import ListExpression
+from mathics.core.symbols import Symbol
+from mathics.core.systemsymbols import SymbolConjugate, SymbolDot
 
 
 class KroneckerProduct(SympyFunction):
     """
-    <url>:Kronecker product: https://en.wikipedia.org/wiki/Kronecker_product</url> (<url>:SymPy: https://docs.sympy.org/latest/modules/physics/quantum/tensorproduct.html</url>, <url>:WMA: https://reference.wolfram.com/language/ref/KroneckerProduct.html</url>)
+    <url>
+    :Kronecker product:
+    https://en.wikipedia.org/wiki/Kronecker_product</url> (<url>
+    :SymPy:
+    https://docs.sympy.org/latest/modules/physics/quantum/tensorproduct.html</url>, <url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/KroneckerProduct.html</url>)
 
     <dl>
       <dt>'KroneckerProduct[$m1$, $m2$, ...]'
@@ -57,7 +63,7 @@ class KroneckerProduct(SympyFunction):
     summary_text = "Kronecker product"
     sympy_name = "physics.quantum.TensorProduct"
 
-    def apply(self, mi: ListExpression, evaluation: Evaluation):
+    def eval(self, mi: ListExpression, evaluation: Evaluation):
         "KroneckerProduct[mi__List]"
         sympy_mi = [to_sympy_matrix(m) for m in mi.elements]
         return from_sympy(TensorProduct(*sympy_mi))
@@ -132,7 +138,7 @@ class Projection(Builtin):
 
     summary_text = "find the projection of one vector on another"
 
-    def apply(self, u: ListExpression, v: ListExpression, evaluation):
+    def eval(self, u: ListExpression, v: ListExpression, evaluation):
         "Projection[u_, v_]"
 
         all_elements = u.elements + v.elements
@@ -177,7 +183,7 @@ class UnitVector(Builtin):
     }
     summary_text = "unit vector along a coordinate direction"
 
-    def apply(self, n: Integer, k: Integer, evaluation):
+    def eval(self, n: Integer, k: Integer, evaluation):
         "UnitVector[n_Integer, k_Integer]"
 
         py_n = n.value


### PR DESCRIPTION
Break url lines. "def eval" -> "def apply" (where appropriate)

This was inspired by the desire to update the developer docs which include some of the Builtins defined here. See corresponding changes in the developer doc as well.

imports isort'ed

<a href="https://gitpod.io/#https://github.com/Mathics3/mathics-core/pull/647"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
>
