### PR TITLE
Set requires in classes, rather than in Helper functions; adjust `requirements-full.txt`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,12 @@
 CHANGES
 =======
 
-5.0.3dev0
+6.0.0dev0
 ---------
+
+A fair bit of code refactoring has gone on so that we might be able to scale the code, get it to be more performant, and more in line with other interpreters.
+
+Image Routines have been gone over. A number of Built-in functions that were implemented were not accessible for various reasons.
 
 API
 +++
@@ -53,6 +57,7 @@ Documentation
 #. "Exponential Functional" split out from "Trigonometry Functions"
 #. "Functional Programming" section split out.
 #. "Image Manipulation" has been split off from Graphics and Drawing and turned into a guide section.
+#. Image examples now appear in the PDF doc
 #. "Logic and Boolean Algebra" section reinstated.
 #. "Forms of Input and Output" is its own guide section.
 #. More url links to Wiki pages added; more internal cross links added.
@@ -83,6 +88,8 @@ Bugs
 #. ``RandomSample`` with one list argument now returns a random ordering of the list items. Previously it would return just one item.
 #. Origin placement corrected on ``ListPlot`` and ``LinePlot``.
 #. Fix long-standing bugs in Image handling
+#. Some scikit image routines line ``EdgeDetect`` were getting omitted due to overly stringent PYPI requirements
+
 #. Units and Quantities were sometimes failing. Also they were omitted from documentation.
 
 PyPI Package requirements

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -65,8 +65,10 @@ def check_requires_list(requires: list) -> bool:
         try:
             lib_is_installed = importlib.util.find_spec(package) is not None
         except ImportError:
+            # print("XXX requires import error", requires)
             lib_is_installed = False
         if not lib_is_installed:
+            # print("XXX requires not found error", requires)
             return False
     return True
 

--- a/mathics/builtin/image/base.py
+++ b/mathics/builtin/image/base.py
@@ -16,18 +16,10 @@ from mathics.core.list import ListExpression
 from mathics.core.systemsymbols import SymbolImage, SymbolRule
 from mathics.eval.image import image_pixels, pixels_as_float, pixels_as_ubyte
 
-_skimage_requires = ("skimage",)
+skimage_requires = ("skimage",)
 
 # No user docs here.
 no_doc = True
-
-
-class SkimageBuiltin:
-    """
-    Image Builtins that require scikit-image.
-    """
-
-    requires = _skimage_requires
 
 
 class Image(Atom):

--- a/mathics/builtin/image/misc.py
+++ b/mathics/builtin/image/misc.py
@@ -9,7 +9,7 @@ import numpy
 import PIL
 
 from mathics.builtin.base import Builtin, String
-from mathics.builtin.image.base import Image, SkimageBuiltin
+from mathics.builtin.image.base import Image, skimage_requires
 from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
@@ -17,8 +17,6 @@ from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolNull
 from mathics.core.systemsymbols import SymbolFailed, SymbolRule
 from mathics.eval.image import extract_exif
-
-_skimage_requires = ("skimage", "scipy", "matplotlib", "networkx")
 
 # The following classes are used to allow inclusion of
 # Builtin Functions only when certain Python packages
@@ -177,9 +175,8 @@ class RandomImage(Builtin):
         return Image(data, cs)
 
 
-class EdgeDetect(SkimageBuiltin):
+class EdgeDetect(Builtin):
     """
-
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/EdgeDetect.html</url>
@@ -199,6 +196,8 @@ class EdgeDetect(SkimageBuiltin):
     """
 
     summary_text = "detect edges in an image using Canny and other methods"
+    requires = skimage_requires
+
     rules = {
         "EdgeDetect[i_Image]": "EdgeDetect[i, 2, 0.2]",
         "EdgeDetect[i_Image, r_?RealNumberQ]": "EdgeDetect[i, r, 0.2]",

--- a/mathics/builtin/image/morph.py
+++ b/mathics/builtin/image/morph.py
@@ -3,13 +3,13 @@ Morphological Image Processing
 """
 
 from mathics.builtin.base import Builtin
-from mathics.builtin.image.base import Image, SkimageBuiltin
+from mathics.builtin.image.base import Image, skimage_requires
 from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Evaluation
 from mathics.eval.image import matrix_to_numpy, pixels_as_float, pixels_as_ubyte
 
 
-class _MorphologyFilter(SkimageBuiltin, Builtin):
+class _MorphologyFilter(Builtin):
     """
     Base class for many Morphological Image Processing filters.
     This requires scikit-mage to be installed.
@@ -19,6 +19,7 @@ class _MorphologyFilter(SkimageBuiltin, Builtin):
         "grayscale": "Your image has been converted to grayscale as color images are not supported yet."
     }
 
+    requires = skimage_requires
     rules = {"%(name)s[i_Image, r_?RealNumberQ]": "%(name)s[i, BoxMatrix[r]]"}
 
     def eval(self, image, k, evaluation: Evaluation):
@@ -88,10 +89,10 @@ class Erosion(_MorphologyFilter):
      = -Image-
     """
 
-    summary_text = "give the erotion with respect to a range-r square"
+    summary_text = "give erosion with respect to a range-r square"
 
 
-class MorphologicalComponents(SkimageBuiltin):
+class MorphologicalComponents(Builtin):
     """
     <url>
     :WMA link:

