### PR TITLE
fix inconsistency in ListExpression.__str__ and Expression.__repr__

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -245,16 +245,16 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
     def __repr__(self) -> str:
         return "<Expression: %s[%s]>" % (
-            self._head.__repr__(),
-            ", ".join([element.__repr__() for element in self._elements]),
+            repr(self.head),
+            ", ".join([repr(element) for element in self.elements]),
         )
 
         return "<Expression: %s>" % self
 
     def __str__(self) -> str:
         return "%s[%s]" % (
-            self._head.__str__(),
-            ", ".join([element.__str__() for element in self._elements]),
+            str(self.head),
+            ", ".join([str(element) for element in self.elements]),
         )
 
     def _as_sympy_function(self, **kwargs) -> sympy.Function:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -244,11 +244,16 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         return hash(("Expression", self._head) + tuple(self._elements))
 
     def __repr__(self) -> str:
+        return "<Expression: %s[%s]>" % (
+            self._head.__repr__(),
+            ", ".join([element.__repr__() for element in self._elements]),
+        )
+
         return "<Expression: %s>" % self
 
     def __str__(self) -> str:
         return "%s[%s]" % (
-            self._head,
+            self._head.__str__(),
             ", ".join([element.__str__() for element in self._elements]),
         )
 

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -83,7 +83,7 @@ class ListExpression(Expression):
 
     def __str__(self) -> str:
         """str() representation of ListExpression. May be longer than repr()"""
-        return f"<ListExpression: {self._elements}>"
+        return "{" + ",".join(e.__str__() for e in self._elements) + "}"
 
     # @timeit
     def evaluate_elements(self, evaluation: Evaluation) -> Expression:

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -83,7 +83,7 @@ class ListExpression(Expression):
 
     def __str__(self) -> str:
         """str() representation of ListExpression. May be longer than repr()"""
-        return "{" + ",".join(e.__str__() for e in self._elements) + "}"
+        return "{" + ",".join(str(e) for e in self.elements) + "}"
 
     # @timeit
     def evaluate_elements(self, evaluation: Evaluation) -> Expression:

--- a/test/builtin/box/test_custom_boxexpression.py
+++ b/test/builtin/box/test_custom_boxexpression.py
@@ -113,5 +113,5 @@ def test_custom_graphicsbox_constructor():
     formatted = session.format_result().boxes_to_mathml()
     assert (
         formatted
-        == "--custom graphics--: I should plot (<Expression: System`Circle[<ListExpression: (<Integer: 0>, <Integer: 0>)>, 1]>,) items"
+        == "--custom graphics--: I should plot (<Expression: <Symbol: System`Circle>[<ListExpression: (<Integer: 0>, <Integer: 0>)>, <Integer: 1>]>,) items"
     )


### PR DESCRIPTION
In the `BaseElement` hierarchy, as any other Python object, the elements have two different internal methods: `__str__` and `__repr__`. The general aim of these methods is explained here:

https://stackoverflow.com/questions/1436703/what-is-the-difference-between-str-and-repr

In Mathics, we have different ways to store the same expression. For example, we want to distinguish between 
`ListExpression(Integer0, Integer1)` and `Expression(SymbolList, Integer0, Integer1)`. `__repr__` does this by sorrounding each element of the expression with "<type: ....>".
On the other hand, `__str__` returns something that should be evaluable, because it is used to convert any of these objects into a string representation.

However, in the current master, there is an inconsistency that originates the issue  #846. This PR fixes that issue.