### PR TITLE
split to_sympy from BaseElement

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -31,7 +31,7 @@ from mathics.core.attributes import (
     A_READ_PROTECTED,
 )
 from mathics.core.convert.expression import to_expression
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import (
@@ -347,16 +347,16 @@ class Plus(BinaryOperator, SympyFunction):
                 else:
                     return Expression(SymbolTimes, IntegerM1, *item.elements)
             elif isinstance(item, Number):
-                return from_sympy(-item.to_sympy())
+                return from_sympy(to_sympy(-item))
             else:
                 return Expression(SymbolTimes, IntegerM1, item)
 
         def is_negative(value) -> bool:
             if isinstance(value, Complex):
-                real, imag = value.to_sympy().as_real_imag()
+                real, imag = to_sympy(value).as_real_imag()
                 if real <= 0 and imag <= 0:
                     return True
-            elif isinstance(value, Number) and value.to_sympy() < 0:
+            elif isinstance(value, Number) and to_sympy(value) < 0:
                 return True
             return False
 
@@ -786,7 +786,7 @@ class Times(BinaryOperator, SympyFunction):
             if (
                 item.has_form("Power", 2)
                 and isinstance(item.elements[1], (Integer, Rational, Real))
-                and item.elements[1].to_sympy() < 0
+                and to_sympy(item.elements[1]) < 0
             ):  # nopep8
 
                 negative.append(inverse(item))

--- a/mathics/builtin/base.py
+++ b/mathics/builtin/base.py
@@ -22,7 +22,7 @@ from mathics.core.attributes import A_HOLD_ALL, A_NO_ATTRIBUTES, A_PROTECTED
 from mathics.core.convert.expression import to_expression
 from mathics.core.convert.op import ascii_operator_to_symbol
 from mathics.core.convert.python import from_bool
-from mathics.core.convert.sympy import from_sympy, to_numeric_sympy_args
+from mathics.core.convert.sympy import from_sympy, to_numeric_sympy_args, to_sympy
 from mathics.core.definitions import Definition
 from mathics.core.evaluation import Evaluation
 from mathics.core.exceptions import MessageException
@@ -691,7 +691,7 @@ class IterationFunction(Builtin):
             whole_expr = to_expression(
                 self.get_name(), expr, ListExpression(i, imin, imax)
             )
-            sympy_expr = whole_expr.to_sympy(evaluation=evaluation)
+            sympy_expr = to_sympy(whole_expr, evaluation=evaluation)
             if sympy_expr is None:
                 return None
 
@@ -964,7 +964,7 @@ class SympyFunction(SympyObject):
         try:
             if self.sympy_name:
                 elements = self.prepare_sympy(expr.elements)
-                sympy_args = [element.to_sympy(**kwargs) for element in elements]
+                sympy_args = [to_sympy(element, **kwargs) for element in elements]
                 if None in sympy_args:
                     return None
                 sympy_function = self.get_sympy_function(elements)

--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -29,6 +29,7 @@ from mathics.core.atoms import (
     String,
     StringFromPython,
 )
+from mathics.core.convert.sympy import to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import BoxError, Expression
 from mathics.core.list import ListExpression
@@ -124,7 +125,7 @@ class BaseForm(Builtin):
             return None
 
         if isinstance(expr, PrecisionReal):
-            x = expr.to_sympy()
+            x = to_sympy(expr)
             p = int(ceil(expr.get_precision() / LOG2_10) + 1)
         elif isinstance(expr, MachineReal):
             x = expr.value
@@ -796,7 +797,7 @@ class PythonForm(FormBaseClass):
 
         def build_python_form(expr):
             if isinstance(expr, Symbol):
-                return expr.to_sympy()
+                return to_sympy(expr)
             return expr.to_python()
 
         try:
@@ -832,7 +833,7 @@ class SympyForm(FormBaseClass):
         "MakeBoxes[expr_, SympyForm]"
 
         try:
-            sympy_equivalent = expr.to_sympy()
+            sympy_equivalent = to_sympy(expr)
         except Exception:
             return
         return StringFromPython(sympy_equivalent)

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -15,7 +15,7 @@ from mathics.builtin.box.layout import RowBox
 from mathics.core.atoms import Integer, is_integer_rational_or_real
 from mathics.core.attributes import A_HOLD_FIRST, A_LISTABLE, A_LOCKED, A_PROTECTED
 from mathics.core.convert.expression import to_expression
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.element import ElementsProperties
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression, structure
@@ -263,9 +263,9 @@ class Range(Builtin):
                 *result, elements_properties=range_list_elements_properties
             )
 
