### PR TITLE
refactor arithmetic power

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -7,6 +7,9 @@ on a calculator.
 
 """
 
+
+import sympy
+
 from mathics.builtin.arithmetic import create_infix
 from mathics.builtin.base import (
     BinaryOperator,
@@ -45,7 +48,6 @@ from mathics.core.symbols import (
     Symbol,
     SymbolDivide,
     SymbolHoldForm,
-    SymbolNull,
     SymbolPower,
     SymbolTimes,
 )
@@ -56,10 +58,17 @@ from mathics.core.systemsymbols import (
     SymbolInfix,
     SymbolLeft,
     SymbolMinus,
+    SymbolOverflow,
     SymbolPattern,
-    SymbolSequence,
 )
-from mathics.eval.arithmetic import eval_Plus, eval_Times
+from mathics.eval.arithmetic import (
+    associate_powers,
+    eval_Exponential,
+    eval_Plus,
+    eval_Power_inexact,
+    eval_Power_number,
+    eval_Times,
+)
 from mathics.eval.nevaluator import eval_N
 from mathics.eval.numerify import numerify
 
@@ -535,15 +544,15 @@ class Power(BinaryOperator, MPMathFunction):
     # Remember to up sympy doc link when this is corrected
     sympy_name = "Pow"
 
+    def eval_exp(self, x, evaluation):
+        "Power[E, x]"
+        return eval_Exponential(x)
+
     def eval_check(self, x, y, evaluation):
         "Power[x_, y_]"
-
-        # Power uses MPMathFunction but does some error checking first
-        if isinstance(x, Number) and x.is_zero:
-            if isinstance(y, Number):
-                y_err = y
-            else:
-                y_err = eval_N(y, evaluation)
+        # if x is zero
+        if x.is_zero:
+            y_err = y if isinstance(y, Number) else eval_N(y, evaluation)
             if isinstance(y_err, Number):
                 py_y = y_err.round_to_float(permit_complex=True).real
                 if py_y > 0:
@@ -557,17 +566,47 @@ class Power(BinaryOperator, MPMathFunction):
                     evaluation.message(
                         "Power", "infy", Expression(SymbolPower, x, y_err)
                     )
-                    return SymbolComplexInfinity
-        if isinstance(x, Complex) and x.real.is_zero:
-            yhalf = Expression(SymbolTimes, y, RationalOneHalf)
-            factor = self.eval(Expression(SymbolSequence, x.imag, y), evaluation)
-            return Expression(
-                SymbolTimes, factor, Expression(SymbolPower, IntegerM1, yhalf)
-            )
+                return SymbolComplexInfinity
 
-        result = self.eval(Expression(SymbolSequence, x, y), evaluation)
-        if result is None or result != SymbolNull:
-            return result
+        # If x and y are inexact numbers, use the numerical function
+
+        if x.is_inexact() and y.is_inexact():
+            try:
+                return eval_Power_inexact(x, y)
+            except OverflowError:
+                evaluation.message("General", "ovfl")
+                return Expression(SymbolOverflow)
+
+        # Tries to associate powers a^b^c-> a^(b*c)
+        assoc = associate_powers(x, y)
+        if not assoc.has_form("Power", 2):
+            return assoc
+
+        assoc = numerify(assoc, evaluation)
+        x, y = assoc.elements
+        # If x and y are numbers
+        if isinstance(x, Number) and isinstance(y, Number):
+            try:
+                return eval_Power_number(x, y)
+            except OverflowError:
+                evaluation.message("General", "ovfl")
+                return Expression(SymbolOverflow)
+
+        # if x or y are inexact, leave the expression
+        # as it is:
+        if x.is_inexact() or y.is_inexact():
+            return assoc
+
+        # Finally, try to convert to sympy
+        base_sp, exp_sp = x.to_sympy(), y.to_sympy()
+        if base_sp is None or exp_sp is None:
+            # If base or exp can not be converted to sympy,
+            # returns the result of applying the associative
+            # rule.
+            return assoc
+
+        result = from_sympy(sympy.Pow(base_sp, exp_sp))
+        return result.evaluate_elements(evaluation)
 
 
 class Sqrt(SympyFunction):

--- a/test/builtin/arithmetic/test_basic.py
+++ b/test/builtin/arithmetic/test_basic.py
@@ -197,7 +197,7 @@ def test_directed_infinity_precedence(str_expr, str_expected, msg):
         ("I^(2/3)", "(-1) ^ (1 / 3)", None),
         # In WMA, the next test would return ``-(-I)^(2/3)``
         # which is less compact and elegant...
-        #        ("(-I)^(2/3)", "(-1) ^ (-1 / 3)", None),
+        ("(-I)^(2/3)", "(-1) ^ (-1 / 3)", None),
         ("(2+3I)^3", "-46 + 9 I", None),
         ("(1.+3. I)^.6", "1.46069 + 1.35921 I", None),
         ("3^(1+2 I)", "3 ^ (1 + 2 I)", None),
@@ -208,15 +208,15 @@ def test_directed_infinity_precedence(str_expr, str_expected, msg):
         # sympy, which produces the result
         ("(3/Pi)^(-I)", "(3 / Pi) ^ (-I)", None),
         # Association rules
-        #        ('(a^"w")^2', 'a^(2 "w")', "Integer power of a power with string exponent"),
+        ('(a^"w")^2', 'a^(2 "w")', "Integer power of a power with string exponent"),
         ('(a^2)^"w"', '(a ^ 2) ^ "w"', None),
         ('(a^2)^"w"', '(a ^ 2) ^ "w"', None),
         ("(a^2)^(1/2)", "Sqrt[a ^ 2]", None),
         ("(a^(1/2))^2", "a", None),
         ("(a^(1/2))^2", "a", None),
         ("(a^(3/2))^3.", "(a ^ (3 / 2)) ^ 3.", None),
-        #        ("(a^(1/2))^3.", "a ^ 1.5", "Power associativity rational, real"),
-        #        ("(a^(.3))^3.", "a ^ 0.9", "Power associativity for real powers"),
+        ("(a^(1/2))^3.", "a ^ 1.5", "Power associativity rational, real"),
+        ("(a^(.3))^3.", "a ^ 0.9", "Power associativity for real powers"),
         ("(a^(1.3))^3.", "(a ^ 1.3) ^ 3.", None),
         # Exponentials involving expressions
         ("(a^(p-2 q))^3", "a ^ (3 p - 6 q)", None),

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -456,34 +456,53 @@ all_test = {
     "Sqrt[1/(1+1/(1+1/a))]": {
         "msg": "SqrtBox",
         "text": {
-            "System`StandardForm": "Sqrt[1 / (1+1 / (1+1 / a))]",
-            "System`TraditionalForm": "Sqrt[1 / (1+1 / (1+1 / a))]",
-            "System`InputForm": "Sqrt[1 / (1 + 1 / (1 + 1 / a))]",
-            "System`OutputForm": "Sqrt[1 / (1 + 1 / (1 + 1 / a))]",
+            "System`StandardForm": "1 / Sqrt[1+1 / (1+1 / a)]",
+            "System`TraditionalForm": "1 / Sqrt[1+1 / (1+1 / a)]",
+            "System`InputForm": "1 / Sqrt[1 + 1 / (1 + 1 / a)]",
+            "System`OutputForm": "1 / Sqrt[1 + 1 / (1 + 1 / a)]",
         },
         "mathml": {
             "System`StandardForm": (
-                "<msqrt> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow></mfrac> </msqrt>",
+                (
+                    r"<mfrac><mn>1</mn> <msqrt> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> "
+                    r"<mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow> "
+                    r"</msqrt></mfrac>"
+                ),
                 "Fragile!",
             ),
             "System`TraditionalForm": (
-                "<msqrt> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow></mfrac> </msqrt>",
+                (
+                    r"<mfrac><mn>1</mn> <msqrt> <mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> "
+                    r"<mrow><mn>1</mn> <mo>+</mo> <mfrac><mn>1</mn> <mi>a</mi></mfrac></mrow></mfrac></mrow> "
+                    r"</msqrt></mfrac>"
+                ),
                 "Fragile!",
             ),
             "System`InputForm": (
-                "<mrow><mi>Sqrt</mi> <mo>[</mo> <mrow><mtext>1</mtext> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mtext>1</mtext> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mtext>1</mtext> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mtext>1</mtext> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mtext>1</mtext> <mtext>&nbsp;/&nbsp;</mtext> <mi>a</mi></mrow></mrow> <mo>)</mo></mrow></mrow></mrow> <mo>)</mo></mrow></mrow> <mo>]</mo></mrow>",
+                (
+                    r"<mrow><mtext>1</mtext> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mi>Sqrt</mi> <mo>[</mo> "
+                    r"<mrow><mtext>1</mtext> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mtext>1</mtext> <mtext>&nbsp;/&nbsp;</mtext> "
+                    r"<mrow><mo>(</mo> <mrow><mtext>1</mtext> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mtext>1</mtext> <mtext>"
+                    r"&nbsp;/&nbsp;</mtext> <mi>a</mi></mrow></mrow> <mo>)</mo></mrow></mrow></mrow> <mo>]</mo></mrow></mrow>"
+                ),
                 "Fragile!",
             ),
             "System`OutputForm": (
-                "<mrow><mi>Sqrt</mi> <mo>[</mo> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mi>a</mi></mrow></mrow> <mo>)</mo></mrow></mrow></mrow> <mo>)</mo></mrow></mrow> <mo>]</mo></mrow>",
+                (
+                    r"<mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> <mrow><mi>Sqrt</mi> <mo>["
+                    r"</mo> <mrow><mn>1</mn> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> "
+                    r"<mtext>&nbsp;/&nbsp;</mtext> <mrow><mo>(</mo> <mrow><mn>1</mn> <mtext>"
+                    r"&nbsp;+&nbsp;</mtext> <mrow><mn>1</mn> <mtext>&nbsp;/&nbsp;</mtext> "
+                    r"<mi>a</mi></mrow></mrow> <mo>)</mo></mrow></mrow></mrow> <mo>]</mo></mrow></mrow>"
+                ),
                 "Fragile!",
             ),
         },
         "latex": {
-            "System`StandardForm": "\\sqrt{\\frac{1}{1+\\frac{1}{1+\\frac{1}{a}}}}",
-            "System`TraditionalForm": "\\sqrt{\\frac{1}{1+\\frac{1}{1+\\frac{1}{a}}}}",
-            "System`InputForm": "\\text{Sqrt}\\left[1\\text{ / }\\left(1\\text{ + }1\\text{ / }\\left(1\\text{ + }1\\text{ / }a\\right)\\right)\\right]",
-            "System`OutputForm": "\\text{Sqrt}\\left[1\\text{ / }\\left(1\\text{ + }1\\text{ / }\\left(1\\text{ + }1\\text{ / }a\\right)\\right)\\right]",
+            "System`StandardForm": "\\frac{1}{\\sqrt{1+\\frac{1}{1+\\frac{1}{a}}}}",
+            "System`TraditionalForm": "\\frac{1}{\\sqrt{1+\\frac{1}{1+\\frac{1}{a}}}}",
+            "System`InputForm": r"1\text{ / }\text{Sqrt}\left[1\text{ + }1\text{ / }\left(1\text{ + }1\text{ / }a\right)\right]",
+            "System`OutputForm": r"1\text{ / }\text{Sqrt}\left[1\text{ + }1\text{ / }\left(1\text{ + }1\text{ / }a\right)\right]",
         },
     },
     # Grids, arrays and matrices


### PR DESCRIPTION
This is another chuck of #766. This part is related to the way in which powers are evaluated. 

Part of this code is dealing with the fact that the output from Sympy is not compatible with the way in which WL handles expressions involving powers. Tests were fixed here according to the behavior in WMA. 