### PR TITLE
Fix infix 1

### DIFF
--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -175,9 +175,6 @@ class Infix(Builtin):
     >> g[a, b] * c
      = c (a # b)
 
-    >> Infix[{a, b, c}, {"+", "-"}]
-     = a + b - c
-
     #> Format[r[items___]] := Infix[If[Length[{items}] > 1, {items}, {ab}], "~"]
     #> r[1, 2, 3]
      = 1 ~ 2 ~ 3


### PR DESCRIPTION
Once the arithmetic format is fixed, then we can fix how `Infix[...]` expressions are formatted.
Now,
* Operator (the second argument) is always a string (or at least, Lists are not processed in an special way)
* associativity is controlled by the group property of the elements of Infix, and not from outside, according to WL.

For example, `Infix[{a, Infix[{b,c},"#",300, Left]}, "@", 300, Right]` means that the inner `Infix` is embraced by parenthesis (because Left associative are embraced except if they are in the first position).