### PR TITLE
mathics.eval eval_Capital fns

### DIFF
--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -22,7 +22,7 @@ from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.number import MACHINE_EPSILON
 from mathics.core.symbols import SymbolDivide, SymbolMachinePrecision, SymbolTimes
-from mathics.eval.nevaluator import eval_nvalues
+from mathics.eval.nevaluator import eval_NValues
 
 
 def chop(expr, delta=10.0 ** (-10.0)):
@@ -244,12 +244,12 @@ class N(Builtin):
                 preference_queue.pop()
                 return result
 
-        return eval_nvalues(expr, prec, evaluation)
+        return eval_NValues(expr, prec, evaluation)
 
     def eval_N(self, expr, evaluation: Evaluation):
         """N[expr_]"""
         # TODO: Specialize for atoms
-        return eval_nvalues(expr, SymbolMachinePrecision, evaluation)
+        return eval_NValues(expr, SymbolMachinePrecision, evaluation)
 
 
 class Rationalize(Builtin):

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -44,7 +44,7 @@ class All(Predefined):
     >> {{1, 3}, {5, 7}}[[All, 1]]
      = {1, 5}
 
-    while in <url>
+    While in <url>
     :Take:
     /doc/reference-of-built-in-symbols/list-functions/elements-of-lists/part</url>, \
     'All' extracts as a column matrix the first element as a list for each of the list elements:

--- a/mathics/builtin/vectors/math_ops.py
+++ b/mathics/builtin/vectors/math_ops.py
@@ -9,7 +9,7 @@ import sympy
 from mathics.builtin.base import Builtin, SympyFunction
 from mathics.core.attributes import A_PROTECTED
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
-from mathics.eval.math_ops import eval_2_Norm, eval_p_norm
+from mathics.eval.math_ops import eval_Norm, eval_Norm_p
 
 
 class Cross(Builtin):
@@ -32,7 +32,7 @@ class Cross(Builtin):
     >> Cross[{x1, y1, z1}, {x2, y2, z2}]
      = {y1 z2 - y2 z1, -x1 z2 + x2 z1, x1 y2 - x2 y1}
 
-    Cross is antisymmetric, so:
+    'Cross' is antisymmetric, so:
 
     >> Cross[{x, y}]
      = {-y, x}
@@ -43,6 +43,7 @@ class Cross(Builtin):
      = {-Sqrt[3], 1}
 
     Visualize this:
+
     >> Graphics[{Arrow[{{0, 0}, v1}], Red, Arrow[{{0, 0}, v2}]}, Axes -> True]
      = -Graphics-
 
@@ -60,8 +61,9 @@ class Cross(Builtin):
             "their length."
         )
     }
+
     rules = {"Cross[{x_, y_}]": "{-y, x}"}
-    summary_text = "vector cross product"
+    summary_text = "get vector cross product"
 
     def eval(self, a, b, evaluation):
         "Cross[a_, b_]"
@@ -121,14 +123,15 @@ class Curl(SympyFunction):
            D[f2, x1] - D[f1, x2]
          }""",
     }
-    summary_text = "curl vector operator"
+    summary_text = "get vector curl"
     sympy_name = "curl"
 
 
 class Norm(Builtin):
     """
     <url>
-    :Matrix norms induced by vector p-norms: https://en.wikipedia.org/wiki/Matrix_norm#Matrix_norms_induced_by_vector_p-norms</url> (<url>
+    :Matrix norms induced by vector p-norms:
+    https://en.wikipedia.org/wiki/Matrix_norm#Matrix_norms_induced_by_vector_p-norms</url> (<url>
     :SymPy:
     https://docs.sympy.org/latest/modules/matrices/matrices.html#sympy.matrices.matrices.MatrixBase.norm</url>, <url>
     :WMA:
@@ -142,7 +145,7 @@ class Norm(Builtin):
      <dd>computes the 2-norm of matrix m.
     </dl>
 
-    The Norm of of a vector is its Euclidean distance:
+    The 'Norm' of of a vector is its Euclidean distance:
     >> Norm[{x, y, z}]
      = Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2 + Abs[z] ^ 2]
 
@@ -163,7 +166,7 @@ class Norm(Builtin):
     For complex numbers, 'Norm[$z$]' is 'Abs[$z$]':
     >> Norm[1 + I]
      = Sqrt[2]
