### PR TITLE
Yet another round of documentation-inspired fixes

### DIFF
--- a/mathics/builtin/drawing/drawing_options.py
+++ b/mathics/builtin/drawing/drawing_options.py
@@ -18,7 +18,7 @@ option values are described here.
 from mathics.builtin.base import Builtin
 
 # This tells documentation how to sort this module
-sort_order = "mathics.builtin.drawing-options-and-option-values"
+sort_order = "mathics.builtin.graphing-and-drawing.drawing-options-and-option-values"
 
 
 class Automatic(Builtin):

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -69,8 +69,8 @@ class Graphics3D(Graphics):
           <dt>'Graphics3D[$primitives$, $options$]'
           <dd>represents a three-dimensional graphic.
 
-          See also the <url>:Drawing Option and Option Values:
-    /doc/reference-of-built-in-symbols/drawing-options-and-option-values
+          See <url>:Drawing Option and Option Values:
+    /doc/reference-of-built-in-symbols/graphics-and-drawing/drawing-options-and-option-values
     </url> for a list of Plot options.
         </dl>
 

--- a/mathics/builtin/drawing/plot.py
+++ b/mathics/builtin/drawing/plot.py
@@ -1100,6 +1100,7 @@ class BarChart(_Chart):
         <dt>'BarChart[{$b1$, $b2$ ...}]'
         <dd>makes a bar chart with lengths $b1$, $b2$, ....
     </dl>
+
     Drawing options include -
     Charting:
     <ul>
@@ -2563,23 +2564,10 @@ class Plot3D(_Plot3D):
       <dd>creates a three-dimensional plot of $f$ with $x$ ranging from $xmin$ to \
           $xmax$ and $y$ ranging from $ymin$ to $ymax$.
 
+          See <url>:Drawing Option and Option Values:
+    /doc/reference-of-built-in-symbols/graphics-and-drawing/drawing-options-and-option-values
+    </url> for a list of Plot options.
     </dl>
-
-    Plot3D has the same options as <url>:Graphics3D:
-/doc/reference-of-built-in-symbols/graphics-and-drawing/three-dimensional-graphics/graphics3d</url>,\
-    in particular:
-    <ul>
-    <li><url>
-    :Mesh:
-    /doc/reference-of-built-in-symbols/drawing-options-and-option-values/mesh</url>
-    <li><url>
-    :PlotPoints:
-    /doc/reference-of-built-in-symbols/drawing-options-and-option-values/plotpoints</url>
-    <li><url>
-    :MaxRecursion:
-    /doc/reference-of-built-in-symbols/drawing-options-and-option-values/maxrecursion</url>
-    </ul>
-
 
     >> Plot3D[x ^ 2 + 1 / y, {x, -1, 1}, {y, 1, 4}]
      = -Graphics3D-

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -59,7 +59,7 @@ class All(Predefined):
     /doc/reference-of-built-in-symbols/graphics-and-drawing/plotting-data/plot</url>, \
     setting the <url>
     :Mesh:
-    /doc/reference-of-built-in-symbols/drawing-options-and-option-values/mesh</url> \
+/doc/reference-of-built-in-symbols/graphics-and-drawing/drawing-options-and-option-values/mesh</url> \
     option to 'All' will show the specific plot points:
 
     >> Plot[x^2, {x, -1, 1}, MaxRecursion->5, Mesh->All]
@@ -180,7 +180,7 @@ class None_(Predefined):
 
         Plot3D shows the mesh grid between computed points by default. This the <url>
         :Mesh:
-    /doc/reference-of-built-in-symbols/drawing-options-and-option-values/mesh</url> option.
+/doc/reference-of-built-in-symbols/graphics-and-drawing/drawing-options-and-option-values/mesh</url> \
 
         However, you hide the mesh by setting the 'Mesh' option value to 'None':
 

--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -10,7 +10,7 @@ BASH ?= /bin/bash
 DOCTEST_LATEX_DATA_PCL ?= $(HOME)/.local/var/mathics/doctest_latex_data.pcl
 
 # Variable indicating Mathics3 Modules you have available on your system, in latex2doc option format
-MATHICS3_MODULE_OPTION ?= # --load-module pymathics.graph,pymathics.natlang
+MATHICS3_MODULE_OPTION ?=--load-module pymathics.graph,pymathics.natlang
 
 #: Default target: Make everything
 all doc texdoc: mathics.pdf

--- a/mathics/doc/latex/sed-hack.sh
+++ b/mathics/doc/latex/sed-hack.sh
@@ -43,3 +43,8 @@ sed -i -e "s/′/'/g" documentation.tex
 
 # assumes LaTeX gensymb package
 sed -i -e "s/°/\\\\degree{}/g" documentation.tex
+
+# Work around a doc2latex.py bug which strips "s"
+# from Properties in a Section heading.
+# TODO: figure out how to fix that bug.
+sed -i -e "s/Propertie\\\\/Properties\\\\/g" documentation.tex


### PR DESCRIPTION
Move graphics-drawing options under drawing. (The creation of this predated when we had guide sections. This not only makes more sense, but currently we can't reference chapters in LaTeX

Makefile: build we build documentation in include the non-test/tutorial Pymathics modules.

sed-hack.sh work around doctest bug that strips the "s" in a Section name.