### PR TITLE
Clean up precedence testing ...

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -36,6 +36,8 @@ from mathics.builtin.base import (
     mathics_to_python,
 )
 from mathics.core.pattern import pattern_objects
+from mathics.core.symbols import Symbol
+from mathics.eval.makeboxes import builtins_precedence
 from mathics.settings import ENABLE_FILES_MODULE
 from mathics.version import __version__  # noqa used in loading to check consistency.
 
@@ -60,7 +62,7 @@ def add_builtins(new_builtins):
                 # print("XXX1", sympy_name)
                 sympy_to_mathics[sympy_name] = builtin
         if isinstance(builtin, Operator):
-            builtins_precedence[name] = builtin.precedence
+            builtins_precedence[Symbol(name)] = builtin.precedence
         if isinstance(builtin, PatternObject):
             pattern_objects[name] = builtin.__class__
     _builtins.update(dict(new_builtins))
@@ -237,8 +239,6 @@ for module in modules:
 
 mathics_to_sympy = {}  # here we have: name -> sympy object
 sympy_to_mathics = {}
-
-builtins_precedence = {}
 
 new_builtins = _builtins_list
 

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -95,7 +95,7 @@ class Grid(Builtin):
     options = GridBox.options
     summary_text = " 2D layout containing arbitrary objects"
 
