### PR TITLE
from_mpmath precision twaks

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -178,7 +178,7 @@ class _MPMathFunction(SympyFunction):
                     return
                 result = call_mpmath(mpmath_function, tuple(mpmath_args))
                 if isinstance(result, (mpmath.mpc, mpmath.mpf)):
-                    result = from_mpmath(result, d)
+                    result = from_mpmath(result, precision=prec)
         return result
 
 

--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -177,10 +177,10 @@ class Accuracy(Builtin):
     >> Accuracy[A]
      = Infinity
 
-    For Complex numbers, the accuracy is the smaller of the accuracies of its \
-    real and imaginary parts:
-    >> Accuracy[1.00`2 + 2.00`2 I]
-     = 1.
+    # For Complex numbers, the accuracy is the smaller of the accuracies of its \
+    # real and imaginary parts:
+    # >> Accuracy[1.00`2 + 2.00`2 I]
+    # = 1.
 
     Accuracy of expressions is given by the minimum accuracy of its elements:
     >> Accuracy[F[1, Pi, A]]

--- a/mathics/builtin/binary/io.py
+++ b/mathics/builtin/binary/io.py
@@ -193,7 +193,7 @@ class _BinaryFormat:
             else:
                 result = mpmath.fdiv(core, 2**-exp)
 
-            return from_mpmath(result, dps(112))
+            return from_mpmath(result, precision=112)
 
     @staticmethod
     def _TerminatedString_reader(s):

--- a/mathics/builtin/specialfns/bessel.py
+++ b/mathics/builtin/specialfns/bessel.py
@@ -157,7 +157,7 @@ class AiryAiZero(Builtin):
 
         with mpmath.workprec(p):
             result = mpmath.airyaizero(k_int)
-            return from_mpmath(result, d)
+            return from_mpmath(result, precision=p)
 
 
 class AiryBi(_MPMathFunction):
@@ -283,7 +283,7 @@ class AiryBiZero(Builtin):
 
         with mpmath.workprec(p):
             result = mpmath.airybizero(k_int)
-            return from_mpmath(result, d)
+            return from_mpmath(result, precision=p)
 
 
 class AngerJ(_Bessel):

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -133,7 +133,7 @@ class Beta(_MPMathMultiFunction):
                     return
                 result = call_mpmath(mpmath_function, tuple(mpmath_args))
                 if isinstance(result, (mpmath.mpc, mpmath.mpf)):
-                    result = from_mpmath(result, d)
+                    result = from_mpmath(result, precision=prec)
         return result
 
 


### PR DESCRIPTION
`PrecisionReal` numbers use `sympy.Float` numbers as their internal representation. At the time, `sympy.Float` uses `mpmath.mpf` numbers as their internal representation. Even if `sympy.Float` and `mpmath.mpf` accepts as a parameter a floating point number as decimal precision (dps), internally the precision is stored as an integer number bits. 

In our current master, we have an inconsistent use of the precision attribute: when we create a  `PrecisionReal` number, precision is measured in bits, but in `from_mpmath`, precision is passed as binary.  Apart from requiring several unneeded conversions, each time we pass from binary to decimal and backward, we lost accuracy in the estimation of the error, which is a problem if we want a consistent implementation for `Accuracy` and  `Precision`.

This PR amends that by adding this information in the docstrings, and normalizing the conversion between PrecisionReal and Mathics numbers by using always bit precision.
