### PR TITLE
Start adding Limit[] rules

### DIFF
--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -4,14 +4,14 @@
    These were culled from symja_android_library/rules/LimitRules.m.
  *)
 
-BeginPackage["Limit"]
+(* BeginPackage["Limit"] *)
 
-Begin["`private`"]
+(* Begin["`private`"] *)
 Unprotect[Limit];
 Limit[Tan[System`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
 Limit[Cot[System`Limit`x_], System`Limit`x_Symbol->0] = Indeterminate;
-Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limitx_^-1), System`Limit`x_Symbol->Infinity] = E;
+Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limit`x_^-1), System`Limit`x_Symbol->Infinity] = E;
 Protect[Limit];
-End[]
+(* End[] *)
 
-EndPackage[]
+(* EndPackage[] *)

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -14,9 +14,7 @@ To be false when it should be true.
  Huh?
  ****)
 
-(****
-Limit[Tan[x_], x_Symbol->Pi/2] = Indeterminate;
-Limit[Cot[x_], x_Symbol->0] = Indeterminate;
-Limit[x_*Sqrt[2*Pi]^(x_^-1)*(Sin[x_]/(x_!))^(x^-1), x_Symbol->Infinity] = E;
- ****)
+Limit[Tan[Sysetm`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
+Limit[Cot[System`Limit`x_], System`Limit`x_Symbol->0] = Indeterminate;
+Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limitx_^-1), System`Limit`x_Symbol->Infinity] = E;
 Protect[Limit];

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -5,7 +5,18 @@
  *)
 
 Unprotect[Limit];
-Limit[Tan[x_], x_Symbol->Pi/2] := Indeterminate;
-Limit[Cot[x_], x_Symbol->0] := Indeterminate;
-Limit[x_*Sqrt[2*Pi]^(x_^-1)*(Sin[x_]/(x_!))^(x^-1), x_Symbol->Infinity] := E;
+(*****
+ Fixme  Uncommenting any of the below causes:
+
+  G[x_Real]=x^2; a={G[x]}; {x=1.; a, x=.; a} == {{1.}, {G[x]}}
+
+To be false when it should be true.
+ Huh?
+ ****)
+
+(****
+Limit[Tan[x_], x_Symbol->Pi/2] = Indeterminate;
+Limit[Cot[x_], x_Symbol->0] = Indeterminate;
+Limit[x_*Sqrt[2*Pi]^(x_^-1)*(Sin[x_]/(x_!))^(x^-1), x_Symbol->Infinity] = E;
+ ****)
 Protect[Limit];

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -8,9 +8,9 @@ BeginPackage["Limit"]
 
 Begin["`private`"]
 Unprotect[Limit];
-Limit[Tan[x_], x_Symbol->Pi/2] = Indeterminate;
-Limit[Cot[x_], x_Symbol->0] = Indeterminate;
-Limit[x_ Sqrt[2 Pi]^(x_^-1) (Sin[x_]/(x_!))^(x_^-1), x_Symbol->Infinity] = E;
+Limit[Tan[System`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
+Limit[Cot[System`Limit`x_], System`Limit`x_Symbol->0] = Indeterminate;
+Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limitx_^-1), System`Limit`x_Symbol->Infinity] = E;
 Protect[Limit];
 End[]
 

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -1,0 +1,11 @@
+(* Additions to mathics.builtin.numbers.trig that are either wrong
+   or not covered by SymPy.
+
+   These were culled from symja_android_library/rules/LimitRules.m.
+ *)
+
+Unprotect[Limit];
+Limit[Tan[x_], x_Symbol->Pi/2] := Indeterminate;
+Limit[Cot[x_], x_Symbol->0] := Indeterminate;
+Limit[x_*Sqrt[2*Pi]^(x_^-1)*(Sin[x_]/(x_!))^(x^-1), x_Symbol->Infinity] := E;
+Protect[Limit];

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -4,8 +4,14 @@
    These were culled from symja_android_library/rules/LimitRules.m.
  *)
 
