### PR TITLE
Add setuptools to install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ INSTALL_REQUIRES += [
     "pint",
     "python-dateutil",
     "requests",
+    "setuptools",
 ]
 
 print(f'Installation requires "{", ".join(INSTALL_REQUIRES)}')


### PR DESCRIPTION
mathics/settings.py imports and uses `pkg_resources`, which comes from setuptools. While this is normally installed, it might not be present in very minimal deployments, so it's good to list it explicitly.