-        imin = imin.to_sympy()
-        imax = imax.to_sympy()
-        di = di.to_sympy()
+        imin = to_sympy(imin)
+        imax = to_sympy(imax)
+        di = to_sympy(di)
         index = imin
         result = []
         while index <= imax:

--- a/mathics/builtin/numbers/diffeqns.py
+++ b/mathics/builtin/numbers/diffeqns.py
@@ -7,7 +7,7 @@ Differential Equations
 import sympy
 
 from mathics.builtin.base import Builtin
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -153,8 +153,8 @@ class DSolve(Builtin):
         f_name = func.get_head_name()
 
         conversion_args = {"converted_functions": set([f_name])}
-        sym_func = func.to_sympy(**conversion_args)
-        sym_eq = eqn.to_sympy(**conversion_args)
+        sym_func = to_sympy(func, **conversion_args)
+        sym_eq = to_sympy(eqn, **conversion_args)
 
         # XXX when sympy adds support for higher-order PDE we will have to
         # change this to a tuple of solvefuns

--- a/mathics/builtin/numbers/hyperbolic.py
+++ b/mathics/builtin/numbers/hyperbolic.py
@@ -17,7 +17,7 @@ from typing import Optional
 from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.builtin.base import Builtin, SympyFunction
 from mathics.core.atoms import IntegerM1
-from mathics.core.convert.sympy import SympyExpression
+from mathics.core.convert.sympy import SympyExpression, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -148,9 +148,11 @@ class ArcCsch(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs) -> Optional[SympyExpression]:
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolArcSinh, Expression(SymbolPower, expr.elements[0], IntegerM1)
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolArcSinh, Expression(SymbolPower, expr.elements[0], IntegerM1)
+                )
+            )
 
 
 class ArcSech(_MPMathFunction):
@@ -184,9 +186,11 @@ class ArcSech(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs) -> Optional[SympyExpression]:
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolArcCosh, Expression(SymbolPower, expr.elements[0], IntegerM1)
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolArcCosh, Expression(SymbolPower, expr.elements[0], IntegerM1)
+                )
+            )
 
 
 class ArcSinh(_MPMathFunction):
@@ -462,9 +466,11 @@ class Sech(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs) -> Optional[SympyExpression]:
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolPower, Expression(SymbolCosh, expr.elements[0]), IntegerM1
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolPower, Expression(SymbolCosh, expr.elements[0]), IntegerM1
+                )
+            )
 
 
 class Sinh(_MPMathFunction):

--- a/mathics/builtin/numbers/integer.py
+++ b/mathics/builtin/numbers/integer.py
@@ -12,7 +12,7 @@ from mathics.builtin.base import Builtin, SympyFunction
 from mathics.core.atoms import Integer, Integer0, String
 from mathics.core.attributes import A_LISTABLE, A_NUMERIC_FUNCTION, A_PROTECTED
 from mathics.core.convert.expression import to_mathics_list
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import SymbolPlus, SymbolTimes
@@ -110,7 +110,7 @@ class Ceiling(SympyFunction):
 
     def eval(self, x, evaluation):
         "Ceiling[x_]"
-        x = x.to_sympy()
+        x = to_sympy(x)
         if x is None:
             return
         return from_sympy(sympy.ceiling(x))
@@ -216,7 +216,7 @@ class Floor(SympyFunction):
 
     def eval_real(self, x, evaluation):
         "Floor[x_]"
-        x = x.to_sympy()
+        x = to_sympy(x)
         if x is not None:
             return from_sympy(sympy.floor(x))
 

--- a/mathics/builtin/numbers/linalg.py
+++ b/mathics/builtin/numbers/linalg.py
@@ -13,7 +13,7 @@ from mathics.core.atoms import Integer, Integer0
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.convert.matrix import matrix_data
 from mathics.core.convert.mpmath import from_mpmath, to_mpmath_matrix
-from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
+from mathics.core.convert.sympy import from_sympy, to_sympy, to_sympy_matrix
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -547,7 +547,7 @@ class LinearSolve(Builtin):
                 evaluation.message("LinearSolve", "matrix", b, 2)
                 return
 
-        system = [mm + [v.to_sympy()] for mm, v in zip(matrix, b.elements)]
+        system = [mm + [to_sympy(v)] for mm, v in zip(matrix, b.elements)]
         system = to_sympy_matrix(system)
         if system is None:
             evaluation.message("LinearSolve", "matrix", b, 2)
@@ -651,7 +651,7 @@ class MatrixPower(Builtin):
             evaluation.message("MatrixPower", "matrix", m, 1)
             return
 
