### PR TITLE
Make explicit the need for serialization ...

### DIFF
--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -60,10 +60,16 @@ no_doc = True
 
 class DefaultOptionChecker:
     """
-    Callable used to check options
+    Callable class that is used in checking that options are valid.
+
+    If initialized with ``strict`` set to True,
+    then a instantance calls will return True only if all
+    options listed in ``options_to_check`` are in the constructor's
+    list of options. In either case, when an option is not in the
+    constructor list, give an "optx" message.
     """
 
-    def __init__(self, builtin, options, strict):
+    def __init__(self, builtin, options, strict: bool):
         self.name = builtin.get_name()
         self.strict = strict
         self.options = options
@@ -89,7 +95,7 @@ class DefaultOptionChecker:
 
 class UnavailableFunction:
     """
-    Callable used when the evaluation function is not available
+    Callable class used when the evaluation function is not available.
     """
 
     def __init__(self, builtin):
@@ -98,14 +104,16 @@ class UnavailableFunction:
     def __call__(self, **kwargs):
         kwargs["evaluation"].message(
             "General",
-            "pyimport",  # see inout.py
+            "pyimport",  # see messages.py for error message definition
             strip_context(self.name),
         )
 
 
 def check_requires_list(requires: list) -> bool:
     """
-    Check if module names in ``requires`` can be imported and return True if they can or False if not.
+    Check if module names in ``requires`` can be imported and return
+    True if they can, or False if not.
+
     """
     for package in requires:
         lib_is_installed = True
@@ -149,8 +157,9 @@ mathics_to_python = {}  # here we have: name -> string
 
 class Builtin:
     """
-    A base class for a Built-in function symbols, like List, or variables, like $SystemID,
-    and Built-in Objects, like DateTimeObject.
+    A base class for a Built-in function symbols, like List, or
+    variables, like $SystemID, and Built-in Objects, like
+    DateTimeObject.
 
     Some of the class variables of the Builtin object are used to
     create a definition object for that built-in symbol.  In particular,
@@ -160,8 +169,9 @@ class Builtin:
     Function application pattern matching
     -------------------------------------
 
-    Method names of a builtin-class that start with the word ``eval`` are evaluation methods that
-    will get called when the docstring of that method matches the expression to be evaluated.
+    Method names of a builtin-class that start with the word ``eval``
+    are evaluation methods that will get called when the docstring of
+    that method matches the expression to be evaluated.
 
     For example:
 
@@ -171,7 +181,8 @@ class Builtin:
              return Expression(Symbol("G"), x*2)
     ```
 
-    adds a ``BuiltinRule`` to the symbol's definition object that implements ``F[x_]->G[x*2]``.
+    adds a ``BuiltinRule`` to the symbol's definition object that implements
+    ``F[x_]->G[x*2]``.
 
     As shown in the example above, leading argument names of the
     function are the arguments mentioned in the names given up to the
@@ -179,7 +190,8 @@ class Builtin:
     ``x``. The method must also have an evaluation parameter, and may
     have an optional `options` parameter.
 
-    If the ``eval*`` method returns ``None``, the replacement fails, and the expression keeps its original form.
+    If the ``eval*`` method returns ``None``, the replacement fails,
+    and the expression keeps its original form.
 
     For rules including ``OptionsPattern``
     ```
@@ -187,20 +199,27 @@ class Builtin:
              '''F[x_Real, OptionsPattern[]]'''
              ...
     ```
-    the options are stored as a dictionary in the last parameter. For example, if the rule is applied to ``F[x, Method->Automatic]``
-    the expression is replaced by the output of ``eval_with_options(x, evaluation, {"System`Method": Symbol("Automatic")})
 
-    The method ``contribute`` stores the definition of the  ``Builtin`` ` `Symbol`` into a set of ``Definitions``. For example,
+    the options are stored as a dictionary in the last parameter. For
+    example, if the rule is applied to ``F[x, Method->Automatic]`` the
+    expression is replaced by the output of ``eval_with_options(x,
+    evaluation, {"System`Method": Symbol("Automatic")})
+
+    The method ``contribute`` stores the definition of the ``Builtin``
+    ` `Symbol`` into a set of ``Definitions``. For example,
 
     ```
     definitions = Definitions(add_builtin=False)
     List(expression=False).contribute(definitions)
     ```
-    produces a ``Definitions`` object with just one definition, for the ``Symbol`` ``System`List``.
 
-    Notice that for creating a Builtin, we must pass to the constructor the option ``expression=False``. Otherwise,
-    an Expression object is created, with the ``Symbol`` associated to the definition as the ``Head``.
-    For example,
+    produces a ``Definitions`` object with just one definition, for
+    the ``Symbol`` ``System`List``.
+
+    Notice that for creating a Builtin, we must pass to the
+    constructor the option ``expression=False``. Otherwise, an
+    Expression object is created, with the ``Symbol`` associated to
+    the definition as the ``Head``.  For example,
 
     ```
     builtinlist = List(expression=False)
@@ -214,6 +233,7 @@ class Builtin:
     ```
     expr_list = ListExpression(Integer(1), Integer(2), Integer(3))
     ```
+
     """
 
     name: Optional[str] = None
