### PR TITLE
Unprotect RealNumberQ 

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -1128,6 +1128,8 @@ class RealNumberQ(Test):
      = True
     """
 
+    attributes = A_NO_ATTRIBUTES
+
     summary_text = "test whether an expression is a real number"
 
     def test(self, expr):


### PR DESCRIPTION
This is not a WMA builtin so it should not be protected. Possibly we should remove this altogether and add ExactNumberQ

Rubi 5 defines RealNumberQ so this is a problem.