+BeginPackage["Limit"]
+
+Begin["`private`"]
 Unprotect[Limit];
-Limit[Tan[System`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
-Limit[Cot[System`Limit`x_], System`Limit`x_Symbol->0] = Indeterminate;
-Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limitx_^-1), System`Limit`x_Symbol->Infinity] = E;
+Limit[Tan[x_], x_Symbol->Pi/2] = Indeterminate;
+Limit[Cot[x_], x_Symbol->0] = Indeterminate;
+Limit[x_ Sqrt[2 Pi]^(x_^-1) (Sin[x_]/(x_!))^(x_^-1), x_Symbol->Infinity] = E;
 Protect[Limit];
+End[]
+
+EndPackage[]

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -5,7 +5,7 @@
  *)
 
 Unprotect[Limit];
-Limit[Tan[Sysetm`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
+Limit[Tan[System`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
 Limit[Cot[System`Limit`x_], System`Limit`x_Symbol->0] = Indeterminate;
 Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limitx_^-1), System`Limit`x_Symbol->Infinity] = E;
 Protect[Limit];

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1230,10 +1230,6 @@ class Limit(Builtin):
      = Infinity
     >> Limit[1/x, x->0, Direction->1]
      = -Infinity
-
-    #> Limit[x, x -> x0, Direction -> x]
-     : Value of Direction -> x should be -1 or 1.
-     = Limit[x, x -> x0, Direction -> x]
     """
 
     """

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1296,10 +1296,12 @@ class NIntegrate(Builtin):
 
     <dl>
        <dt>'NIntegrate[$expr$, $interval$]'
-       <dd>returns a numeric approximation to the definite integral of $expr$ with limits $interval$ and with a precision of $prec$ digits.
+       <dd>returns a numeric approximation to the definite integral of $expr$ with \
+           limits $interval$ and with a precision of $prec$ digits.
 
         <dt>'NIntegrate[$expr$, $interval1$, $interval2$, ...]'
-        <dd>returns a numeric approximation to the multiple integral of $expr$ with limits $interval1$, $interval2$ and with a precision of $prec$ digits.
+        <dd>returns a numeric approximation to the multiple integral of $expr$ with \
+            limits $interval1$, $interval2$ and with a precision of $prec$ digits.
     </dl>
 
     >> NIntegrate[Exp[-x],{x,0,Infinity},Tolerance->1*^-6, Method->"Internal"]

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1232,12 +1232,6 @@ class Limit(Builtin):
      = -Infinity
     """
 
-    """
-    The following test is currently causing PyPy to segfault...
-     #> Limit[(1 + cos[x]) / x, x -> 0]
-     = Limit[(1 + cos[x]) / x, x -> 0]
-    """
-
     attributes = A_LISTABLE | A_PROTECTED
 
     messages = {

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -2128,7 +2128,8 @@ class Solve(Builtin):
     <url>:Equation solving:
     https://en.wikipedia.org/wiki/Equation_solving</url> (<url>
     :SymPy:
-    https://docs.sympy.org/latest/modules/solvers/solvers.html#module-sympy.solvers</url>, \
+    https://docs.sympy.org/latest/modules
+/solvers/solvers.html#module-sympy.solvers</url>, \
     <url>:WMA:
     https://reference.wolfram.com/language/ref/Solve.html</url>)
 
@@ -2137,7 +2138,8 @@ class Solve(Builtin):
       <dd>attempts to solve $equation$ for the variables $vars$.
 
       <dt>'Solve[$equation$, $vars$, $domain$]'
-      <dd>restricts variables to $domain$, which can be 'Complexes' or 'Reals' or 'Integers'.
+      <dd>restricts variables to $domain$, which can be 'Complexes' \
+         or 'Reals' or 'Integers'.
     </dl>
 
     >> Solve[x ^ 2 - 3 x == 4, x]

--- a/test/builtin/arithmetic/__init__.py
+++ b/test/builtin/arithmetic/__init__.py
@@ -1,1 +1,3 @@
-# -*- coding: utf-8 -*-
+"""
+Test of builtin functions in mathics.builtin.arithmetic
+"""

--- a/test/builtin/calculus/__init__.py
+++ b/test/builtin/calculus/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test of builtin functions in mathics.builtin.calculus
+"""

--- a/test/builtin/calculus/test_limit.py
+++ b/test/builtin/calculus/test_limit.py
@@ -10,15 +10,14 @@ import pytest
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        # Defining limit rules is broken! FIXME
-        # ("Limit[Tan[x], x->Pi/2]", "Indeterminate", None),
-        # ("Limit[Cot[x], x->0]", "Indeterminate", None),
-        # ("Limit[x*Sqrt[2*Pi]^(x^-1)*(Sin[x]/(x!))^(x^-1), x->Infinity]", "E", None),
+        ("Limit[Tan[x], x->Pi/2]", "Indeterminate", None),
+        ("Limit[Cot[x], x->0]", "Indeterminate", None),
+        ("Limit[x*Sqrt[2*Pi]^(x^-1)*(Sin[x]/(x!))^(x^-1), x->Infinity]", "E", None),
         (
             "Limit[x, x -> x0, Direction -> x]",
             "Limit[x, x -> x0, Direction -> x]",
             "Value of Direction -> x should be -1 or 1.",
-        )
+        ),
     ],
 )
 def test_limit(str_expr, str_expected, msg):

--- a/test/builtin/calculus/test_limit.py
+++ b/test/builtin/calculus/test_limit.py
@@ -10,9 +10,15 @@ import pytest
 @pytest.mark.parametrize(
     ("str_expr", "str_expected", "msg"),
     [
-        ("Limit[Tan[x], x->Pi/2]", "Indeterminate", None),
-        ("Limit[Cot[x], x->0]", "Indeterminate", None),
-        ("Limit[x*Sqrt[2*Pi]^(x^-1)*(Sin[x]/(x!))^(x^-1), x->Infinity]", "E", None),
+        # Defining limit rules is broken! FIXME
+        # ("Limit[Tan[x], x->Pi/2]", "Indeterminate", None),
+        # ("Limit[Cot[x], x->0]", "Indeterminate", None),
+        # ("Limit[x*Sqrt[2*Pi]^(x^-1)*(Sin[x]/(x!))^(x^-1), x->Infinity]", "E", None),
+        (
+            "Limit[x, x -> x0, Direction -> x]",
+            "Limit[x, x -> x0, Direction -> x]",
+            "Value of Direction -> x should be -1 or 1.",
+        )
     ],
 )
 def test_limit(str_expr, str_expected, msg):

--- a/test/builtin/calculus/test_limit.py
+++ b/test/builtin/calculus/test_limit.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtins.arithmetic.Element
+"""
+from test.helper import check_evaluation
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        ("Limit[Tan[x], x->Pi/2]", "Indeterminate", None),
+        ("Limit[Cot[x], x->0]", "Indeterminate", None),
+        ("Limit[x*Sqrt[2*Pi]^(x^-1)*(Sin[x]/(x!))^(x^-1), x->Infinity]", "E", None),
+    ],
+)
+def test_limit(str_expr, str_expected, msg):
+    check_evaluation(str_expr, str_expected, failure_message=msg)

--- a/test/builtin/calculus/test_solve.py
+++ b/test/builtin/calculus/test_solve.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests from builtins ... calculus.py
+Unit tests for mathics.builtins.arithmetic.Solve
 """
 
-from .helper import check_evaluation, session
+from test.helper import check_evaluation, session
 
 
-def test_calculus():
+def test_solve():
     for str_expr, str_expected, message in (
         (
             "Solve[{(7+x)*ma == 167, (5+x)*mb == 167, (7+5)*(ma+mb) == 334}, {ma, mb, x}]",


### PR DESCRIPTION
These were culled from symja_android_library/rules/LimitRules.m. More to come. 

I have noticed that as we add add more autoloaded rules, initial loading slows down. At some point I hope to rectify this by some sort of image loading mechanism that Lisps and Smalltalk have.

But also, we need to speed up readling loading overall.