### PR TITLE
fix MakeBoxes[PrecedenceForm[...],form]

### DIFF
--- a/SYMBOLS_MANIFEST.txt
+++ b/SYMBOLS_MANIFEST.txt
@@ -769,6 +769,7 @@ System`PowerMod
 System`PreDecrement
 System`PreIncrement
 System`Precedence
+System`PrecedenceForm
 System`Precision
 System`Prefix
 System`Prepend

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -288,6 +288,19 @@ class Precedence(Builtin):
         return Real(precedence)
 
 
+class PrecedenceForm(Builtin):
+    """
+    <url>:WMA link:https://reference.wolfram.com/language/ref/PrecedenceForm.html</url>
+
+    <dl>
+      <dt>'PrecedenceForm'[$expr$, $prec$]
+      <dd> format $expr$ parenthesized as it would be if it contained an operator of precedence $prec$.
+    </dl>
+    """
+
+    summary_text = "parenthesize with a precedence"
+
+
 class Prefix(BinaryOperator):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/Prefix.html</url>

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -400,12 +400,12 @@ class MakeBoxes(Builtin):
             result.append(to_boxes(String(right), evaluation))
             return RowBox(*result)
 
-    def eval_outerprecedenceform(self, expr, precedence, evaluation):
+    def eval_outerprecedenceform(self, expr, precedence, form, evaluation):
         """MakeBoxes[PrecedenceForm[expr_, precedence_],
-        StandardForm|TraditionalForm|OutputForm|InputForm]"""
+        form:StandardForm|TraditionalForm|OutputForm|InputForm]"""
 
         py_precedence = precedence.get_int_value()
-        boxes = MakeBoxes(expr)
+        boxes = MakeBoxes(expr, form)
         return parenthesize(py_precedence, expr, boxes, True)
 
     def eval_postprefix(self, p, expr, h, precedence, form, evaluation):


### PR DESCRIPTION
This came up during the #766 rebase: `PrecisionForm` didn't have a `Builtin` symbol, and the `Makeboxes` rule didn't take into account the `form` parameter. This PR fixes these two issues.