--- a/mathics/builtin/image/test.py
+++ b/mathics/builtin/image/test.py
@@ -2,21 +2,13 @@
 Image testing
 """
 from mathics.builtin.base import Test
-from mathics.builtin.image.base import Image, _skimage_requires
+from mathics.builtin.image.base import Image, skimage_requires
 
 # This tells documentation how to sort this module
 sort_order = "mathics.builtin.image.image-filters"
 
 
-class _ImageTest(Test):
-    """
-    Testing Image Builtins -- those function names ending with "Q" -- that require scikit-image.
-    """
-
-    requires = _skimage_requires
-
-
-class BinaryImageQ(_ImageTest):
+class BinaryImageQ(Test):
     """
     <url>:WMA link:
     https://reference.wolfram.com/language/ref/BinaryImageQ.html</url>
@@ -35,13 +27,15 @@ class BinaryImageQ(_ImageTest):
      : ...
     """
 
+    requires = skimage_requires
+
     summary_text = "test whether pixels in an image are binary bit values"
 
     def test(self, expr):
         return isinstance(expr, Image) and expr.storage_type() == "Bit"
 
 
-class ImageQ(_ImageTest):
+class ImageQ(Test):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/ImageQ.html</url>
 
@@ -65,6 +59,8 @@ class ImageQ(_ImageTest):
     >> ImageQ["abc"]
      = False
     """
+
+    requires = skimage_requires
 
     summary_text = "test whether is a valid image"
 

--- a/mathics/builtin/manipulate.py
+++ b/mathics/builtin/manipulate.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+Interactive Manipulation
+"""
+
+# This largely is not usable.
+no_doc = True
 
 
 from mathics import settings
@@ -241,21 +247,28 @@ class ManipulateOutput(Output):
 
 class Manipulate(Builtin):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Manipulate.html</url>
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/Manipulate.html</url>
 
     <dl>
-    <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$}]'
-        <dd>interactively compute and display an expression with different values of $u$.
-    <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$, $du$}]'
-        <dd>allows $u$ to vary between $u_min$ and $u_max$ in steps of $du$.
-    <dt>'Manipulate[$expr1$, {{$u$, $u_init$}, $u_min$, $u_max$, ...}]'
-        <dd>starts with initial value of $u_init$.
-    <dt>'Manipulate[$expr1$, {{$u$, $u_init$, $u_lbl$}, ...}]'
-        <dd>labels the $u$ controll by $u_lbl$.
-    <dt>'Manipulate[$expr1$, {$u$, {$u_1$, $u_2$, ...}}]'
-        <dd>sets $u$ to take discrete values $u_1$, $u_2$, ... .
-    <dt>'Manipulate[$expr1$, {$u$, ...}, {$v$, ...}, ...]'
-        <dd>control each of $u$, $v$, ... .
+      <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$}]'
+      <dd>interactively compute and display an expression with different values of $u$.
+
+      <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$, $du$}]'
+      <dd>allows $u$ to vary between $u_min$ and $u_max$ in steps of $du$.
+
+      <dt>'Manipulate[$expr1$, {{$u$, $u_init$}, $u_min$, $u_max$, ...}]'
+      <dd>starts with initial value of $u_init$.
+
+      <dt>'Manipulate[$expr1$, {{$u$, $u_init$, $u_lbl$}, ...}]'
+      <dd>labels the $u$ controll by $u_lbl$.
+
+      <dt>'Manipulate[$expr1$, {$u$, {$u_1$, $u_2$, ...}}]'
+      <dd>sets $u$ to take discrete values $u_1$, $u_2$, ... .
+
+      <dt>'Manipulate[$expr1$, {$u$, ...}, {$v$, ...}, ...]'
+      <dd>control each of $u$, $v$, ... .
     </dl>
 
     >> Manipulate[N[Sin[y]], {y, 1, 20, 2}]
@@ -300,6 +313,8 @@ class Manipulate(Builtin):
         "widgetargs": "Illegal variable range or step parameters for ``.",
         "widgetdisp": "Jupyter failed to display the widget.",
     }
+
+    no_doc = True  # This largely doesn't work
 
     requires = ("ipywidgets",)
     summary_text = "interactively manipulate any expression, graphic, or other object"

--- a/mathics/builtin/manipulate.py
+++ b/mathics/builtin/manipulate.py
@@ -4,381 +4,381 @@ Interactive Manipulation
 """
 
 # This largely is not usable.
-no_doc = True
+# no_doc = True
 
 
-from mathics import settings
-from mathics.builtin.base import Builtin
-from mathics.core.atoms import Integer, String
-from mathics.core.attributes import A_HOLD_ALL, A_PROTECTED
-from mathics.core.convert.python import from_python
-from mathics.core.evaluation import Output
-from mathics.core.expression import Expression
-from mathics.core.list import ListExpression
-from mathics.core.symbols import Symbol, strip_context
-from mathics.core.systemsymbols import SymbolSet
+# from mathics import settings
+# from mathics.builtin.base import Builtin
+# from mathics.core.atoms import Integer, String
+# from mathics.core.attributes import A_HOLD_ALL, A_PROTECTED
+# from mathics.core.convert.python import from_python
+# from mathics.core.evaluation import Output
+# from mathics.core.expression import Expression
+# from mathics.core.list import ListExpression
+# from mathics.core.symbols import Symbol, strip_context
+# from mathics.core.systemsymbols import SymbolSet
 
-try:
-    from ipykernel.kernelbase import Kernel
+# try:
+#     from ipykernel.kernelbase import Kernel
 
-    _jupyter = True
-except ImportError:
-    _jupyter = False
+#     _jupyter = True
+# except ImportError:
+#     _jupyter = False
 
