### PR TITLE
removing the use of Evaluation.format_output in builtins

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -40,10 +40,11 @@ from mathics.core.read import (
     read_name_and_stream_from_channel,
 )
 from mathics.core.streams import path_search, stream_manager
-from mathics.core.symbols import Symbol, SymbolNull, SymbolTrue
+from mathics.core.symbols import Symbol, SymbolFullForm, SymbolNull, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolFailed,
     SymbolHold,
+    SymbolInputForm,
     SymbolOutputForm,
     SymbolReal,
 )
@@ -694,10 +695,18 @@ class Put(BinaryOperator):
             evaluation.message("Put", "openx", to_expression("OutputSteam", name, n))
             return
 
-        text = [
-            evaluation.format_output(to_expression("InputForm", expr))
-            for expr in exprs.get_sequence()
-        ]
+        # In Mathics-server, evaluation.format_output is modified.
+        # Let's avoid to use it if we want a front-end independent result.
+        # Eventually, we are going to replace this by a `MakeBoxes` call.
+        def do_format_output(expr, evaluation):
+            try:
+                boxed_expr = format_element(expr, evaluation, SymbolInputForm)
+            except BoxError:
+                boxed_expr = format_element(expr, evaluation, SymbolFullForm)
+
+            return boxed_expr.boxes_to_text()
+
+        text = [do_format_output(expr, evaluation) for expr in exprs.get_sequence()]
         text = "\n".join(text) + "\n"
         text.encode("utf-8")
 

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -12,7 +12,7 @@ from mathics_scanner import TranslateError
 from mathics import settings
 from mathics.core.atoms import Integer, String
 from mathics.core.convert.python import from_python
-from mathics.core.element import KeyComparable, ensure_context
+from mathics.core.element import BaseElement, KeyComparable, ensure_context
 from mathics.core.interrupt import (
     AbortInterrupt,
     BreakInterrupt,
@@ -380,8 +380,8 @@ class Evaluation:
         self.stopped = True
 
     def format_output(
-        self, expr: "Expression", format: Optional[str] = None
-    ) -> Union["Expression", str]:
+        self, expr: BaseElement, format: Optional[str] = None
+    ) -> Union[BaseElement, str]:
         """
         This function takes an expression `expr` and
         a format `format`. If `format` is None, then returns `expr`. Otherwise,

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -5,7 +5,7 @@ import sys
 import time
 from queue import Queue
 from threading import Thread, stack_size as set_thread_stack_size
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from mathics_scanner import TranslateError
 
@@ -379,7 +379,17 @@ class Evaluation:
     def stop(self) -> None:
         self.stopped = True
 
-    def format_output(self, expr, format=None):
+    def format_output(
+        self, expr: "Expression", format: Optional[str] = None
+    ) -> Union["Expression", str]:
+        """
+        This function takes an expression `expr` and
+        a format `format`. If `format` is None, then returns `expr`. Otherwise,
+        produce an str with the proper format.
+
+        Notice that this function can be overwritten by the front-ends, so it should not be
+        used in Builtin classes where it is expected a front-end independent result.
+        """
         from mathics.eval.makeboxes import format_element
 
         if format is None:


### PR DESCRIPTION
This PR fixes an issue reported by @rocky, where the behavior or `Put` was modified when is was called from mathics-server.  Now, in `mathics.builtin` all the references to `format_output` which is modified by mathics-server  were rempaced by calls to `format_element` and `boxes_to_text`.

