### PR TITLE
Move `mathics.core.builtin` initialization code into `system_initialize()`

### DIFF
--- a/examples/symbolic_logic/gries_schneider/test_gs.py
+++ b/examples/symbolic_logic/gries_schneider/test_gs.py
@@ -2,10 +2,12 @@
 # -*- coding: utf-8 -*-
 
 
+from mathics.builtin.system_init import initialize_system
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
 from mathics.core.parser import MathicsSingleLineFeeder, parse
 
+initialize_system()
 definitions = Definitions(add_builtin=True)
 
 for i in range(0, 4):

--- a/examples/symbolic_logic/gries_schneider/test_gs.py
+++ b/examples/symbolic_logic/gries_schneider/test_gs.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 
-from mathics.builtin.system_init import initialize_system
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
 from mathics.core.parser import MathicsSingleLineFeeder, parse
+from mathics.core.system_init import initialize_system
 
 initialize_system()
 definitions = Definitions(add_builtin=True)

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Mathics Builtin Functions and  Variables.
+Mathics Builtin Functions and Variables.
 
 Mathics has over a thousand Built-in functions and variables, all of
 which are defined here.
@@ -47,6 +47,14 @@ __py_files__ = [
 ]
 
 
+mathics_to_sympy = {}  # here we have: name -> sympy object
+sympy_to_mathics = {}
+builtins_list = []
+
+builtins_precedence = {}
+
+system_builtins = {}
+
 def add_builtins(new_builtins):
     for var_name, builtin in new_builtins:
         name = builtin.get_name()
@@ -63,7 +71,7 @@ def add_builtins(new_builtins):
             builtins_precedence[name] = builtin.precedence
         if isinstance(builtin, PatternObject):
             pattern_objects[name] = builtin.__class__
-    _builtins.update(dict(new_builtins))
+    system_builtins.update(dict(new_builtins))
 
 
 def builtins_dict():
@@ -76,8 +84,8 @@ def builtins_dict():
 
 def contribute(definitions):
     # let MakeBoxes contribute first
-    _builtins["System`MakeBoxes"].contribute(definitions)
-    for name, item in _builtins.items():
+    system_builtins["System`MakeBoxes"].contribute(definitions)
+    for name, item in system_builtins.items():
         if name != "System`MakeBoxes":
             item.contribute(definitions)
 