-try:
-    from IPython.core.formatters import IPythonDisplayFormatter
-    from ipywidgets import Box, DOMWidget, FloatSlider, IntSlider, ToggleButtons
+# try:
+#     from IPython.core.formatters import IPythonDisplayFormatter
+#     from ipywidgets import Box, DOMWidget, FloatSlider, IntSlider, ToggleButtons
 
-    _ipywidgets = True
-except ImportError:
-    # fallback to non-Manipulate-enabled build if we don't have ipywidgets installed.
-    _ipywidgets = False
-
-
-SymbolModule = Symbol("Module")
-SymbolReleaseHold = Symbol("ReleaseHold")
-
-"""
-A basic implementation of Manipulate[]. There is currently no support for Dynamic[] elements.
-This implementation is basically a port from ipywidget.widgets.interaction for Mathics.
-"""
-
-
-def _interactive(interact_f, kwargs_widgets):
-    # this is a modified version of interactive() in ipywidget.widgets.interaction
-
-    container = Box(_dom_classes=["widget-interact"])
-    container.children = [w for w in kwargs_widgets if isinstance(w, DOMWidget)]
-
-    def call_f(name=None, old=None, new=None):
-        kwargs = dict((widget._kwarg, widget.value) for widget in kwargs_widgets)
-        try:
-            interact_f(**kwargs)
-        except Exception as e:
-            container.log.warn("Exception in interact callback: %s", e, exc_info=True)
-
-    for widget in kwargs_widgets:
-        widget.on_trait_change(call_f, "value")
-
-    container.on_displayed(lambda _: call_f(None, None, None))
-
-    return container
-
-
-class IllegalWidgetArguments(Exception):
-    def __init__(self, var):
-        super(IllegalWidgetArguments, self).__init__()
-        self.var = var
-
-
-class JupyterWidgetError(Exception):
-    def __init__(self, err):
-        super(JupyterWidgetError, self).__init__()
-        self.err = err
-
-
-class ManipulateParameter(
-    Builtin
-):  # parses one Manipulate[] parameter spec, e.g. {x, 1, 2}, see _WidgetInstantiator
-    context = "System`Private`"
-
-    rules = {
-        # detect x and {x, default} and {x, default, label}.
-        "System`Private`ManipulateParameter[{s_Symbol, r__}]": "System`Private`ManipulateParameter[{Symbol -> s, Label -> s}, {r}]",
-        "System`Private`ManipulateParameter[{{s_Symbol, d_}, r__}]": "System`Private`ManipulateParameter[{Symbol -> s, Default -> d, Label -> s}, {r}]",
-        "System`Private`ManipulateParameter[{{s_Symbol, d_, l_}, r__}]": "System`Private`ManipulateParameter[{Symbol -> s, Default -> d, Label -> l}, {r}]",
-        # detect different kinds of widgets. on the use of the duplicate key "Default ->", see _WidgetInstantiator.add()
-        "System`Private`ManipulateParameter[var_, {min_?RealNumberQ, max_?RealNumberQ}]": 'Join[{Type -> "Continuous", Minimum -> min, Maximum -> max, Default -> min}, var]',
-        "System`Private`ManipulateParameter[var_, {min_?RealNumberQ, max_?RealNumberQ, step_?RealNumberQ}]": 'Join[{Type -> "Discrete", Minimum -> min, Maximum -> max, Step -> step, Default -> min}, var]',
-        "System`Private`ManipulateParameter[var_, {opt_List}] /; Length[opt] > 0": 'Join[{Type -> "Options", Options -> opt, Default -> Part[opt, 1]}, var]',
-    }
-
-    summary_text = "interactive manipulation (not implemented yet)"
-
-
-def _manipulate_label(x):  # gets the label that is displayed for a symbol or name
-    if isinstance(x, String):
-        return x.get_string_value()
-    elif isinstance(x, Symbol):
-        return strip_context(x.get_name())
-    else:
-        return str(x)
-
-
-def _create_widget(widget, **kwargs):
-    try:
-        return widget(**kwargs)
-    except Exception as e:
-        raise JupyterWidgetError(str(e))
-
-
-class _WidgetInstantiator:
-    # we do not want to have widget instances (like FloatSlider) get into the evaluation pipeline (e.g. via Expression
-    # or Atom), since there might be all kinds of problems with serialization of these widget classes.  therefore, the
-    # elegant recursive solution for parsing parameters (like in Table[]) is not feasible here; instead, we must create
-    # and use the widgets in one "transaction" here, without holding them in expressions or atoms.
-
-    def __init__(self):
-        self._widgets = []  # the ipywidget widgets to control the manipulated variables
-        self._parsers = (
-            {}
-        )  # lambdas to decode the widget values into Mathics expressions
-
-    def add(self, expression, evaluation):
-        expr = Expression("System`Private`ManipulateParameter", expression).evaluate(
-            evaluation
-        )
-        if (
-            expr.get_head_name() != "System`List"
-        ):  # if everything was parsed ok, we get a List
-            return False
-        # convert the rules given us by ManipulateParameter[] into a dict. note: duplicate keys
-        # will be overwritten, the latest one wins.
-        kwargs = {"evaluation": evaluation}
-        for rule in expr.elements:
-            if rule.get_head_name() != "System`Rule" or len(rule.elements) != 2:
-                return False
-            kwargs[strip_context(rule.elements[0].to_python()).lower()] = rule.elements[
-                1
-            ]
-        widget = kwargs["type"].get_string_value()
-        del kwargs["type"]
-        getattr(self, "_add_%s_widget" % widget.lower())(**kwargs)  # create the widget
-        return True
-
-    def get_widgets(self):
-        return self._widgets
-
-    def build_callback(self, callback):
-        parsers = self._parsers
-
-        def new_callback(**kwargs):
-            callback(
-                **dict((name, parsers[name](value)) for (name, value) in kwargs.items())
-            )
-
-        return new_callback
-
-    def _add_continuous_widget(
-        self, symbol, label, default, minimum, maximum, evaluation
-    ):
-        minimum_value = minimum.to_python()
-        maximum_value = maximum.to_python()
-        if minimum_value > maximum_value:
-            raise IllegalWidgetArguments(symbol)
-        else:
-            defval = min(max(default.to_python(), minimum_value), maximum_value)
-            widget = _create_widget(
-                FloatSlider, value=defval, min=minimum_value, max=maximum_value
-            )
-            self._add_widget(widget, symbol.get_name(), lambda x: from_python(x), label)
-
-    def _add_discrete_widget(
-        self, symbol, label, default, minimum, maximum, step, evaluation
-    ):
-        minimum_value = minimum.to_python()
-        maximum_value = maximum.to_python()
-        step_value = step.to_python()
-        if (
-            minimum_value > maximum_value
-            or step_value <= 0
-            or step_value > (maximum_value - minimum_value)
-        ):
-            raise IllegalWidgetArguments(symbol)
-        else:
-            default_value = min(max(default.to_python(), minimum_value), maximum_value)
-            if all(isinstance(x, Integer) for x in [minimum, maximum, default, step]):
-                widget = _create_widget(
-                    IntSlider,
-                    value=default_value,
-                    min=minimum_value,
-                    max=maximum_value,
-                    step=step_value,
-                )
-            else:
-                widget = _create_widget(
-                    FloatSlider,
-                    value=default_value,
-                    min=minimum_value,
-                    max=maximum_value,
-                    step=step_value,
-                )
-            self._add_widget(widget, symbol.get_name(), lambda x: from_python(x), label)
-
-    def _add_options_widget(self, symbol, options, default, label, evaluation):
-        formatted_options = []
-        for i, option in enumerate(options.elements):
-            data = evaluation.format_output(option, format="text")
-            formatted_options.append((data, i))
-
-        default_index = 0
-        for i, option in enumerate(options.elements):
-            if option.sameQ(default):
-                default_index = i
-
-        widget = _create_widget(
-            ToggleButtons, options=formatted_options, value=default_index
-        )
-        self._add_widget(
-            widget, symbol.get_name(), lambda j: options.elements[j], label
-        )
-
-    def _add_widget(self, widget, name, parse, label):
-        if not widget.description:
-            widget.description = _manipulate_label(label)
-        widget._kwarg = name  # see _interactive() above
-        self._parsers[name] = parse
-        self._widgets.append(widget)
-
-
-class ManipulateOutput(Output):
-    def max_stored_size(self, settings):
-        return self.output.max_stored_size(settings)
-
-    def out(self, out):
-        return self.output.out(out)
-
-    def clear_output(wait=False):
-        raise NotImplementedError
-
-    def display_data(self, result):
-        raise NotImplementedError
-
-
-class Manipulate(Builtin):
-    """
-    <url>
-    :WMA link:
-    https://reference.wolfram.com/language/ref/Manipulate.html</url>
-
-    <dl>
-      <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$}]'
-      <dd>interactively compute and display an expression with different values of $u$.
-
-      <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$, $du$}]'
-      <dd>allows $u$ to vary between $u_min$ and $u_max$ in steps of $du$.
-
-      <dt>'Manipulate[$expr1$, {{$u$, $u_init$}, $u_min$, $u_max$, ...}]'
-      <dd>starts with initial value of $u_init$.
-
-      <dt>'Manipulate[$expr1$, {{$u$, $u_init$, $u_lbl$}, ...}]'
-      <dd>labels the $u$ controll by $u_lbl$.
-
-      <dt>'Manipulate[$expr1$, {$u$, {$u_1$, $u_2$, ...}}]'
-      <dd>sets $u$ to take discrete values $u_1$, $u_2$, ... .
-
-      <dt>'Manipulate[$expr1$, {$u$, ...}, {$v$, ...}, ...]'
-      <dd>control each of $u$, $v$, ... .
-    </dl>
-
-    >> Manipulate[N[Sin[y]], {y, 1, 20, 2}]
-     : Manipulate[] only works inside a Jupyter notebook.
-     = Manipulate[N[Sin[y]], {y, 1, 20, 2}]
-
-    >> Manipulate[i ^ 3, {i, {2, x ^ 4, a}}]
-     : Manipulate[] only works inside a Jupyter notebook.
-     = Manipulate[i ^ 3, {i, {2, x ^ 4, a}}]
-
-    >> Manipulate[x ^ y, {x, 1, 20}, {y, 1, 3}]
-     : Manipulate[] only works inside a Jupyter notebook.
-     = Manipulate[x ^ y, {x, 1, 20}, {y, 1, 3}]
-
-    >> Manipulate[N[1 / x], {{x, 1}, 0, 2}]
-     : Manipulate[] only works inside a Jupyter notebook.
-     = Manipulate[N[1 / x], {{x, 1}, 0, 2}]
-
-    >> Manipulate[N[1 / x], {{x, 1}, 0, 2, 0.1}]
-     : Manipulate[] only works inside a Jupyter notebook.
-     = Manipulate[N[1 / x], {{x, 1}, 0, 2, 0.1}]
-    """
-
-    # TODO: correct in the jupyter interface but can't be checked in tests
-    """
-    #> Manipulate[x, {x}]
-     = Manipulate[x, {x}]
-
-    #> Manipulate[x, {x, 1, 0}]
-     : 'Illegal variable range or step parameters for `x`.
-     = Manipulate[x, {x, 1, 0}]
-    """
-    attributes = (
-        A_HOLD_ALL | A_PROTECTED
-    )  # we'll call ReleaseHold at the time of evaluation below
-
-    messages = {
-        "jupyter": "Manipulate[] only works inside a Jupyter notebook.",
-        "imathics": "Your IMathics kernel does not seem to support all necessary operations. "
-        + "Please check that you have the latest version installed.",
-        "widgetmake": 'Jupyter widget construction failed with "``".',
-        "widgetargs": "Illegal variable range or step parameters for ``.",
-        "widgetdisp": "Jupyter failed to display the widget.",
-    }
-
-    no_doc = True  # This largely doesn't work
-
-    requires = ("ipywidgets",)
-    summary_text = "interactively manipulate any expression, graphic, or other object"
-
-    def eval(self, expr, args, evaluation):
-        "Manipulate[expr_, args__]"
-        if (not _jupyter) or (not Kernel.initialized()) or (Kernel.instance() is None):
-            return evaluation.message("Manipulate", "jupyter")
-
-        instantiator = (
-            _WidgetInstantiator()
-        )  # knows about the arguments and their widgets
-
-        for arg in args.get_sequence():
-            try:
-                if not instantiator.add(
-                    arg, evaluation
-                ):  # not a valid argument pattern?
-                    return
-            except IllegalWidgetArguments as e:
-                return evaluation.message(
-                    "Manipulate", "widgetargs", strip_context(str(e.var))
-                )
-            except JupyterWidgetError as e:
-                return evaluation.message("Manipulate", "widgetmake", e.err)
-
-        clear_output_callback = evaluation.output.clear
-        display_data_callback = evaluation.output.display  # for pushing updates
-
-        try:
-            clear_output_callback(wait=True)
-        except NotImplementedError:
-            return evaluation.message("Manipulate", "imathics")
-
-        def callback(**kwargs):
-            clear_output_callback(wait=True)
-
-            line_no = evaluation.definitions.get_line_no()
-
-            vars = [
-                Expression(SymbolSet, Symbol(name), value)
-                for name, value in kwargs.items()
-            ]
-            evaluatable = Expression(
-                SymbolReleaseHold, Expression(SymbolModule, ListExpression(*vars), expr)
-            )
-
-            result = evaluation.evaluate(evaluatable, timeout=settings.TIMEOUT)
-            if result:
-                display_data_callback(data=result.result, metadata={})
-
-            evaluation.definitions.set_line_no(
-                line_no
-            )  # do not increment line_no for manipulate computations
-
-        widgets = instantiator.get_widgets()
-        if len(widgets) > 0:
-            box = _interactive(
-                instantiator.build_callback(callback), widgets
-            )  # create the widget
-            formatter = IPythonDisplayFormatter()
-            if not formatter(box):  # make the widget appear on the Jupyter notebook
-                return evaluation.message("Manipulate", "widgetdisp")
-
-        return Symbol(
-            "Null"
-        )  # the interactive output is pushed via kernel.display_data_callback (see above)
+#     _ipywidgets = True
+# except ImportError:
+#     # fallback to non-Manipulate-enabled build if we don't have ipywidgets installed.
+#     _ipywidgets = False
+
+
+# SymbolModule = Symbol("Module")
+# SymbolReleaseHold = Symbol("ReleaseHold")
+
+# """
+# A basic implementation of Manipulate[]. There is currently no support for Dynamic[] elements.
+# This implementation is basically a port from ipywidget.widgets.interaction for Mathics.
+# """
+
+
+# def _interactive(interact_f, kwargs_widgets):
+#     # this is a modified version of interactive() in ipywidget.widgets.interaction
+
+#     container = Box(_dom_classes=["widget-interact"])
+#     container.children = [w for w in kwargs_widgets if isinstance(w, DOMWidget)]
+
+#     def call_f(name=None, old=None, new=None):
+#         kwargs = dict((widget._kwarg, widget.value) for widget in kwargs_widgets)
+#         try:
+#             interact_f(**kwargs)
+#         except Exception as e:
+#             container.log.warn("Exception in interact callback: %s", e, exc_info=True)
+
+#     for widget in kwargs_widgets:
+#         widget.on_trait_change(call_f, "value")
+
+#     container.on_displayed(lambda _: call_f(None, None, None))
+
+#     return container
+
+
+# class IllegalWidgetArguments(Exception):
+#     def __init__(self, var):
+#         super(IllegalWidgetArguments, self).__init__()
+#         self.var = var
+
+
+# class JupyterWidgetError(Exception):
+#     def __init__(self, err):
+#         super(JupyterWidgetError, self).__init__()
+#         self.err = err
+
+
+# class ManipulateParameter(
+#     Builtin
+# ):  # parses one Manipulate[] parameter spec, e.g. {x, 1, 2}, see _WidgetInstantiator
+#     context = "System`Private`"
+
+#     rules = {
+#         # detect x and {x, default} and {x, default, label}.
+#         "System`Private`ManipulateParameter[{s_Symbol, r__}]": "System`Private`ManipulateParameter[{Symbol -> s, Label -> s}, {r}]",
+#         "System`Private`ManipulateParameter[{{s_Symbol, d_}, r__}]": "System`Private`ManipulateParameter[{Symbol -> s, Default -> d, Label -> s}, {r}]",
+#         "System`Private`ManipulateParameter[{{s_Symbol, d_, l_}, r__}]": "System`Private`ManipulateParameter[{Symbol -> s, Default -> d, Label -> l}, {r}]",
+#         # detect different kinds of widgets. on the use of the duplicate key "Default ->", see _WidgetInstantiator.add()
+#         "System`Private`ManipulateParameter[var_, {min_?RealNumberQ, max_?RealNumberQ}]": 'Join[{Type -> "Continuous", Minimum -> min, Maximum -> max, Default -> min}, var]',
+#         "System`Private`ManipulateParameter[var_, {min_?RealNumberQ, max_?RealNumberQ, step_?RealNumberQ}]": 'Join[{Type -> "Discrete", Minimum -> min, Maximum -> max, Step -> step, Default -> min}, var]',
+#         "System`Private`ManipulateParameter[var_, {opt_List}] /; Length[opt] > 0": 'Join[{Type -> "Options", Options -> opt, Default -> Part[opt, 1]}, var]',
+#     }
+
+#     summary_text = "interactive manipulation (not implemented yet)"
+
+
+# def _manipulate_label(x):  # gets the label that is displayed for a symbol or name
+#     if isinstance(x, String):
+#         return x.get_string_value()
+#     elif isinstance(x, Symbol):
+#         return strip_context(x.get_name())
+#     else:
+#         return str(x)
+
+
+# def _create_widget(widget, **kwargs):
+#     try:
+#         return widget(**kwargs)
+#     except Exception as e:
+#         raise JupyterWidgetError(str(e))
+
+
+# class _WidgetInstantiator:
+#     # we do not want to have widget instances (like FloatSlider) get into the evaluation pipeline (e.g. via Expression
+#     # or Atom), since there might be all kinds of problems with serialization of these widget classes.  therefore, the
+#     # elegant recursive solution for parsing parameters (like in Table[]) is not feasible here; instead, we must create
+#     # and use the widgets in one "transaction" here, without holding them in expressions or atoms.
+
+#     def __init__(self):
+#         self._widgets = []  # the ipywidget widgets to control the manipulated variables
+#         self._parsers = (
+#             {}
+#         )  # lambdas to decode the widget values into Mathics expressions
+
+#     def add(self, expression, evaluation):
+#         expr = Expression("System`Private`ManipulateParameter", expression).evaluate(
+#             evaluation
+#         )
+#         if (
+#             expr.get_head_name() != "System`List"
+#         ):  # if everything was parsed ok, we get a List
+#             return False
+#         # convert the rules given us by ManipulateParameter[] into a dict. note: duplicate keys
+#         # will be overwritten, the latest one wins.
+#         kwargs = {"evaluation": evaluation}
+#         for rule in expr.elements:
+#             if rule.get_head_name() != "System`Rule" or len(rule.elements) != 2:
+#                 return False
+#             kwargs[strip_context(rule.elements[0].to_python()).lower()] = rule.elements[
+#                 1
+#             ]
+#         widget = kwargs["type"].get_string_value()
+#         del kwargs["type"]
+#         getattr(self, "_add_%s_widget" % widget.lower())(**kwargs)  # create the widget
+#         return True
+
+#     def get_widgets(self):
+#         return self._widgets
+
+#     def build_callback(self, callback):
+#         parsers = self._parsers
+
+#         def new_callback(**kwargs):
+#             callback(
+#                 **dict((name, parsers[name](value)) for (name, value) in kwargs.items())
+#             )
+
+#         return new_callback
+
+#     def _add_continuous_widget(
+#         self, symbol, label, default, minimum, maximum, evaluation
+#     ):
+#         minimum_value = minimum.to_python()
+#         maximum_value = maximum.to_python()
+#         if minimum_value > maximum_value:
+#             raise IllegalWidgetArguments(symbol)
+#         else:
+#             defval = min(max(default.to_python(), minimum_value), maximum_value)
+#             widget = _create_widget(
+#                 FloatSlider, value=defval, min=minimum_value, max=maximum_value
+#             )
+#             self._add_widget(widget, symbol.get_name(), lambda x: from_python(x), label)
+
+#     def _add_discrete_widget(
+#         self, symbol, label, default, minimum, maximum, step, evaluation
+#     ):
+#         minimum_value = minimum.to_python()
+#         maximum_value = maximum.to_python()
+#         step_value = step.to_python()
+#         if (
+#             minimum_value > maximum_value
+#             or step_value <= 0
+#             or step_value > (maximum_value - minimum_value)
+#         ):
+#             raise IllegalWidgetArguments(symbol)
+#         else:
+#             default_value = min(max(default.to_python(), minimum_value), maximum_value)
+#             if all(isinstance(x, Integer) for x in [minimum, maximum, default, step]):
+#                 widget = _create_widget(
+#                     IntSlider,
+#                     value=default_value,
+#                     min=minimum_value,
+#                     max=maximum_value,
+#                     step=step_value,
+#                 )
+#             else:
+#                 widget = _create_widget(
+#                     FloatSlider,
+#                     value=default_value,
+#                     min=minimum_value,
+#                     max=maximum_value,
+#                     step=step_value,
+#                 )
+#             self._add_widget(widget, symbol.get_name(), lambda x: from_python(x), label)
+
+#     def _add_options_widget(self, symbol, options, default, label, evaluation):
+#         formatted_options = []
+#         for i, option in enumerate(options.elements):
+#             data = evaluation.format_output(option, format="text")
+#             formatted_options.append((data, i))
+
+#         default_index = 0
+#         for i, option in enumerate(options.elements):
+#             if option.sameQ(default):
+#                 default_index = i
+
+#         widget = _create_widget(
+#             ToggleButtons, options=formatted_options, value=default_index
+#         )
+#         self._add_widget(
+#             widget, symbol.get_name(), lambda j: options.elements[j], label
+#         )
+
+#     def _add_widget(self, widget, name, parse, label):
+#         if not widget.description:
+#             widget.description = _manipulate_label(label)
+#         widget._kwarg = name  # see _interactive() above
+#         self._parsers[name] = parse
+#         self._widgets.append(widget)
+
+
+# class ManipulateOutput(Output):
+#     def max_stored_size(self, settings):
+#         return self.output.max_stored_size(settings)
+
+#     def out(self, out):
+#         return self.output.out(out)
+
+#     def clear_output(wait=False):
+#         raise NotImplementedError
+
+#     def display_data(self, result):
+#         raise NotImplementedError
+
+
+# class Manipulate(Builtin):
+#     """
+#     <url>
+#     :WMA link:
+#     https://reference.wolfram.com/language/ref/Manipulate.html</url>
+
+#     <dl>
+#       <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$}]'
+#       <dd>interactively compute and display an expression with different values of $u$.
+
+#       <dt>'Manipulate[$expr1$, {$u$, $u_min$, $u_max$, $du$}]'
+#       <dd>allows $u$ to vary between $u_min$ and $u_max$ in steps of $du$.
+
+#       <dt>'Manipulate[$expr1$, {{$u$, $u_init$}, $u_min$, $u_max$, ...}]'
+#       <dd>starts with initial value of $u_init$.
+
+#       <dt>'Manipulate[$expr1$, {{$u$, $u_init$, $u_lbl$}, ...}]'
+#       <dd>labels the $u$ controll by $u_lbl$.
+
+#       <dt>'Manipulate[$expr1$, {$u$, {$u_1$, $u_2$, ...}}]'
+#       <dd>sets $u$ to take discrete values $u_1$, $u_2$, ... .
+
+#       <dt>'Manipulate[$expr1$, {$u$, ...}, {$v$, ...}, ...]'
+#       <dd>control each of $u$, $v$, ... .
+#     </dl>
+
+#     >> Manipulate[N[Sin[y]], {y, 1, 20, 2}]
+#      : Manipulate[] only works inside a Jupyter notebook.
+#      = Manipulate[N[Sin[y]], {y, 1, 20, 2}]
+
+#     >> Manipulate[i ^ 3, {i, {2, x ^ 4, a}}]
+#      : Manipulate[] only works inside a Jupyter notebook.
+#      = Manipulate[i ^ 3, {i, {2, x ^ 4, a}}]
+
+#     >> Manipulate[x ^ y, {x, 1, 20}, {y, 1, 3}]
+#      : Manipulate[] only works inside a Jupyter notebook.
+#      = Manipulate[x ^ y, {x, 1, 20}, {y, 1, 3}]
+
+#     >> Manipulate[N[1 / x], {{x, 1}, 0, 2}]
+#      : Manipulate[] only works inside a Jupyter notebook.
+#      = Manipulate[N[1 / x], {{x, 1}, 0, 2}]
+
+#     >> Manipulate[N[1 / x], {{x, 1}, 0, 2, 0.1}]
+#      : Manipulate[] only works inside a Jupyter notebook.
+#      = Manipulate[N[1 / x], {{x, 1}, 0, 2, 0.1}]
+#     """
+
+#     # TODO: correct in the jupyter interface but can't be checked in tests
+#     """
+#     #> Manipulate[x, {x}]
+#      = Manipulate[x, {x}]
+
+#     #> Manipulate[x, {x, 1, 0}]
+#      : 'Illegal variable range or step parameters for `x`.
+#      = Manipulate[x, {x, 1, 0}]
+#     """
+#     attributes = (
+#         A_HOLD_ALL | A_PROTECTED
+#     )  # we'll call ReleaseHold at the time of evaluation below
+
+#     messages = {
+#         "jupyter": "Manipulate[] only works inside a Jupyter notebook.",
+#         "imathics": "Your IMathics kernel does not seem to support all necessary operations. "
+#         + "Please check that you have the latest version installed.",
+#         "widgetmake": 'Jupyter widget construction failed with "``".',
+#         "widgetargs": "Illegal variable range or step parameters for ``.",
+#         "widgetdisp": "Jupyter failed to display the widget.",
+#     }
+
+#     no_doc = True  # This largely doesn't work
+
+#     requires = ("ipywidgets",)
+#     summary_text = "interactively manipulate any expression, graphic, or other object"
+
+#     def eval(self, expr, args, evaluation):
+#         "Manipulate[expr_, args__]"
+#         if (not _jupyter) or (not Kernel.initialized()) or (Kernel.instance() is None):
+#             return evaluation.message("Manipulate", "jupyter")
+
+#         instantiator = (
+#             _WidgetInstantiator()
+#         )  # knows about the arguments and their widgets
+
+#         for arg in args.get_sequence():
+#             try:
+#                 if not instantiator.add(
+#                     arg, evaluation
+#                 ):  # not a valid argument pattern?
+#                     return
+#             except IllegalWidgetArguments as e:
+#                 return evaluation.message(
+#                     "Manipulate", "widgetargs", strip_context(str(e.var))
+#                 )
+#             except JupyterWidgetError as e:
+#                 return evaluation.message("Manipulate", "widgetmake", e.err)
+
+#         clear_output_callback = evaluation.output.clear
+#         display_data_callback = evaluation.output.display  # for pushing updates
+
+#         try:
+#             clear_output_callback(wait=True)
+#         except NotImplementedError:
+#             return evaluation.message("Manipulate", "imathics")
+
+#         def callback(**kwargs):
+#             clear_output_callback(wait=True)
+
+#             line_no = evaluation.definitions.get_line_no()
+
+#             vars = [
+#                 Expression(SymbolSet, Symbol(name), value)
+#                 for name, value in kwargs.items()
+#             ]
+#             evaluatable = Expression(
+#                 SymbolReleaseHold, Expression(SymbolModule, ListExpression(*vars), expr)
+#             )
+
+#             result = evaluation.evaluate(evaluatable, timeout=settings.TIMEOUT)
+#             if result:
+#                 display_data_callback(data=result.result, metadata={})
+
+#             evaluation.definitions.set_line_no(
+#                 line_no
+#             )  # do not increment line_no for manipulate computations
+
+#         widgets = instantiator.get_widgets()
+#         if len(widgets) > 0:
+#             box = _interactive(
+#                 instantiator.build_callback(callback), widgets
+#             )  # create the widget
+#             formatter = IPythonDisplayFormatter()
+#             if not formatter(box):  # make the widget appear on the Jupyter notebook
+#                 return evaluation.message("Manipulate", "widgetdisp")
+
+#         return Symbol(
+#             "Null"
+#         )  # the interactive output is pushed via kernel.display_data_callback (see above)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1325,13 +1325,13 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             return False
         if self is other:
             return True
