### PR TITLE
storing attributes when a pattern is created

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -24,6 +24,7 @@ from mathics.core.convert.op import ascii_operator_to_symbol
 from mathics.core.convert.python import from_bool
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.definitions import Definition
+from mathics.core.evaluation import Evaluation
 from mathics.core.exceptions import MessageException
 from mathics.core.expression import Expression, SymbolDefault
 from mathics.core.interrupt import BreakInterrupt, ContinueInterrupt, ReturnInterrupt
@@ -932,14 +933,16 @@ class PatternObject(BuiltinElement, Pattern):
 
     arg_counts: List[int] = []
 
-    def init(self, expr):
-        super().init(expr)
+    def init(self, expr, evaluation: Optional[Evaluation] = None):
+        super().init(expr, evaluation=evaluation)
         if self.arg_counts is not None:
             if len(expr.elements) not in self.arg_counts:
                 self.error_args(len(expr.elements), *self.arg_counts)
         self.expr = expr
-        self.head = Pattern.create(expr.head)
-        self.elements = [Pattern.create(element) for element in expr.elements]
+        self.head = Pattern.create(expr.head, evaluation=evaluation)
+        self.elements = [
+            Pattern.create(element, evaluation=evaluation) for element in expr.elements
+        ]
 
     def error(self, tag, *args):
         raise PatternError(self.get_name(), tag, *args)

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -3,6 +3,7 @@
 
 from inspect import signature
 from itertools import chain
+from typing import Callable, Optional
 
 from mathics.core.element import KeyComparable
 from mathics.core.evaluation import Evaluation
@@ -38,8 +39,13 @@ class BaseRule(KeyComparable):
 
     """
 
-    def __init__(self, pattern, system=False) -> None:
-        self.pattern = Pattern.create(pattern)
+    def __init__(
+        self,
+        pattern: Expression,
+        system: bool = False,
+        evaluation: Optional[Evaluation] = None,
+    ) -> None:
+        self.pattern = Pattern.create(pattern, evaluation=evaluation)
         self.system = system
 
     def apply(
@@ -134,8 +140,14 @@ class Rule(BaseRule):
     ``G[1.^2, a^2]``
     """
 
-    def __init__(self, pattern, replace, system=False) -> None:
-        super(Rule, self).__init__(pattern, system=system)
+    def __init__(
+        self,
+        pattern: Expression,
+        replace: Expression,
+        system=False,
+        evaluation: Optional[Evaluation] = None,
+    ) -> None:
+        super(Rule, self).__init__(pattern, system=system, evaluation=evaluation)
         self.replace = replace
 
     def do_replace(self, expression, vars, options: dict, evaluation: Evaluation):
@@ -201,8 +213,16 @@ class BuiltinRule(BaseRule):
     This will cause `Expression.evalate() to perform an additional ``rewrite_apply_eval()`` step.
     """
 
-    def __init__(self, name, pattern, function, check_options, system=False) -> None:
-        super(BuiltinRule, self).__init__(pattern, system=system)
+    def __init__(
+        self,
+        name: str,
+        pattern: Expression,
+        function: Callable,
+        check_options: Callable,
+        system: bool = False,
+        evaluation: Optional[Evaluation] = None,
+    ) -> None:
+        super(BuiltinRule, self).__init__(pattern, system=system, evaluation=evaluation)
         self.name = name
         self.function = function
         self.check_options = check_options


### PR DESCRIPTION
Inspired in discussion #800, this changes a little bit the implementation of `Pattern`, in a way that attributes are stored in the object instead of looking at it in the Definitions object. Just with this, doctest cuts other 7s (~7% faster than master in Pyston).  
Also, I added a pytest with the tests proposed in #800.