### PR TITLE
Reinstate pymathics doc

### DIFF
--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -66,17 +66,17 @@ class LoadModule(Builtin):
       <dd>'Load Mathics definitions from the python module $module$
     </dl>
     >> LoadModule["nomodule"]
-     : Python module nomodule does not exist.
+     : Problem importing Python module: nomodule.
      = $Failed
     >> LoadModule["sys"]
-     : Python module sys is not a pymathics module.
+     : Python module "sys" is not a Mathics3 module.
      = $Failed
     """
 
     name = "LoadModule"
     messages = {
-        "notfound": "Python module `1` does not import.",
-        "notmathicslib": "Python module `1` is not a Mathics3 module.",
+        "notfound": """Problem importing Python module: `1`.""",
+        "notmathicslib": """Python module "`1`" is not a Mathics3 module.""",
     }
     summary_text = "load a pymathics module"
 

--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -75,8 +75,8 @@ class LoadModule(Builtin):
 
     name = "LoadModule"
     messages = {
-        "notfound": "Python module `1` does not exist.",
-        "notmathicslib": "Python module `1` is not a pymathics module.",
+        "notfound": "Python module `1` does not import.",
+        "notmathicslib": "Python module `1` is not a Mathics3 module.",
     }
     summary_text = "load a pymathics module"
 

--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -11,6 +11,7 @@ from mathics.core.assignment import (
     assign_store_rules_by_tag,
     normalize_lhs,
 )
+from mathics.core.atoms import String
 from mathics.core.attributes import (
     A_HOLD_ALL,
     A_HOLD_FIRST,
@@ -66,7 +67,7 @@ class LoadModule(Builtin):
       <dd>'Load Mathics definitions from the python module $module$
     </dl>
     >> LoadModule["nomodule"]
-     : Problem importing Python module: nomodule.
+     : Python import errors with: No module named 'nomodule'.
      = $Failed
     >> LoadModule["sys"]
      : Python module "sys" is not a Mathics3 module.
@@ -75,7 +76,7 @@ class LoadModule(Builtin):
 
     name = "LoadModule"
     messages = {
-        "notfound": """Problem importing Python module: `1`.""",
+        "loaderror": """Python import errors with: `1`.""",
         "notmathicslib": """Python module "`1`" is not a Mathics3 module.""",
     }
     summary_text = "load a pymathics module"
@@ -87,8 +88,8 @@ class LoadModule(Builtin):
         except PyMathicsLoadException:
             evaluation.message(self.name, "notmathicslib", module)
             return SymbolFailed
-        except ImportError:
-            evaluation.message(self.get_name(), "notfound", module)
+        except Exception as e:
+            evaluation.message(self.get_name(), "loaderror", String(str(e)))
             return SymbolFailed
         return module
 

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -551,6 +551,7 @@ class Unique(Predefined):
     #> Unique[{}]
     = {}
 
+    ## FIXME: include the rest of these in test/builtin/test-unique.py
     ## Each use of Unique[symbol] increments $ModuleNumber:
     ## >> {$ModuleNumber, Unique[x], $ModuleNumber}
     ##  = ...

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -551,7 +551,6 @@ class Unique(Predefined):
     #> Unique[{}]
     = {}
 
-    ## FIXME: include the rest of these in test/builtin/test-unique.py
     ## Each use of Unique[symbol] increments $ModuleNumber:
     ## >> {$ModuleNumber, Unique[x], $ModuleNumber}
     ##  = ...

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -1022,6 +1022,9 @@ class DocText:
     def get_tests(self):
         return []
 
+    def is_private(self):
+        return False
+
     def test_indices(self):
         return []
 
@@ -1033,6 +1036,9 @@ class DocTests:
 
     def get_tests(self):
         return self.tests
+
+    def is_private(self):
+        return all(test.private for test in self.tests)
 
     def __str__(self):
         return "\n".join(str(test) for test in self.tests)

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -437,7 +437,9 @@ class Documentation:
             if module.__file__.endswith("__init__.py"):
                 # We have a Guide Section.
                 name = get_doc_name_from_module(module)
-                self.add_section(chapter, name, module, operator=None, is_guide=True)
+                guide_section = self.add_section(
+                    chapter, name, module, operator=None, is_guide=True
+                )
                 submodules = [
                     value
                     for value in module.__dict__.values()
@@ -471,8 +473,10 @@ class Documentation:
                         submodule,
                         operator=None,
                         is_guide=False,
+                        in_guide=True,
                     )
                     modules_seen.add(submodule)
+                    guide_section.subsections.append(section)
 
                     builtins = builtins_by_module.get(submodule.__name__, [])
                     subsections = [builtin for builtin in builtins]
@@ -922,16 +926,28 @@ class DocTest:
 
 
 class MathicsMainDocumentation(Documentation):
+    """
+    This module is used for creating test data and saving it to a Python Pickle file
+    and running tests that appear in the documentation (doctests).
+
+    There are other classes DjangoMathicsDocumentation and LaTeXMathicsDocumentation
+    format the data accumulated here.
+    """
+
     def __init__(self, want_sorting=False):
+        self.doc_chapter_fn = DocChapter
         self.doc_dir = settings.DOC_DIR
+        self.doc_fn = XMLDoc
+        self.doc_guide_section_fn = DocGuideSection
+        self.doc_part_fn = DocPart
+        self.doc_section_fn = DocSection
+        self.doc_subsection_fn = DocSubsection
         self.latex_pcl_path = settings.DOC_LATEX_DATA_PCL
         self.parts = []
         self.parts_by_slug = {}
         self.pymathics_doc_loaded = False
         self.doc_data_file = settings.get_doc_latex_data_path(should_be_readable=True)
         self.title = "Overview"
-
-        self.gather_doc_data()
 
 
 class XMLDoc:

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -493,7 +493,7 @@ class Documentation:
                             instance.get_name(short=True),
                             instance,
                             instance.get_operator(),
-                            in_guide=False,
+                            in_guide=True,
                         )
             else:
                 self.doc_sections(sections, modules_seen, chapter)
@@ -590,8 +590,7 @@ class Documentation:
         for tests in self.get_tests():
             for test in tests.tests:
                 test.key = (tests.part, tests.chapter, tests.section, test.index)
-
-        pass
+        return
 
     def get_part(self, part_slug):
         return self.parts_by_slug.get(part_slug)

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -561,6 +561,15 @@ class Documentation:
                 modules_seen.add(instance)
 
     def gather_doc_data(self):
+        """
+        Extract documentation data from various static XML-like doc files, Mathics3 Built-in functions
+        (inside mathics.builtin), and external Mathics3 Modules.
+
+        The extracted structure is stored in ``self``.
+        """
+
+        # First gather data from static XML-like files. This constitutes "Part 1" of the
+        # documentation.
         files = listdir(self.doc_dir)
         files.sort()
         appendix = []
@@ -607,6 +616,10 @@ class Documentation:
                     part.is_appendix = True
                     appendix.append(part)
 
+        # Next extract data that has been loaded into Mathics3 when it runs.
+        # This is information from  `mathics.builtin`.
+        # This is Part 2 of the documentation.
+
         for title, modules, builtins_by_module, start in [
             (
                 "Reference of Built-in Symbols",
@@ -616,6 +629,11 @@ class Documentation:
             )
         ]:
             self.doc_part(title, modules, builtins_by_module, start)
+
+        # Now extract external Mathics3 Modules that have been loaded via
+        # LoadModule, or eval_LoadModule.
+
+        # This is Part 3 of the documentation.
 
         for title, modules, builtins_by_module, start in [
             (
@@ -627,10 +645,18 @@ class Documentation:
         ]:
             self.doc_part(title, modules, builtins_by_module, start)
 
+        # Now extract Appendix information. This include License text
+
+        # This is the final Part of the documentation.
+
         for part in appendix:
             self.parts.append(part)
 
-        # set keys of tests
+        # Via the wanderings above, collect all tests that have been
+        # seen.
+        #
+        # Each test is accessble by its part + chapter + section and test number
+        # in that section.
         for tests in self.get_tests():
             for test in tests.tests:
                 test.key = (tests.part, tests.chapter, tests.section, test.index)
@@ -894,7 +920,7 @@ class DocSubsection:
 
         if text.count("<dl>") != text.count("</dl>"):
             raise ValueError(
-                "Missing openning or closing <dl> tag in "
+                "Missing opening or closing <dl> tag in "
                 "{} documentation".format(title)
             )
         self.section.subsections_by_slug[self.slug] = self
@@ -991,13 +1017,16 @@ class DocTest:
         return self.test
 
 
+# FIXME: think about - do we need this? Or can we use DjangoMathicsDocumentation and
+# LatTeXMathicsDocumentation only?
 class MathicsMainDocumentation(Documentation):
     """
     This module is used for creating test data and saving it to a Python Pickle file
     and running tests that appear in the documentation (doctests).
 
     There are other classes DjangoMathicsDocumentation and LaTeXMathicsDocumentation