-        if not self._head.sameQ(other.get_head()):
+        if not self._head.sameQ(other._head):
             return False
-        if len(self._elements) != len(other.get_elements()):
+        if len(self._elements) != len(other._elements):
             return False
         return all(
             (id(element) == id(oelement) or element.sameQ(oelement))
-            for element, oelement in zip(self._elements, other.get_elements())
+            for element, oelement in zip(self._elements, other._elements)
         )
 
     def sequences(self):

--- a/mathics/version.py
+++ b/mathics/version.py
@@ -5,4 +5,4 @@
 # well as importing into Python. That's why there is no
 # space around "=" below.
 # fmt: off
-__version__="5.0.3dev0"  # noqa
+__version__="6.0.0dev0"  # noqa

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,6 +1,8 @@
 # Optional packages which add functionality or speed things up
-psutil # SystemMemory and MemoryAvailable
-scikit-image >= 0.17 # FindMinimum can use this; used by Image as well
+ipywidgets  # For Manipulate
 lxml  # for HTML parsing used in builtin/fileformats/html
-wordcloud # Used in builtin/image.py by WordCloud()
+psutil # SystemMemory and MemoryAvailable
 pyocr # Used for TextRecognize
+scikit-image >= 0.17 # FindMinimum can use this; used by Image as well
+unidecode # Used in Transliterate
+wordcloud # Used in builtin/image.py by WordCloud()

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ INSTALL_REQUIRES = [
     # Pillow 9.1.0 supports BigTIFF with big-endian byte order.
     # ExampleData image hedy.tif is in this format.
     # Pillow 9.2 handles sunflowers.jpg
-    "pillow >= 9.2.0",
 ]
 
 # Ensure user has the correct Python version
