### PR TITLE
Move more builtin module loading code out of `mathics/builtin/__init__.py`

### DIFF
--- a/mathics/builtin/__init__.py
+++ b/mathics/builtin/__init__.py
@@ -19,62 +19,34 @@ among other things.
 import os
 import os.path as osp
 
-from mathics.builtin.base import Builtin
 from mathics.core.load_builtin import (
-    add_builtins,
-    get_module_filenames,
+    add_builtins_from_builtin_modules,
+    get_module_names,
     import_builtin_subdirectories,
     import_builtins,
-    name_is_builtin_symbol,
+    initialize_display_operators_set,
 )
 from mathics.settings import ENABLE_FILES_MODULE
 
+# Get import modules in this directory of Python modules that contain
+# Mathics3 Builtin class definitions.
+
 builtin_path = osp.dirname(__file__)
-
-# Get filenames in this directory of Python modules that contain the
-# builtin functions that we need to load and process.
 exclude_files = {"codetables", "base"}
-module_names = [f for f in get_module_filenames(builtin_path) if f not in exclude_files]
-
+module_names = get_module_names(builtin_path, exclude_files)
 modules = []
 import_builtins(module_names, modules)
 
-builtins_by_module = {}
+# Get import modules in subdirectories of this directory of Python
+# modules that contain Mathics3 Builtin class definitions.
 
 # The files_io module handles local file access, reading and writing..
 # In some sandboxed settings, such as running Mathics from as a remote
 # server, we disallow local file access.
-disable_file_module_names = [] if ENABLE_FILES_MODULE else ["files_io"]
+disable_file_module_names = set() if ENABLE_FILES_MODULE else {"files_io"}
 
 subdirectories = next(os.walk(builtin_path))[1]
 import_builtin_subdirectories(subdirectories, disable_file_module_names, modules)
 
-_builtins_list = []
-for module in modules:
-    builtins_by_module[module.__name__] = []
-    module_vars = dir(module)
-
-    for name in module_vars:
-        builtin_class = name_is_builtin_symbol(module, name)
-        if builtin_class is not None:
-            instance = builtin_class(expression=False)
-
-            if isinstance(instance, Builtin):
-                # This set the default context for symbols in mathics.builtins
-                if not type(instance).context:
-                    type(instance).context = "System`"
-                _builtins_list.append((instance.get_name(), instance))
-                builtins_by_module[module.__name__].append(instance)
-
-
-new_builtins = _builtins_list
-
-add_builtins(new_builtins)
-
-display_operators_set = set()
-for modname, builtins in builtins_by_module.items():
-    for builtin in builtins:
-        # name = builtin.get_name()
-        operator = builtin.get_operator_display()
-        if operator is not None:
-            display_operators_set.add(operator)
+add_builtins_from_builtin_modules(modules)
+initialize_display_operators_set()

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -8,6 +8,8 @@ or namespace, and can have a variety of type of values and attributes.
 
 import re
 
+from mathics_scanner import is_symbol_name
+
 from mathics.builtin.base import Builtin, PrefixOperator, Test
 from mathics.core.assignment import get_symbol_values
 from mathics.core.atoms import String
@@ -714,8 +716,6 @@ class Symbol_(Builtin):
 
     def eval(self, string, evaluation):
         "Symbol[string_String]"