-    format the data accumulated here.
+    that format the data accumulated here. In fact I think those can sort of serve
+    instead of this.
     """
 
     def __init__(self, want_sorting=False):

--- a/mathics/doc/latex/doc2latex.py
+++ b/mathics/doc/latex/doc2latex.py
@@ -17,7 +17,7 @@ from sympy import __version__ as SymPyVersion
 
 import mathics
 from mathics import __version__, settings, version_string
-from mathics.doc.latex_doc import LaTeXMathicsMainDocumentation
+from mathics.doc.latex_doc import LaTeXMathicsDocumentation
 
 # Global variables
 logfile = None
@@ -95,7 +95,7 @@ def get_versions():
 def write_latex(
     doc_data, quiet=False, filter_parts=None, filter_chapters=None, filter_sections=None
 ):
-    documentation = LaTeXMathicsMainDocumentation()
+    documentation = LaTeXMathicsDocumentation()
     if not quiet:
         print(f"Writing LaTeX document to {DOC_LATEX_FILE}")
     with open_ensure_dir(DOC_LATEX_FILE, "wb") as doc:

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -650,7 +650,9 @@ class LaTeXDoc(XMLDoc):
                 # We have text but no tests
                 return escape_latex(self.rawdoc)
 
-        return "\n".join(item.latex(doc_data) for item in self.items)
+        return "\n".join(
+            item.latex(doc_data) for item in self.items if not item.is_private()
+        )
 
 
 class LaTeXMathicsDocumentation(Documentation):

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -34,7 +34,6 @@ from mathics.doc.common_doc import (
     DocTests,
     DocText,
     Documentation,
-    MathicsMainDocumentation,
     XMLDoc,
     _replace_all,
     gather_tests,
@@ -669,7 +668,7 @@ class LaTeXMathicsDocumentation(Documentation):
         self.parts_by_slug = {}
         self.title = "Overview"
 
-        self.gather_doc_data(want_sorting)
+        self.gather_doc_data()
 
     def latex(
         self,

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -612,7 +612,6 @@ def main():
             chapters, stop_on_failure=args.stop_on_failure, reload=args.reload
         )
     else:
-        # if we want to check also the pymathics modules
         if args.doc_only:
             extract_doc_from_source(
                 quiet=args.quiet,

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -580,7 +580,7 @@ def main():
 
     global documentation
     documentation = LaTeXMathicsDocumentation()
-    documentation.gather_doc_data(want_sorting=args.want_sorting)
+    documentation.gather_doc_data()
 
     if args.sections:
         sections = set(args.sections.split(","))

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -26,7 +26,6 @@ from mathics.core.evaluation import Evaluation, Output
 from mathics.core.parser import MathicsSingleLineFeeder
 from mathics.doc.common_doc import MathicsMainDocumentation
 
-# from mathics.eval.pymathics import eval_LoadModule
 from mathics.timing import show_lru_cache_statistics
 
 builtins = builtins_dict()
@@ -580,7 +579,9 @@ def main():
         logfile = open(args.logfilename, "wt")
 
     global documentation
-    documentation = MathicsMainDocumentation(want_sorting=args.want_sorting)
+    documentation = LaTeXMathicsDocumentation()
+    documentation.gather_doc_data(want_sorting=args.want_sorting)
+
     if args.sections:
         sections = set(args.sections.split(","))
         if args.pymathics:  # in case the section is in a pymathics module...
@@ -622,7 +623,7 @@ def main():
                 count=args.count,
                 doc_even_if_error=args.keep_going,
                 excludes=excludes,
-                want_sorting=args.want_sorting,
+v                want_sorting=args.want_sorting,
             )
             end_time = datetime.now()
             print("Tests took ", end_time - start_time)

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -553,11 +553,12 @@ def main():
         action="store_true",
         help="print cache statistics",
     )
-    # FIXME: there is some weird interacting going on with
-    # mathics when tests in sorted order. Some of the Plot
-    # show a noticeable 2 minute delay in processing.
-    # I think the problem is in Mathics itself rather than
-    # sorting, but until we figure that out, use
+    # FIXME: historically was weird interacting going on with
+    # mathics when tests in sorted order. Possibly a
+    # mpmath precsion reset bug.
+    # We see a noticeable 2 minute delay in processing.
+    # WHile the problem is in Mathics itself rather than
+    # sorting, until we get this fixed, use
     # sort as an option only. For normal testing we don't
     # want it for speed. But for document building which is
     # rarely done, we do want sorting of the sections and chapters.
@@ -629,7 +630,7 @@ def main():
                 count=args.count,
                 doc_even_if_error=args.keep_going,
                 excludes=excludes,
-v                want_sorting=args.want_sorting,
+                want_sorting=args.want_sorting,
             )
             end_time = datetime.now()
             print("Tests took ", end_time - start_time)

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -592,8 +592,8 @@ def main():
             except PyMathicsLoadException:
                 print(f"Python module {module_name} is not a Mathics3 module.")
 
-            except ImportError:
-                print(f"Python module {module_name} does not exist")
+            except Exception as e:
+                print(f"Python import errors with: {e}.")
             else:
                 print(f"Mathics3 Module {module_name} loaded")
 

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -485,11 +485,13 @@ def main():
         help="stores the output in [logfilename]. ",
     )
     parser.add_argument(
-        "--pymathics",
+        "--load-module",
         "-l",
         dest="pymathics",
-        metavar="MATHIC3-MODULE",
-        help="load Mathics3 module MATHICS3-MODULE. ",
+        metavar="MATHIC3-MODULES",
+        help="load Mathics3 module MATHICS3-MODULES. "
+        "You can list multiple Mathics3 Modules by adding a comma (and no space) in between "
+        "module names.",
     )
     parser.add_argument(
         "--time-each",

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -580,7 +580,7 @@ def main():
         logfile = open(args.logfilename, "wt")
 
     global documentation
-    documentation = MathicsMainDocumentation()
+    documentation = MathicsMainDocumentation(want_sorting=args.want_sorting)
 
     # LoadModule Mathics3 modules
     if args.pymathics:


### PR DESCRIPTION
This allows Mathics3 Modules loaded via `-l` or `--load-module` on the `docpipetest.py` command like to get loaded 
using  `eval_LoadModule` the underlying eval method for `LoadModule[]`.

In other words, from Mathics3 core you can test Mathics3 Modules or select individual sections Mathics3 Module tests. But that also means, we are collecting XML-like  documentation and test data which can then be put into the LaTeX-generated PDF.

 I believe the information will go into the PCL (Python Pickle file), but I haven't tested that yet.

 And I  haven't looked at the piece that puts creates `documentation.tex`  (`mathics/doc/latex/doc2latex.py`)

 I think that will be another (small) PR.  This is large enough as it is.

For expediency in being able to get this accomplished over the weekend in a limited time, there are/were several separable commits here.  I am sure you know the pattern - you want to get X done but bug Y gets in the way. So you fix Y, and then bug Z pops up. 

Over the week I will try to extract these so that they can be reviewed/discussed independently.

Here are two that I can think of though.

I would like to change the name Pymathics or Pymathics module to the simpler "Mathics3 Module" which has always been loaded via `LoadModule`. 

The messages when a Mathics3 Module can't be loaded have been changed.