@@ -176,7 +184,6 @@ module_names = [
 modules = []
 import_builtins(module_names)
 
-_builtins_list = []
 builtins_by_module = {}
 
 disable_file_module_names = (
@@ -232,19 +239,10 @@ for module in modules:
                 # This set the default context for symbols in mathics.builtins
                 if not type(instance).context:
                     type(instance).context = "System`"
-                _builtins_list.append((instance.get_name(), instance))
+                builtins_list.append((instance.get_name(), instance))
                 builtins_by_module[module.__name__].append(instance)
 
-mathics_to_sympy = {}  # here we have: name -> sympy object
-sympy_to_mathics = {}
-
-builtins_precedence = {}
-
-new_builtins = _builtins_list
-
-# FIXME: some magic is going on here..
-_builtins = {}
-
+new_builtins = builtins_list
 add_builtins(new_builtins)
 
 display_operators_set = set()

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -37,7 +37,6 @@ from mathics.builtin.base import (
 )
 from mathics.core.pattern import pattern_objects
 from mathics.settings import ENABLE_FILES_MODULE
-from mathics.version import __version__  # noqa used in loading to check consistency.
 
 # Get a list of files in this directory. We'll exclude from the start
 # files with leading characters we don't want like __init__ with its leading underscore.
@@ -54,6 +53,7 @@ builtins_list = []
 builtins_precedence = {}
 
 system_builtins = {}
+
 
 def add_builtins(new_builtins):
     for var_name, builtin in new_builtins:
@@ -72,14 +72,6 @@ def add_builtins(new_builtins):
         if isinstance(builtin, PatternObject):
             pattern_objects[name] = builtin.__class__
     system_builtins.update(dict(new_builtins))
-
-
-def builtins_dict():
-    return {
-        builtin.get_name(): builtin
-        for modname, builtins in builtins_by_module.items()
-        for builtin in builtins
-    }
 
 
 def contribute(definitions):
@@ -244,11 +236,3 @@ for module in modules:
 
 new_builtins = builtins_list
 add_builtins(new_builtins)
-
-display_operators_set = set()
-for modname, builtins in builtins_by_module.items():
-    for builtin in builtins:
-        # name = builtin.get_name()
-        operator = builtin.get_operator_display()
-        if operator is not None:
-            display_operators_set.add(operator)

--- a/mathics/builtin/system_init.py
+++ b/mathics/builtin/system_init.py
@@ -1,0 +1,111 @@
+"""
+One-time initialization of Mathics module loading, and creation of built-in functions.
+"""
+
+import glob
+import os.path as osp
+
+from mathics.builtin.base import (
+    Builtin,
+    Operator,
+    PatternObject,
+    SympyObject,
+    mathics_to_python,
+)
+
+from mathics.core.pattern import pattern_objects
+
+builtins_precedence = {}
+mathics_to_sympy = {}  # here we have: name -> sympy object
+sympy_to_mathics = {}
+
+# builtins_by_module maps a full module name, e.g. "mathics.builtin.evaluation" to a
+# list of Builtin classes.
+builtins_by_module = {}
+builtins_list = []
+
+# Get a list of files in this directory. We'll exclude from the start
+# files with leading characters we don't want like __init__ with its leading underscore.
+__py_files__ = [
+    osp.basename(f[0:-3])
+    for f in glob.glob(osp.join(osp.dirname(__file__), "[a-z]*.py"))
+]
+
+builtins_precedence = {}
+
+system_builtins = {}
+
+
+def add_builtins(new_builtins):
+    for var_name, builtin in new_builtins:
+        name = builtin.get_name()
+        if hasattr(builtin, "python_equivalent"):
+            # print("XXX0", builtin.python_equivalent)
+            mathics_to_python[name] = builtin.python_equivalent
+
+        if isinstance(builtin, SympyObject):
+            mathics_to_sympy[name] = builtin
+            for sympy_name in builtin.get_sympy_names():
+                # print("XXX1", sympy_name)
+                sympy_to_mathics[sympy_name] = builtin
+        if isinstance(builtin, Operator):
+            builtins_precedence[name] = builtin.precedence
+        if isinstance(builtin, PatternObject):
+            pattern_objects[name] = builtin.__class__
+    system_builtins.update(dict(new_builtins))
+
+
+def builtins_dict():
+    return {
+        builtin.get_name(): builtin
+        for modname, builtins in builtins_by_module.items()
+        for builtin in builtins
+    }
+
+
+def create_builtins_by_module():
+    from mathics.builtin import modules, name_is_builtin_symbol, sanity_check
+
+    for module in modules:
+        builtins_by_module[module.__name__] = []
+        module_vars = dir(module)
+
+        for name in module_vars:
+            builtin_class = name_is_builtin_symbol(module, name)
+            if builtin_class is not None:
+                instance = builtin_class(expression=False)
+
+                if isinstance(instance, Builtin):
+                    # This set the default context for symbols in mathics.builtins
+                    if not type(instance).context:
+                        type(instance).context = "System`"
+                    assert sanity_check(
+                        builtin_class, module
+                    ), f"In {module.__name__} Builtin <<{builtin_class.__name__}>> did not pass the sanity check."
+
+                    builtins_list.append((instance.get_name(), instance))
+                    builtins_by_module[module.__name__].append(instance)
+
+
+display_operators_set = set()
+
+# TODO: after doing more, e.g. moving Builtin class processing,
+# consider adding an administrative routine to write definitions in
+# Python Pickle format (or something suitable. Then we can add a flag
+# here to read this in which might be faster.
+#
+def initialize_system():
+    """
+    One-time Builtin initialization.
+    Not much here but more may be added.
+    """
+    create_builtins_by_module()
+    from mathics.builtin import __py_files__ as old_py_files
+
+    assert __py_files__ == old_py_files
+    for modname, builtins in builtins_by_module.items():
+        for builtin in builtins:
+            # name = builtin.get_name()
+            operator = builtin.get_operator_display()
+            if operator is not None:
+                display_operators_set.add(operator)

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -21,6 +21,7 @@ from mathics.core.symbols import (
     Symbol,
     strip_context,
 )
+from mathics.core.system_init import contribute
 from mathics.core.systemsymbols import SymbolGet
 
 from mathics_scanner.tokeniser import full_names_pattern
@@ -130,7 +131,7 @@ class Definitions:
         self.timing_trace_evaluation = False
 
         if add_builtin:
-            from mathics.builtin import modules, contribute
+            from mathics.builtin import modules
             from mathics.settings import ROOT_DIR
 
             loaded = False

--- a/mathics/core/pymathics.py
+++ b/mathics/core/pymathics.py
@@ -7,6 +7,7 @@ import importlib
 import sys
 
 
+from mathics.builtin.system_init import builtins_by_module
 from mathics.core.evaluation import Evaluation
 
 # This dict probably does not belong here.
@@ -22,7 +23,6 @@ class PyMathicsLoadException(Exception):
 # Why do we need this?
 def eval_clear_pymathics_modules():
     global pymathics
-    from mathics.builtin import builtins_by_module
 
     for key in list(builtins_by_module.keys()):
         if not key.startswith("mathics."):

--- a/mathics/core/pymathics.py
+++ b/mathics/core/pymathics.py
@@ -7,8 +7,8 @@ import importlib
 import sys
 
 
-from mathics.builtin.system_init import builtins_by_module
 from mathics.core.evaluation import Evaluation
+from mathics.core.system_init import builtins_by_module, name_is_builtin_symbol
 
 # This dict probably does not belong here.
 pymathics = {}
@@ -61,7 +61,6 @@ def load_pymathics_module(definitions, module):
     """
     from mathics.builtin import (
         builtins_by_module,
-        name_is_builtin_symbol,
         Builtin,
     )
 

--- a/mathics/core/system_init.py
+++ b/mathics/core/system_init.py
@@ -3,15 +3,9 @@ One-time initialization of Mathics module loading, and creation of built-in func
 """
 
 import glob
+import inspect
 import os.path as osp
-
-from mathics.builtin.base import (
-    Builtin,
-    Operator,
-    PatternObject,
-    SympyObject,
-    mathics_to_python,
-)
+from typing import Optional
 
 from mathics.core.pattern import pattern_objects
 
@@ -37,6 +31,13 @@ system_builtins = {}
 
 
 def add_builtins(new_builtins):
+    from mathics.builtin.base import (
+        Operator,
+        PatternObject,
+        SympyObject,
+        mathics_to_python,
+    )
+
     for var_name, builtin in new_builtins:
         name = builtin.get_name()
         if hasattr(builtin, "python_equivalent"):
@@ -63,8 +64,29 @@ def builtins_dict():
     }
 
 
+def contribute(definitions):
+    # let MakeBoxes contribute first
+    system_builtins["System`MakeBoxes"].contribute(definitions)
+    for name, item in system_builtins.items():
+        if name != "System`MakeBoxes":
+            item.contribute(definitions)
+
+    from mathics.core.definitions import Definition
+    from mathics.core.expression import ensure_context
+    from mathics.core.parser import all_operator_names
+
+    # All builtins are loaded. Create dummy builtin definitions for
+    # any remaining operators that don't have them. This allows
+    # operators like \[Cup] to behave correctly.
+    for operator in all_operator_names:
+        if not definitions.have_definition(ensure_context(operator)):
+            op = ensure_context(operator)
+            definitions.builtin[op] = Definition(name=op)
+
+
 def create_builtins_by_module():
-    from mathics.builtin import modules, name_is_builtin_symbol, sanity_check
+    from mathics.builtin import modules
+    from mathics.builtin.base import Builtin
 
     for module in modules:
         builtins_by_module[module.__name__] = []
@@ -79,12 +101,22 @@ def create_builtins_by_module():
                     # This set the default context for symbols in mathics.builtins
                     if not type(instance).context:
                         type(instance).context = "System`"
-                    assert sanity_check(
-                        builtin_class, module
-                    ), f"In {module.__name__} Builtin <<{builtin_class.__name__}>> did not pass the sanity check."
-
                     builtins_list.append((instance.get_name(), instance))
                     builtins_by_module[module.__name__].append(instance)
+    add_builtins(builtins_list)
+
+
+def get_builtin_pyfiles() -> tuple:
+    """
+    Return a list of files in this directory. We'll exclude from the start
+    files with leading characters we don't want like __init__ with its leading underscore.
+    """
+    return tuple(
+        osp.basename(f[0:-3])
+        for f in glob.glob(
+            osp.join(osp.dirname(__file__), "..", "builtin", "[a-z]*.py")
+        )
+    )
 
 
 display_operators_set = set()
@@ -100,12 +132,53 @@ def initialize_system():
     Not much here but more may be added.
     """
     create_builtins_by_module()
-    from mathics.builtin import __py_files__ as old_py_files
-
-    assert __py_files__ == old_py_files
     for modname, builtins in builtins_by_module.items():
         for builtin in builtins:
             # name = builtin.get_name()
             operator = builtin.get_operator_display()
             if operator is not None:
                 display_operators_set.add(operator)
+
+
+def name_is_builtin_symbol(module, name: str) -> Optional[type]:
+    """
+    Checks if ``name`` should be added to definitions, and return
+    its associated Builtin class.
+
+    Return ``None`` if the name should not get added to definitions.
+    """
+    from mathics.builtin.base import Builtin
+
+    if name.startswith("_"):
+        return None
+
+    module_object = getattr(module, name)
+
+    # Look only at Class objects.
+    if not inspect.isclass(module_object):
+        return None
+
+    # FIXME: tests involving module_object.__module__ are fragile and
+    # Python implementation specific. Figure out how to do this
+    # via the inspect module which is not implementation specific.
+
+    # Skip those builtins defined in or imported from another module.
+    if module_object.__module__ != module.__name__:
+        return None
+
+    # Skip objects in module mathics.builtin.base.
+    if module_object.__module__ == "mathics.builtin.base":
+        return None
+
+    # Skip those builtins that are not submodules of mathics.builtin.
+    if not module_object.__module__.startswith("mathics.builtin."):
+        return None
+
+    # If it is not a subclass of Builtin, skip it.
+    if not issubclass(module_object, Builtin):
+        return None
+
+    # Skip Builtin classes that were explicitly marked for skipping.
+    if module_object in getattr(module, "DOES_NOT_ADD_BUILTIN_DEFINITION", []):
+        return None
+    return module_object

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -34,11 +34,14 @@ from os import getenv, listdir
 from types import ModuleType
 from typing import Callable
 
+import mathics.core as core
 from mathics import builtin
 from mathics import settings
 from mathics.builtin.base import check_requires_list
 from mathics.core.evaluation import Message, Print
 from mathics.core.util import IS_PYPY
+from mathics.core.system_init import name_is_builtin_symbol
+
 from mathics.doc.utils import slugify
 
 # These regular expressions pull out information from docstring or text in a file.
@@ -830,7 +833,7 @@ class MathicsMainDocumentation(Documentation):
             (
                 "Reference of Built-in Symbols",
                 builtin.modules,
-                builtin.system_init.builtins_by_module,
+                core.system_init.builtins_by_module,
                 True,
             )
         ]:  # nopep8

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -830,7 +830,7 @@ class MathicsMainDocumentation(Documentation):
             (
                 "Reference of Built-in Symbols",
                 builtin.modules,
-                builtin.builtins_by_module,
+                builtin.system_init.builtins_by_module,
                 True,
             )
         ]:  # nopep8

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -24,13 +24,14 @@ import mathics.settings
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import MathicsSingleLineFeeder
-from mathics.builtin import builtins_dict
+from mathics.builtin.system_init import builtins_dict, initialize_system
 
 from mathics import version_string
 from mathics import settings
 from mathics.doc.common_doc import MathicsMainDocumentation
 from mathics.timing import show_lru_cache_statistics
 
+initialize_system()
 builtins = builtins_dict()
 
 

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -24,7 +24,7 @@ import mathics.settings
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import MathicsSingleLineFeeder
-from mathics.builtin.system_init import builtins_dict, initialize_system
+from mathics.core.system_init import builtins_dict, initialize_system
 
 from mathics import version_string
 from mathics import settings

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -21,6 +21,7 @@ from mathics.builtin.box.layout import (
 )
 from mathics.builtin.box.graphics import GraphicsBox
 from mathics.builtin.box.graphics3d import Graphics3DBox
+from mathics.builtin.system_init import display_operators_set as operators
 
 
 from mathics.core.atoms import String
@@ -62,7 +63,6 @@ extra_operators = {
 
 
 def string(self, **options) -> str:
-    from mathics.builtin import display_operators_set as operators
 
     text = self.value
 

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -21,7 +21,6 @@ from mathics.builtin.box.layout import (
 )
 from mathics.builtin.box.graphics import GraphicsBox
 from mathics.builtin.box.graphics3d import Graphics3DBox
-from mathics.builtin.system_init import display_operators_set as operators
 
 
 from mathics.core.atoms import String
@@ -33,6 +32,7 @@ from mathics.core.formatter import (
 )
 from mathics.core.parser import is_symbol_name
 from mathics.core.symbols import SymbolTrue
+from mathics.core.system_init import display_operators_set as operators
 
 
 def encode_mathml(text: str) -> str:

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -14,7 +14,6 @@ import os.path as osp
 from mathics import settings
 from mathics import version_string, license_string, __version__
 from mathics.builtin.trace import TraceBuiltins, traced_do_replace
-from mathics.builtin.system_init import initialize_system
 from mathics.core.atoms import String
 from mathics.core.definitions import autoload_files, Definitions, Symbol
 from mathics.core.evaluation import Evaluation, Output
@@ -24,6 +23,7 @@ from mathics.core.read import channel_to_stream
 from mathics.core.rules import BuiltinRule
 from mathics.core.symbols import strip_context, SymbolNull
 from mathics.core.streams import stream_manager
+from mathics.core.system_init import initialize_system
 from mathics.timing import show_lru_cache_statistics
 
 

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -14,6 +14,7 @@ import os.path as osp
 from mathics import settings
 from mathics import version_string, license_string, __version__
 from mathics.builtin.trace import TraceBuiltins, traced_do_replace
+from mathics.builtin.system_init import initialize_system
 from mathics.core.atoms import String
 from mathics.core.definitions import autoload_files, Definitions, Symbol
 from mathics.core.evaluation import Evaluation, Output
@@ -369,6 +370,7 @@ Please contribute to Mathics!""",
     if args.show_statistics:
         atexit.register(show_lru_cache_statistics)
 
+    initialize_system()
     definitions = Definitions(add_builtin=True, extension_modules=extension_modules)
     definitions.set_line_no(0)
 

--- a/mathics/session.py
+++ b/mathics/session.py
@@ -12,11 +12,11 @@ In particular we provide:
 import os.path as osp
 from typing import Optional
 
-from mathics.builtin.system_init import initialize_system
 from mathics.core.definitions import autoload_files
 from mathics.core.parser import parse, MathicsSingleLineFeeder
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
+from mathics.core.system_init import initialize_system
 import mathics.settings
 
 

--- a/mathics/session.py
+++ b/mathics/session.py
@@ -12,6 +12,7 @@ In particular we provide:
 import os.path as osp
 from typing import Optional
 
+from mathics.builtin.system_init import initialize_system
 from mathics.core.definitions import autoload_files
 from mathics.core.parser import parse, MathicsSingleLineFeeder
 from mathics.core.definitions import Definitions
@@ -63,6 +64,7 @@ class MathicsSession:
         form="InputForm",
         character_encoding=Optional[str],
     ):
