### PR TITLE
mathics.core.pymathics -> mathics.eval.pymathics

### DIFF
--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -17,9 +17,9 @@ from mathics.core.attributes import (
     A_PROTECTED,
     A_SEQUENCE_HOLD,
 )
-from mathics.core.pymathics import PyMathicsLoadException, eval_load_module
 from mathics.core.symbols import SymbolNull
 from mathics.core.systemsymbols import SymbolFailed
+from mathics.eval.pymathics import PyMathicsLoadException, eval_LoadModule
 
 
 class _SetOperator:
@@ -83,7 +83,7 @@ class LoadModule(Builtin):
     def eval(self, module, evaluation):
         "LoadModule[module_String]"
         try:
-            eval_load_module(module.value, evaluation)
+            eval_LoadModule(module.value, evaluation)
         except PyMathicsLoadException:
             evaluation.message(self.name, "notmathicslib", module)
             return SymbolFailed

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -110,7 +110,7 @@ class Definitions:
         # Rocky: this smells of something not quite right in terms of
         # modularity.
         import mathics.format  # noqa
-        from mathics.core.pymathics import PyMathicsLoadException, load_pymathics_module
+        from mathics.eval.pymathics import PyMathicsLoadException, load_pymathics_module
 
         self.printforms = list(PrintForms)
         self.outputforms = list(OutputForms)

--- a/mathics/eval/pymathics.py
+++ b/mathics/eval/pymathics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyMathics3 module handling
 """
@@ -24,7 +23,7 @@ class PyMathicsLoadException(Exception):
         self.module = module
 
 
-def eval_load_module(module_name: str, evaluation: Evaluation) -> str:
+def eval_LoadModule(module_name: str, evaluation: Evaluation) -> str:
     try:
         load_pymathics_module(evaluation.definitions, module_name)
     except (PyMathicsLoadException, ImportError):


### PR DESCRIPTION
What is in mathics.eval is primarily for builtin LoadModule

mathics.core are for atoms, symbols, parsing, conversion - things at the very lowest level that aren't focused directly around evaluation of a particular Mathics3 builtin function.