### PR TITLE
Handle degenerate LineBox when there are no points

### DIFF
--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -1034,7 +1034,9 @@ class InsetBox(_GraphicsElementBox):
 
 
 class LineBox(_Polyline):
-    # Boxing methods for a list of Line.
+    """
+    Boxing methods for a list of Lines.
+    """
 
     def init(self, graphics, style, item=None, lines=None):
         super(LineBox, self).init(graphics, item, style)

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -2348,7 +2348,9 @@ class Plot(_Plot):
 
 class ParametricPlot(_Plot):
     """
-    <url>:WMA link: https://reference.wolfram.com/language/ref/ParametricPlot.html</url>
+    <url>
+    :WMA link
+    : https://reference.wolfram.com/language/ref/ParametricPlot.html</url>
     <dl>
       <dt>'ParametricPlot[{$f_x$, $f_y$}, {$u$, $umin$, $umax$}]'
       <dd>plots a parametric function $f$ with the parameter $u$ ranging from $umin$ to $umax$.

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -343,6 +343,14 @@ class Graphics(Builtin):
 
 
 class _Polyline(_GraphicsElementBox):
+    """
+    A structure containing a list of line segments
+    stored in ``self.lines`` created from
+    a list of points.
+
+    Lines are formed by pairs of consecutive point.
+    """
+
     def do_init(self, graphics, points):
         if not points.has_form("List", None):
             raise BoxExpressionError
@@ -356,6 +364,10 @@ class _Polyline(_GraphicsElementBox):
         ):
             elements = points.elements
             self.multi_parts = True
+        elif len(points.elements) == 0:
+            # Ensure there are no line segments if there are no points.
+            self.lines = []
+            return
         else:
             elements = [ListExpression(*points.elements)]
             self.multi_parts = False


### PR DESCRIPTION
I encountered this when building the docs and something along the lines of

```
ParametricPlot[{Sin[u], Cos[3 u]}, {u, 0, 2 Pi}]
```
which creates in `mathics-229.asy`: 

In creating an axis it uses:

```
draw(, rgb(0.2472, 0.24, 0.6)+linewidth(0.66667));
```

The empty list of points is mysteriously coming from the default TickStyle `{}`.

We are seeing this  Asymptote only

Also TicksStyle handling seems weird since we shouldn't try to create LineBox in the first place.