-    so the norm is always real even when the input is complex.
+    So the norm is always real, even when the input is complex.
 
 
     'Norm'[$m$,"Frobenius"] gives the Frobenius norm of $m$:
@@ -186,15 +189,15 @@ class Norm(Builtin):
         "Norm[m_?NumberQ]": "Abs[m]",
         "Norm[m_?VectorQ, DirectedInfinity[1]]": "Max[Abs[m]]",
     }
-    summary_text = "norm of a vector or matrix"
+    summary_text = "get norm of a vector or matrix"
 
-    def eval_two_norm(self, m, evaluation):
+    def eval(self, m, evaluation):
         "Norm[m_]"
-        return eval_2_Norm(m, evaluation)
+        return eval_Norm(m, evaluation)
 
-    def eval_p_norm(self, m, p, evaluation):
+    def eval_with_p(self, m, p, evaluation):
         "Norm[m_, p_]"
-        return eval_p_norm(m, p, evaluation)
+        return eval_Norm_p(m, p, evaluation)
 
 
 # TODO: Div

--- a/mathics/eval/math_ops.py
+++ b/mathics/eval/math_ops.py
@@ -7,9 +7,9 @@ from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol
 
 
-def eval_2_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
+def eval_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
     """
-    2-Norm[] evaluation function
+    Norm[m] evaluation function - the 2-norm of matrix m
     """
     sympy_m = to_sympy_matrix(m)
     if sympy_m is None:
@@ -19,11 +19,11 @@ def eval_2_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
     return from_sympy(sympy_m.norm())
 
 
