### PR TITLE
alternative implementation for MakeBoxes[Infix[...],format]

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -36,6 +36,8 @@ from mathics.builtin.base import (
     mathics_to_python,
 )
 from mathics.core.pattern import pattern_objects
+from mathics.core.symbols import Symbol
+from mathics.eval.makeboxes import builtins_precedence
 from mathics.settings import ENABLE_FILES_MODULE
 from mathics.version import __version__  # noqa used in loading to check consistency.
 
@@ -60,7 +62,7 @@ def add_builtins(new_builtins):
                 # print("XXX1", sympy_name)
                 sympy_to_mathics[sympy_name] = builtin
         if isinstance(builtin, Operator):
-            builtins_precedence[name] = builtin.precedence
+            builtins_precedence[Symbol(name)] = builtin.precedence
         if isinstance(builtin, PatternObject):
             pattern_objects[name] = builtin.__class__
     _builtins.update(dict(new_builtins))
@@ -235,8 +237,6 @@ for module in modules:
 
 mathics_to_sympy = {}  # here we have: name -> sympy object
 sympy_to_mathics = {}
-
-builtins_precedence = {}
 
 new_builtins = _builtins_list
 

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 """
-This module contains symbols used to define the high level layout for
+This module contains symbols used to define the high level layout for \
 expression formatting.
 
-For instance, to represent a set of consecutive expressions in a row,
-we can use ``Row``
+For instance, to represent a set of consecutive expressions in a row, \
+we can use ``Row``.
 
 """
 from typing import Optional, Union
@@ -18,48 +18,51 @@ from mathics.builtin.options import options_to_rules
 from mathics.core.atoms import Integer, Integer1, Real, String
 from mathics.core.convert.op import operator_to_ascii, operator_to_unicode
 from mathics.core.element import BaseElement
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Atom, Symbol
 from mathics.core.systemsymbols import (
     SymbolFullForm,
-    SymbolInfix,
     SymbolInputForm,
     SymbolLeft,
     SymbolMakeBoxes,
     SymbolNone,
     SymbolOutputForm,
     SymbolRight,
+    SymbolRowBox,
 )
-from mathics.eval.makeboxes import (
-    eval_fullform_makeboxes,
-    format_element,
-    make_boxes_infix,
-)
+from mathics.eval.makeboxes import eval_fullform_makeboxes, format_element, parenthesize
 
 SymbolNonAssociative = Symbol("System`NonAssociative")
 SymbolSubscriptBox = Symbol("System`SubscriptBox")
 
 
-def eval_makeboxes_infix(
+####################################################################
+# This section might get moved to mathics.box
+#
+# Some of the code below get replace Mathics code or may get put in
+# collection of boxing modules,
+# e.g. ``mathics.box.boxes_operators.box_infix()``.
+#
+####################################################################
+
+
+def box_infix(
     expr: Expression,
     operator: BaseElement,
     form: Symbol,
-    evaluation,
-    precedence_value: Optional[int] = None,
+    evaluation: Evaluation,
+    precedence_value: Optional[int] = 0,
     grouping: Optional[str] = None,
-):
-    """Implements MakeBoxes[Infix[...]]."""
+) -> Optional[Expression]:
+    """Implements MakeBoxes[Infix[...]].
+    This function kicks off boxing for Infix operators.
 
-    # Actually, this function implements one part of the evaluation:
-    # the one that should be done at the "format" level. In that point,
-    # the operators are processed to add spaces and use the right
-    # encoding. This should be done at the level of the formatter, not
-    # in the "MakeBoxes" step.
-    # Then, the true implementation is done
-    # in  ```mathics.eval.makeboxes.make_boxes_infix```.
+    Operators are processed to add spaces and to use the right encoding.
+    """
 