@@ -57,6 +56,7 @@ elif sys.version_info[:2] == (3, 6):
         "recordclass",
         "numpy",
         "llvmlite<0.37",
+        "pillow >= 8.4.0",
         "sympy>=1.8,<1.12",
     ]
     if is_PyPy:

--- a/test/core/test_expression.py
+++ b/test/core/test_expression.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from test.helper import check_evaluation
+from test.helper import check_evaluation, evaluate_value
 
 import pytest
 
 from mathics.builtin.base import check_requires_list
+from mathics.core.expression import Expression
+from mathics.core.symbols import Symbol, SymbolPlus, SymbolTimes
 
 
 # FIXME: come up with an example that doesn't require skimage.
@@ -25,3 +27,35 @@ def test_canonical_sort():
         r"SortBy[Table[IntegerDigits[2^n], {n, 10}], First]",
         r"{{1, 6}, {1, 2, 8}, {1, 0, 2, 4}, {2}, {2, 5, 6}, {3, 2}, {4}, {5, 1, 2}, {6, 4}, {8}}",
     )
+
+
+def test_Expression_sameQ():
+    """
+    Test Expression.SameQ
+    """
+    symbolX = Symbol("X")
+    expr_plus = Expression(SymbolPlus, symbolX, Symbol("Y"))
+    assert (
+        expr_plus.sameQ(expr_plus) == True
+    ), "should pass when head and elements are the same"
+
+    assert (
+        expr_plus.sameQ(symbolX) == False
+    ), "should fail because 'other' in Expression.SameQ() is not an Expression"
+
+    expr_times = Expression(SymbolTimes, symbolX, Symbol("Y"))
+
+    assert (
+        expr_plus.sameQ(expr_times) == False
+    ), "should fail when Expression head's mismatch"
+
+    expr_plus_copy = Expression(SymbolPlus, symbolX, Symbol("Y"))
+    assert (
+        expr_plus.sameQ(expr_plus_copy) == True
+    ), "should pass when Expressions are different Python objects, but otherwise the same"
+
+    # Try where we compare and expression with something that contains itself
+    nested_expr = Expression(SymbolPlus, expr_plus)
+    assert (
+        nested_expr.sameQ(expr_plus) == False
+    ), "should fail when one expression has the other embedded in it"


### PR DESCRIPTION
 Set requires in builtins; adjust `requirements-full.txt`.
    
 `_SkimageRequires` and `_ImageTest` set only some requires and that wasn't working.
    
But more fundamentally we shouldn't use class inheritance for just setting a class variable.
    
Instead, set the class variable inside the class. This is more direct and clear.
    
Add additional PyPI packages that are used in Manipulate and Transliterate Set requires in builtins; adjust requirements-full.