-        sympy_power = power.to_sympy()
+        sympy_power = to_sympy(power)
         if sympy_power is None:
             return
 

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -18,7 +18,7 @@ from mathics.core.attributes import (
 )
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.convert.python import from_bool, from_python
-from mathics.core.convert.sympy import SympyPrime, from_sympy
+from mathics.core.convert.sympy import SympyPrime, from_sympy, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -71,7 +71,7 @@ class ContinuedFraction(SympyFunction):
     def eval_with_n(self, x, n: Integer, evaluation: Evaluation):
         "%(name)s[x_, n_Integer]"
         py_n = n.value
-        sympy_x = x.to_sympy()
+        sympy_x = to_sympy(x)
         it = sympy.continued_fraction_iterator(sympy_x)
         return from_sympy([next(it) for _ in range(py_n)])
 
@@ -243,7 +243,7 @@ class FactorInteger(Builtin):
 
 
 def _fractional_part(self, n, expr, evaluation: Evaluation):
-    n_sympy = n.to_sympy()
+    n_sympy = to_sympy(n)
     if n_sympy.is_constant():
         if n_sympy >= 0:
             positive_integer_part = (
@@ -426,7 +426,7 @@ class MantissaExponent(Builtin):
 
     def eval(self, n, evaluation: Evaluation):
         "MantissaExponent[n_]"
-        n_sympy = n.to_sympy()
+        n_sympy = to_sympy(n)
         expr = Expression(SymbolMantissaExponent, n)
 
         if isinstance(n.to_python(), complex):
@@ -447,7 +447,7 @@ class MantissaExponent(Builtin):
     def eval_with_b(self, n, b, evaluation: Evaluation):
         "MantissaExponent[n_, b_]"
         # Handle Input with special cases such as PI and E
-        n_sympy, b_sympy = n.to_sympy(), b.to_sympy()
+        n_sympy, b_sympy = to_sympy(n), to_sympy(b)
 
         expr = Expression(SymbolMantissaExponent, n, b)
 
@@ -608,11 +608,11 @@ class Prime(SympyFunction):
 
     def eval(self, n, evaluation: Evaluation):
         "Prime[n_]"
-        return from_sympy(SympyPrime(n.to_sympy()))
+        return from_sympy(SympyPrime(to_sympy(n)))
 
     def to_sympy(self, expr, **kwargs):
         if expr.has_form("Prime", 1):
-            return SympyPrime(expr.elements[0].to_sympy(**kwargs))
+            return SympyPrime(to_sympy(expr.elements[0], **kwargs))
 
 
 class PrimePi(SympyFunction):

--- a/mathics/builtin/numbers/trig.py
+++ b/mathics/builtin/numbers/trig.py
@@ -18,6 +18,7 @@ from mathics.builtin.arithmetic import _MPMathFunction
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import Integer, Integer0, IntegerM1, Real
 from mathics.core.convert.python import from_python
+from mathics.core.convert.sympy import to_sympy
 from mathics.core.exceptions import IllegalStepSpecification
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -442,9 +443,11 @@ class ArcCsc(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs):
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolArcSin, Expression(SymbolPower, expr.elements[0], Integer(-1))
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolArcSin, Expression(SymbolPower, expr.elements[0], Integer(-1))
+                )
+            )
 
 
 class ArcSec(_MPMathFunction):
@@ -484,9 +487,11 @@ class ArcSec(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs):
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolArcCos, Expression(SymbolPower, expr.elements[0], IntegerM1)
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolArcCos, Expression(SymbolPower, expr.elements[0], IntegerM1)
+                )
+            )
 
 
 class ArcSin(_MPMathFunction):
@@ -697,9 +702,11 @@ class Csc(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs):
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolPower, Expression(SymbolSin, expr.elements[0]), Integer(-1)
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolPower, Expression(SymbolSin, expr.elements[0]), Integer(-1)
+                )
+            )
 
 
 class Haversine(_MPMathFunction):
@@ -783,9 +790,11 @@ class Sec(_MPMathFunction):
 
     def to_sympy(self, expr, **kwargs):
         if len(expr.elements) == 1:
-            return Expression(
-                SymbolPower, Expression(SymbolCos, expr.elements[0]), Integer(-1)
-            ).to_sympy()
+            return to_sympy(
+                Expression(
+                    SymbolPower, Expression(SymbolCos, expr.elements[0]), Integer(-1)
+                )
+            )
 
 
 class Sin(_MPMathFunction):

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -17,7 +17,7 @@ import sympy
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import Complex, Integer, Integer0, Rational, Real
 from mathics.core.attributes import A_LISTABLE, A_NUMERIC_FUNCTION, A_PROTECTED
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.number import MACHINE_EPSILON
@@ -309,7 +309,7 @@ class Rationalize(Builtin):
     def eval(self, x, evaluation: Evaluation):
         "Rationalize[x_]"
 
