### PR TITLE
adding Elements. Local symbols in rules/Bessel.m  inside a private context.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ CHANGES
 =======
 
 
+New Builtins
+++++++++++++
+
+
+* `Elements`
+
+
 Compatibility
 -------------
 

--- a/SYMBOLS_MANIFEST.txt
+++ b/SYMBOLS_MANIFEST.txt
@@ -337,6 +337,7 @@ System`EditDistance
 System`Eigensystem
 System`Eigenvalues
 System`Eigenvectors
+System`Element
 System`ElementData
 System`EllipticE
 System`EllipticF

--- a/mathics/autoload/rules/Bessel.m
+++ b/mathics/autoload/rules/Bessel.m
@@ -1,6 +1,6 @@
 (*Extended rules for handling expressions with Bessel functions*)
 
-
+Begin["internals`bessel`"]
 
 Unprotect[HankelH1];
 (*HankelH1[x_Integer?NegativeQ, z_]:=-HankelH1[-x, z];*)
@@ -77,3 +77,4 @@ Integrate[Cos[z_ Sin[Theta_]], {Theta_, 0, Pi}]:= ConditionalExpression[Pi Besse
 Protect[Integrate];
 
 (*TODO: extend me with series expansions, integrals, etc*)
+End[]

--- a/mathics/autoload/rules/Element.m
+++ b/mathics/autoload/rules/Element.m
@@ -1,0 +1,120 @@
+(*Rules for Elements*)
+
+
+System`Integers::usage="Represents the set of the Integers numbers";
+System`Primes::usage="Represents the set of the prime numbers";
+System`Rationals::usage="Represents the set of the Rational numbers";
+System`Reals::usage="Represents the field of the Real numbers";
+System`Complexes::usage="Represents the field of the Complex numbers";
+System`Algebraics::usage="Represents the set of the algebraic numbers";
+System`Booleans::usage="Represents the set of boolean values";
+
+Begin["internals`elements`"]
+Unprotect[Element]
+
+
+Element[_Integer, Reals]:=True;
+
+(*Booleans*)
+Element[True|False, Booleans]:=True;
+Element[E|I|EulerGamma|Khinchin|MachinePrecision|Pi, Booleans]:=False;
+Element[_Integer|_Rational|_Real|_Complex, Booleans]:=False;
+
+
+
+(*Integers*)
+Element[True|False|E|I|EulerGamma|Khinchin|MachinePrecision|Pi, Integers]:=False;
+Element[_Integer, Integers]:=True;
+Element[_Rational|_Complex, Integers]:=False;
+Element[x_Real/;(FractionalPart[x]!=0.), Integers]:=False;
+
+
+
+
+(*Rationals*)
+Element[True|False|E|I|EulerGamma|Khinchin|MachinePrecision|Pi, Rationals]:=False;
+Element[_Integer|_Rational, Rationals]:=True;
+Element[_Complex, Rationals]:=False;
+
+
+
+
+
+
+(*Reals*)
+Element[True|False|I, Reals]:=False;
+Element[E|EulerGamma|Khinchin|MachinePrecision|Pi, Reals]:=True;
+Element[_Rational, Reals]:=True;
+Element[_Real, Reals]:=True;
+Element[_Complex, Reals]:=False;
+
+
+
+(*Complex*)
+Element[True|False, Complexes]:=False;
+Element[E|EulerGamma|I|Khinchin|MachinePrecision|Pi, Complexes]:=True;
+Element[_Integer|_Rational|_Real|_Complex, Complexes]:=True;
+
+
+
+(*Elementary inexact functions*)
+Element[f:(Sin[_]|Cos[_]|Tan[_]|Cot[_]|Sec[_]|Cosec[_]|Sinh[_]|Cosh[_]|Tanh[_]|Coth[_]|Sech[_]|Cosech[_]|
+	 Log[_]|Exp[_]| ArcSin[_]|ArcCos[_]|ArcTan[_]|ArcCot[_]|ArcSec[_]|ArcCosec[_]|
+	 ArcSinh[_]|ArcCosh[_]|ArcTanh[_]|ArcCoth[_]|ArcSech[_]|ArcCosech[_]), domine:Reals|Complexes]:=Element[f[[1]], domine];
+
+
+
+
+
+(*Primes*)
+Element[True|False|E|I|EulerGamma|Khinchin|MachinePrecision|Pi, Primes]:=False;
+Element[z_Integer, Primes]:=PrimeQ[z];
+Element[_Rational|_Complex, Primes]:=False;
+Element[x_Real/;(FractionalPart[x]!=0.), Primes]:=False;
+(*TODO: Check this condition. Probably this need to be implemented in Python...*)
+Element[x_, Primes]:=If[Element[x, Algebraics]===True, False, HoldForm[Element[x, Primes]]];
+
+
+indice=9;
+
+(*General Algebraic*)
+
+Element[z:(_Plus|_Times), domine:(Booleans|Integers|Rationals|Reals|Complexes|Algebraics)]:=Element[Alternatives@@z, domine];
+Element[_Times, Primes]:=Element[Alternatives@@z, Primes];
+
+
+Element[z_Power, Algebraics]:=Element[Alternatives@@z, Algebraics];
+Element[z:(_Integer|_Rational|_Complex), Algebraics]:=True;
+Element[I, Algebraics]:=True;
+Element[True|False|E|EulerGamma|Khinchin|MachinePrecision|Pi, Algebraics]:=False;
+Element[z_DirectedInfinity, domine:(Booleans|Integers|Rationals|Reals|Complexes)]:=False;
+Element[z_Power, Integers]:= (Element[Alternatives@@z, Integers] && z[[2]]>=0);
+Element[z_Power/;Element[Alternatives@@z, ], Integers]:= (z[[2]]>=0);
+
+Element[z_Power, Complexes]:= Element[z, Algebraics];
+Element[Power[b_,p_], Rationals]:=Element[b, Rationals] && Element[p, Integers] ;
+
+
+indice=10;
+
+
+
+
+Element[Sin[_]|Cos[_]|Tan[_]|Cot[_]|Sec[_]|Cosec[_]|
+         Sinh[_]|Cosh[_]|Tanh[_]|Coth[_]|Sech[_]|Cosech[_]|
+	 Log[_]|Exp[_]|
+	 ArcSin[_]|ArcCos[_]|ArcTan[_]|ArcCot[_]|ArcSec[_]|ArcCosec[_]|
+	 ArcSinh[_]|ArcCosh[_]|ArcTanh[_]|ArcCoth[_]|ArcSech[_]|ArcCosech[_]
+	 , Integers|Primes|Rationals|Algebraics|Booleans]:=False;
+
+
+
+indice=11;
+
+
+Element[Power[b_Real|b_Rational|b_Integer, _Real|_Rational], Reals]:= (b>=0);
+Element[Power[_Real|_Rational|_Integer, p_Integer], Reals]:= True;
+Element[Power[b_/;(Element[b, Reals]), p_/;Element[p, Reals]], Reals]:=(Element[p, Integers] || b>=0);
+
+Protect[Element]
+End[]

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -705,20 +705,23 @@ class Element(Builtin):
       <dt>'Element[$expr$, $domain$]'
       <dd>returns $True$ if $expr$ is an element of $domain$
       <dt>'Element[$expr_1$|$expr_2$|..., $domain$]'
-      <dd>returns $True$ if all the $expr_i$ belongs to $domain$, and $False$ if \
-      one of the items doesn't.
+      <dd>returns $True$ if all the $expr_i$ belongs to $domain$, and \
+    $False$ if one of the items doesn't.
     </dl>
 
 
-    Check if $3$ and $a$ are both integers. If $a$ is not defined, then 'Element' reduces the condition:
+    Check if $3$ and $a$ are both integers. If $a$ is not defined, then \
+'Element' reduces the condition:
     >> Element[3 | a, Integers]
      = Element[a, Integers]
 
-    Notice that standard domain names ('Primes', 'Integers', 'Rationals', 'Algebraics', 'Reals', 'Complexes', and 'Booleans')\
+    Notice that standard domain names ('Primes', 'Integers', 'Rationals', \
+'Algebraics', 'Reals', 'Complexes', and 'Booleans')\
     are in plural form. If a singular form is used, a warning is shown:
 
     >> Element[a, Real]
-     : The second argument Real of Element should be one of: Primes, Integers, Rationals, Algebraics, Reals, Complexes, or Booleans.
+     : The second argument Real of Element should be one of: Primes, Integers, \
+Rationals, Algebraics, Reals, Complexes, or Booleans.
      = Element[a, Real]
 
     """
@@ -736,7 +739,10 @@ class Element(Builtin):
     def eval_wrong_domain(
         self, elem: BaseElement, domain: BaseElement, evaluation: Evaluation
     ):
-        """Element[elem_, domain:(Alternatives[Algebraic, Bool, Integer, Prime, Rational, Real, Complex])]"""
+        (
+            "Element[elem_, domain:(Alternatives["
+            "Algebraic, Bool, Integer, Prime, Rational, Real, Complex])]"
+        )
         evaluation.message("Element", "bset", domain)
         return None
 

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -43,7 +43,7 @@ from mathics.core.attributes import (
 )
 from mathics.core.convert.expression import to_expression
 from mathics.core.convert.sympy import SympyExpression, from_sympy, sympy_symbol_prefix
-from mathics.core.element import ElementsProperties
+from mathics.core.element import BaseElement, ElementsProperties
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -694,6 +694,71 @@ class DirectedInfinity(SympyFunction):
                 return sympy.Mul((expr.elements[0].to_sympy()), sympy.zoo)
         else:
             return sympy.zoo
+
+
+class Element(Builtin):
+    """
+    <url>:Element of:https://en.wikipedia.org/wiki/Element_(mathematics)</url> \
+    (<url>:WMA:https://reference.wolfram.com/language/ref/Element.html</url>)
+
+    <dl>
+      <dt>'Element[$expr$, $domain$]'
+      <dd>returns $True$ if $expr$ is an element of $domain$
+      <dt>'Element[$expr_1$|$expr_2$|..., $domain$]'
+      <dd>returns $True$ if all the $expr_i$ belongs to $domain$, and $False$ if \
+      one of the items doesn't.
+    </dl>
+
+
+    Check if $3$ and $a$ are both integers. If $a$ is not defined, then 'Element' reduces the condition:
+    >> Element[3 | a, Integers]
+     = Element[a, Integers]
+
+    Notice that standard domain names ('Primes', 'Integers', 'Rationals', 'Algebraics', 'Reals', 'Complexes', and 'Booleans')\
+    are in plural form. If a singular form is used, a warning is shown:
+
+    >> Element[a, Real]
+     : The second argument Real of Element should be one of: Primes, Integers, Rationals, Algebraics, Reals, Complexes, or Booleans.
+     = Element[a, Real]
+
+    """
+
+    messages = {
+        "bset": (
+            "The second argument `1` of Element should be one of: "
+            "Primes, Integers, Rationals, Algebraics, "
+            "Reals, Complexes, or Booleans."
+        ),
+    }
+
+    summary_text = "check whether belongs the domain"
+
+    def eval_wrong_domain(
+        self, elem: BaseElement, domain: BaseElement, evaluation: Evaluation
+    ):
+        """Element[elem_, domain:(Alternatives[Algebraic, Bool, Integer, Prime, Rational, Real, Complex])]"""
+        evaluation.message("Element", "bset", domain)
+        return None
+
+    def eval_Element_alternatives(
+        self, elems: BaseElement, domain: BaseElement, evaluation: Evaluation
+    ) -> Optional[Expression]:
+        """Element[elems_Alternatives, domain_]"""
+        items = elems.elements
+        unknown = []
+        for item in items:
+            item_belongs = Element(item, domain).evaluate(evaluation)
+            if item_belongs is SymbolTrue:
+                continue
+            if item_belongs is SymbolFalse:
+                return SymbolFalse
+            unknown.append(item)
+        if len(unknown) == len(items):
+            return None
+        if len(unknown) == 0:
+            return SymbolTrue
+        # If some of the items remain unkown, return a reduced expression
+        return Element(Expression(elems.head, *unknown), domain)
 
 
 class I_(Predefined):

--- a/test/builtin/arithmetic/test_element.py
+++ b/test/builtin/arithmetic/test_element.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtins.arithmetic.Element
+"""
+from test.helper import check_evaluation
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            "Table[Element[elem, Integers], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2,Sin[3]}}]",
+            "{True, False, False, Element[a, Integers], False, False, False}",
+            "Integers",
+        ),
+        (
+            "Table[Element[elem, Primes], {elem, {1, 2, 1.3, Pi, a, True, Sqrt[5]-2,Sin[3]}}]",
+            "{False, True, False, False, Element[a, Primes], False, False, False}",
+            "Primes",
+        ),
+        (
+            "Table[Element[elem, Rationals], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2,Sin[3]}}]",
+            "{True, Element[1.3, Rationals], False, Element[a, Rationals], False, False, False}",
+            "Rationals",
+        ),
+        (
+            "Table[Element[elem, Reals], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
+            "{True, True, True, Element[a, Reals], False, True, True}",
+            "Reals",
+        ),
+        (
+            "Table[Element[elem, Complexes], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
+            "{True, True, True, Element[a, Complexes], False, True, True}",
+            "Complexes",
+        ),
+        (
+            "Table[Element[elem, Algebraics], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
+            "{True, Element[1.3, Algebraics], False, Element[a, Algebraics], False, True, False}",
+            "Algebraics",
+        ),
+        (
+            "Table[Element[elem, Booleans], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
+            "{False, False, False, Element[a, Booleans], True, False, False}",
+            "Booleans",
+        ),
+    ],
+)
+def test_element(str_expr, str_expected, msg):
+    check_evaluation(str_expr, str_expected, failure_message=msg)

--- a/test/builtin/arithmetic/test_element.py
+++ b/test/builtin/arithmetic/test_element.py
@@ -6,45 +6,45 @@ from test.helper import check_evaluation
 
 import pytest
 
+test_set = "{elem, {1, 2, 4, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}"
+
+domains = {
+    "Integers": (
+        "{True, True, True, False, False, " "Element[a, Integers], False, False, False}"
+    ),
+    "Primes": (
+        "{False, True, False, False, False, " "Element[a, Primes], False, False, False}"
+    ),
+    "Rationals": (
+        "{True, True, True, Element[1.3, Rationals], False, "
+        "Element[a, Rationals], False, False, False}"
+    ),
+    "Reals": (
+        "{True, True, True, True, True, " "Element[a, Reals], False, True, True}"
+    ),
+    "Complexes": (
+        "{True, True, True, True, True, " "Element[a, Complexes], False, True, True}"
+    ),
+    "Algebraics": (
+        "{True, True, True, Element[1.3, Algebraics], False, "
+        "Element[a, Algebraics], False, True, False}"
+    ),
+    "Booleans": (
+        "{False, False, False, False, False, "
+        "Element[a, Booleans], True, False, False}"
+    ),
+}
+
 
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
         (
-            "Table[Element[elem, Integers], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2,Sin[3]}}]",
-            "{True, False, False, Element[a, Integers], False, False, False}",
-            "Integers",
-        ),
-        (
-            "Table[Element[elem, Primes], {elem, {1, 2, 1.3, Pi, a, True, Sqrt[5]-2,Sin[3]}}]",
-            "{False, True, False, False, Element[a, Primes], False, False, False}",
-            "Primes",
-        ),
-        (
-            "Table[Element[elem, Rationals], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2,Sin[3]}}]",
-            "{True, Element[1.3, Rationals], False, Element[a, Rationals], False, False, False}",
-            "Rationals",
-        ),
-        (
-            "Table[Element[elem, Reals], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
-            "{True, True, True, Element[a, Reals], False, True, True}",
-            "Reals",
-        ),
-        (
-            "Table[Element[elem, Complexes], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
-            "{True, True, True, Element[a, Complexes], False, True, True}",
-            "Complexes",
-        ),
-        (
-            "Table[Element[elem, Algebraics], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
-            "{True, Element[1.3, Algebraics], False, Element[a, Algebraics], False, True, False}",
-            "Algebraics",
-        ),
-        (
-            "Table[Element[elem, Booleans], {elem, {1, 1.3, Pi, a, True, Sqrt[5]-2, Sin[3]}}]",
-            "{False, False, False, Element[a, Booleans], True, False, False}",
-            "Booleans",
-        ),
+            f"Table[Element[elem, {key}], {test_set}]",
+            domains[key],
+            key,
+        )
+        for key in domains
     ],
 )
 def test_element(str_expr, str_expected, msg):

--- a/test/builtin/specialfns/test_bessel.py
+++ b/test/builtin/specialfns/test_bessel.py
@@ -14,16 +14,16 @@ import pytest
     [
         (
             "BesselI[1/2,z]",
-            "Sqrt[2] Sinh[z] / (Sqrt[Pi] Sqrt[z])",
+            "Sqrt[2] Sinh[z] / (Sqrt[z] Sqrt[Pi])",
             "BesselI 1/2 rule",
         ),
         (
             "BesselI[-1/2,z]",
-            "Sqrt[2] Cosh[z] / (Sqrt[Pi] Sqrt[z])",
+            "Sqrt[2] Cosh[z] / (Sqrt[z] Sqrt[Pi])",
             "BesselI -1/2 rule",
         ),
-        ("BesselJ[-1/2,z]", "Sqrt[2] Cos[z] / (Sqrt[Pi] Sqrt[z])", "BesselJ -1/2 rule"),
-        ("BesselJ[1/2,z]", "Sqrt[2] Sin[z] / (Sqrt[Pi] Sqrt[z])", "BesselJ 1/2 rule"),
+        ("BesselJ[-1/2,z]", "Sqrt[2] Cos[z] / (Sqrt[z] Sqrt[Pi])", "BesselJ -1/2 rule"),
+        ("BesselJ[1/2,z]", "Sqrt[2] Sin[z] / (Sqrt[z] Sqrt[Pi])", "BesselJ 1/2 rule"),
     ],
 )
 def test_add(str_expr, str_expected, assert_failure_msg):


### PR DESCRIPTION
This PR adds the built-in `Element`, which is used in defining certain integrals. In particular, it would be useful to extend more the support for integral representations of special functions.

Also, I noticed that when `Set`/`SetDelayed` expressions with a LHS involving named patterns appear in autoload files, the temporal names can spoil the `System` namespace, making some test fail. A way to prevent that is to enclose the code of the modules in a `Begin`/`End` statement. Public symbols defined in the module appear then before the private block, by assigning a usage string.