@@ -285,10 +305,11 @@ class Builtin:
                 if option not in definitions.builtin:
                     definitions.builtin[option] = Definition(name=name)
 
-        # Check if the given options are actually supported by the Builtin.
-        # If not, we might issue an optx error and abort. Using '$OptionSyntax'
-        # in your Builtin's 'options', you can specify the exact behaviour
-        # using one of the following values:
+        # Check if the given options are actually supported by the
+        # Builtin.  If not, we might issue an "optx" error and
+        # abort. Using '$OptionSyntax' in your Builtin's 'options',
+        # you can specify the exact behaviour using one of the
+        # following values:
 
         if option_syntax in ("Strict", "System`Strict"):
             check_options = DefaultOptionChecker(self, options, True)
@@ -335,15 +356,18 @@ class Builtin:
                     new_rules.append(rule)
             rules = new_rules
 
-        def extract_forms(name, pattern):
-            # Handle a tuple of (forms, pattern) as well as a pattern
-            # on the left-hand side of a format rule. 'forms' can be
-            # an empty string (=> the rule applies to all forms), or a
-            # form name (like 'System`TraditionalForm'), or a sequence
-            # of form names.
+        def extract_forms(pattern):
+            """Handle a tuple of (forms, pattern) as well as a pattern
+            on the left-hand side of a format rule. 'forms' can be
+            an empty string (=> the rule applies to all forms), or a
+            form name (like 'System`TraditionalForm'), or a sequence
+            of form names.
+            """
+
             def contextify_form_name(f):
-                # Handle adding 'System`' to a form name, unless it's
-                # '' (meaning the rule applies to all forms).
+                """Handle adding 'System`' to a form name, unless it's
+                ' (meaning the rule applies to all forms).
+                """
                 return "" if f == "" else ensure_context(f)
 
             if isinstance(pattern, tuple):
@@ -358,7 +382,7 @@ class Builtin:
 
         formatvalues = {"": []}
         for pattern, function in self.get_functions("format_"):
-            forms, pattern = extract_forms(name, pattern)
+            forms, pattern = extract_forms(pattern)
             for form in forms:
                 if form not in formatvalues:
                     formatvalues[form] = []
@@ -366,7 +390,7 @@ class Builtin:
                     BuiltinRule(name, pattern, function, None, system=True)
                 )
         for pattern, replace in self.formats.items():
-            forms, pattern = extract_forms(name, pattern)
+            forms, pattern = extract_forms(pattern)
             for form in forms:
                 if form not in formatvalues:
                     formatvalues[form] = []
@@ -1036,7 +1060,7 @@ class CountableInteger:
     _integer: Union[str, int]
     _support_infinity = False
 
