### PR TITLE
Include Mathics3 modules in docs...

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install wheel
-        choco install llvm tesseract
+        choco install --force llvm
+        choco install tesseract
         set LLVM_DIR="C:\Program Files\LLVM"
     - name: Install Mathics3 with Python dependencies
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install wheel
+        # use --force because llvm may already exist, but it also may not exist.
+        # so we will be safe here. Another possibility would be check and install
+        # conditionally.
         choco install --force llvm
         choco install tesseract
         set LLVM_DIR="C:\Program Files\LLVM"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ MATHICS3_MODULE_OPTION ?= --load-module pymathics.graph,pymathics.natlang
    dist \
    doc \
    doctest \
-   doc-data \
+   doctest-data \
    djangotest \
    gstest \
    latexdoc \
@@ -123,8 +123,8 @@ gstest:
 	(cd examples/symbolic_logic/gries_schneider && $(PYTHON) test_gs.py)
 
 
-#: Create data that is used to in Django docs and to build LaTeX PDF
-doc-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/documentation/images/*
+#: Create doctest test data and test results that is used to build LaTeX PDF
+doctest-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/documentation/images/*
 	MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) mathics/docpipeline.py --output --keep-going $(MATHICS3_MODULE_OPTION)
 
 #: Run tests that appear in docstring in the code.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ PIP ?= pip3
 BASH ?= bash
 RM  ?= rm
 
+# Variable indicating Mathics3 Modules you have available on your system, in latex2doc option format
+MATHICS3_MODULE_OPTION ?= --load-module pymathics.graph,pymathics.natlang
+
 .PHONY: \
    all \
    build \
@@ -122,7 +125,7 @@ gstest:
 
 #: Create data that is used to in Django docs and to build LaTeX PDF
 doc-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/documentation/images/*
-	MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) mathics/docpipeline.py --output --keep-going
+	MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) mathics/docpipeline.py --output --keep-going $(MATHICS3_MODULE_OPTION)
 
 #: Run tests that appear in docstring in the code.
 doctest:

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -560,9 +560,9 @@ class Documentation:
                 )
                 modules_seen.add(instance)
 
-    def gather_doc_data(self):
+    def gather_doctest_data(self):
         """
-        Extract documentation data from various static XML-like doc files, Mathics3 Built-in functions
+        Extract doctest data from various static XML-like doc files, Mathics3 Built-in functions
         (inside mathics.builtin), and external Mathics3 Modules.
 
         The extracted structure is stored in ``self``.
@@ -1037,11 +1037,13 @@ class MathicsMainDocumentation(Documentation):
         self.doc_part_fn = DocPart
         self.doc_section_fn = DocSection
         self.doc_subsection_fn = DocSubsection
-        self.latex_pcl_path = settings.DOC_LATEX_DATA_PCL
+        self.doctest_latex_pcl_path = settings.DOCTEST_LATEX_DATA_PCL
         self.parts = []
         self.parts_by_slug = {}
         self.pymathics_doc_loaded = False
-        self.doc_data_file = settings.get_doc_latex_data_path(should_be_readable=True)
+        self.doc_data_file = settings.get_doctest_latex_data_path(
+            should_be_readable=True
+        )
         self.title = "Overview"
 
 

--- a/mathics/doc/images.sh
+++ b/mathics/doc/images.sh
@@ -9,8 +9,8 @@ mydir=$(dirname $bs)
 cd $mydir
 mydir=$(pwd)
 
-if [[ -n $DOC_LATEX_DATA_PCL ]]; then
-    LATEX_DIR=$(basename $DOC_LATEX_DATA_PCL)
+if [[ -n $DOCTEST_LATEX_DATA_PCL ]]; then
+    LATEX_DIR=$(basename $DOCTEST_LATEX_DATA_PCL)
 else
     LATEX_DIR=${mydir}/latex
 fi

--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -6,22 +6,26 @@ LATEXMK ?= latexmk
 BASH ?= /bin/bash
 #-quiet
 
-DOC_LATEX_DATA_PCL ?= $(HOME)/.local/var/mathics/doc_latex_data.pcl
+# Location of Python Pickle file containg doctest tests and test results formatted for LaTeX
+DOCTEST_LATEX_DATA_PCL ?= $(HOME)/.local/var/mathics/doctest_latex_data.pcl
+
+# Variable indicating Mathics3 Modules you have available on your system, in latex2doc option format
+MATHICS3_MODULE_OPTION ?= --load-module pymathics.graph,pymathics.natlang
 
 #: Default target: Make everything
 all doc texdoc: mathics.pdf
 
 #: Create internal Document Data from .mdoc and Python builtin module docstrings
-doc-data $(DOC_LATEX_DATA_PCL):
-	(cd ../.. && MATHICS_CHARACTER_ENCODING="" $(PYTHON) docpipeline.py --output --keep-going --want-sorting)
+doc-data $(DOCTEST_LATEX_DATA_PCL):
+	(cd ../.. && MATHICS_CHARACTER_ENCODING="" $(PYTHON) docpipeline.py --output --keep-going --want-sorting $(MATHICS3_MODULE_OPTION))
 
 #: Build mathics PDF
-mathics.pdf: mathics.tex documentation.tex logo-text-nodrop.pdf logo-heptatom.pdf version-info.tex $(DOC_LATEX_DATA_PCL)
+mathics.pdf: mathics.tex documentation.tex logo-text-nodrop.pdf logo-heptatom.pdf version-info.tex $(DOCTEST_LATEX_DATA_PCL)
 	$(LATEXMK) --verbose -f -pdf -pdflatex="$(XETEX) -halt-on-error" mathics
 
 #: File containing version information
 version-info.tex: doc2latex.py
-	$(PYTHON) doc2latex.py && $(BASH) ./sed-hack.sh
+	$(PYTHON) doc2latex.py $(MATHICS3_MODULE_OPTION )&& $(BASH) ./sed-hack.sh
 
 #: Build test PDF
 mathics-test.pdf: mathics-test.tex testing.tex
@@ -32,9 +36,9 @@ mathics-test.pdf: mathics-test.tex testing.tex
 logo-heptatom.pdf logo-text-nodrop.pdf:
 	(cd .. && $(BASH) ./images.sh)
 
-#: The build of the documentation which is derived from docstrings in the Python code
-documentation.tex: $(DOC_LATEX_DATA_PCL)
-	$(PYTHON) ./doc2latex.py
+#: The build of the documentation which is derived from docstrings in the Python code and doctest data
+documentation.tex: $(DOCTEST_LATEX_DATA_PCL)
+	$(PYTHON) ./doc2latex.py $(MATHICS3_MODULE_OPTION)
 
 #: Same as mathics.pdf
 pdf latex: mathics.pdf
@@ -46,6 +50,6 @@ clean:
 	rm -f mathics.fdb_latexmk mathics.ilg mathics.ind mathics.maf mathics.pre || true
 	rm -f mathics_*.* || true
 	rm -f mathics-test.asy mathics-test.aux mathics-test.idx mathics-test.log mathics-test.mtc mathicsest.mtc* mathics-test.out mathics-test.toc || true
-	rm -f documentation.tex $(DOC_LATEX_DATA_PCL) || true
+	rm -f documentation.tex $(DOCTEST_LATEX_DATA_PCL) || true
 	rm -f mathics.pdf mathics.dvi test-mathics.pdf test-mathics.dvi || true
 	rm -f mathics-test.pdf mathics-test.dvi version-info.tex || true

--- a/mathics/doc/latex/doc2latex.py
+++ b/mathics/doc/latex/doc2latex.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Reads in Pickle'd file and write LaTeX file containing the entire User Manual
+"""Writes a LaTeX file containing the entire User Manual.
+
+The information for this comes from:
+
+* the docstrings from loading in Mathics3 core (mathics)
+
+* the docstrings from loading Mathics3 modules that have been specified
+  on the command line
+
+* doctest tests and test result that have been stored in a Python
+  Pickle file, from a privious docpipeline.py run.  Ideally the
+  Mathics3 Modules given to docpipeline.py are the same as
+  given on the command line for this program
 """
 
 import os
@@ -10,6 +21,7 @@ import pickle
 import subprocess
 import sys
 from argparse import ArgumentParser
+from typing import Optional
 
 from mpmath import __version__ as mpmathVersion
 from numpy import __version__ as NumPyVersion
@@ -17,30 +29,43 @@ from sympy import __version__ as SymPyVersion
 
 import mathics
 from mathics import __version__, settings, version_string
+from mathics.core.definitions import Definitions
 from mathics.doc.latex_doc import LaTeXMathicsDocumentation
+from mathics.eval.pymathics import PyMathicsLoadException, eval_LoadModule
 
 # Global variables
 logfile = None
 
-DOC_LATEX_DATA_PCL = settings.DOC_LATEX_DATA_PCL
+# Input doctest PCL FILE. This contains just the
+# tests and test results.
+#
+# This information is stitched in with information comes from
+# docstrings that are loaded from load Mathics builtins and external modules.
+
+DOCTEST_LATEX_DATA_PCL = settings.DOCTEST_LATEX_DATA_PCL
+
+# Output location information
 DOC_LATEX_DIR = os.environ.get("DOC_LATEX_DIR", settings.DOC_LATEX_DIR)
 DOC_LATEX_FILE = os.environ.get("DOC_LATEX_FILE", settings.DOC_LATEX_FILE)
 
 
-def extract_doc_from_source(quiet=False):
+def read_doctest_data(quiet=False) -> Optional[dict]:
     """
-    Write internal (pickled) TeX doc mdoc files and example data in docstrings.
+    Read doctest information from PCL file and return this.
+    This is a wrapper around laod_doctest_data().
     """
     if not quiet:
-        print(f"Extracting internal doc data for {version_string}")
+        print(f"Extracting internal doctest data for {version_string}")
     try:
-        return load_doc_data(settings.get_doc_latex_data_path(should_be_readable=True))
+        return load_doctest_data(
+            settings.get_doctest_latex_data_path(should_be_readable=True)
+        )
     except KeyboardInterrupt:
         print("\nAborted.\n")
         return
 
 
-def load_doc_data(data_path, quiet=False):
+def load_doctest_data(data_path, quiet=False):
     if not quiet:
         print(f"Loading LaTeX internal data from {data_path}")
     with open_ensure_dir(data_path, "rb") as doc_data_fp:
@@ -145,6 +170,15 @@ def main():
         "You can list multiple chapters by adding a comma (and no space) in between chapter names.",
     )
     parser.add_argument(
+        "--load-module",
+        "-l",
+        dest="pymathics",
+        metavar="MATHIC3-MODULES",
+        help="load Mathics3 module MATHICS3-MODULES. "
+        "You can list multiple Mathics3 Modules by adding a comma (and no space) in between "
+        "module names.",
+    )
+    parser.add_argument(
         "--parts",
         "-p",
         dest="parts",
@@ -160,9 +194,25 @@ def main():
         help="Don't show formatting progress tests",
     )
     args = parser.parse_args()
-    doc_data = extract_doc_from_source(quiet=args.quiet)
+
+    # LoadModule Mathics3 modules to pull in modules, and
+    # their docstrings
+    if args.pymathics:
+        definitions = Definitions(add_builtin=True)
+        for module_name in args.pymathics.split(","):
+            try:
+                eval_LoadModule(module_name, definitions)
+            except PyMathicsLoadException:
+                print(f"Python module {module_name} is not a Mathics3 module.")
+
+            except Exception as e:
+                print(f"Python import errors with: {e}.")
+            else:
+                print(f"Mathics3 Module {module_name} loaded")
+
+    doctest_data = read_doctest_data(quiet=args.quiet)
     write_latex(
-        doc_data,
+        doctest_data,
         quiet=args.quiet,
         filter_parts=args.parts,
         filter_chapters=args.chapters,

--- a/mathics/doc/latex/doc2latex.py
+++ b/mathics/doc/latex/doc2latex.py
@@ -49,7 +49,7 @@ DOC_LATEX_DIR = os.environ.get("DOC_LATEX_DIR", settings.DOC_LATEX_DIR)
 DOC_LATEX_FILE = os.environ.get("DOC_LATEX_FILE", settings.DOC_LATEX_FILE)
 
 
-def read_doctest_data(quiet=False) -> Optional[dict]:
+def read_doctest_data(quiet=False) -> Optional[Dict[tuple, dict]]:
     """
     Read doctest information from PCL file and return this.
     This is a wrapper around laod_doctest_data().
@@ -65,7 +65,20 @@ def read_doctest_data(quiet=False) -> Optional[dict]:
         return
 
 
-def load_doctest_data(data_path, quiet=False):
+def load_doctest_data(data_path, quiet=False) -> Dict[tuple, dict]:
+    """
+    Read doctest information from PCL file and return this.
+
+    The return value is a dictionary of test results. The key is a tuple
+    of:
+    * Part name,
+    * Chapter name,
+    * [Guide Section name],
+    * Section name,
+    * Subsection name,
+    * test number
+    and the value is a dictionary of a Result.getdata() dictionary.
+    """
     if not quiet:
         print(f"Loading LaTeX internal data from {data_path}")
     with open_ensure_dir(data_path, "rb") as doc_data_fp:

--- a/mathics/doc/latex/doc2latex.py
+++ b/mathics/doc/latex/doc2latex.py
@@ -21,7 +21,7 @@ import pickle
 import subprocess
 import sys
 from argparse import ArgumentParser
-from typing import Optional
+from typing import Dict, Optional
 
 from mpmath import __version__ as mpmathVersion
 from numpy import __version__ as NumPyVersion

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -660,17 +660,19 @@ class LaTeXMathicsDocumentation(Documentation):
         self.doc_chapter_fn = LaTeXDocChapter
         self.doc_dir = settings.DOC_DIR
         self.doc_fn = LaTeXDoc
-        self.doc_data_file = settings.get_doc_latex_data_path(should_be_readable=True)
+        self.doc_data_file = settings.get_doctest_latex_data_path(
+            should_be_readable=True
+        )
         self.doc_guide_section_fn = LaTeXDocGuideSection
         self.doc_part_fn = LaTeXDocPart
         self.doc_section_fn = LaTeXDocSection
         self.doc_subsection_fn = LaTeXDocSubsection
-        self.latex_pcl_path = settings.DOC_LATEX_DATA_PCL
+        self.doctest_latex_pcl_path = settings.DOCTEST_LATEX_DATA_PCL
         self.parts = []
         self.parts_by_slug = {}
         self.title = "Overview"
 
-        self.gather_doc_data()
+        self.gather_doctest_data()
 
     def latex(
         self,

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -539,7 +539,7 @@ class LaTeXDocTest(DocTest):
         The key for doc_data is the part/chapter/section{/subsection} test number
         and the value contains Result object data turned into a dictionary.
 
-        In partuclar, each test in the test sequence includes the, input test,
+        In particular, each test in the test sequence includes the, input test,
         the result produced and any additional error output.
         The LaTeX-formatted string fragment is returned.
         """

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -414,7 +414,7 @@ def load_doctest_data() -> Dict[tuple, dict]:
     doctest_latex_data_path = settings.get_doctest_latex_data_path(
         should_be_readable=True
     )
-    print(f"Loading internal doctrest data from {doctest_latex_data_path}")
+    print(f"Loading internal doctest data from {doctest_latex_data_path}")
     with open_ensure_dir(doctest_latex_data_path, "rb") as doctest_data_file:
         return pickle.load(doctest_data_file)
 

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -16,6 +16,7 @@ import re
 import sys
 from argparse import ArgumentParser
 from datetime import datetime
+from typing import Dict
 
 import mathics
 import mathics.settings
@@ -403,7 +404,13 @@ def test_all(
         return sys.exit(1)  # Travis-CI knows the tests have failed
 
 
-def load_doctest_data():
+def load_doctest_data() -> Dict[tuple, dict]:
+    """
+    Load doctest tests and test results from Python PCL file.
+
+    See ``save_doctest_data()`` for the format of the loaded PCL data
+    (a dict).
+    """
     doctest_latex_data_path = settings.get_doctest_latex_data_path(
         should_be_readable=True
     )
@@ -412,7 +419,20 @@ def load_doctest_data():
         return pickle.load(doctest_data_file)
 
 
-def save_doctest_data(output_data):
+def save_doctest_data(output_data: Dict[tuple, dict]):
+    """
+    Save doctest tests and test results to a Python PCL file.
+
+    ``output_data`` is a dictionary of test results. The key is a tuple
+    of:
+    * Part name,
+    * Chapter name,
+    * [Guide Section name],
+    * Section name,
+    * Subsection name,
+    * test number
+    and the value is a dictionary of a Result.getdata() dictionary.
+    """
     doctest_latex_data_path = settings.get_doctest_latex_data_path(
         should_be_readable=False, create_parent=True
     )
@@ -423,7 +443,8 @@ def save_doctest_data(output_data):
 
 def write_doctest_data(quiet=False, reload=False):
     """
-    Get doctest information and write that out.
+    Get doctest information, which involves running the tests to obtain
+    test results and write out both the tests and the test results.
     """
     if not quiet:
         print(f"Extracting internal doc data for {version_string}")

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -204,7 +204,7 @@ def test_tests(
 
 
 # FIXME: move this to common routine
-def create_output(tests, doc_data, format="latex"):
+def create_output(tests, doctest_data, format="latex"):
     definitions.reset_user_definitions()
     for test in tests.tests:
         if test.private:
@@ -221,7 +221,7 @@ def create_output(tests, doc_data, format="latex"):
             result = []
         else:
             result = [result.get_data()]
-        doc_data[key] = {
+        doctest_data[key] = {
             "query": test.test,
             "results": result,
         }
@@ -239,7 +239,7 @@ def test_chapters(
     index = 0
     chapter_names = ", ".join(chapters)
     print(f"Testing chapter(s): {chapter_names}")
-    output_data = load_doc_data() if reload else {}
+    output_data = load_doctest_data() if reload else {}
     prev_key = []
     for tests in documentation.get_tests():
         if tests.chapter in chapters:
@@ -281,7 +281,7 @@ def test_sections(
     section_names = ", ".join(sections)
     print(f"Testing section(s): {section_names}")
     sections |= {"$" + s for s in sections}
-    output_data = load_doc_data() if reload else {}
+    output_data = load_doctest_data() if reload else {}
     prev_key = []
     for tests in documentation.get_tests():
         if tests.section in sections:
@@ -309,7 +309,7 @@ def test_sections(
     else:
         print_and_log("All tests passed.")
     if generate_output and (failed == 0):
-        save_doc_data(output_data)
+        save_doctest_data(output_data)
 
 
 def open_ensure_dir(f, *args, **kwargs):
@@ -339,7 +339,7 @@ def test_all(
     if generate_output:
         if texdatafolder is None:
             texdatafolder = osp.dirname(
-                settings.get_doc_latex_data_path(
+                settings.get_doctest_latex_data_path(
                     should_be_readable=False, create_parent=True
                 )
             )
@@ -393,7 +393,7 @@ def test_all(
             print_and_log("  - %s in %s / %s" % (section, part, chapter))
 
     if generate_output and (failed == 0 or doc_even_if_error):
-        save_doc_data(output_data)
+        save_doctest_data(output_data)
         return True
 
     if failed == 0:
@@ -403,32 +403,34 @@ def test_all(
         return sys.exit(1)  # Travis-CI knows the tests have failed
 
 
-def load_doc_data():
-    doc_latex_data_path = settings.get_doc_latex_data_path(should_be_readable=True)
-    print(f"Loading internal document data from {doc_latex_data_path}")
-    with open_ensure_dir(doc_latex_data_path, "rb") as doc_data_file:
-        return pickle.load(doc_data_file)
+def load_doctest_data():
+    doctest_latex_data_path = settings.get_doctest_latex_data_path(
+        should_be_readable=True
+    )
+    print(f"Loading internal doctrest data from {doctest_latex_data_path}")
+    with open_ensure_dir(doctest_latex_data_path, "rb") as doctest_data_file:
+        return pickle.load(doctest_data_file)
 
 
-def save_doc_data(output_data):
-    doc_latex_data_path = settings.get_doc_latex_data_path(
+def save_doctest_data(output_data):
+    doctest_latex_data_path = settings.get_doctest_latex_data_path(
         should_be_readable=False, create_parent=True
     )
-    print(f"Writing internal document data to {doc_latex_data_path}")
-    with open(doc_latex_data_path, "wb") as output_file:
+    print(f"Writing internal document data to {doctest_latex_data_path}")
+    with open(doctest_latex_data_path, "wb") as output_file:
         pickle.dump(output_data, output_file, 4)
 
 
-def extract_doc_from_source(quiet=False, reload=False):
+def write_doctest_data(quiet=False, reload=False):
     """
-    Write internal (pickled) doc files and example data in docstrings.
+    Get doctest information and write that out.
     """
     if not quiet:
         print(f"Extracting internal doc data for {version_string}")
         print("This may take a while...")
 
     try:
-        output_data = load_doc_data() if reload else {}
+        output_data = load_doctest_data() if reload else {}
         for tests in documentation.get_tests():
             create_output(tests, output_data)
     except KeyboardInterrupt:
@@ -436,7 +438,7 @@ def extract_doc_from_source(quiet=False, reload=False):
         return
 
     print("done.\n")
-    save_doc_data(output_data)
+    save_doctest_data(output_data)
 
 
 def main():
@@ -597,7 +599,7 @@ def main():
             else:
                 print(f"Mathics3 Module {module_name} loaded")
 
-    documentation.gather_doc_data()
+    documentation.gather_doctest_data()
 
     if args.sections:
         sections = set(args.sections.split(","))
@@ -616,7 +618,7 @@ def main():
         )
     else:
         if args.doc_only:
-            extract_doc_from_source(
+            write_doctest_data(
                 quiet=args.quiet,
                 reload=args.reload,
             )

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -41,19 +41,24 @@ else:
 # from checked-out source and that is where this should be put.
 LOCAL_ROOT_DIR = get_srcdir()
 
-# Location of internal document data. Currently this is in Python
-# Pickle form, but storing this in JSON if possible would be preferable and faster
+# Location of doctests and test results formated for LaTeX.  This data
+# is stoared as a Python Pickle format, but storing this in JSON if
+# possible would be preferable and faster
 
-# We need two versions, one in the user space which is updated with
+# We need two versions of doctest data, one is in the user space which is updated with
 # local packages installed and is user writable.
-DOC_LATEX_DATA_PCL = os.environ.get(
-    "DOC_LATEX_DATA_PCL", osp.join(DATA_DIR, "doc_latex_data.pcl")
+
+
+DOCTEST_LATEX_DATA_PCL = os.environ.get(
+    "DOCTEST_LATEX_DATA_PCL", osp.join(DATA_DIR, "doctest_latex_data.pcl")
 )
 
-# We need another version as a fallback, and that is distributed with the
+# We need another version of doctest data as a fallback, and that is distributed with the
 # package. It is note user writable and not in the user space.
-DOC_SYSTEM_LATEX_DATA_PCL = os.environ.get(
-    "DOC_SYSTEM_LATEX_DATA_PCL", osp.join(LOCAL_ROOT_DIR, "data", "doc_latex_data.pcl")
+
+DOCTEST_SYSTEM_LATEX_DATA_PCL = os.environ.get(
+    "DOCTEST_SYSTEM_LATEX_DATA_PCL",
+    osp.join(LOCAL_ROOT_DIR, "data", "doctest_latex_data.pcl"),
 )
 
 DOC_DIR = osp.join(LOCAL_ROOT_DIR, "doc", "documentation")
@@ -77,23 +82,23 @@ character_encoding = os.environ.get(
 SYSTEM_CHARACTER_ENCODING = "UTF-8" if character_encoding == "utf-8" else "ASCII"
 
 
-def get_doc_latex_data_path(should_be_readable=False, create_parent=False) -> str:
-    """Returns a string path where we can find Python Pickle data for LaTeX
+def get_doctest_latex_data_path(should_be_readable=False, create_parent=False) -> str:
+    """Returns a string path where we can find Python Pickle doctest data for LaTeX
     processing.
 
     If `should_be_readable` is True, the we will check to see whether this file is
-    readable (which also means it exists). If not, we'll return the `DOC_SYSTEM_DATA_PATH`.
+    readable (which also means it exists). If not, we'll return the `DOCTEST_SYSTEM_DATA_PATH`.
     """
-    doc_user_latex_data_pcl = Path(DOC_LATEX_DATA_PCL)
+    doc_user_latex_data_pcl = Path(DOCTEST_LATEX_DATA_PCL)
     base_config_dir = doc_user_latex_data_pcl.parent
     if not base_config_dir.is_dir() and create_parent:
         Path("base_config_dir").mkdir(parents=True, exist_ok=True)
 
     if should_be_readable:
         return (
-            DOC_LATEX_DATA_PCL
+            DOCTEST_LATEX_DATA_PCL
             if doc_user_latex_data_pcl.is_file()
-            else DOC_SYSTEM_LATEX_DATA_PCL
+            else DOCTEST_SYSTEM_LATEX_DATA_PCL
         )
     else:
-        return DOC_LATEX_DATA_PCL
+        return DOCTEST_LATEX_DATA_PCL


### PR DESCRIPTION
Add the ability to include Mathics3 Modules into the LaTeX/PDf documentionat 

Make it clear that Python Pick PCL info has just doctests - test input and output result, keyed by part/section/subsection/test/number)