-        py_x = x.to_sympy()
+        py_x = to_sympy(x)
         if py_x is None or (not py_x.is_number) or (not py_x.is_real):
             return x
 
@@ -351,10 +351,10 @@ class Rationalize(Builtin):
 
     def eval_dx(self, x, dx, evaluation: Evaluation):
         "Rationalize[x_, dx_]"
-        py_x = x.to_sympy()
+        py_x = to_sympy(x)
         if py_x is None:
             return x
-        py_dx = dx.to_sympy()
+        py_dx = to_sympy(dx)
         if (
             py_dx is None
             or (not py_dx.is_number)

--- a/mathics/builtin/optimization.py
+++ b/mathics/builtin/optimization.py
@@ -22,7 +22,7 @@ from mathics.builtin.base import Builtin
 from mathics.core.atoms import IntegerM1
 from mathics.core.attributes import A_CONSTANT, A_PROTECTED, A_READ_PROTECTED
 from mathics.core.convert.python import from_python
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -60,7 +60,7 @@ class Maximize(Builtin):
     def eval(self, f, vars, evaluation: Evaluation):
         "Maximize[f_?NotListQ, vars_]"
 
-        dual_f = f.to_sympy() * (-1)
+        dual_f = to_sympy(f) * (-1)
 
         dual_solutions = (
             Expression(SymbolMinimize, from_sympy(dual_f), vars)
@@ -79,7 +79,7 @@ class Maximize(Builtin):
         "Maximize[f_List, vars_]"
 
         constraints = [function for function in f.elements]
-        constraints[0] = from_sympy(constraints[0].to_sympy() * IntegerM1)
+        constraints[0] = from_sympy(to_sympy(constraints[0]) * IntegerM1)
 
         dual_solutions = (
             Expression(SymbolMinimize, constraints, vars).evaluate(evaluation).elements
@@ -121,8 +121,8 @@ class Minimize(Builtin):
     def eval_onevariable(self, f, x, evaluation: Evaluation):
         "Minimize[f_?NotListQ, x_?NotListQ]"
 
-        sympy_x = x.to_sympy()
-        sympy_f = f.to_sympy()
+        sympy_x = to_sympy(x)
+        sympy_f = to_sympy(f)
 
         derivative = sympy.diff(sympy_f, sympy_x)
         second_derivative = sympy.diff(derivative, sympy_x)
@@ -165,8 +165,8 @@ class Minimize(Builtin):
                 evaluation.message("Minimize", "ivar", vars_or)
                 return
 
-        vars_sympy = [var.to_sympy() for var in vars]
-        sympy_f = f.to_sympy()
+        vars_sympy = [to_sympy(var) for var in vars]
+        sympy_f = to_sympy(f)
 
         jacobian = [sympy.diff(sympy_f, x) for x in vars_sympy]
         hessian = sympy.Matrix(
@@ -242,9 +242,9 @@ class Minimize(Builtin):
                 evaluation.message("Minimize", "ivar", vars_or)
                 return
 
-        vars_sympy = [var.to_sympy() for var in vars]
+        vars_sympy = [to_sympy(var) for var in vars]
         constraints = [function for function in f.elements]
-        objective_function = constraints[0].to_sympy()
+        objective_function = to_sympy(constraints[0])
 
         constraints = constraints[1:]
 
@@ -258,8 +258,8 @@ class Minimize(Builtin):
             left, right = constraint.elements
             head_name = constraint.get_head_name()
 
-            left = left.to_sympy()
-            right = right.to_sympy()
+            left = to_sympy(left)
+            right = to_sympy(right)
 
             if head_name == "System`LessEqual" or head_name == "System`Less":
                 eq = left - right

--- a/mathics/builtin/quantum_mechanics/angular.py
+++ b/mathics/builtin/quantum_mechanics/angular.py
@@ -22,7 +22,7 @@ from mathics.core.attributes import (  # A_LISTABLE,; A_NUMERIC_FUNCTION,
     A_READ_PROTECTED,
 )
 from mathics.core.convert.python import from_python
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol
@@ -78,7 +78,7 @@ class ClebschGordan(SympyFunction):
         for pair in (j1m1, j2m2, jm):
             if len(pair.elements) != 2:
                 return
-            sympy_jms += [p.to_sympy() for p in pair.elements]
+            sympy_jms += [to_sympy(p) for p in pair.elements]
         return from_sympy(CG(*sympy_jms).doit())
 
 
@@ -204,7 +204,7 @@ class SixJSymbol(SympyFunction):
                         "SixJSymbol", "6jsymbol_symbol", i, triple, element
                     )
                     return
-                py_element = element.to_sympy()
+                py_element = to_sympy(element)
                 sympy_js.append(py_element)
 
         try:
@@ -288,7 +288,7 @@ class ThreeJSymbol(SympyFunction):
                 if isinstance(element, Symbol):
                     evaluation.message("ThreeJSymbol", "threejsymbol", i, pair, element)
                     return
-                py_element = element.to_sympy()
+                py_element = to_sympy(element)
                 # SymPy wants all of the j's together first and then all of the m's together
                 # rather than pairs if (j, m).
                 sympy_js[j * 3 + i] = py_element

--- a/mathics/builtin/recurrence.py
+++ b/mathics/builtin/recurrence.py
@@ -15,7 +15,7 @@ import sympy
 from mathics.builtin.base import Builtin
 from mathics.core.atoms import IntegerM1
 from mathics.core.attributes import A_CONSTANT
-from mathics.core.convert.sympy import from_sympy, sympy_symbol_prefix
+from mathics.core.convert.sympy import from_sympy, sympy_symbol_prefix, to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -119,7 +119,7 @@ class RSolve(Builtin):
                     and ri.is_numeric(evaluation)
                 ):
 
-                    r_sympy = ri.to_sympy()
+                    r_sympy = to_sympy(ri)
                     if r_sympy is None:
                         raise ValueError
                     conditions[le.elements[0].to_python()] = r_sympy
@@ -138,7 +138,7 @@ class RSolve(Builtin):
             SymbolPlus, left, Expression(SymbolTimes, IntegerM1, right)
         ).evaluate(evaluation)
 
-        sym_eq = relation.to_sympy(converted_functions={func.get_head_name()})
+        sym_eq = to_sympy(relation, converted_functions={func.get_head_name()})
         if sym_eq is None:
             return
         sym_n = sympy.core.symbols(str(sympy_symbol_prefix + n.name))

--- a/mathics/builtin/specialfns/elliptic.py
+++ b/mathics/builtin/specialfns/elliptic.py
@@ -15,7 +15,7 @@ import sympy
 from mathics.builtin.base import SympyFunction
 from mathics.core.atoms import Integer
 from mathics.core.attributes import A_LISTABLE, A_NUMERIC_FUNCTION, A_PROTECTED
-from mathics.core.convert.sympy import from_sympy, to_numeric_sympy_args
+from mathics.core.convert.sympy import from_sympy, to_numeric_sympy_args, to_sympy
 from mathics.eval.numerify import numerify
 
 
@@ -61,7 +61,7 @@ class EllipticE(SympyFunction):
 
     def eval_m(self, m, evaluation):
         "%(name)s[m_]"
-        sympy_arg = numerify(m, evaluation).to_sympy()
+        sympy_arg = to_sympy(numerify(m, evaluation))
         try:
             return from_sympy(sympy.elliptic_e(sympy_arg))
         except Exception:
@@ -69,7 +69,7 @@ class EllipticE(SympyFunction):
 
     def eval_phi_m(self, phi, m, evaluation):
         "%(name)s[phi_, m_]"
-        sympy_args = [numerify(a, evaluation).to_sympy() for a in (phi, m)]
+        sympy_args = [to_sympy(numerify(a, evaluation)) for a in (phi, m)]
         try:
             return from_sympy(sympy.elliptic_e(*sympy_args))
         except Exception:
@@ -115,7 +115,7 @@ special.html#sympy.functions.special.elliptic_integrals.elliptic_f</url>, <url>
 
     def eval(self, phi, m, evaluation):
         "%(name)s[phi_, m_]"
-        sympy_args = [numerify(a, evaluation).to_sympy() for a in (phi, m)]
+        sympy_args = [to_sympy(numerify(a, evaluation)) for a in (phi, m)]
         try:
             return from_sympy(sympy.elliptic_f(*sympy_args))
         except Exception:
@@ -162,7 +162,7 @@ class EllipticK(SympyFunction):
     def eval(self, m, evaluation):
         "%(name)s[m_]"
         args = numerify(m, evaluation).get_sequence()
-        sympy_args = [a.to_sympy() for a in args]
+        sympy_args = [to_sympy(a) for a in args]
         try:
             return from_sympy(sympy.elliptic_k(*sympy_args))
         except Exception:

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -12,7 +12,7 @@ from mathics.core.atoms import Integer, Integer0, Number
 from mathics.core.attributes import A_LISTABLE, A_NUMERIC_FUNCTION, A_PROTECTED
 from mathics.core.convert.mpmath import from_mpmath
 from mathics.core.convert.python import from_python
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.expression import Expression
 from mathics.core.number import FP_MANTISA_BINARY_DIGITS, dps, min_prec
 from mathics.core.symbols import Symbol, SymbolSequence
@@ -229,7 +229,7 @@ class Factorial2(PostfixOperator, _MPMathFunction):
             convert_from_fn = from_mpmath
             fact2_fn = getattr(mpmath, self.mpmath_name)
         elif preference == "sympy":
-            number_arg = number.to_sympy()
+            number_arg = to_sympy(number)
             convert_from_fn = from_sympy
             fact2_fn = getattr(sympy, self.sympy_name)
         else:

--- a/mathics/builtin/testing_expressions/equality_inequality.py
+++ b/mathics/builtin/testing_expressions/equality_inequality.py
@@ -18,6 +18,7 @@ from mathics.core.attributes import (
     A_PROTECTED,
 )
 from mathics.core.convert.expression import to_expression, to_numeric_args
+from mathics.core.convert.sympy import to_sympy
 from mathics.core.expression import Expression
 from mathics.core.expression_predefined import (
     MATHICS3_COMPLEX_INFINITY,
@@ -154,8 +155,8 @@ class _EqualityOperator(_InequalityOperator):
 
     def sympy_equal(self, lhs, rhs, max_extra_prec=None) -> Optional[bool]:
         try:
-            lhs_sympy = lhs.to_sympy(evaluate=True, prec=COMPARE_PREC)
-            rhs_sympy = rhs.to_sympy(evaluate=True, prec=COMPARE_PREC)
+            lhs_sympy = to_sympy(lhs, evaluate=True, prec=COMPARE_PREC)
+            rhs_sympy = to_sympy(rhs, evaluate=True, prec=COMPARE_PREC)
         except NotImplementedError:
             return None
 

--- a/mathics/builtin/testing_expressions/numerical_properties.py
+++ b/mathics/builtin/testing_expressions/numerical_properties.py
@@ -9,6 +9,7 @@ from mathics.builtin.base import Builtin, SympyFunction, Test
 from mathics.core.atoms import Integer, Integer0, Number
 from mathics.core.attributes import A_LISTABLE, A_NUMERIC_FUNCTION, A_PROTECTED
 from mathics.core.convert.python import from_bool, from_python
+from mathics.core.convert.sympy import to_sympy
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.symbols import BooleanType, SymbolFalse, SymbolTrue
@@ -465,12 +466,12 @@ class PossibleZeroQ(SympyFunction):
         if test_zero_arithmetic_expr(expr):
             return SymbolTrue
 
-        sympy_expr = expr.to_sympy()
+        sympy_expr = to_sympy(expr)
         result = _iszero(sympy_expr)
         if result is None:
             # try expanding the expression
             exprexp = Expression(SymbolExpandAll, expr).evaluate(evaluation)
-            exprexp = exprexp.to_sympy()
+            exprexp = to_sympy(exprexp)
             result = _iszero(exprexp)
         if result is None:
             # Can't get exact answer, so try approximate equal

--- a/mathics/core/convert/matrix.py
+++ b/mathics/core/convert/matrix.py
@@ -4,13 +4,15 @@
 
 
 def matrix_data(m):
+    from mathics.core.convert.sympy import to_sympy
+
     if not m.has_form("List", None):
         return None
     if all(element.has_form("List", None) for element in m.elements):
-        result = [[item.to_sympy() for item in row.elements] for row in m.elements]
+        result = [[to_sympy(item) for item in row.elements] for row in m.elements]
         if not any(None in row for row in result):
             return result
     elif not any(element.has_form("List", None) for element in m.elements):
-        result = [item.to_sympy() for item in m.elements]
+        result = [to_sympy(item) for item in m.elements]
         if None not in result:
             return result

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -425,9 +425,6 @@ class BaseElement(KeyComparable):
     def to_mpmath(self):
         raise NotImplementedError
 
-    def to_sympy(self, **kwargs):
-        raise NotImplementedError
-
 
 class EvalMixin:
     """

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -251,17 +251,6 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             ", ".join([str(element) for element in self.elements]),
         )
 
-    def _as_sympy_function(self, **kwargs) -> Optional[sympy.Function]:
-        from mathics.core.convert.sympy import sympy_symbol_prefix
-
-        sym_args = [element.to_sympy(**kwargs) for element in self._elements]
-
-        if None in sym_args:
-            return None
-
-        f = sympy.Function(str(sympy_symbol_prefix + self.get_head_name()))
-        return f(*sym_args)
-
     # Note: this function is called a *lot* so it needs to be fast.
     def _build_elements_properties(self):
         """
@@ -1496,11 +1485,6 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         # Notice that in this case, `to_python` returns a Mathics Expression object,
         # instead of a builtin native object.
         return self
-
-    def to_sympy(self, **kwargs):
-        from mathics.core.convert.sympy import expression_to_sympy
-
-        return expression_to_sympy(self, **kwargs)
 
     def process_style_box(self, options):
         if self.has_form("StyleBox", 1, None):

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -621,11 +621,6 @@ class Symbol(Atom, NumericOperators, EvalMixin):
         # dictionaries.
         return self.name
 
-    def to_sympy(self, **kwargs):
-        from mathics.core.convert.sympy import symbol_to_sympy
-
-        return symbol_to_sympy(self, **kwargs)
-
 
 class SymbolConstant(Symbol):
     """

--- a/mathics/eval/arithmetic.py
+++ b/mathics/eval/arithmetic.py
@@ -27,7 +27,7 @@ from mathics.core.atoms import (
     Real,
 )
 from mathics.core.convert.mpmath import from_mpmath
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.element import BaseElement, ElementsProperties
 from mathics.core.expression import Expression
 from mathics.core.number import FP_MANTISA_BINARY_DIGITS, SpecialValueError, min_prec
@@ -152,7 +152,7 @@ def eval_Exp(exp: BaseElement) -> BaseElement:
     # use sympy.
 
     if not exp.is_inexact():
-        exp_sp = exp.to_sympy()
+        exp_sp = to_sympy(exp)
         if exp_sp is None:
             return None
         return from_sympy(sympy.Exp(exp_sp))
@@ -377,7 +377,7 @@ def eval_Plus(*items: BaseElement) -> BaseElement:
         if item.has_form("Times", None):
             for element in item.elements:
                 if isinstance(element, Number):
-                    count = element.to_sympy()
+                    count = to_sympy(element)
                     rest = item.get_mutable_elements()
                     rest.remove(element)
                     if len(rest) == 1:
@@ -442,7 +442,7 @@ def eval_Power_number(base: Number, exp: Number) -> Optional[Number]:
         """
         # This function is called just if useful native rules
         # are available.
-        result = from_sympy(sympy.Pow(base.to_sympy(), exp.to_sympy()))
+        result = from_sympy(sympy.Pow(to_sympy(base), to_sympy(exp)))
         if result.has_form("Power", 2):
             # If the expression didn´t change, return None
             if result.elements[0].sameQ(base):
@@ -670,7 +670,7 @@ def eval_add_numbers(
             number = mpmath.fsum(terms)
             return from_mpmath(number, precision=prec)
     else:
-        return from_sympy(sum(item.to_sympy() for item in numbers))
+        return from_sympy(sum(to_sympy(item) for item in numbers))
 
 
 def eval_inverse_number(n: Number) -> Number:
@@ -715,7 +715,7 @@ def eval_multiply_numbers(*numbers: Number) -> Number:
             number = mpmath.fprod(factors)
             return from_mpmath(number, prec)
     else:
-        return from_sympy(sympy.Mul(*(item.to_sympy() for item in numbers)))
+        return from_sympy(sympy.Mul(*(to_sympy(item) for item in numbers)))
 
 
 def eval_negate_number(n: Number) -> Number:

--- a/mathics/eval/hyperbolic.py
+++ b/mathics/eval/hyperbolic.py
@@ -3,15 +3,15 @@ Mathics3 builtins from mathics.core.numbers.hyperbolic
 """
 from sympy import Symbol as SympySymbol
 
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 
 
 def eval_ComplexExpand(expr, vars):
-    sympy_expr = expr.to_sympy()
+    sympy_expr = to_sympy(expr)
     if hasattr(vars, "elements"):
-        sympy_vars = {v.to_sympy() for v in vars.elements}
+        sympy_vars = {to_sympy(v) for v in vars.elements}
     else:
-        sympy_vars = {vars.to_sympy()}
+        sympy_vars = {to_sympy(vars)}
     # All vars are assumed to be real
     replaces = [
         (fs, SympySymbol(fs.name, real=True))

--- a/mathics/eval/math_ops.py
+++ b/mathics/eval/math_ops.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional
 
 from mathics.core.atoms import Integer, Real, String
-from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
+from mathics.core.convert.sympy import from_sympy, to_sympy, to_sympy_matrix
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol
@@ -29,13 +29,13 @@ def eval_Norm_p(
     Norm[m, p] evaluation function - the p-norm of matrix m.
     """
     if isinstance(p, Symbol):
-        sympy_p = p.to_sympy()
+        sympy_p = to_sympy(p)
     elif isinstance(p, String):
         sympy_p = p.value
         if sympy_p == "Frobenius":
             sympy_p = "fro"
     elif isinstance(p, (Real, Integer)) and p.to_python() >= 1:
-        sympy_p = p.to_sympy()
+        sympy_p = to_sympy(p)
     else:
         if show_message:
             show_message("Norm", "ptype", p)

--- a/mathics/eval/numbers.py
+++ b/mathics/eval/numbers.py
@@ -4,7 +4,7 @@ import mpmath
 import sympy
 
 from mathics.core.atoms import Complex, MachineReal, PrecisionReal
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.element import BaseElement
 from mathics.core.expression import Expression
 from mathics.core.number import MACHINE_PRECISION_VALUE, ZERO_MACHINE_ACCURACY, dps
@@ -115,7 +115,7 @@ def cancel(expr):
         return Expression(SymbolPlus, *[cancel(element) for element in expr.elements])
     else:
         try:
-            result = expr.to_sympy()
+            result = to_sympy(expr)
             if result is None:
                 return None
 

--- a/mathics/eval/testing_expressions.py
+++ b/mathics/eval/testing_expressions.py
@@ -3,6 +3,7 @@ from typing import Optional
 import sympy
 
 from mathics.core.atoms import Complex, Integer0, Integer1, IntegerM1
+from mathics.core.convert.sympy import to_sympy
 from mathics.core.expression import Expression
 from mathics.core.systemsymbols import SymbolDirectedInfinity
 
@@ -17,8 +18,8 @@ def do_cmp(x1, x2) -> Optional[int]:
         ):
             return None
 
-    s1 = x1.to_sympy()
-    s2 = x2.to_sympy()
+    s1 = to_sympy(x1)
+    s2 = to_sympy(x2)
 
     # Use internal comparisons only for Real which is uses
     # WL's interpretation of equal (which allows for slop

--- a/test/core/convert/test_sympy.py
+++ b/test/core/convert/test_sympy.py
@@ -19,7 +19,7 @@ from mathics.core.atoms import (
     Real,
     String,
 )
-from mathics.core.convert.sympy import from_sympy, sympy_singleton_to_mathics
+from mathics.core.convert.sympy import from_sympy, sympy_singleton_to_mathics, to_sympy
 from mathics.core.expression import Expression
 from mathics.core.expression_predefined import (
     MATHICS3_COMPLEX_INFINITY,
@@ -78,7 +78,7 @@ def test_from_to_sympy_invariant(expr):
     """
     Check if the conversion back and forward is consistent.
     """
-    result_sympy = expr.to_sympy()
+    result_sympy = to_sympy(expr)
     back_to_mathics = from_sympy(result_sympy)
     print([expr, result_sympy, back_to_mathics])
     assert expr.sameQ(back_to_mathics)
@@ -122,9 +122,9 @@ def test_from_to_sympy_change(expr, result, msg):
     """
     print([expr, result])
     if msg:
-        assert result.sameQ(from_sympy(expr.to_sympy())), msg
+        assert result.sameQ(from_sympy(to_sympy(expr))), msg
     else:
-        assert result.sameQ(from_sympy(expr.to_sympy()))
+        assert result.sameQ(from_sympy(to_sympy(expr)))
 
 
 def test_convert_sympy_singletons():
@@ -139,6 +139,6 @@ def test_convert_sympy_singletons():
             print("  ->  ", res)
             assert from_sympy(key).sameQ(val)
 
-            res = val.to_sympy()
+            res = to_sympy(val)
             print(res, "  <-  ")
             assert res is key

--- a/test/core/test_sympy_python_convert.py
+++ b/test/core/test_sympy_python_convert.py
@@ -17,7 +17,7 @@ from mathics.core.atoms import (
     String,
 )
 from mathics.core.convert.python import from_python
-from mathics.core.convert.sympy import from_sympy
+from mathics.core.convert.sympy import from_sympy, to_sympy
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolPlus
@@ -32,7 +32,7 @@ from mathics.core.systemsymbols import (
 
 class SympyConvert(unittest.TestCase):
     def compare_to_sympy(self, mathics_expr, sympy_expr, **kwargs):
-        mathics_expr.to_sympy(**kwargs) == sympy_expr
+        to_sympy(mathics_expr, **kwargs) == sympy_expr
 
     def compare_to_mathics(self, mathics_expr, sympy_expr, **kwargs):
         mathics_expr == from_sympy(sympy_expr, **kwargs)
@@ -76,7 +76,7 @@ class SympyConvert(unittest.TestCase):
         )
 
     def testString(self):
-        String("abc").to_sympy() is None
+        to_sympy(String("abc")) is None
 
     def testAdd(self):
         self.compare(


### PR DESCRIPTION
This PR is a proposal to disentangle  Sympy conversions from the core. This allows to eliminate some local imports, and localizes a little bit more where Sympy is used.