-    def __init__(self, value="Infinity", upper_limit=True):
+    def __init__(self, value: Union[int, str] = "Infinity", upper_limit=True):
         self._finite = value != "Infinity"
         if self._finite:
             assert isinstance(value, int) and value >= 0

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -83,18 +83,23 @@ def autoload_files(
 
 
 class Definitions:
-    """
-    The state of one instance of the Mathics interpreter is stored in this object.
+    """The state of one instance of the Mathics3 interpreter is stored in this object.
 
-    The state is then stored as ``Definition`` object of the different symbols defined during the runtime.
+    The state is then stored as ``Definition`` object of the different
+    symbols defined during the runtime.
 
-    In the current implementation, the ``Definitions`` object stores ``Definition`` s in four dictionaries:
+    In the current implementation, the ``Definitions`` object stores
+    ``Definition`` s in four dictionaries:
 
     - builtins: stores the definitions of the ``Builtin`` symbols
-    - pymathics: stores the definitions of the ``Builtin`` symbols added from pymathics modules.
+    - pymathics: stores the definitions of the ``Builtin`` symbols added from pymathics
+      modules.
     - user: stores the definitions created during the runtime.
-    - definition_cache: keep definitions obtained by merging builtins, pymathics, and user definitions associated to the
-     same symbol.
+    - definition_cache: keep definitions obtained by merging builtins, pymathics, and
+      user definitions associated to the same symbol.
+
+    Note: we want Rules to be serializable so that we can dump and
+    restore Rules in order to make startup time faster.
     """
 
     def __init__(
@@ -160,20 +165,29 @@ class Definitions:
             autoload_files(self, ROOT_DIR, "autoload")
 
     def clear_cache(self, name=None):
-        # the definitions cache (self.definitions_cache) caches (incomplete and complete) names -> Definition(),
-        # e.g. "xy" -> d and "MyContext`xy" -> d. we need to clear this cache if a Definition() changes (which
-        # would happen if a Definition is combined from a builtin and a user definition and some content in the
-        # user definition is updated) or if the lookup rules change, and we could end up at a completely different
+        # The definitions cache (self.definitions_cache) caches
+        # (incomplete and complete) names -> Definition(), e.g. "xy"
+        # -> d and "MyContext`xy" -> d. we need to clear this cache if
+        # a Definition() changes (which would happen if a Definition
+        # is combined from a builtin and a user definition and some
+        # content in the user definition is updated) or if the lookup
+        # rules change, and we could end up at a completely different
         # Definition.
 
-        # the lookup cache (self.lookup_cache) caches what lookup_name() does. we only need to update this if some
-        # change happens that might change the result lookup_name() calculates. we do not need to change it if a
-        # Definition() changes.
+        # The lookup cache (self.lookup_cache) caches what
+        # lookup_name() does. we only need to update this if some
+        # change happens that might change the result lookup_name()
+        # calculates. we do not need to change it if a Definition()
+        # changes.
 
-        # self.proxy keeps track of all the names we cache. if we need to clear the caches for only one name, e.g.
-        # 'MySymbol', then we need to be able to look up all the entries that might be related to it, e.g. 'MySymbol',
-        # 'A`MySymbol', 'C`A`MySymbol', and so on. proxy identifies symbols using their stripped name and thus might
-        # give us symbols in other contexts that are actually not affected. still, this is a safe solution.
+        # self.proxy keeps track of all the names we cache. if we need
+        # to clear the caches for only one name, e.g.  'MySymbol',
+        # then we need to be able to look up all the entries that
+        # might be related to it, e.g. 'MySymbol', 'A`MySymbol',
+        # 'C`A`MySymbol', and so on. proxy identifies symbols using
+        # their stripped name and thus might give us symbols in other
+        # contexts that are actually not affected. still, this is a
+        # safe solution.
 
         if name is None:
             self.definitions_cache = {}

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -37,6 +37,8 @@ class BaseRule(KeyComparable):
 
     Important subclasses: BuiltinRule and Rule.
 
+    Note: we want Rules to be serializable so that we can dump and
+    restore Rules in order to make startup time faster.
     """
 
     def __init__(
@@ -127,8 +129,7 @@ class BaseRule(KeyComparable):
 
 
 class Rule(BaseRule):
-    """
-    There are two kinds of Rules.  This kind of Rule transforms an
+    """There are two kinds of Rules.  This kind of Rule transforms an
     Expression into another Expression based on the pattern and a
     replacement term and doesn't involve function application.
 
@@ -143,6 +144,10 @@ class Rule(BaseRule):
     ``F[x_]`` is a pattern and ``x^2`` is the replacement term. When
     applied to the expression ``G[F[1.], F[a]]`` the result is
     ``G[1.^2, a^2]``
+
+
+    Note: we want Rules to be serializable so that we can dump and
+    restore Rules in order to make startup time faster.
     """
 
     def __init__(
@@ -161,17 +166,23 @@ class Rule(BaseRule):
         new = self.replace.replace_vars(vars)
         new.options = options
 
-        # if options is a non-empty dict, we need to ensure reevaluation of the whole expression, since 'new' will
-        # usually contain one or more matching OptionValue[symbol_] patterns that need to get replaced with the
-        # options' values. this is achieved through Expression.evaluate(), which then triggers OptionValue.apply,
-        # which in turn consults evaluation.options to return an option value.
+        # If options is a non-empty dict, we need to ensure
+        # reevaluation of the whole expression, since 'new' will
+        # usually contain one or more matching OptionValue[symbol_]
+        # patterns that need to get replaced with the options'
+        # values. This is achieved through Expression.evaluate(),
+        # which then triggers OptionValue.apply, which in turn
+        # consults evaluation.options to return an option value.
 
-        # in order to get there, we copy 'new' using copy(reevaluate=True), as this will ensure that the whole thing
-        # will get reevaluated.
+        # In order to get there, we copy 'new' using
+        # copy(reevaluate=True), as this will ensure that the whole
+        # thing will get reevaluated.
 
-        # if the expression contains OptionValue[] patterns, but options is empty here, we don't need to act, as the
-        # expression won't change in that case. the Expression.options would be None anyway, so OptionValue.apply
-        # would just return the unchanged expression (which is what we have already).
+        # If the expression contains OptionValue[] patterns, but
+        # options is empty here, we don't need to act, as the
+        # expression won't change in that case. the Expression.options
+        # would be None anyway, so OptionValue.apply would just return
+        # the unchanged expression (which is what we have already).
 
         if options:
             new = new.copy(reevaluate=True)
@@ -200,7 +211,8 @@ class BuiltinRule(BaseRule):
 
     The pattern ``items___`` matches a list of Expressions.
 
-    When applied to the expression ``F[a+a]`` the method ``mathics.builtin.arithfns.basic.Plus.apply`` is called
+    When applied to the expression ``F[a+a]`` the method
+    ``mathics.builtin.arithfns.basic.Plus.apply`` is called
     binding the parameter  ``items`` to the value ``Sequence[a,a]``.
 
     The return value of this function is ``Times[2, a]`` (or more compactly: ``2*a``).
@@ -215,9 +227,11 @@ class BuiltinRule(BaseRule):
 
     when applied to the expression ``SetAttributes[F,  NumericFunction]``
 
-    sets the attribute ``NumericFunction`` in the  definition of the symbol ``F`` and returns Null (``SymbolNull`)`.
+    sets the attribute ``NumericFunction`` in the  definition of the symbol ``F`` and
+    returns Null (``SymbolNull`)`.
 
-    This will cause `Expression.evalate() to perform an additional ``rewrite_apply_eval()`` step.
+    This will cause `Expression.evalate() to perform an additional
+    ``rewrite_apply_eval()`` step.
     """
 
     def __init__(
@@ -225,7 +239,7 @@ class BuiltinRule(BaseRule):
         name: str,
         pattern: Expression,
         function: Callable,
-        check_options: Callable,
+        check_options: Optional[Callable],
         system: bool = False,
         evaluation: Optional[Evaluation] = None,
     ) -> None:
@@ -262,6 +276,4 @@ class BuiltinRule(BaseRule):
         return odict
 
     def __setstate__(self, dict):
-        from mathics.builtin import _builtins
-
         self.__dict__.update(dict)  # update attributes

--- a/test/builtin/arithmetic/__init__.py
+++ b/test/builtin/arithmetic/__init__.py
@@ -1,1 +1,1 @@
-# -*- coding: utf-8 -*-
+"""Unit tests for test.builtin.arithmetic"""

--- a/test/builtin/calculus/__init__.py
+++ b/test/builtin/calculus/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for test.builtin.calculus"""

--- a/test/builtin/calculus/test_integrate.py
+++ b/test/builtin/calculus/test_integrate.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtins.calculus.Integrate
+"""
+
+from test.helper import check_evaluation, session
+
+
+def test_integtrate():
+    for str_expr, str_expected, message in (
+        ("Integrate[Integrate[1,{y,0,E^x}],{x,0,Log[13]}]", "12", "Issue #153"),
+        (
+            "g/:Integrate[g[u_],u_]:=f[u]; Integrate[g[x],x]",
+            "f[x]",
+            "This should pass SymPy evaluation.",
+        ),
+        (
+            "h=x;Integrate[Do[h=x*h,{5}]; h,x]",
+            "x^7/7",
+            "a more agressive SymPy translation.",
+        ),
+    ):
+        session.evaluate("Clear[h]; Clear[g]; Clear[f];")
+        check_evaluation(str_expr, str_expected, message)

--- a/test/builtin/calculus/test_solve.py
+++ b/test/builtin/calculus/test_solve.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests from builtins ... calculus.py
+Unit tests for mathics.builtins.calculus.Solve
+
 """
 
-from .helper import check_evaluation, session
+from test.helper import check_evaluation, session
 
 
-def test_calculus():
+def test_solve():
     for str_expr, str_expected, message in (
         (
             "Solve[{(7+x)*ma == 167, (5+x)*mb == 167, (7+5)*(ma+mb) == 334}, {ma, mb, x}]",
@@ -37,17 +38,6 @@ def test_calculus():
             "v1 := Exp[x] - 3x; v2 = {x, 2}; FindRoot[v1, v2]",
             "{x->1.51213}",
             "Issue #1235",
-        ),
-        ("Integrate[Integrate[1,{y,0,E^x}],{x,0,Log[13]}]", "12", "Issue #153"),
-        (
-            "g/:Integrate[g[u_],u_]:=f[u]; Integrate[g[x],x]",
-            "f[x]",
-            "This should pass after implementing an earlier sympy evaluation.",
-        ),
-        (
-            "h=x;Integrate[Do[h=x*h,{5}]; h,x]",
-            "x^7/7",
-            "another sanity check for a more agressive sympy translation.",
         ),
     ):
         session.evaluate("Clear[h]; Clear[g]; Clear[f];")

--- a/test/core/test_rules.py
+++ b/test/core/test_rules.py
@@ -1,4 +1,4 @@
-from test.helper import check_evaluation, evaluate_value
+from test.helper import check_evaluation
 
 import pytest
 
@@ -7,7 +7,7 @@ In WL, pattern matching and rule application is dependent on the evaluation cont
 This happens at two levels. On the one hand, patterns like `PatternTest[pat, test]`
 matches with `expr` depending both on the `pat` and the result of the evaluation of `test`.
 
-On the other hand, attributes like `Orderless` or `Flat` in the head of the pattern 
+On the other hand, attributes like `Orderless` or `Flat` in the head of the pattern
 also affects how patterns are applied to expressions. However, in WMA, the effect
 of these parameters are established in the point in which a rule is created, and not
 when it is applied.
@@ -28,20 +28,24 @@ Out[2]= True
 because it ignores that the attribute is clean at the time in which the rule is applied.
 
 
-In Mathics, on the other hand, attributes are taken into accout just at the moment of the replacement, 
-so the output of both expressions are the opposite.
+In Mathics, on the other hand, attributes are taken into accout just
+at the moment of the replacement, so the output of both expressions
+are the opposite.
 
 
-This set of tests are proposed to drive the behaviour of Rules in Mathics closer to the one in WMA.
-In particular, the way in which `Orderless` and `Flat` attributes affects evaluation are currently tested.
+This set of tests are proposed to drive the behaviour of Rules in
+Mathics closer to the one in WMA.  In particular, the way in which
+`Orderless` and `Flat` attributes affects evaluation are currently
+tested.
 
-For the case of `Flat`, there is still another issue in Mathics, since by not it is not taken into account
-at the pattern matching level. For example, in WMA,
+For the case of `Flat`, there is still another issue in Mathics, since
+by not it is not taken into account at the pattern matching level. For
+example, in WMA,
 
 ```
 In[3]:=SetAttributes[Q,{Flat}]; rule=Q[a,_Integer]->True; Q[a,1,b]/.rule
 Out[3]=Q[True, b]
-``` 
+```
 
 The xfail mark can be removed once these issues get fixed.
 """

--- a/test/core/test_serialization.py
+++ b/test/core/test_serialization.py
@@ -5,17 +5,21 @@ from mathics.session import MathicsSession
 
 
 def test_session_serialization():
-    """
-    Check that a session (and its Definitions object)
-    be properly serialized.
+    """Check that a session, with Definitions and Rules can be serialized properly,
+    that is, that they can be dumped and loaded.
     """
 
     original_session = MathicsSession()
-    original_session.evaluate("x=4")
+    original_session.evaluate("x = 4")
+    original_session.evaluate("r = y -> 3")
 
     pickle_buffer = io.BytesIO()
     pickle.dump(original_session, pickle_buffer)
     pickle_buffer.seek(0)
     restored_session = pickle.load(pickle_buffer)
     result = restored_session.evaluate("ToString[x]").value
-    assert result == "4"
+    assert result == "4", "Assign[] did not dump and restore properly"
+    result = restored_session.evaluate("x + y /. r")
+    assert (
+        result.to_python() == 7
+    ), "Rule[] and Assign[] did not dump and restore properly"


### PR DESCRIPTION
in Definition and Rule.

Some small linting was doine to shorten long lines, remove an uneeded import, correct a type annotation here and there.

test_serialization was expanded to include a rule test.

test_calculus was split and moved into test/builtin/calculus.