### PR TITLE
Format to LaTeX when we are writing to LaTeX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,9 @@ gstest:
 
 
 #: Create doctest test data and test results that is used to build LaTeX PDF
+# For LaTeX docs we assume Unicode
 doctest-data: mathics/builtin/*.py mathics/doc/documentation/*.mdoc mathics/doc/documentation/images/*
-	MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) mathics/docpipeline.py --output --keep-going $(MATHICS3_MODULE_OPTION)
+	MATHICS_CHARACTER_ENCODING="UTF-8" $(PYTHON) mathics/docpipeline.py --output --keep-going $(MATHICS3_MODULE_OPTION)
 
 #: Run tests that appear in docstring in the code.
 doctest:

--- a/mathics/builtin/exp_structure/general.py
+++ b/mathics/builtin/exp_structure/general.py
@@ -48,32 +48,49 @@ class ApplyLevel(BinaryOperator):
 class BinarySearch(Builtin):
     """
     <url>
-    :WMA link:
-    https://reference.wolfram.com/language/ref/BinarySearch.html</url>
+    :Binary search algorithm:
+    https://en.wikipedia.org/wiki/Binary_search_algorithm</url> (<url>
+    :WMA:
+    https://reference.wolfram.com/language/ref/BinarySearch.html</url>)
 
     <dl>
       <dt>'CombinatoricaOld`BinarySearch[$l$, $k$]'
-      <dd>searches the list $l$, which has to be sorted, for key $k$ and returns its index in $l$. If $k$ does not
-        exist in $l$, 'BinarySearch' returns (a + b) / 2, where a and b are the indices between which $k$ would have
-        to be inserted in order to maintain the sorting order in $l$. Please note that $k$ and the elements in $l$
-        need to be comparable under a strict total order (see https://en.wikipedia.org/wiki/Total_order).
+      <dd>searches the list $l$, which has to be sorted, for key $k$ and \
+          returns its index in $l$.
+
+          If $k$ does not exist in $l$, 'BinarySearch' returns ($a$ + $b$) / 2, \
+          where $a$ and $b$ are the indices between which $k$ would have  \
+          to be inserted in order to maintain the sorting order in $l$.
+
+          Please note that $k$ and the elements in $l$ need to be comparable \
+          under a <url>
+          :strict total order:
+          https://en.wikipedia.org/wiki/Total_order</url>.
 
       <dt>'CombinatoricaOld`BinarySearch[$l$, $k$, $f$]'
-      <dd>the index of $k in the elements of $l$ if $f$ is applied to the latter prior to comparison. Note that $f$
-        needs to yield a sorted sequence if applied to the elements of $l.
+      <dd>gives the index of $k$ in the elements of $l$ if $f$ is applied to the \
+          latter prior to comparison. Note that $f$ \
+          needs to yield a sorted sequence if applied to the elements of $l$.
     </dl>
+
+    Number 100 is found at exactly in the fourth place of the given list:
 
     >> CombinatoricaOld`BinarySearch[{3, 4, 10, 100, 123}, 100]
      = 4
 
+     Number 7 is found in between the second and third place (3, and 9)\
+     of the given list. The numerical difference between 3 and 9 does \
+     not figure into the .5 part of 2.5:
+
     >> CombinatoricaOld`BinarySearch[{2, 3, 9}, 7] // N
      = 2.5
 
-    >> CombinatoricaOld`BinarySearch[{2, 7, 9, 10}, 3] // N
-     = 1.5
+    0.5 is what you get when the item comes before the given list:
 
     >> CombinatoricaOld`BinarySearch[{-10, 5, 8, 10}, -100] // N
      = 0.5
+
+    And here is what you see when the item comes at the end of the list:
 
     >> CombinatoricaOld`BinarySearch[{-10, 5, 8, 10}, 20] // N
      = 4.5

--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -38,7 +38,7 @@ logo-heptatom.pdf logo-text-nodrop.pdf:
 
 #: The build of the documentation which is derived from docstrings in the Python code and doctest data
 documentation.tex: $(DOCTEST_LATEX_DATA_PCL)
-	$(PYTHON) ./doc2latex.py $(MATHICS3_MODULE_OPTION)
+	$(PYTHON) ./doc2latex.py $(MATHICS3_MODULE_OPTION )&& $(BASH) ./sed-hack.sh
 
 #: Same as mathics.pdf
 pdf latex: mathics.pdf

--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -38,7 +38,7 @@ logo-heptatom.pdf logo-text-nodrop.pdf:
 
 #: The build of the documentation which is derived from docstrings in the Python code and doctest data
 documentation.tex: $(DOCTEST_LATEX_DATA_PCL)
-	$(PYTHON) ./doc2latex.py $(MATHICS3_MODULE_OPTION )&& $(BASH) ./sed-hack.sh
+	$(PYTHON) ./doc2latex.py $(MATHICS3_MODULE_OPTION) && $(BASH) ./sed-hack.sh
 
 #: Same as mathics.pdf
 pdf latex: mathics.pdf

--- a/mathics/doc/latex/mathics.tex
+++ b/mathics/doc/latex/mathics.tex
@@ -23,6 +23,7 @@
 
 %\usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
+\usepackage{gensymb} % For \degree. usepackage needs to be early.
 \usepackage{lmodern}
 \usepackage[english]{babel}
 \usepackage{makeidx}
@@ -37,7 +38,6 @@
 \usepackage{graphics}
 \usepackage{listings}
 \usepackage{paralist}
-\usepackage{textcomp}
 \usepackage{mathpazo}
 \usepackage[mathpazo]{flexisym}
 \usepackage{breqn}

--- a/mathics/doc/latex/sed-hack.sh
+++ b/mathics/doc/latex/sed-hack.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -x
 # Brute force convert Unicode characters in LaTeX that it can't handle
+# Workaround for messages of the form:
+#    Missing character: There is no ⩵ ("2A75) in font pplr7t!
+# Mathics3 MakeBox rules should handle this but they don't.
+
+# Characters that only work in math mode we convert back
+# to their ASCII equivalent. Otherwise, since we don't
+# understand context, it might not be right to
+# use a math-mode designation.
 if [[ -f documentation.tex ]] ; then
     cp documentation.tex{,-before-sed}
 fi
@@ -12,5 +20,20 @@ sed -i -e s/″/''/g documentation.tex
 # sed -i -e s/\\′/'/g documentation.text
 #sed -i -e s/′/'/ documentation.tex
 sed -i -e s/μ/$\\\\mu$/g documentation.tex
-sed -i -e s/–/--/g documentation.tex
-sed -i -e s/Φ/$\\\\Phi$/g documentation.tex
+sed -i -e 's/–/--/g' documentation.tex
+sed -i -e 's/Φ/$\\\\Phi$/g' documentation.tex
+sed -i -e 's/ϕ/Phi/g' documentation.tex
+sed -i -e 's/→/->/g' documentation.tex
+sed -i -e 's/→/->/g' documentation.tex
+sed -i -e 's/⧴/:>/g' documentation.tex
+sed -i -e 's/—/-/g' documentation.tex
+sed -i -e 's/≤/<=/g' documentation.tex
+sed -i -e 's/≠/!=/g' documentation.tex
+sed -i -e 's/⩵/==/g' documentation.tex
+sed -i -e 's/∧/&&/g' documentation.tex
+sed -i -e 's/⧦/\\\\Equiv/g' documentation.tex
+sed -i -e 's/⊻/xor/g' documentation.tex
+sed -i -e 's/∧/&&/g' documentation.tex
+# This may looks he same as the above, but it is different.
+sed -i -e 's/∧/&&/g' documentation.tex
+sed -i -e 's/‖/||/g' documentation.tex

--- a/mathics/doc/latex/sed-hack.sh
+++ b/mathics/doc/latex/sed-hack.sh
@@ -19,12 +19,13 @@ sed -i -e s/”/''/g documentation.tex
 sed -i -e s/″/''/g documentation.tex
 # sed -i -e s/\\′/'/g documentation.text
 #sed -i -e s/′/'/ documentation.tex
-sed -i -e s/μ/$\\\\mu$/g documentation.tex
 sed -i -e 's/–/--/g' documentation.tex
+
+# Greek
 sed -i -e 's/Φ/$\\\\Phi$/g' documentation.tex
-sed -i -e 's/ϕ/Phi/g' documentation.tex
-sed -i -e 's/→/->/g' documentation.tex
-sed -i -e 's/→/->/g' documentation.tex
+sed -i -e 's/ϕ/phi/g' documentation.tex
+sed -i -e s/μ/$\\\\mu$/g documentation.tex
+
 sed -i -e 's/⧴/:>/g' documentation.tex
 sed -i -e 's/—/-/g' documentation.tex
 sed -i -e 's/≤/<=/g' documentation.tex
@@ -34,6 +35,11 @@ sed -i -e 's/∧/&&/g' documentation.tex
 sed -i -e 's/⧦/\\\\Equiv/g' documentation.tex
 sed -i -e 's/⊻/xor/g' documentation.tex
 sed -i -e 's/∧/&&/g' documentation.tex
-# This may looks he same as the above, but it is different.
-sed -i -e 's/∧/&&/g' documentation.tex
 sed -i -e 's/‖/||/g' documentation.tex
+sed -i -e 's/→/->/g' documentation.tex
+
+# This kind of tick mark appears in latitude/longitude "minute" tick marks of ExampleData/PrimeMeridian.html
+sed -i -e "s/′/'/g" documentation.tex
+
+# assumes LaTeX gensymb package
+sed -i -e "s/°/\\\\degree{}/g" documentation.tex

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -81,7 +81,9 @@ def compare(result, wanted) -> bool:
 stars = "*" * 10
 
 
-def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bool:
+def test_case(
+    test, tests, index=0, subindex=0, quiet=False, section=None, format="text"
+) -> bool:
     global check_partial_elapsed_time
     test, wanted_out, wanted = test.test, test.outs, test.result
 
@@ -103,7 +105,9 @@ def test_case(test, tests, index=0, subindex=0, quiet=False, section=None) -> bo
         print(f"{index:4d} ({subindex:2d}): TEST {test}".encode("utf-8"))
 
     feeder = MathicsSingleLineFeeder(test, "<test>")
-    evaluation = Evaluation(definitions, catch_interrupt=False, output=TestOutput())
+    evaluation = Evaluation(
+        definitions, catch_interrupt=False, output=TestOutput(), format=format
+    )
     try:
         time_parsing = datetime.now()
         query = evaluation.parse_feeder(feeder)
@@ -284,6 +288,7 @@ def test_sections(
     sections |= {"$" + s for s in sections}
     output_data = load_doctest_data() if reload else {}
     prev_key = []
+    format = "latex" if generate_output else "text"
     for tests in documentation.get_tests():
         if tests.section in sections:
             for test in tests.tests:
@@ -295,7 +300,7 @@ def test_sections(
                 if test.ignore:
                     continue
                 index += 1
-                if not test_case(test, tests, index, quiet=quiet):
+                if not test_case(test, tests, index, quiet=quiet, format=format):
                     failed += 1
                     if stop_on_failure:
                         break

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -225,7 +225,10 @@ def create_output(tests, doctest_data, format="latex"):
         if result is None:
             result = []
         else:
-            result = [result.get_data()]
+            result_data = result.get_data()
+            result_data["form"] = format
+            result = [result_data]
+
         doctest_data[key] = {
             "query": test.test,
             "results": result,
@@ -239,6 +242,7 @@ def test_chapters(
     generate_output=False,
     reload=False,
     want_sorting=False,
+    keep_going=False,
 ):
     failed = 0
     index = 0
@@ -268,7 +272,8 @@ def test_chapters(
     if index == 0:
         print_and_log(f"No chapters found named {chapter_names}.")
     elif failed > 0:
-        print_and_log("%d test%s failed." % (failed, "s" if failed != 1 else ""))
+        if not (keep_going and format == "latex"):
+            print_and_log("%d test%s failed." % (failed, "s" if failed != 1 else ""))
     else:
         print_and_log("All tests passed.")
 
@@ -280,6 +285,7 @@ def test_sections(
     generate_output=False,
     reload=False,
     want_sorting=False,
+    keep_going=False,
 ):
     failed = 0
     index = 0
@@ -304,17 +310,18 @@ def test_sections(
                     failed += 1
                     if stop_on_failure:
                         break
-            if generate_output and failed == 0:
-                create_output(tests, output_data)
+            if generate_output and (failed == 0 or keep_going):
+                create_output(tests, output_data, format=format)
 
     print()
     if index == 0:
         print_and_log(f"No sections found named {section_names}.")
     elif failed > 0:
-        print_and_log("%d test%s failed." % (failed, "s" if failed != 1 else ""))
+        if not (keep_going and format == "latex"):
+            print_and_log("%d test%s failed." % (failed, "s" if failed != 1 else ""))
     else:
         print_and_log("All tests passed.")
-    if generate_output and (failed == 0):
+    if generate_output and (failed == 0 or keep_going):
         save_doctest_data(output_data)
 
 
@@ -635,6 +642,7 @@ def main():
             stop_on_failure=args.stop_on_failure,
             generate_output=args.output,
             reload=args.reload,
+            keep_going=args.keep_going,
         )
     elif args.chapters:
         chapters = set(args.chapters.split(","))


### PR DESCRIPTION
I noticed this when looking into what it would take to get pymathics.graph graphs to format properly. 

<strike>I don't see a beneficial effect when doing this, but I imagine that</strike> as we get more proper formatting it <strike>may be</strike>  is an issue, so may as well fix it here now. 

(Short story there - all of this should be doable on the pymathics.graph side, but it will take writing some MakeBox rules, and adding a asymptote formatter for GraphBox on the pymathics.graph side. This is probably not something we should undertake before release.)

