### PR TITLE
removing blanks from url

### DIFF
--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -233,6 +233,19 @@ def escape_latex(text):
     def repl_hypertext(match) -> str:
         tag = match.group("tag")
         content = match.group("content")
+        #
+        # Sometimes it happens that the URL does not
+        # fit in 80 characters. Then, to avoid that
+        # flake8 complains, and also to have a
+        # nice and readable ASCII representation,
+        # we would like to split the URL in several,
+        # lines, having indentation spaces.
+        #
+        # The following line removes these extra
+        # characters, which would spoil the URL,
+        # producing a single line, space-free string.
+        #
+        content = content.replace(" ", "").replace("\n", "")
         if tag == "em":
             return r"\emph{%s}" % content
         elif tag == "url":


### PR DESCRIPTION
The same as in https://github.com/Mathics3/mathics-django/pull/190

This single line PR is a proposal about how to handle long urls in docstrings. With this patch

```
<url>:NetworkX:
     https://networkx.org/documentation/networkx-2.8.8/reference/algorithms/\
      generated/networkx.algorithms.tree.mst.minimum_spanning_edges.html
</url>
```

the <url></url> tag is processed as
```
<a href=https://networkx.org/documentation/networkx-2.8.8/reference/algorithms/generated/networkx.algorithms.tree.mst.minimum_spanning_edges.html>NetworkX</a>
```
