### PR TITLE
Enclosing autoload Limit rules between Begin/End context

### DIFF
--- a/mathics/autoload/rules/Bessel.m
+++ b/mathics/autoload/rules/Bessel.m
@@ -1,5 +1,7 @@
 (*Extended rules for handling expressions with Bessel functions*)
 
+
+
 Begin["internals`bessel`"]
 
 Unprotect[HankelH1];

--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -4,14 +4,11 @@
    These were culled from symja_android_library/rules/LimitRules.m.
  *)
 
-(* BeginPackage["Limit"] *)
 
-(* Begin["`private`"] *)
+Begin["System`Limit`private`"]
 Unprotect[Limit];
-Limit[Tan[System`Limit`x_], System`Limit`x_Symbol->Pi/2] = Indeterminate;
-Limit[Cot[System`Limit`x_], System`Limit`x_Symbol->0] = Indeterminate;
-Limit[System`Limit`x_ Sqrt[2 Pi]^(System`Limit`x_^-1) (Sin[System`Limit`x_]/(System`Limit`x_!))^(System`Limit`x_^-1), System`Limit`x_Symbol->Infinity] = E;
+Limit[Tan[x_], x_Symbol->Pi/2] = Indeterminate;
+Limit[Cot[x_], x_Symbol->0] = Indeterminate;
+Limit[x_ Sqrt[2 Pi]^(x_^-1) (Sin[x_]/(x_!))^(x_^-1), x_Symbol->Infinity] = E;
 Protect[Limit];
-(* End[] *)
-
-(* EndPackage[] *)
+End[]


### PR DESCRIPTION
This just adds the Begin/End block to the `autoload/rules/Limit.m`  module. The `BeginPackage`  is not used here because we are not trying to define a package, but just to define the default context.