### PR TITLE
Small bugs...

### DIFF
--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -179,7 +179,7 @@ class Accuracy(Builtin):
 
     For Complex numbers, the accuracy is estimated as (minus) the base-10 log
     of the square root of the squares of the errors on the real and complex parts:
-    >> z=Complex[3.00``2, 4..00``2]; 
+    >> z=Complex[3.00``2, 4..00``2];
     >> Accuracy[z] == -Log[10, Sqrt[10^(-2 Accuracy[Re[z]]) + 10^(-2 Accuracy[Im[z]])]]
      = True
 

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -551,14 +551,14 @@ class InterpretedBox(PrefixOperator):
     precedence = 670
     summary_text = "interpret boxes as an expression"
 
-    def eval_dummy(self, boxes, evaluation: Evaluation):
+    def eval(self, boxes, evaluation: Evaluation):
         """InterpretedBox[boxes_]"""
         # TODO: the following is a very raw and dummy way to
         # handle these expressions.
         # In the first place, this should handle different kind
         # of boxes in different ways.
         reinput = boxes.boxes_to_text()
-        return Expression(SymbolToExpression, reinput).evaluate(evaluation)
+        return Expression(SymbolToExpression, String(reinput)).evaluate(evaluation)
 
 
 class LetterNumber(Builtin):

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -542,25 +542,16 @@ class Unique(Predefined):
 
     Create a unique symbol with no particular name:
     >> Unique[]
-    = $1
-
-    >> Unique[sym]
-    = sym$1
+    = $...
 
     Create a unique symbol whose name begins with x:
     >> Unique["x"]
-    = x2
-
-    #> $3 = 3;
-    #> Unique[]
-    = $4
+    = x...
 
     #> Unique[{}]
     = {}
 
-    #> Unique[{x, x}]
-     = {x$2, x$3}
-
+    ## FIXME: include the rest of these in test/builtin/test-unique.py
     ## Each use of Unique[symbol] increments $ModuleNumber:
     ## >> {$ModuleNumber, Unique[x], $ModuleNumber}
     ##  = ...

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -168,8 +168,8 @@ Of course, \Mathics has complex numbers:
 ('!' denotes the factorial function.)
 The precision of numerical evaluation can be set:
 
-  >> N[Pi, 100]
-  = 3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068
+  >> N[Pi, 30]
+  = 3.14159265358979323846264338328
 
 Division by zero is forbidden:
   >> 1 / 0

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -42,7 +42,7 @@ sep = "-" * 70 + "\n"
 # Global variables
 definitions = None
 documentation = None
-check_partial_enlapsed_time = False
+check_partial_elapsed_time = False
 logfile = None
 
 
@@ -82,7 +82,7 @@ stars = "*" * 10
 
 
 def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bool:
-    global check_partial_enlapsed_time
+    global check_partial_elapsed_time
     test, wanted_out, wanted = test.test, test.outs, test.result
 
     def fail(why):
@@ -107,7 +107,7 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bo
     try:
         time_parsing = datetime.now()
         query = evaluation.parse_feeder(feeder)
-        if check_partial_enlapsed_time:
+        if check_partial_elapsed_time:
             print("   parsing took", datetime.now() - time_parsing)
         if query is None:
             # parsed expression is None
@@ -115,7 +115,7 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bo
             out = evaluation.out
         else:
             result = evaluation.evaluate(query)
-            if check_partial_enlapsed_time:
+            if check_partial_elapsed_time:
                 print("   evaluation took", datetime.now() - time_parsing)
             out = result.out
             result = result.result
@@ -128,7 +128,7 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bo
     time_comparing = datetime.now()
     comparison_result = compare(result, wanted)
 
-    if check_partial_enlapsed_time:
+    if check_partial_elapsed_time:
         print("   comparison took ", datetime.now() - time_comparing)
     if not comparison_result:
         print("result =!=wanted")
@@ -151,7 +151,7 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bo
             if not got == wanted and wanted.text != "...":
                 output_ok = False
                 break
-    if check_partial_enlapsed_time:
+    if check_partial_elapsed_time:
         print("   comparing messages took ", datetime.now() - time_comparing)
     if not output_ok:
         return fail(
@@ -443,12 +443,8 @@ def extract_doc_from_source(quiet=False, reload=False):
 def main():
     global definitions
     global logfile
-    global check_partial_enlapsed_time
+    global check_partial_elapsed_time
     definitions = Definitions(add_builtin=True)
-
-    # # Add pymathics modules load here
-    # for name in ("pymathics.graph", "pymathics.natlang"):
-    #     print(eval_LoadModule, name, definitions)
 
     parser = ArgumentParser(description="Mathics test suite.", add_help=False)
     parser.add_argument(
@@ -499,7 +495,7 @@ def main():
     parser.add_argument(
         "--time-each",
         "-d",
-        dest="enlapsed_times",
+        dest="elapsed_times",
         action="store_true",
         help="check the time that take each test to parse, evaluate and compare.",
     )
@@ -576,8 +572,8 @@ def main():
 
     args = parser.parse_args()
 
-    if args.enlapsed_times:
-        check_partial_enlapsed_time = True
+    if args.elapsed_times:
+        check_partial_elapsed_time = True
     # If a test for a specific section is called
     # just test it
     if args.logfilename:

--- a/test/builtin/test_scoping.py
+++ b/test/builtin/test_scoping.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests from mathics.builtin.scoping.
+"""
+
+from test.helper import session
+
+from mathics.core.symbols import Symbol
+
+
+def test_unique():
+    """
+    test Unique
+    """
+
+    # test Unique[]
+    symbol = session.evaluate("Unique[]")
+    assert isinstance(
+        symbol, Symbol
+    ), f"Unique[] should return a Symbol; got {type(symbol)}"
+    symbol_set = set([symbol])
+    for i in range(5):
+        symbol = session.evaluate("Unique[]")
+        assert (
+            symbol not in symbol_set
+        ), "Unique[] should return different symbols; {symbol.name} is duplicated"
+        symbol_set.add(symbol)
+
+    # test Unique[<prefix>]
+    symbol_prefix = symbol.name[0]
+
+    for i in range(5):
+        symbol = session.evaluate(f"Unique[{symbol_prefix}]")
+        assert (
+            symbol not in symbol_set
+        ), "Unique[{symbol_prefix}] should return different symbols; {symbol.name} is duplicated"


### PR DESCRIPTION
* Fix InterpretedBox[] bug
* Turn flaky UniqueSym[] doctests into pytests. More could be done here
* typo: enlapsed -> elapsed
* Use `N[Pi, 100]` -> `N[Pi, 30]` until we get the mp.mpath precision reset bug fixed