-
-        from mathics.core.parser import is_symbol_name
 
         text = string.value
         if is_symbol_name(text):

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -3,6 +3,7 @@
 Scoping Constructs
 """
 
+from mathics_scanner import is_symbol_name
 
 from mathics.builtin.base import Builtin, Predefined
 from mathics.core.assignment import get_symbol_list
@@ -617,8 +618,6 @@ class Unique(Predefined):
 
     def eval_symbol(self, vars, attributes, evaluation: Evaluation):
         "Unique[vars_, attributes___]"
-
-        from mathics.core.parser import is_symbol_name
 
         attributes = attributes.get_sequence()
         if len(attributes) > 1:

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -34,6 +34,7 @@ from typing import Callable
 from mathics import builtin, settings
 from mathics.builtin.base import check_requires_list
 from mathics.core.evaluation import Message, Print
+from mathics.core.load_builtin import builtins_by_module as global_builtins_by_module
 from mathics.core.util import IS_PYPY
 from mathics.doc.utils import slugify
 from mathics.eval.pymathics import pymathics_builtins_by_module, pymathics_modules
@@ -621,7 +622,7 @@ class Documentation:
             (
                 "Reference of Built-in Symbols",
                 builtin.modules,
-                builtin.builtins_by_module,
+                global_builtins_by_module,
                 True,
             )
         ]:

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -22,10 +22,9 @@ from typing import Dict
 import mathics
 import mathics.settings
 from mathics import settings, version_string
-from mathics.builtin import builtins_by_module
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Output
-from mathics.core.load_builtin import builtins_dict
+from mathics.core.load_builtin import builtins_by_module, builtins_dict
 from mathics.core.parser import MathicsSingleLineFeeder
 from mathics.doc.common_doc import MathicsMainDocumentation
 from mathics.eval.pymathics import PyMathicsLoadException, eval_LoadModule

--- a/mathics/eval/pymathics.py
+++ b/mathics/eval/pymathics.py
@@ -6,10 +6,9 @@ import importlib
 import inspect
 import sys
 
-from mathics.builtin import builtins_by_module
 from mathics.builtin.base import Builtin
 from mathics.core.definitions import Definitions
-from mathics.core.load_builtin import name_is_builtin_symbol
+from mathics.core.load_builtin import builtins_by_module, name_is_builtin_symbol
 
 # The below set and dictionary are used in document generation
 # for Pymathics modules.

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -8,6 +8,8 @@ MathML formatting is usually initiated in Mathics via MathMLForm[].
 import base64
 import html
 
+from mathics_scanner import is_symbol_name
+
 from mathics.builtin.box.graphics import GraphicsBox
 from mathics.builtin.box.graphics3d import Graphics3DBox
 from mathics.builtin.box.layout import (
@@ -27,7 +29,7 @@ from mathics.core.formatter import (
     add_conversion_fn,
     lookup_method as lookup_conversion_method,
 )
-from mathics.core.parser import is_symbol_name
+from mathics.core.load_builtin import display_operators_set as operators
 from mathics.core.symbols import SymbolTrue
 
 
@@ -59,8 +61,6 @@ extra_operators = {
 
 
 def string(self, **options) -> str:
-    from mathics.builtin import display_operators_set as operators
-
     text = self.value
 
     number_as_text = options.get("number_as_text", None)

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -8,8 +8,9 @@ import os
 
 import pytest
 
-from mathics.builtin import modules, name_is_builtin_symbol
+from mathics.builtin import modules
 from mathics.builtin.base import Builtin
+from mathics.core.load_builtin import name_is_builtin_symbol
 
 
 @pytest.mark.skipif(

--- a/test/consistency-and-style/test_summary_text.py
+++ b/test/consistency-and-style/test_summary_text.py
@@ -7,8 +7,8 @@ import pkgutil
 import pytest
 
 from mathics import __file__ as mathics_initfile_path
-from mathics.builtin import name_is_builtin_symbol
 from mathics.builtin.base import Builtin
+from mathics.core.load_builtin import name_is_builtin_symbol
 from mathics.doc.common_doc import skip_doc
 
 # Get file system path name for mathics.builtin


### PR DESCRIPTION
Next iteration in sequence of refactorings. 

Here, the remaining code that should have been put into a function has been moved out of `mathics/builtin/__init__.py` and into `mathics.core.builtin_load` and imports have been adjusted which reduces circular dependencies. 

Remaining refactoring: 

Initiate the module loading from  the `mathics.core.builtin_load` module. 

Loading currently needs to be rewritten. It currently gets _all_ builtin module names. then from that returned collection imports _all_ module names, then from that collection ... _all_ ... _all_ ...

Instead,  of many "all" loops, we need to do follow through everything a specific module name.  To do everything, that is in one loop (over builtin module names) and no further loops would follow.