### PR TITLE
Expose more settings...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Internals
 ---
 
 * ``eval_abs`` and ``eval_sign`` extracted from ``Abs`` and ``Sign`` and added to ``mathics.eval.arithmetic``.
+* Maximum number of digits allowed in a string set to 7000 and can be adjusted using environment variable
+  ``MATHICS_MAX_STR_DIGITS`` on Python versions that don't adjust automatically (like pyston).
 
 
 Bugs

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
+"""
+Mathics3 global system settings.
+
+Some of the values can be adjusted via Environment Variables.
+"""
 import os
 import os.path as osp
 import sys
@@ -15,13 +20,29 @@ def get_srcdir():
 DEBUG = True
 
 DEBUG_PRINT = False
+
+# Maximum recursion depth is safe for all Python environments
+# without setting a custom thread stack size.
+DEFAULT_MAX_RECURSION_DEPTH = 512
+
+# Maximum number of digits allows in a string representation of a string number.
+# We picked this to be able to handle 1989 ^ 1989.
+DEFAULT_MAX_STR_DIGITS = 7000
+str_digits: str = os.environ.get("MATHICS_MAX_STR_DIGITS", str(DEFAULT_MAX_STR_DIGITS))
+MAX_STR_DIGITS = (
+    int(DEFAULT_MAX_STR_DIGITS) if str_digits.isnumeric() else DEFAULT_MAX_STR_DIGITS
+)
+
+# Let Python know what value of MAX_STR_DIGITS to use.
+if hasattr(sys, "set_int_max_str_digits"):
+    # pyston 2.3.5
+    sys.set_int_max_str_digits(MAX_STR_DIGITS)
+else:
+    MAX_STR_DIGITS = -1
+
 # Either None (no timeout) or a positive integer.
 # Unix only
 TIMEOUT = None
-
-# specifies a maximum recursion depth is safe for all Python environments
-# without setting a custom thread stack size.
-DEFAULT_MAX_RECURSION_DEPTH = 512
 
 # max pickle.dumps() size for storing results in DB
 # historically 10000 was used on public mathics servers
@@ -86,8 +107,10 @@ def get_doctest_latex_data_path(should_be_readable=False, create_parent=False) -
     """Returns a string path where we can find Python Pickle doctest data for LaTeX
     processing.
 
-    If `should_be_readable` is True, the we will check to see whether this file is
-    readable (which also means it exists). If not, we'll return the `DOCTEST_SYSTEM_DATA_PATH`.
+    If `should_be_readable` is True, the we will check to see whether
+    this file is readable (which also means it exists). If not, we'll
+    return the `DOCTEST_SYSTEM_DATA_PATH`.
+
     """
     doc_user_latex_data_pcl = Path(DOCTEST_LATEX_DATA_PCL)
     base_config_dir = doc_user_latex_data_pcl.parent

--- a/mathics/system_info.py
+++ b/mathics/system_info.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+"""
+Mathics3 System Information that front-ends can use to show as
+configuration information.
+
+Some of these we get from mathics.settings and are configurable
+via Environment Variables.
+"""
 
 import os
 import platform
@@ -10,8 +17,10 @@ import mathics.builtin.directories.system_directories as system_directories
 import mathics.builtin.directories.user_directories as user_directories
 import mathics.builtin.system as msystem
 from mathics.core.evaluation import Evaluation
+from mathics.settings import MAX_STR_DIGITS, SYSTEM_CHARACTER_ENCODING, TIME_12HOUR
 
 
+# Largest number of digits Python allows in a string.
 def python_implementation() -> str:
     """
     Returns the Python implementation, e.g Pyston, PyPy, CPython...
@@ -53,5 +62,8 @@ def mathics_system_info(defs):
         "$TemporaryDirectory": eval(system_directories.TemporaryDirectory),
         "$UserName": eval(msystem.UserName),
         "MachinePrecision": eval(numeric.MachinePrecision_),
+        "MaximumDigitsInString": MAX_STR_DIGITS,
         "MemoryAvailable[]": eval(msystem.MemoryAvailable, needs_head=False),
+        "SystemCharacterEncoding": SYSTEM_CHARACTER_ENCODING,
+        "Time12Hour": TIME_12HOUR,
     }

--- a/test/test_system_info.py
+++ b/test/test_system_info.py
@@ -28,7 +28,10 @@ def test_system_info():
             "$TemporaryDirectory",
             "$UserName",
             "MachinePrecision",
+            "MaximumDigitsInString",
             "MemoryAvailable[]",
+            "SystemCharacterEncoding",
+            "Time12Hour",
         ]
     )
     assert set(info.keys()) == expected_keys


### PR DESCRIPTION
* Set `sys.set_int_max_str_digits() `on systems that need it - this is everything except pyston
* expose this setting and `MATHICS_CHARACTER_ENCODING` to front-ends via mathics.system_info