### PR TITLE
Make builtin/atomic/symbols.py current...

### DIFF
--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -2,41 +2,33 @@
 """
 Symbolic Handling
 
-Symbolic data. Every symbol has a unique name, exists in a certain context or namespace, and can have a variety of type of values and attributes.
+Symbolic data. Every symbol has a unique name, exists in a certain context \
+or namespace, and can have a variety of type of values and attributes.
 """
 
 import re
 
-from mathics.builtin.base import (
-    Builtin,
-    PrefixOperator,
-    Test,
-)
-
 from mathics.builtin.atomic.strings import to_regex
-
+from mathics.builtin.base import Builtin, PrefixOperator, Test
 from mathics.core.assignment import get_symbol_values
 from mathics.core.atoms import String
-
 from mathics.core.attributes import (
-    attributes_bitset_to_list,
     A_HOLD_ALL,
     A_HOLD_FIRST,
     A_LOCKED,
     A_PROTECTED,
     A_READ_PROTECTED,
     A_SEQUENCE_HOLD,
+    attributes_bitset_to_list,
 )
-
-from mathics.core.expression import Expression
 from mathics.core.convert.expression import to_mathics_list
+from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.rules import Rule
-
 from mathics.core.symbols import (
     Symbol,
-    SymbolHoldForm,
     SymbolFalse,
+    SymbolHoldForm,
     SymbolNull,
     SymbolTrue,
     SymbolUpSet,
@@ -99,6 +91,7 @@ def _get_usage_string(symbol, evaluation, is_long_form: bool, htmlout=False):
 
 class Context(Builtin):
     r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/Context.html</url>
     <dl>
       <dt>'Context[$symbol$]'
       <dd>yields the name of the context where $symbol$ is defined in.
@@ -137,7 +130,7 @@ class Context(Builtin):
 
     summary_text = "give the name of the context of a symbol"
 
-    def apply(self, symbol, evaluation):
+    def eval(self, symbol, evaluation):
         "Context[symbol_]"
 
         name = symbol.get_name()
@@ -151,6 +144,7 @@ class Context(Builtin):
 
 class Definition(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/Definition.html</url>
     <dl>
       <dt>'Definition[$symbol$]'
       <dd>prints as the definitions given for $symbol$.
@@ -370,21 +364,22 @@ class Definition(Builtin):
 # In Mathematica 5, this appears under "Types of Values".
 class DownValues(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/DownValues.html</url>
     <dl>
-    <dt>'DownValues[$symbol$]'
-        <dd>gives the list of downvalues associated with $symbol$.
+      <dt>'DownValues[$symbol$]'
+      <dd>gives the list of downvalues associated with $symbol$.
     </dl>
 
-    'DownValues' uses 'HoldPattern' and 'RuleDelayed' to protect the
-    downvalues from being evaluated. Moreover, it has attribute
+    'DownValues' uses 'HoldPattern' and 'RuleDelayed' to protect the \
+    downvalues from being evaluated. Moreover, it has attribute \
     'HoldAll' to get the specified symbol instead of its value.
 
     >> f[x_] := x ^ 2
     >> DownValues[f]
      = {HoldPattern[f[x_]] :> x ^ 2}
 
-    Mathics will sort the rules you assign to a symbol according to
-    their specificity. If it cannot decide which rule is more special,
+    Mathics will sort the rules you assign to a symbol according to \
+    their specificity. If it cannot decide which rule is more special, \
     the newer one will get higher precedence.
     >> f[x_Integer] := 2
     >> f[x_Real] := 3
@@ -397,12 +392,12 @@ class DownValues(Builtin):
     >> f[a]
      = a ^ 2
 
-    The default order of patterns can be computed using 'Sort' with
+    The default order of patterns can be computed using 'Sort' with \
     'PatternsOrderedQ':
     >> Sort[{x_, x_Integer}, PatternsOrderedQ]
      = {x_Integer, x_}
 
-    By assigning values to 'DownValues', you can override the default
+    By assigning values to 'DownValues', you can override the default \
     ordering:
     >> DownValues[g] := {g[x_] :> x ^ 2, g[x_Integer] :> x}
     >> g[2]
@@ -417,7 +412,7 @@ class DownValues(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "give a list of transformation rules corresponding to all downvalues defined for a symbol"
 
-    def apply(self, symbol, evaluation):
+    def eval(self, symbol, evaluation):
         "DownValues[symbol_]"
 
         return get_symbol_values(symbol, "DownValues", "down", evaluation)
@@ -425,11 +420,13 @@ class DownValues(Builtin):
 
 class Information(PrefixOperator):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/Information.html</url>
     <dl>
       <dt>'Information[$symbol$]'
       <dd>Prints information about a $symbol$
     </dl>
     'Information' does not print information for 'ReadProtected' symbols.
+
     'Information' uses 'InputForm' to format values.
 
     #> a = 2;
@@ -596,6 +593,7 @@ class Information(PrefixOperator):
 
 class Names(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/Names.html</url>
     <dl>
       <dt>'Names["$pattern$"]'
       <dd>returns the list of names matching $pattern$.
@@ -626,7 +624,7 @@ class Names(Builtin):
 
     summary_text = "find a list of symbols with names matching a pattern"
 
-    def apply(self, pattern, evaluation):
+    def eval(self, pattern, evaluation):
         "Names[pattern_]"
         headname = pattern.get_head_name()
         if headname == "System`StringExpression":
@@ -650,6 +648,7 @@ class Names(Builtin):
 # In Mathematica 5, this appears under "Types of Values".
 class OwnValues(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/OwnValues.html</url>
     <dl>
       <dt>'OwnValues[$symbol$]'
       <dd>gives the list of ownvalue associated with $symbol$.
@@ -674,7 +673,7 @@ class OwnValues(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "give the rule corresponding to any ownvalue defined for a symbol"
 
-    def apply(self, symbol, evaluation):
+    def eval(self, symbol, evaluation):
         "OwnValues[symbol_]"
 
         return get_symbol_values(symbol, "OwnValues", "own", evaluation)
@@ -682,9 +681,10 @@ class OwnValues(Builtin):
 
 class Symbol_(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/Symbol.html</url>
     <dl>
-    <dt>'Symbol'
-        <dd>is the head of symbols.
+      <dt>'Symbol'
+      <dd>is the head of symbols.
     </dl>
 
     >> Head[x]
@@ -711,7 +711,7 @@ class Symbol_(Builtin):
 
     summary_text = "the head of a symbol; create a symbol from a name"
 
-    def apply(self, string, evaluation):
+    def eval(self, string, evaluation):
         "Symbol[string_String]"
 
         from mathics.core.parser import is_symbol_name
@@ -725,9 +725,10 @@ class Symbol_(Builtin):
 
 class SymbolName(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/SymbolName.html</url>
     <dl>
-    <dt>'SymbolName[$s$]'
-        <dd>returns the name of the symbol $s$ (without any leading
+      <dt>'SymbolName[$s$]'
+      <dd>returns the name of the symbol $s$ (without any leading \
         context name).
     </dl>
 
@@ -740,7 +741,7 @@ class SymbolName(Builtin):
 
     summary_text = "give the name of a symbol as a string"
 
-    def apply(self, symbol, evaluation):
+    def eval(self, symbol, evaluation):
         "SymbolName[symbol_Symbol]"
 
         # MMA docs say "SymbolName always give the short name,
@@ -750,9 +751,10 @@ class SymbolName(Builtin):
 
 class SymbolQ(Test):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/SymbolName.html</url>
     <dl>
-    <dt>'SymbolQ[$x$]'
-        <dd>is 'True' if $x$ is a symbol, or 'False' otherwise.
+      <dt>'SymbolQ[$x$]'
+      <dd>is 'True' if $x$ is a symbol, or 'False' otherwise.
     </dl>
 
     >> SymbolQ[a]
@@ -772,9 +774,11 @@ class SymbolQ(Test):
 # In Mathematica 5, this appears under "Types of Values".
 class UpValues(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/UpValues.html</url>
     <dl>
       <dt>'UpValues[$symbol$]'
-      <dd>gives the list of transformation rules corresponding to upvalues define with $symbol$.
+      <dd>gives the list of transformation rules corresponding to upvalues \
+          define with $symbol$.
     </dl>
 
     >> a + b ^= 2
@@ -793,7 +797,7 @@ class UpValues(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "give a list of transformation rules corresponding to upvalues defined for a symbol"
 
-    def apply(self, symbol, evaluation):
+    def eval(self, symbol, evaluation):
         "UpValues[symbol_]"
 
         return get_symbol_values(symbol, "UpValues", "up", evaluation)
@@ -801,9 +805,10 @@ class UpValues(Builtin):
 
 class ValueQ(Builtin):
     """
+    <url>:WMA: https://reference.wolfram.com/language/ref/ValueQ.html</url>
     <dl>
-    <dt>'ValueQ[$expr$]'
-        <dd>returns 'True' if and only if $expr$ is defined.
+      <dt>'ValueQ[$expr$]'
+      <dd>returns 'True' if and only if $expr$ is defined.
     </dl>
 
     >> ValueQ[x]
@@ -819,7 +824,7 @@ class ValueQ(Builtin):
     attributes = A_HOLD_FIRST | A_PROTECTED
     summary_text = "test whether a symbol can be considered to have a value"
 
-    def apply(self, expr, evaluation):
+    def eval(self, expr, evaluation):
         "ValueQ[expr_]"
         evaluated_expr = expr.evaluate(evaluation)
         if expr.sameQ(evaluated_expr):


### PR DESCRIPTION
Bring code in line with current standards:

* Add WMA links
* use soft line breaks in doctest lines
* apply -> eval
* dl formatting
* isort imports

This is split off from #664. I probably will try to pull out other parts from that in future PRs in order to reduce the size of that PR and narrow it to the part that still needs work.