-    ## FIXME: this should go into a some formatter.
+    # FIXME: this should go into a some formatter.
     def format_operator(operator) -> Union[String, BaseElement]:
         """
         Format infix operator `operator`. To do this outside parameter form is used.
@@ -95,7 +98,7 @@ def eval_makeboxes_infix(
     if len(elements) > 1:
         if operator.has_form("List", len(elements) - 1):
             operator = [format_operator(op) for op in operator.elements]
-            return make_boxes_infix(
+            return box_infix_elements(
                 elements, operator, precedence_value, grouping, form
             )
         else:
@@ -113,7 +116,7 @@ def eval_makeboxes_infix(
                     String(operator_to_unicode.get(op_str, op_str))
                 )
 
-        return make_boxes_infix(elements, operator, precedence_value, grouping, form)
+        return box_infix_elements(elements, operator, precedence_value, grouping, form)
 
     elif len(elements) == 1:
         return MakeBoxes(elements[0], form)
@@ -121,9 +124,42 @@ def eval_makeboxes_infix(
         return MakeBoxes(expr, form)
 
 
+# FIXME: op should be a string, so remove the Union.
+def box_infix_elements(
+    elements, op: Union[String, list], precedence: int, grouping, form: Symbol
+) -> Expression:
+    result = []
+    for index, element in enumerate(elements):
+        if index > 0:
+            if isinstance(op, list):
+                result.append(op[index - 1])
+            else:
+                result.append(op)
+        parenthesized = False
+        if grouping == "System`NonAssociative":
+            parenthesized = True
+        elif grouping == "System`Left" and index > 0:
+            parenthesized = True
+        elif grouping == "System`Right" and index == 0:
+            parenthesized = True
+
+        element_boxes = Expression(SymbolMakeBoxes, element, form)
+        element = parenthesize(precedence, element, element_boxes, parenthesized)
+
+        result.append(element)
+    return Expression(SymbolRowBox, ListExpression(*result))
+
+
+####################################################################
+# End of section of code that might be in mathics.box.
+####################################################################
+
+
 class Center(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Center.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Center.html</url>
 
     <dl>
       <dt>'Center'
@@ -189,7 +225,7 @@ class Grid(Builtin):
     options = GridBox.options
     summary_text = " 2D layout containing arbitrary objects"
 
-    def apply_makeboxes(self, array, f, evaluation, options) -> Expression:
+    def eval_makeboxes(self, array, f, evaluation: Evaluation, options) -> Expression:
         """MakeBoxes[Grid[array_?MatrixQ, OptionsPattern[Grid]],
         f:StandardForm|TraditionalForm|OutputForm]"""
         return GridBox(
@@ -250,7 +286,7 @@ class Infix(Builtin):
 
     # the right rule should be
     # mbexpression:MakeBoxes[Infix[___], form]
-    def eval_makeboxes(self, expression, form, evaluation):
+    def eval_makeboxes(self, expression, form, evaluation: Evaluation):
         """MakeBoxes[Infix[___],
         form:StandardForm|TraditionalForm|OutputForm|InputForm]"""
         infix_expr = expression.elements[0]
@@ -258,15 +294,15 @@ class Infix(Builtin):
         num_parms = len(elements)
 
         if num_parms == 0 or num_parms > 4:
-            evaluation.message("Infix", "argb", Integer(len(parms.get_sequence())))
+            evaluation.message("Infix", "argb", Integer(num_parms))
             return eval_fullform_makeboxes(infix_expr, evaluation, form)
 
         if num_parms == 1:
             expr = elements[0]
-            return eval_makeboxes_infix(expr, String("~"), form, evaluation)
+            return box_infix(expr, String("~"), form, evaluation)
         if num_parms == 2:
             expr, operator = elements
-            return eval_makeboxes_infix(expr, operator, form, evaluation)
+            return box_infix(expr, operator, form, evaluation)
 
         expr, operator, precedence = elements[:3]
         if not isinstance(precedence, Integer):
@@ -279,11 +315,9 @@ class Infix(Builtin):
 
         grouping = SymbolNone if num_parms < 4 else elements[3]
         if grouping is SymbolNone:
-            return eval_makeboxes_infix(
-                expr, operator, form, evaluation, precedence.value
-            )
+            return box_infix(expr, operator, form, evaluation, precedence.value)
         if grouping in (SymbolNonAssociative, SymbolLeft, SymbolRight):
-            return eval_makeboxes_infix(
+            return box_infix(
                 expr, operator, form, evaluation, precedence.value, grouping.get_name()
             )
 
@@ -297,7 +331,8 @@ class Left(Builtin):
 
     <dl>
       <dt>'Left'
-      <dd>is used with operator formatting constructs to specify a left-associative operator.
+      <dd>is used with operator formatting constructs to specify a \
+          left-associative operator.
     </dl>
     """
 
@@ -312,7 +347,8 @@ class NonAssociative(Builtin):
 
         <dl>
           <dt>'NonAssociative'
-          <dd>is used with operator formatting constructs to specify a non-associative operator.
+          <dd>is used with operator formatting constructs to specify a \
+          non-associative operator.
         </dl>
     """
 
@@ -371,7 +407,7 @@ class Precedence(Builtin):
 
     summary_text = "an object to be parenthesized with a given precedence level"
 
-    def apply(self, expr, evaluation) -> Real:
+    def eval(self, expr, evaluation) -> Real:
         "Precedence[expr_]"
 
         name = expr.get_name()
@@ -429,7 +465,8 @@ class Right(Builtin):
 
     <dl>
       <dt>'Right'
-      <dd>is used with operator formatting constructs to specify a right-associative operator.
+      <dd>is used with operator formatting constructs to specify a \
+          right-associative operator.
     </dl>
     """
 