-def eval_p_norm(
+def eval_Norm_p(
     m: Expression, p: Expression, evaluation: Evaluation
 ) -> Optional[Expression]:
     """
-    p2-Norm[] evaluation function
+    Norm[m, p] evaluation function - the p-norm of matrix m.
     """
     if isinstance(p, Symbol):
         sympy_p = p.to_sympy()

--- a/mathics/eval/nevaluator.py
+++ b/mathics/eval/nevaluator.py
@@ -46,9 +46,9 @@ def eval_NValues(
     expr: BaseElement, prec: BaseElement, evaluation: Evaluation
 ) -> Optional[BaseElement]:
     """
-    Looks for the numeric value of ```expr`` with precision ``prec`` by appling NValues rules
+    Looks for the numeric value of ```expr`` with precision ``prec`` by applying NValues rules
     stored in ``evaluation.definitions``.
-    If `prec` can not be evaluated as a number, returns None, otherwise, returns an expression.
+    If ``prec`` can not be evaluated as a number, returns None, otherwise, returns an expression.
     """
 
     # The first step is to determine the precision goal

--- a/mathics/eval/nevaluator.py
+++ b/mathics/eval/nevaluator.py
@@ -34,7 +34,7 @@ def eval_N(
     Equivalent to Expression(SymbolN, expression).evaluate(evaluation)
     """
     evaluated_expression = expression.evaluate(evaluation)
-    result = eval_nvalues(evaluated_expression, prec, evaluation)
+    result = eval_NValues(evaluated_expression, prec, evaluation)
     if result is None:
         return expression
     if isinstance(result, Number):
@@ -42,7 +42,7 @@ def eval_N(
     return result.evaluate(evaluation)
 
 
-def eval_nvalues(
+def eval_NValues(
     expr: BaseElement, prec: BaseElement, evaluation: Evaluation
 ) -> Optional[BaseElement]:
     """
@@ -67,14 +67,14 @@ def eval_nvalues(
 
     # If expr is a List, or a Rule (or maybe expressions with heads for
     # which we are sure do not have NValues or special attributes)
-    # just apply `eval_nvalues` to each element and return the new list.
+    # just apply `eval_NValues` to each element and return the new list.
     if expr.get_head_name() in ("System`List", "System`Rule"):
         elements = expr.elements
 
         # FIXME: incorporate these lines into Expression call
         result = Expression(expr.head)
         new_elements = [
-            eval_nvalues(element, prec, evaluation) for element in expr.elements
+            eval_NValues(element, prec, evaluation) for element in expr.elements
         ]
         result.elements = tuple(
             new_element if new_element else element
@@ -91,7 +91,7 @@ def eval_nvalues(
     # Here we look for the NValues associated to the
     # lookup_name of the expression.
     # If a rule is found and successfuly applied,
-    # reevaluate the result and apply `eval_nvalues` again.
+    # reevaluate the result and apply `eval_NValues` again.
     # This should be implemented as a loop instead of
     # recursively.
     name = expr.get_lookup_name()
@@ -103,7 +103,7 @@ def eval_nvalues(
         if result is not None:
             if not result.sameQ(nexpr):
                 result = result.evaluate(evaluation)
-                result = eval_nvalues(result, prec, evaluation)
+                result = eval_NValues(result, prec, evaluation)
                 return result
 
     # If we are here, is because there are not NValues that matches
@@ -113,7 +113,7 @@ def eval_nvalues(
         return expr
     else:
         # Otherwise, look at the attributes, determine over which elements
-        # we need to apply `eval_nvalues`, and rebuild the expression with
+        # we need to apply `eval_NValues`, and rebuild the expression with
         # the results.
         attributes = expr.head.get_attributes(evaluation.definitions)
         head = expr.head
@@ -130,11 +130,11 @@ def eval_nvalues(
         else:
             eval_range = range(len(elements))
 
-        newhead = eval_nvalues(head, prec, evaluation)
+        newhead = eval_NValues(head, prec, evaluation)
         head = head if newhead is None else newhead
 
         for index in eval_range:
-            new_element = eval_nvalues(elements[index], prec, evaluation)
+            new_element = eval_NValues(elements[index], prec, evaluation)
             if new_element:
                 elements[index] = new_element
 

--- a/test/test_evaluators.py
+++ b/test/test_evaluators.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from mathics.eval.nevaluator import eval_N, eval_nvalues
+from mathics.eval.nevaluator import eval_N, eval_NValues
 from mathics.eval.numerify import numerify as eval_numerify
 from mathics.session import MathicsSession
 
@@ -57,10 +57,10 @@ def test_eval_N(str_expr, prec, str_expected):
     "str_expr, prec, str_expected, setup",
     [
         ("1", "$MachinePrecision", "1.000000000", None),
-        # eval_nvalues does not call  `evaluate` over the input expression. So
+        # eval_NValues does not call  `evaluate` over the input expression. So
         # 2/9 is not evaluated to a Rational number, but kept as a division.
         ("2/9", "$MachinePrecision", "2.000000`5*9.0000000000`5^(-1.`)", None),
-        # eval_nvalues does not call  `evaluate` at the end neither. So
+        # eval_NValues does not call  `evaluate` at the end neither. So
         # Sqrt[2]->Sqrt[2.0`]
         ("Sqrt[2]", "$MachinePrecision", "Sqrt[2.0`]", None),
         ("Pi", "$MachinePrecision", "3.141592653589793`15", None),
@@ -77,13 +77,13 @@ def test_eval_N(str_expr, prec, str_expected):
         ("F[b, 2/9]", "5", "F[1.20`3, 2.*9.^(-1.`)]", "N[b,_]=1.2`3"),
     ],
 )
-def test_eval_nvalues(str_expr, prec, str_expected, setup):
+def test_eval_NValues(str_expr, prec, str_expected, setup):
     if setup:
         session.evaluate(setup)
     expr_in = session.evaluate(f"Hold[{str_expr}]").elements[0]
     prec = session.evaluate(prec)
     expr_expected = session.evaluate(f"Hold[{str_expected}]").elements[0]
-    result = eval_nvalues(expr_in, prec, evaluation)
+    result = eval_NValues(expr_in, prec, evaluation)
     session.evaluate("ClearAll[a,b,c]")
     assert expr_expected.sameQ(result)
 
@@ -95,7 +95,7 @@ def test_eval_nvalues(str_expr, prec, str_expected, setup):
         ("{1, 1.}", "{1, 1.}", None),
         ("{1.000123`6, 1.0001`4, 2/9}", "{1.000123`6, 1.0001`4, .22222`4}", None),
         ("F[1.000123`6, 1.0001`4, 2/9]", "F[1.000123`6, 1.0001`4, .22222`4]", None),
-        # eval_nvalues does not call  `evaluate` over the input expression. So
+        # eval_NValues does not call  `evaluate` over the input expression. So
         # 2/9 is not evaluated to a Rational number, but kept as a division.
         ("2/9", "2 * 9 ^ (-1)", None),
         ("Sqrt[2]", "Sqrt[2]", None),


### PR DESCRIPTION
Go over mathics.eval putting eval functions that might go into an instruction interpreter in the form eval_[Mathics-builtin-name] when there is only one evaluation function and some variation of that when there is more than one.

Some docstrings and summaries have been revised.