-    def eval_makeboxes(self, array, f, evaluation, options) -> Expression:
+    def eval_makeboxes(self, array, f, evaluation: Evaluation, options) -> Expression:
         """MakeBoxes[Grid[array_?MatrixQ, OptionsPattern[Grid]],
         f:StandardForm|TraditionalForm|OutputForm]"""
         return GridBox(
@@ -158,7 +158,8 @@ class Left(Builtin):
 
     <dl>
       <dt>'Left'
-      <dd>is used with operator formatting constructs to specify a left-associative operator.
+      <dd>is used with operator formatting constructs to specify a \
+          left-associative operator.
     </dl>
     """
 
@@ -309,21 +310,21 @@ class Row(Builtin):
 
     summary_text = "1D layouts containing arbitrary objects in a row"
 
-    def eval_makeboxes(self, items, sep, f, evaluation: Evaluation):
+    def eval_makeboxes(self, items, sep, form, evaluation: Evaluation):
         """MakeBoxes[Row[{items___}, sep_:""],
-        f:StandardForm|TraditionalForm|OutputForm]"""
+        form:StandardForm|TraditionalForm|OutputForm]"""
 
         items = items.get_sequence()
         if not isinstance(sep, String):
-            sep = MakeBoxes(sep, f)
+            sep = MakeBoxes(sep, form)
         if len(items) == 1:
-            return MakeBoxes(items[0], f)
+            return MakeBoxes(items[0], form)
         else:
             result = []
             for index, item in enumerate(items):
                 if index > 0 and not sep.sameQ(String("")):
                     result.append(to_boxes(sep, evaluation))
-                item = MakeBoxes(item, f).evaluate(evaluation)
+                item = MakeBoxes(item, form).evaluate(evaluation)
                 item = to_boxes(item, evaluation)
                 result.append(item)
             return RowBox(*result)
@@ -336,22 +337,31 @@ class Style(Builtin):
     <dl>
       <dt>'Style[$expr$, options]'
       <dd>displays $expr$ formatted using the specified option settings.
+
       <dt>'Style[$expr$, "style"]'
       <dd> uses the option settings for the specified style in the current notebook.
+
       <dt>'Style[$expr$, $color$]'
       <dd>displays using the specified color.
+
       <dt>'Style[$expr$, $Bold$]'
       <dd>displays with fonts made bold.
+
       <dt>'Style[$expr$, $Italic$]'
       <dd>displays with fonts made italic.
+
       <dt>'Style[$expr$, $Underlined$]'
       <dd>displays with fonts underlined.
+
       <dt>'Style[$expr$, $Larger$]
       <dd>displays with fonts made larger.
+
       <dt>'Style[$expr$, $Smaller$]'
       <dd>displays with fonts made smaller.
+
       <dt>'Style[$expr$, $n$]'
       <dd>displays with font size n.
+
       <dt>'Style[$expr$, $Tiny$]'
       <dt>'Style[$expr$, $Small$]', etc.
       <dd>display with fonts that are tiny, small, etc.
@@ -399,7 +409,9 @@ class Subscript(Builtin):
 
 class Subsuperscript(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Subsuperscript.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Subsuperscript.html</url>
 
     <dl>
       <dt>'Subsuperscript[$a$, $b$, $c$]'
@@ -421,7 +433,9 @@ class Subsuperscript(Builtin):
 
 class Superscript(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Superscript.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Superscript.html</url>
 
     <dl>
       <dt>'Superscript[$x$, $y$]'

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-
 """
 Low level Format definitions
 """
@@ -21,7 +19,7 @@ from mathics.core.number import dps
 from mathics.core.symbols import Atom, Symbol
 from mathics.core.systemsymbols import SymbolInputForm, SymbolOutputForm, SymbolRowBox
 from mathics.eval.makeboxes import (
-    NO_PARENTHESIS_EVER,
+    NEVER_ADD_PARENTHESIS,
     _boxed_string,
     format_element,
     parenthesize,
@@ -467,7 +465,7 @@ class MakeBoxes(Builtin):
             return operator
 
         py_precedence = (
-            precedence.value if hasattr(precedence, "value") else NO_PARENTHESIS_EVER
+            precedence.value if hasattr(precedence, "value") else NEVER_ADD_PARENTHESIS
         )
         grouping = grouping.get_name()
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -20,7 +20,12 @@ from mathics.core.list import ListExpression
 from mathics.core.number import dps
 from mathics.core.symbols import Atom, Symbol
 from mathics.core.systemsymbols import SymbolInputForm, SymbolOutputForm, SymbolRowBox
-from mathics.eval.makeboxes import _boxed_string, format_element
+from mathics.eval.makeboxes import (
+    NO_PARENTHESIS_EVER,
+    _boxed_string,
+    format_element,
+    parenthesize,
+)
 
 
 def int_to_s_exp(expr, n):
@@ -33,30 +38,6 @@ def int_to_s_exp(expr, n):
         s = str(n)
     exp = len(s) - 1
     return s, exp, nonnegative
-
-
-def parenthesize(precedence, element, element_boxes, when_equal):
-    from mathics.builtin import builtins_precedence
-
-    while element.has_form("HoldForm", 1):
-        element = element.elements[0]
-
-    if element.has_form(("Infix", "Prefix", "Postfix"), 3, None):
-        element_prec = element.elements[2].value
-    elif element.has_form("PrecedenceForm", 2):
-        element_prec = element.elements[1].value
-    # For negative values, ensure that the element_precedence is at least the precedence. (Fixes #332)
-    elif isinstance(element, (Integer, Real)) and element.value < 0:
-        element_prec = precedence
-    else:
-        element_prec = builtins_precedence.get(element.get_head_name())
-    if precedence is not None and element_prec is not None:
-        if precedence > element_prec or (precedence == element_prec and when_equal):
-            return Expression(
-                SymbolRowBox,
-                ListExpression(String("("), element_boxes, String(")")),
-            )
-    return element_boxes
 
 
 # FIXME: op should be a string, so remove the Union.
@@ -420,28 +401,28 @@ class MakeBoxes(Builtin):
             result.append(to_boxes(String(right), evaluation))
             return RowBox(*result)
 
-    def eval_outerprecedenceform(self, expr, prec, evaluation):
-        """MakeBoxes[PrecedenceForm[expr_, prec_],
+    def eval_outerprecedenceform(self, expr, precedence, evaluation):
+        """MakeBoxes[PrecedenceForm[expr_, precedence_],
         StandardForm|TraditionalForm|OutputForm|InputForm]"""
 
-        precedence = prec.get_int_value()
+        py_precedence = precedence.get_int_value()
         boxes = MakeBoxes(expr)
-        return parenthesize(precedence, expr, boxes, True)
+        return parenthesize(py_precedence, expr, boxes, True)
 
-    def eval_postprefix(self, p, expr, h, prec, f, evaluation):
-        """MakeBoxes[(p:Prefix|Postfix)[expr_, h_, prec_:None],
-        f:StandardForm|TraditionalForm|OutputForm|InputForm]"""
+    def eval_postprefix(self, p, expr, h, precedence, form, evaluation):
+        """MakeBoxes[(p:Prefix|Postfix)[expr_, h_, precedence_:None],
+        form:StandardForm|TraditionalForm|OutputForm|InputForm]"""
 
         if not isinstance(h, String):
-            h = MakeBoxes(h, f)
+            h = MakeBoxes(h, form)
 
-        precedence = prec.get_int_value()
+        py_precedence = precedence.get_int_value()
 
         elements = expr.elements
         if len(elements) == 1:
             element = elements[0]
-            element_boxes = MakeBoxes(element, f)
-            element = parenthesize(precedence, element, element_boxes, True)
+            element_boxes = MakeBoxes(element, form)
+            element = parenthesize(py_precedence, element, element_boxes, True)
             if p.get_name() == "System`Postfix":
                 args = (element, h)
             else:
@@ -449,12 +430,12 @@ class MakeBoxes(Builtin):
 
             return Expression(SymbolRowBox, ListExpression(*args).evaluate(evaluation))
         else:
-            return MakeBoxes(expr, f).evaluate(evaluation)
+            return MakeBoxes(expr, form).evaluate(evaluation)
 
     def eval_infix(
-        self, expr, operator, prec: Integer, grouping, form: Symbol, evaluation
+        self, expr, operator, precedence: Integer, grouping, form: Symbol, evaluation
     ):
-        """MakeBoxes[Infix[expr_, operator_, prec_:None, grouping_:None],
+        """MakeBoxes[Infix[expr_, operator_, precedence_:None, grouping_:None],
         form:StandardForm|TraditionalForm|OutputForm|InputForm]"""
 
         ## FIXME: this should go into a some formatter.
@@ -485,7 +466,9 @@ class MakeBoxes(Builtin):
                 return op
             return operator
 
-        precedence = prec.value if hasattr(prec, "value") else 0
+        py_precedence = (
+            precedence.value if hasattr(precedence, "value") else NO_PARENTHESIS_EVER
+        )
         grouping = grouping.get_name()
 
         if isinstance(expr, Atom):
@@ -496,7 +479,9 @@ class MakeBoxes(Builtin):
         if len(elements) > 1:
             if operator.has_form("List", len(elements) - 1):
                 operator = [format_operator(op) for op in operator.elements]
-                return make_boxes_infix(elements, operator, precedence, grouping, form)
+                return make_boxes_infix(
+                    elements, operator, py_precedence, grouping, form
+                )
             else:
                 encoding_rule = evaluation.definitions.get_ownvalue(
                     "$CharacterEncoding"
@@ -518,7 +503,7 @@ class MakeBoxes(Builtin):
                         String(operator_to_unicode.get(op_str, op_str))
                     )
 
-            return make_boxes_infix(elements, operator, precedence, grouping, form)
+            return make_boxes_infix(elements, operator, py_precedence, grouping, form)
 
         elif len(elements) == 1:
             return MakeBoxes(elements[0], form)
@@ -528,7 +513,9 @@ class MakeBoxes(Builtin):
 
 class ToBoxes(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/ToBoxes.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/ToBoxes.html</url>
 
     <dl>
       <dt>'ToBoxes[$expr$]'

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -341,7 +341,11 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     also associated with a ``Definition``. But it has a ``DownValue``
     that is used in its evaluation.
 
-    We also have Symbols which in contrast to Variables Symbols have
+    A Function Symbol, like a Variable Symbol, is a ``Symbol`` that is
+    also associated with a ``Definition``. But it has a ``DownValue``
+    that is used in its evaluation.
+
+    We also have Symbols which, in contrast to Variables Symbols, have
     a constant value that cannot change. System`True and System`False
     are like this.
 

--- a/mathics/eval/makeboxes.py
+++ b/mathics/eval/makeboxes.py
@@ -49,7 +49,7 @@ from mathics.core.systemsymbols import (
 # will be surrounded by parenthesis, e.g. ... (...op...) ...
 # In named-characters.yml of mathics-scanner we start at 0.
 # However, negative values would also work.
-NO_PARENTHESIS_EVER = 0
+NEVER_ADD_PARENTHESIS = 0
 
 # These Strings are used in Boxing output
 StringElipsis = String("...")


### PR DESCRIPTION
* Move precedence() to mathics.eval.makeboxes
* Define NO_PARENTHESIS_EVER constant
* Use the Symbol not a string name in precedence lookup
* style stuff on mathics/builtin.layout.py
* Compute boxing strings like String("...") or String("(") once. 