@@ -448,21 +485,21 @@ class Row(Builtin):
 
     summary_text = "1D layouts containing arbitrary objects in a row"
 
-    def apply_makeboxes(self, items, sep, f, evaluation):
+    def eval_makeboxes(self, items, sep, form, evaluation: Evaluation):
         """MakeBoxes[Row[{items___}, sep_:""],
-        f:StandardForm|TraditionalForm|OutputForm]"""
+        form:StandardForm|TraditionalForm|OutputForm]"""
 
         items = items.get_sequence()
         if not isinstance(sep, String):
-            sep = MakeBoxes(sep, f)
+            sep = MakeBoxes(sep, form)
         if len(items) == 1:
-            return MakeBoxes(items[0], f)
+            return MakeBoxes(items[0], form)
         else:
             result = []
             for index, item in enumerate(items):
                 if index > 0 and not sep.sameQ(String("")):
                     result.append(to_boxes(sep, evaluation))
-                item = MakeBoxes(item, f).evaluate(evaluation)
+                item = MakeBoxes(item, form).evaluate(evaluation)
                 item = to_boxes(item, evaluation)
                 result.append(item)
             return RowBox(*result)
@@ -475,22 +512,31 @@ class Style(Builtin):
     <dl>
       <dt>'Style[$expr$, options]'
       <dd>displays $expr$ formatted using the specified option settings.
+
       <dt>'Style[$expr$, "style"]'
       <dd> uses the option settings for the specified style in the current notebook.
+
       <dt>'Style[$expr$, $color$]'
       <dd>displays using the specified color.
+
       <dt>'Style[$expr$, $Bold$]'
       <dd>displays with fonts made bold.
+
       <dt>'Style[$expr$, $Italic$]'
       <dd>displays with fonts made italic.
+
       <dt>'Style[$expr$, $Underlined$]'
       <dd>displays with fonts underlined.
+
       <dt>'Style[$expr$, $Larger$]
       <dd>displays with fonts made larger.
+
       <dt>'Style[$expr$, $Smaller$]'
       <dd>displays with fonts made smaller.
+
       <dt>'Style[$expr$, $n$]'
       <dd>displays with font size n.
+
       <dt>'Style[$expr$, $Tiny$]'
       <dt>'Style[$expr$, $Small$]', etc.
       <dd>display with fonts that are tiny, small, etc.
@@ -523,7 +569,7 @@ class Subscript(Builtin):
 
     summary_text = "format an expression with a subscript"
 
-    def apply_makeboxes(self, x, y, f, evaluation) -> Expression:
+    def eval_makeboxes(self, x, y, f, evaluation) -> Expression:
         "MakeBoxes[Subscript[x_, y__], f:StandardForm|TraditionalForm]"
 
         y = y.get_sequence()
@@ -536,7 +582,9 @@ class Subscript(Builtin):
 
 class Subsuperscript(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Subsuperscript.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Subsuperscript.html</url>
 
     <dl>
       <dt>'Subsuperscript[$a$, $b$, $c$]'
@@ -558,7 +606,9 @@ class Subsuperscript(Builtin):
 
 class Superscript(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Superscript.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Superscript.html</url>
 
     <dl>
       <dt>'Superscript[$x$, $y$]'

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -49,7 +49,15 @@ def eval_makeboxes_infix(
     precedence_value: Optional[int] = None,
     grouping: Optional[str] = None,
 ):
-    """Implements MakeBoxes[Infix[...]]"""
+    """Implements MakeBoxes[Infix[...]]."""
+
+    # Actually, this function implements one part of the evaluation:
+    # the one that should be done at the "format" level. In that point,
+    # the operators are processed to add spaces and use the right
+    # encoding. This should be done at the level of the formatter, not
+    # in the "MakeBoxes" step.
+    # Then, the true implementation is done
+    # in  ```mathics.eval.makeboxes.make_boxes_infix```.
 
     ## FIXME: this should go into a some formatter.
     def format_operator(operator) -> Union[String, BaseElement]:

--- a/mathics/eval/makeboxes.py
+++ b/mathics/eval/makeboxes.py
@@ -102,6 +102,16 @@ def make_boxes_infix(
     return Expression(SymbolRowBox, ListExpression(*result))
 
 
+def eval_fullform_makeboxes(self, expr, evaluation, f=SymbolStandardForm):
+    """
+    This function takes the definitions prodived by the evaluation
+    object, and produces a boxed form for expr.
+    """
+    # This is going to be reimplemented.
+    expr = Expression(SymbolFullForm, expr)
+    return Expression(SymbolMakeBoxes, expr, f).evaluate(evaluation)
+
+
 def eval_makeboxes(self, expr, evaluation, f=SymbolStandardForm):
     """
     This function takes the definitions prodived by the evaluation

