### PR TITLE
reimplementing eval_makeboxes. step 1

### DIFF
--- a/mathics/builtin/box/layout.py
+++ b/mathics/builtin/box/layout.py
@@ -26,30 +26,7 @@ from mathics.core.systemsymbols import (
     SymbolSubsuperscriptBox,
     SymbolSuperscriptBox,
 )
-from mathics.eval.makeboxes import eval_makeboxes
-
-
-def to_boxes(x, evaluation: Evaluation, options={}) -> BoxElementMixin:
-    """
-    This function takes the expression ``x``
-    and tries to reduce it to a ``BoxElementMixin``
-    expression unsing an evaluation object.
-    """
-    if isinstance(x, BoxElementMixin):
-        return x
-    if isinstance(x, Atom):
-        x = x.atom_to_boxes(SymbolStandardForm, evaluation)
-        return to_boxes(x, evaluation, options)
-    if isinstance(x, Expression):
-        if x.has_form("MakeBoxes", None):
-            x_boxed = x.evaluate(evaluation)
-        else:
-            x_boxed = eval_makeboxes(x, evaluation)
-        if isinstance(x_boxed, BoxElementMixin):
-            return x_boxed
-        if isinstance(x_boxed, Atom):
-            return to_boxes(x_boxed, evaluation, options)
-    raise eval_makeboxes(Expression(SymbolFullForm, x), evaluation)
+from mathics.eval.makeboxes import eval_makeboxes, to_boxes
 
 
 class BoxData(Builtin):

--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -68,6 +68,7 @@ try:
 
     import numpy
     import PIL
+    import PIL.Image
     import PIL.ImageEnhance
     import PIL.ImageFilter
     import PIL.ImageOps

--- a/mathics/builtin/forms/other.py
+++ b/mathics/builtin/forms/other.py
@@ -4,11 +4,12 @@ Forms which are not in '$OutputForms'
 
 import re
 
-from mathics.builtin.box.layout import RowBox, to_boxes
+from mathics.builtin.box.layout import RowBox
 from mathics.builtin.forms.base import FormBaseClass
 from mathics.builtin.makeboxes import MakeBoxes
 from mathics.core.atoms import String
 from mathics.core.element import EvalMixin
+from mathics.eval.makeboxes import to_boxes
 
 
 class StringForm(FormBaseClass):

--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -14,7 +14,7 @@ import re
 from typing import Optional
 
 from mathics.builtin.base import Builtin
-from mathics.builtin.box.layout import GridBox, RowBox, to_boxes
+from mathics.builtin.box.layout import GridBox, RowBox
 from mathics.builtin.comparison import expr_min
 from mathics.builtin.forms.base import FormBaseClass
 from mathics.builtin.makeboxes import MakeBoxes, number_form
@@ -49,7 +49,7 @@ from mathics.core.systemsymbols import (
     SymbolSubscriptBox,
     SymbolSuperscriptBox,
 )
-from mathics.eval.makeboxes import format_element
+from mathics.eval.makeboxes import format_element, to_boxes
 
 MULTI_NEWLINE_RE = re.compile(r"\n{2,}")
 

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -11,7 +11,7 @@ we can use ``Row``
 
 
 from mathics.builtin.base import BinaryOperator, Builtin, Operator
-from mathics.builtin.box.layout import GridBox, RowBox, to_boxes
+from mathics.builtin.box.layout import GridBox, RowBox
 from mathics.builtin.lists import list_boxes
 from mathics.builtin.makeboxes import MakeBoxes
 from mathics.builtin.options import options_to_rules
@@ -20,7 +20,7 @@ from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolMakeBoxes
-from mathics.eval.makeboxes import format_element
+from mathics.eval.makeboxes import format_element, to_boxes
 
 SymbolSubscriptBox = Symbol("System`SubscriptBox")
 

--- a/mathics/eval/image.py
+++ b/mathics/eval/image.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 import numpy
 import PIL
+import PIL.Image
 
 from mathics.builtin.base import String
 from mathics.core.atoms import Rational


### PR DESCRIPTION
This is the first step in my proposal of refactoring  `MakeBoxes`. The main change here is that MakeBoxes rules are applied in `mathics.eval.makeboxes.eval_makeboxes` instead of the `mathics.core.expression.rewrite_apply_eval_step`. In a next step, makeboxes rules are going to be stored not as `downvalues` of the `MakeBoxes` symbol, but as format values.