### PR TITLE
Another look over expression.py

### DIFF
--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -7,9 +7,6 @@ When LLVM and Python libraries are available, compilation \
 produces LLVM code.
 """
 
-# This tells documentation how to sort this module
-sort_order = "mathics.builtin.code-compilation"
-
 import ctypes
 from types import FunctionType
 
@@ -27,8 +24,12 @@ from mathics.core.convert.function import (
 from mathics.core.convert.python import from_python
 from mathics.core.element import ImmutableValueMixin
 from mathics.core.evaluation import Evaluation
-from mathics.core.expression import Expression, SymbolCompiledFunction
+from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, Symbol, SymbolFalse, SymbolTrue
+from mathics.core.systemsymbols import SymbolCompiledFunction
+
+# This tells documentation how to sort this module
+sort_order = "mathics.builtin.code-compilation"
 
 
 class Compile(Builtin):

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -271,6 +271,13 @@ class BaseElement(KeyComparable):
         return A_NO_ATTRIBUTES
 
     def get_head_name(self):
+        """
+        All elements have a "Head" whether or not the element is compount.
+        The Head of an Atom is its type. The Head of an S-expression is
+        its function name.
+
+        Each class must define its own get_head_name.
+        """
         raise NotImplementedError
 
     # FIXME: this behavior of defining a specific default implementation

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -148,7 +148,7 @@ class KeyComparable:
     # FIXME: return type should be a specific kind of Tuple, not a list.
     # FIXME: Describe sensible, and easy to follow rules by which one
     #        can create the kind of tuple for some new kind of element.
-    def get_sort_key(self) -> list:
+    def get_sort_key(self, pattern_sort: bool) -> tuple:
         """
         This returns a tuple in a way that
         it can be used to compare in expressions.

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -716,12 +716,13 @@ class SymbolConstant(Symbol):
 BooleanType = SymbolConstant
 
 
-def symbol_set(*symbols: Tuple[Symbol]) -> FrozenSet[Symbol]:
+def symbol_set(*symbols: Symbol) -> FrozenSet[Symbol]:
     """
     Return a frozenset of symbols from a Symbol arguments.
     We will use this in testing membership, so an immutable object is fine.
 
-    In 2021, we benchmarked frozenset versus list, tuple, and set and frozenset was the fastest.
+    In 2021, we benchmarked frozenset versus list, tuple, and set and
+    frozenset was the fastest.
     """
     return frozenset(symbols)
 

--- a/mathics/eval/arithmetic.py
+++ b/mathics/eval/arithmetic.py
@@ -21,7 +21,6 @@ from mathics.core.atoms import (
     Integer1,
     Integer2,
     IntegerM1,
-    MachineReal,
     Number,
     Rational,
     RationalOneHalf,
@@ -31,13 +30,7 @@ from mathics.core.convert.mpmath import from_mpmath
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.element import BaseElement, ElementsProperties
 from mathics.core.expression import Expression
-from mathics.core.number import (
-    FP_MANTISA_BINARY_DIGITS,
-    MAX_MACHINE_NUMBER,
-    MIN_MACHINE_NUMBER,
-    SpecialValueError,
-    min_prec,
-)
+from mathics.core.number import FP_MANTISA_BINARY_DIGITS, SpecialValueError, min_prec
 from mathics.core.rules import Rule
 from mathics.core.symbols import Atom, Symbol, SymbolPlus, SymbolPower, SymbolTimes
 from mathics.core.systemsymbols import (
@@ -605,6 +598,6 @@ def to_inexact_value(expr: BaseElement) -> BaseElement:
 
     if isinstance(expr, Expression):
         for const, value in NUMERICAL_CONSTANTS.items():
-            expr, success = expr.do_apply_rule(Rule(const, value))
+            expr, _ = expr.do_apply_rule(Rule(const, value))
 
     return eval_multiply_numbers(RealOne, expr)


### PR DESCRIPTION
The motivation for this was originally just to note as a TODO that `get_rules_list()` should be eventually moved inside the `ListExpression` class. 

In doing that though LSP was showing a number of errors, some have been corrected. 

And then in breaking up some (but not all) of the long comment lines, I had a hard time understanding some of the  comments. I have tried to rephrase, but @mmatera please make sure I haven't mangled the meaning in the process.

The comment at the end of `rewrite_apply_eval_step`  I don't quite understand.