--- a/mathics/eval/makeboxes.py
+++ b/mathics/eval/makeboxes.py
@@ -7,7 +7,7 @@ formatting rules.
 
 
 import typing
-from typing import Any, Union
+from typing import Any
 
 from mathics.core.atoms import Complex, Integer, Rational, Real, String, SymbolI
 from mathics.core.convert.expression import to_expression_with_specialization
@@ -50,56 +50,6 @@ def _boxed_string(string: str, **options):
     from mathics.builtin.box.layout import StyleBox
 
     return StyleBox(String(string), **options)
-
-
-def parenthesize(precedence, element, element_boxes, when_equal):
-    from mathics.builtin import builtins_precedence
-
-    while element.has_form("HoldForm", 1):
-        element = element.elements[0]
-
-    if element.has_form(("Infix", "Prefix", "Postfix"), 3, None):
-        element_prec = element.elements[2].value
-    elif element.has_form("PrecedenceForm", 2):
-        element_prec = element.elements[1].value
-    # For negative values, ensure that the element_precedence is at least the precedence. (Fixes #332)
-    elif isinstance(element, (Integer, Real)) and element.value < 0:
-        element_prec = precedence
-    else:
-        element_prec = builtins_precedence.get(element.get_head_name())
-    if precedence is not None and element_prec is not None:
-        if precedence > element_prec or (precedence == element_prec and when_equal):
-            return Expression(
-                SymbolRowBox,
-                ListExpression(String("("), element_boxes, String(")")),
-            )
-    return element_boxes
-
-
-# FIXME: op should be a string, so remove the Union.
-def make_boxes_infix(
-    elements, op: Union[String, list], precedence: int, grouping, form: Symbol
-):
-    result = []
-    for index, element in enumerate(elements):
-        if index > 0:
-            if isinstance(op, list):
-                result.append(op[index - 1])
-            else:
-                result.append(op)
-        parenthesized = False
-        if grouping == "System`NonAssociative":
-            parenthesized = True
-        elif grouping == "System`Left" and index > 0:
-            parenthesized = True
-        elif grouping == "System`Right" and index == 0:
-            parenthesized = True
-
-        element_boxes = Expression(SymbolMakeBoxes, element, form)
-        element = parenthesize(precedence, element, element_boxes, parenthesized)
-
-        result.append(element)
-    return Expression(SymbolRowBox, ListExpression(*result))
 
 
 def eval_fullform_makeboxes(self, expr, evaluation, f=SymbolStandardForm):
@@ -338,6 +288,30 @@ def do_format_expression(
     expr = do_format_element(element, evaluation, form)
     # element._format_cache[form] = (evaluation.definitions.now, expr)
     return expr
+
+
+def parenthesize(precedence, element, element_boxes, when_equal):
+    from mathics.builtin import builtins_precedence
+
+    while element.has_form("HoldForm", 1):
+        element = element.elements[0]
+
+    if element.has_form(("Infix", "Prefix", "Postfix"), 3, None):
+        element_prec = element.elements[2].value
+    elif element.has_form("PrecedenceForm", 2):
+        element_prec = element.elements[1].value
+    # For negative values, ensure that the element_precedence is at least the precedence. (Fixes #332)
+    elif isinstance(element, (Integer, Real)) and element.value < 0:
+        element_prec = precedence
+    else:
+        element_prec = builtins_precedence.get(element.get_head_name())
+    if precedence is not None and element_prec is not None:
+        if precedence > element_prec or (precedence == element_prec and when_equal):
+            return Expression(
+                SymbolRowBox,
+                ListExpression(String("("), element_boxes, String(")")),
+            )
+    return element_boxes
 
 
 element_formatters[Rational] = do_format_rational

--- a/mathics/eval/makeboxes.py
+++ b/mathics/eval/makeboxes.py
@@ -104,7 +104,7 @@ def make_boxes_infix(
 
 def eval_fullform_makeboxes(self, expr, evaluation, f=SymbolStandardForm):
     """
-    This function takes the definitions prodived by the evaluation
+    This function takes the definitions provided by the evaluation
     object, and produces a boxed form for expr.
     """
     # This is going to be reimplemented.
@@ -114,8 +114,8 @@ def eval_fullform_makeboxes(self, expr, evaluation, f=SymbolStandardForm):
 
 def eval_makeboxes(self, expr, evaluation, f=SymbolStandardForm):
     """
-    This function takes the definitions prodived by the evaluation
-    object, and produces a boxed form for expr.
+    This function takes the definitions provided by the evaluation
+    object, and produces a boxed fullform for expr.
     """
     # This is going to be reimplemented.
     return Expression(SymbolMakeBoxes, expr, f).evaluate(evaluation)


### PR DESCRIPTION
This provides an alternative implementation, that avoids using WL pattern matching to handle the different cases in ```MakeBoxes[Infix[...],format]```