+        initialize_system()
         if character_encoding is not None:
             mathics.settings.SYSTEM_CHARACTER_ENCODING = character_encoding
         self.form = form

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -6,8 +6,9 @@ had missing or duplicate build-in functions definitions.
 """
 import pytest
 import os
-from mathics.builtin import name_is_builtin_symbol, modules
+from mathics.builtin import modules
 from mathics.builtin.base import Builtin
+from mathics.core.system_init import name_is_builtin_symbol
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
@mmatera and @TiagoCavalcante : this is kind of important to understand. 

Although we now require a frontend to *explicitly* call ``initialize_system()`` and this may seem more awkward, it is helpful and important for a couple of reasons.

**First**: it provides better modularization and reduces circular imports.

``mathics.builtin``  is close to top-level import and, in contrast to ``mathics.core.system_init`` there are a lot of modules underneath ``mathics.builtin``. (There are none under ``mathics.core.system_init``).

_In general, it is considered bad Python coding practice to put a lot of code in **``__init__.py ``** files._

As a result, we can have more ``import mathics.core.system_init`` from a module where we can't do the same for ``import mathics.builtin``.

**Second**:  by placing initialization of structures which do not change outside of development we are in a better position to write an administrative tool to load all of this and then dump it as a system image file, which can be read in rather than built it up from scratch as happens now. This new function ``initialize_system`` might have a parameter to read the image file rather than do the work it does now.

In its current form though ``initialize_system()`` does as not encapsulate system loading as much as it could.

