### PR TITLE
fix PIL.Image

### DIFF
--- a/mathics/builtin/drawing/image.py
+++ b/mathics/builtin/drawing/image.py
@@ -68,6 +68,7 @@ try:
 
     import numpy
     import PIL
+    import PIL.Image
     import PIL.ImageEnhance
     import PIL.ImageFilter
     import PIL.ImageOps

--- a/mathics/eval/image.py
+++ b/mathics/eval/image.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 import numpy
 import PIL
+import PIL.Image
 
 from mathics.builtin.base import String
 from mathics.core.atoms import Rational


### PR DESCRIPTION
This PR just fix the import of PIL.Image in my setup (Pyston 2.3.4, PIL 8.4.0).