### PR TITLE
fix do_format_element

### DIFF
--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -754,8 +754,12 @@ class OutputForm(FormBaseClass):
      = f'[x]
     >> OutputForm[Derivative[1, 0][f][x]]
      = Derivative[1, 0][f][x]
-    >> OutputForm["A string"]
-     = A string
+
+    'OutputForm' is used by default:
+    >> OutputForm[{"A string", a + b}]
+     = {A string, a + b}
+    >> {"A string", a + b}
+     = {A string, a + b}
     >> OutputForm[Graphics[Rectangle[]]]
      = -Graphics-
     """
@@ -850,11 +854,8 @@ class StandardForm(FormBaseClass):
     </dl>
 
     >> StandardForm[a + b * c]
-     = a + b c
+     = a+b c
     >> StandardForm["A string"]
-     = A string
-    'StandardForm' is used by default:
-    >> "A string"
      = A string
     >> f'[x]
      = f'[x]

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -652,6 +652,9 @@ class Pi(_MPMathConstant, _SympyConstant):
       <dd>is the constant \u03c0.
     </dl>
 
+    >> Pi
+     = Pi
+
     >> N[Pi]
      = 3.14159
 

--- a/mathics/eval/makeboxes.py
+++ b/mathics/eval/makeboxes.py
@@ -142,7 +142,7 @@ def do_format_element(
         # removes the format from the expression.
         if head in OutputForms and len(expr.elements) == 1:
             expr = elements[0]
-            if not (form is SymbolOutputForm and head is SymbolStandardForm):
+            if not form.sameQ(head):
                 form = head
                 include_form = True
 


### PR DESCRIPTION
This fix the issue mentioned in https://github.com/Mathics3/mathics-core/issues/784#issuecomment-1434767955:

With this PR, in the CLI,
```
In[1]:=Pi
Out[1]=Pi

In[2]:=OutputForm[Pi]
Out[2]=Pi

In[3]:=StandardForm[Pi]
Out[3]= π
```