### PR TITLE
Evaluation message to callable

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -189,9 +189,11 @@ def name_is_builtin_symbol(module, name: str) -> Optional[type]:
     return module_object
 
 
-def print_message(symbol_name: str, tag, *msgs, channel=stderr) -> "Message":
+def print_message(symbol_name: str, tag: str, *msgs, channel=stderr):
     """
-    Print to the standard output a message using the default Builtin messages.
+    Print to the standard error a message using the default Builtin messages.
+    Using this instead `evaluation.message` instead of `evaluation.message`
+    when an `Evaluation` object is not available.
     """
     builtins = builtins_dict()
     full_symbol_name = ensure_context(symbol_name)

--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -26,7 +26,6 @@ import inspect
 import os.path as osp
 import pkgutil
 import re
-from sys import stderr
 from typing import List, Optional
 
 from mathics.builtin.base import (
@@ -36,8 +35,6 @@ from mathics.builtin.base import (
     SympyObject,
     mathics_to_python,
 )
-from mathics.core.convert.python import from_python
-from mathics.core.element import ensure_context
 from mathics.core.pattern import pattern_objects
 from mathics.core.symbols import Symbol
 from mathics.eval.makeboxes import builtins_precedence
@@ -187,28 +184,6 @@ def name_is_builtin_symbol(module, name: str) -> Optional[type]:
     if module_object in getattr(module, "DOES_NOT_ADD_BUILTIN_DEFINITION", []):
         return None
     return module_object
-
-
-def print_message(symbol_name: str, tag: str, *msgs, channel=stderr):
-    """
-    Print to the standard error a message using the default Builtin messages.
-    Using this instead `evaluation.message` instead of `evaluation.message`
-    when an `Evaluation` object is not available.
-    """
-    builtins = builtins_dict()
-    full_symbol_name = ensure_context(symbol_name)
-    builtin = builtins.get(full_symbol_name, None)
-    text = builtin.messages.get(tag) if builtin else None
-
-    if text is None:
-        text = builtins["System`General"].messages.get(tag)
-
-    if text is None:
-        text = "Message %s::%s not found." % (symbol_name, tag)
-
-    for i, arg in enumerate((from_python(arg) for arg in msgs)):
-        text = text.replace(f"`{i+1}`", str(arg))
-    print(text, file=channel)
 
 
 # FIXME: redo using importlib since that is probably less fragile.

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -133,7 +133,7 @@ def _pattern_search(name, string, patt, evaluation, options, matched):
         patts = [patt]
     re_patts = []
     for p in patts:
-        py_p = to_regex(p, evaluation)
+        py_p = to_regex(p, show_message=evaluation.message)
         if py_p is None:
             evaluation.message("StringExpression", "invld", p, patt)
             return
@@ -618,7 +618,7 @@ class _StringFind(Builtin):
         # convert rule
         def convert_rule(r):
             if r.has_form("Rule", None) and len(r.elements) == 2:
-                py_s = to_regex(r.elements[0], evaluation)
+                py_s = to_regex(r.elements[0], show_message=evaluation.message)
                 if py_s is None:
                     evaluation.message(
                         "StringExpression", "invld", r.elements[0], r.elements[0]
@@ -627,7 +627,7 @@ class _StringFind(Builtin):
                 py_sp = r.elements[1]
                 return py_s, py_sp
             elif cases:
-                py_s = to_regex(r, evaluation)
+                py_s = to_regex(r, show_message=evaluation.message)
                 if py_s is None:
                     evaluation.message("StringExpression", "invld", r, r)
                     return

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -629,7 +629,7 @@ class Names(Builtin):
         "Names[pattern_]"
         headname = pattern.get_head_name()
         if headname == "System`StringExpression":
-            pattern = re.compile(to_regex(pattern, evaluation))
+            pattern = re.compile(to_regex(pattern, show_message=evaluation.messages))
         else:
             pattern = pattern.get_string_value()
 

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -1350,7 +1350,10 @@ class FileNames(Builtin):
         if options.get("System`IgnoreCase", None) is SymbolTrue:
             patterns = [
                 re.compile(
-                    "^" + to_regex(p, evaluation, abbreviated_patterns=True),
+                    "^"
+                    + to_regex(
+                        p, abbreviated_patterns=True, show_message=evaluation.messages
+                    ),
                     re.IGNORECASE,
                 )
                 + "$"
@@ -1359,7 +1362,14 @@ class FileNames(Builtin):
         else:
             patterns = [
                 re.compile(
-                    "^" + to_regex(p, evaluation, abbreviated_patterns=True) + "$"
+                    "^"
+                    + to_regex(
+                        p,
+                        evaluation,
+                        abbreviated_patterns=True,
+                        show_message=evaluation.message,
+                    )
+                    + "$"
                 )
                 for p in str_forms
             ]

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -558,7 +558,7 @@ class StringPosition(Builtin):
             patts = [patt]
         re_patts = []
         for p in patts:
-            py_p = to_regex(p, evaluation)
+            py_p = to_regex(p, show_message=evaluation.message)
             if py_p is None:
                 evaluation.message("StringExpression", "invld", p, patt)
                 return
@@ -972,7 +972,7 @@ class StringSplit(Builtin):
             patts = [patt]
         re_patts = []
         for p in patts:
-            py_p = to_regex(p, evaluation)
+            py_p = to_regex(p, show_message=evaluation.message)
             if py_p is None:
                 evaluation.message("StringExpression", "invld", p, patt)
                 return
@@ -1142,7 +1142,7 @@ class StringTrim(Builtin):
         if not text:
             return s
 
-        py_patt = to_regex(patt, evaluation)
+        py_patt = to_regex(patt, show_message=evaluation.message)
         if py_patt is None:
             evaluation.message("StringExpression", "invld", patt, expression)
             return

--- a/mathics/builtin/string/patterns.py
+++ b/mathics/builtin/string/patterns.py
@@ -474,7 +474,9 @@ class StringMatchQ(Builtin):
             )
             return
 
-        re_patt = to_regex(patt, evaluation, abbreviated_patterns=True)
+        re_patt = to_regex(
+            patt, show_message=evaluation.message, abbreviated_patterns=True
+        )
         if re_patt is None:
             evaluation.message(
                 "StringExpression",

--- a/mathics/builtin/vectors/math_ops.py
+++ b/mathics/builtin/vectors/math_ops.py
@@ -193,11 +193,11 @@ class Norm(Builtin):
 
     def eval(self, m, evaluation):
         "Norm[m_]"
-        return eval_Norm(m, evaluation)
+        return eval_Norm(m, evaluation.message)
 
     def eval_with_p(self, m, p, evaluation):
         "Norm[m_, p_]"
-        return eval_Norm_p(m, p, evaluation)
+        return eval_Norm_p(m, p, evaluation.message)
 
 
 # TODO: Div

--- a/mathics/eval/math_ops.py
+++ b/mathics/eval/math_ops.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Callable, Optional
 
 from mathics.core.atoms import Integer, Real, String
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
@@ -7,20 +7,23 @@ from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol
 
 
-def eval_Norm(m: Expression, evaluation: Evaluation) -> Optional[Expression]:
+def eval_Norm(
+    m: Expression, show_message: Optional[Callable] = None
+) -> Optional[Expression]:
     """
     Norm[m] evaluation function - the 2-norm of matrix m
     """
     sympy_m = to_sympy_matrix(m)
     if sympy_m is None:
-        evaluation.message("Norm", "nvm")
+        if show_message:
+            show_message("Norm", "nvm")
         return
 
     return from_sympy(sympy_m.norm())
 
 
 def eval_Norm_p(
-    m: Expression, p: Expression, evaluation: Evaluation
+    m: Expression, p: Expression, show_message: Optional[Callable] = None
 ) -> Optional[Expression]:
     """
     Norm[m, p] evaluation function - the p-norm of matrix m.
@@ -34,7 +37,8 @@ def eval_Norm_p(
     elif isinstance(p, (Real, Integer)) and p.to_python() >= 1:
         sympy_p = p.to_sympy()
     else:
-        evaluation.message("Norm", "ptype", p)
+        if show_message:
+            show_message("Norm", "ptype", p)
         return
 
     if sympy_p is None:
@@ -42,7 +46,8 @@ def eval_Norm_p(
     matrix = to_sympy_matrix(m)
 
     if matrix is None:
-        evaluation.message("Norm", "nvm")
+        if show_message:
+            show_message("Norm", "nvm")
         return
     if len(matrix) == 0:
         return
@@ -50,7 +55,8 @@ def eval_Norm_p(
     try:
         res = matrix.norm(sympy_p)
     except NotImplementedError:
-        evaluation.message("Norm", "normnotimplemented")
+        if show_message:
+            show_message("Norm", "normnotimplemented")
         return
 
     return from_sympy(res)

--- a/test/core/convert/test_to_regex.py
+++ b/test/core/convert/test_to_regex.py
@@ -17,9 +17,9 @@ from mathics.core.convert.regex import to_regex
 def test_to_regex(str_expr, str_expected, msg):
     expr = evaluate(str_expr)
     if msg:
-        assert to_regex(expr, session.evaluation) == str_expected, msg
+        assert to_regex(expr) == str_expected, msg
     else:
-        assert to_regex(expr, session.evaluation) == str_expected
+        assert to_regex(expr) == str_expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This implements the idea of passing a `Callable` object instead of an `Evaluation` object when the object is just used to show a message. 
Also, a default `Callable` was introduced which does the same than `Evaluation.message` when an evaluation object is not available.