### PR TITLE
Compute Symbol.__hash__() once

### DIFF
--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -1,9 +1,10 @@
 # cython: language_level=3
 # -*- coding: utf-8 -*-
 
-import sympy
 import time
 from typing import Any, FrozenSet, List, Optional, Tuple
+
+import sympy
 
 from mathics.core.element import (
     BaseElement,
@@ -359,13 +360,14 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     """
 
     name: str
+    hash: str
     sympy_dummy: Any
     defined_symbols = {}
     class_head_name = "System`Symbol"
 
     # __new__ instead of __init__ is used here because we want
     # to return the same object for a given "name" value.
-    def __new__(cls, name, sympy_dummy=None, value=None):
+    def __new__(cls, name: str, sympy_dummy=None, value=None):
         """
         Allocate an object ensuring that for a given `name` we get back the same object.
         """
@@ -374,6 +376,14 @@ class Symbol(Atom, NumericOperators, EvalMixin):
         if self is None:
             self = super(Symbol, cls).__new__(cls)
             self.name = name
+
+            # Set a value for self.__hash__() once so that every time
+            # it is used this is fast.
+            # This tuple with "Symbol" is used to give a different hash
+            # than the hash that would be returned if just name were
+            # used.
+            self.hash = hash(("Symbol", name))
+
             # TODO: revise how we convert sympy.Dummy
             # symbols.
             #
@@ -412,8 +422,11 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def __getnewargs__(self):
         return (self.name, self.sympy_dummy)
 
-    def __hash__(self):
-        return hash(("Symbol", self.name))  # to distinguish from String
+    def __hash__(self) -> int:
+        """
+        We need self.__hash__() so that we can use Symbols as keys in dictionaries.
+        """
+        return self.hash
 
     def __ne__(self, other) -> bool:
         return self is not other


### PR DESCRIPTION
Also note *why* we need `Symbol.__hash__()`


A while back, but I forget where, the justification for why we using Strings in function instead of  Symbols in the code was because `is` or equality testing was slow.  This simple change addresses that. 

I forget where the benchmarking data was posted for previous comparisons. I'd be interested though in what the change (if any) is. 