### PR TITLE
Bump requirement on Pillow to 9.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ INSTALL_REQUIRES = [
     "Mathics-Scanner >= 1.3.0.dev0",
     # Pillow 9.1.0 supports BigTIFF with big-endian byte order.
     # ExampleData image hedy.tif is in this format.
-    "pillow >= 9.1.0",
+    # Pillow 9.2 handles sunflowers.jpg
+    "pillow >= 9.2.0",
 ]
 
 # Ensure user has the correct Python version


### PR DESCRIPTION
Testing shows that we need this to read sunflowers.jpg and possibly do ColorNegate of that.