### PR TITLE
Moving private doctests to pytests. Fix the compatibility issue 0. I-> 0.

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -78,25 +78,6 @@ class CubeRoot(Builtin):
 
     >> CubeRoot[16]
      = 2 2 ^ (1 / 3)
-
-    #> CubeRoot[-5]
-     = -5 ^ (1 / 3)
-
-    #> CubeRoot[-510000]
-     = -10 510 ^ (1 / 3)
-
-    #> CubeRoot[-5.1]
-     = -1.7213
-
-    #> CubeRoot[b]
-     = b ^ (1 / 3)
-
-    #> CubeRoot[-0.5]
-     = -0.793701
-
-    #> CubeRoot[3 + 4 I]
-     : The parameter 3 + 4 I should be real valued.
-     = (3 + 4 I) ^ (1 / 3)
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
@@ -163,14 +144,6 @@ class Divide(BinaryOperator):
      = a d / (b c e)
     >> a / (b ^ 2 * c ^ 3 / e)
      = a e / (b ^ 2 c ^ 3)
-
-    #> 1 / 4.0
-     = 0.25
-    #> 10 / 3 // FullForm
-     = Rational[10, 3]
-    #> a / b // FullForm
-     = Times[a, Power[b, -1]]
-
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
@@ -291,26 +264,6 @@ class Plus(BinaryOperator, SympyFunction):
     The sum of 2 red circles and 3 red circles is...
     >> 2 Graphics[{Red,Disk[]}] + 3 Graphics[{Red,Disk[]}]
      = 5 -Graphics-
-
-    #> -2a - 2b
-     = -2 a - 2 b
-    #> -4+2x+2*Sqrt[3]
-     = -4 + 2 Sqrt[3] + 2 x
-    #> 2a-3b-c
-     = 2 a - 3 b - c
-    #> 2a+5d-3b-2c-e
-     = 2 a - 3 b - 2 c + 5 d - e
-
-    #> 1 - I * Sqrt[3]
-     = 1 - I Sqrt[3]
-
-    #> Head[3 + 2 I]
-     = Complex
-
-    #> N[Pi, 30] + N[E, 30]
-     = 5.85987448204883847382293085463
-    #> % // Precision
-     = 30.
     """
 
     attributes = (
@@ -440,47 +393,6 @@ class Power(BinaryOperator, MPMathFunction):
      = -3.68294 + 6.95139 I
     >> (1.5 + 1.0 I) ^ (3.5 + 1.5 I)
      = -3.19182 + 0.645659 I
-
-    #> 1/0
-     : Infinite expression 1 / 0 encountered.
-     = ComplexInfinity
-    #> 0 ^ -2
-     : Infinite expression 1 / 0 ^ 2 encountered.
-     = ComplexInfinity
-    #> 0 ^ (-1/2)
-     : Infinite expression 1 / Sqrt[0] encountered.
-     = ComplexInfinity
-    #> 0 ^ -Pi
-     : Infinite expression 1 / 0 ^ 3.14159 encountered.
-     = ComplexInfinity
-    #> 0 ^ (2 I E)
-     : Indeterminate expression 0 ^ (0. + 5.43656 I) encountered.
-     = Indeterminate
-    #> 0 ^ - (Pi + 2 E I)
-     : Infinite expression 0 ^ (-3.14159 - 5.43656 I) encountered.
-     = ComplexInfinity
-
-    #> 0 ^ 0
-     : Indeterminate expression 0 ^ 0 encountered.
-     = Indeterminate
-
-    #> Sqrt[-3+2. I]
-     = 0.550251 + 1.81735 I
-    #> Sqrt[-3+2 I]
-     = Sqrt[-3 + 2 I]
-    #> (3/2+1/2I)^2
-     = 2 + 3 I / 2
-    #> I ^ I
-     = (-1) ^ (I / 2)
-
-    #> 2 ^ 2.0
-     = 4.
-
-    #> Pi ^ 4.
-     = 97.4091
-
-    #> a ^ b
-     = a ^ b
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_ONE_IDENTITY | A_PROTECTED
@@ -602,9 +514,6 @@ class Sqrt(SympyFunction):
 
     >> Plot[Sqrt[a^2], {a, -2, 2}]
      = -Graphics-
-
-    #> N[Sqrt[2], 50]
-     = 1.4142135623730950488016887242096980785696718753769
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
@@ -690,56 +599,6 @@ class Times(BinaryOperator, SympyFunction):
      = {HoldPattern[Default[Times]] :> 1}
     >> a /. n_. * x_ :> {n, x}
      = {1, a}
-
-    #> -a*b // FullForm
-     = Times[-1, a, b]
-    #> -(x - 2/3)
-     = 2 / 3 - x
-    #> -x*2
-     = -2 x
-    #> -(h/2) // FullForm
-     = Times[Rational[-1, 2], h]
-
-    #> x / x
-     = 1
-    #> 2x^2 / x^2
-     = 2
-
-    #> 3. Pi
-     = 9.42478
-
-    #> Head[3 * I]
-     = Complex
-
-    #> Head[Times[I, 1/2]]
-     = Complex
-
-    #> Head[Pi * I]
-     = Times
-
-    #> 3 * a //InputForm
-     = 3*a
-    #> 3 * a //OutputForm
-     = 3 a
-
-    #> -2.123456789 x
-     = -2.12346 x
-    #> -2.123456789 I
-     = 0. - 2.12346 I
-
-    #> N[Pi, 30] * I
-     = 3.14159265358979323846264338328 I
-    #> N[I Pi, 30]
-     = 3.14159265358979323846264338328 I
-
-    #> N[Pi * E, 30]
-     = 8.53973422267356706546355086955
-    #> N[Pi, 30] * N[E, 30]
-     = 8.53973422267356706546355086955
-    #> N[Pi, 30] * E
-     = 8.53973422267356706546355086955
-    #> % // Precision
-     = 30.
     """
 
     attributes = (

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -279,45 +279,6 @@ class Complex_(Builtin):
      = 1 + 2 I / 3
     >> Abs[Complex[3, 4]]
      = 5
-
-    #> OutputForm[Complex[2.0 ^ 40, 3]]
-     = 1.09951×10^12 + 3. I
-    #> InputForm[Complex[2.0 ^ 40, 3]]
-     = 1.099511627776*^12 + 3.*I
-
-    #> -2 / 3 - I
-     = -2 / 3 - I
-
-    #> Complex[10, 0]
-     = 10
-
-    #> 0. + I
-     = 0. + 1. I
-
-    #> 1 + 0 I
-     = 1
-    #> Head[%]
-     = Integer
-
-    #> Complex[0.0, 0.0]
-     = 0. + 0. I
-    #> 0. I
-     = 0.
-    #> 0. + 0. I
-     = 0.
-
-    #> 1. + 0. I
-     = 1.
-    #> 0. + 1. I
-     = 0. + 1. I
-
-    ## Check Nesting Complex
-    #> Complex[1, Complex[0, 1]]
-     = 0
-    #> Complex[1, Complex[1, 0]]
-     = 1 + I
-    #> Complex[1, Complex[1, 1]]
-     = I
     """
 
     summary_text = "head for complex numbers"
@@ -442,10 +403,6 @@ class Conjugate(MPMathFunction):
     >> Conjugate[{{1, 2 + I 4, a + I b}, {I}}]
      = {{1, 2 - 4 I, Conjugate[a] - I Conjugate[b]}, {-I}}
 
-    ## Issue #272
-    #> {Conjugate[Pi], Conjugate[E]}
-     = {Pi, E}
-
     >> Conjugate[1.5 + 2.5 I]
      = 1.5 - 2.5 I
     """
@@ -485,11 +442,6 @@ class DirectedInfinity(SympyFunction):
     >> DirectedInfinity[0]
      = ComplexInfinity
 
-    #> DirectedInfinity[1+I]+DirectedInfinity[2+I]
-     = (2 / 5 + I / 5) Sqrt[5] Infinity + (1 / 2 + I / 2) Sqrt[2] Infinity
-
-    #> DirectedInfinity[Sqrt[3]]
-     = Infinity
     """
 
     summary_text = "infinite quantity with a defined direction in the complex plane"
@@ -703,11 +655,6 @@ class Im(SympyFunction):
 
     >> Plot[{Sin[a], Im[E^(I a)]}, {a, 0, 2 Pi}]
      = -Graphics-
-
-    #> Re[0.5 + 2.3 I]
-     = 0.5
-    #> % // Precision
-     = MachinePrecision
     """
 
     summary_text = "imaginary part"
@@ -740,10 +687,6 @@ class Integer_(Builtin):
 
     >> Head[5]
      = Integer
-
-    ## Test large Integer comparison bug
-    #> {a, b} = {2^10000, 2^10000 + 1}; {a == b, a < b, a <= b}
-     = {False, True, True}
     """
 
     summary_text = "head for integer numbers"
@@ -789,10 +732,6 @@ class Product(IterationFunction, SympyFunction):
     >> primorial[12]
      = 7420738134810
 
-    ## Used to be a bug in sympy, but now it is solved exactly!
-    ## Again a bug in sympy - regressions between 0.7.3 and 0.7.6 (and 0.7.7?)
-    ## #> Product[1 + 1 / i ^ 2, {i, Infinity}]
-    ##  = 1 / ((-I)! I!)
     """
 
     summary_text = "discrete product"
@@ -847,9 +786,6 @@ class Rational_(Builtin):
 
     >> Rational[1, 2]
      = 1 / 2
-
-    #> -2/3
-     = -2 / 3
     """
 
     summary_text = "head for rational numbers"
@@ -878,11 +814,6 @@ class Re(SympyFunction):
 
     >> Plot[{Cos[a], Re[E^(I a)]}, {a, 0, 2 Pi}]
      = -Graphics-
-
-    #> Im[0.5 + 2.3 I]
-     = 2.3
-    #> % // Precision
-     = MachinePrecision
     """
 
     summary_text = "real part"
@@ -919,61 +850,6 @@ class Real_(Builtin):
     >> Head[x]
      = Real
 
-    ## Formatting tests
-    #> 1. * 10^6
-     = 1.×10^6
-    #> 1. * 10^5
-     = 100000.
-    #> -1. * 10^6
-     = -1.×10^6
-    #> -1. * 10^5
-     = -100000.
-    #> 1. * 10^-6
-     = 1.×10^-6
-    #> 1. * 10^-5
-     = 0.00001
-    #> -1. * 10^-6
-     = -1.×10^-6
-    #> -1. * 10^-5
-     = -0.00001
-
-    ## Mathematica treats zero strangely
-    #> 0.0000000000000
-     = 0.
-    #> 0.0000000000000000000000000000
-     = 0.×10^-28
-
-    ## Parse *^ Notation
-    #> 1.5×10^24
-     = 1.5×10^24
-    #> 1.5*^+24
-     = 1.5×10^24
-    #> 1.5*^-24
-     = 1.5×10^-24
-
-    ## Don't accept *^ with spaces
-    #> 1.5 *^10
-     : "1.5 *" cannot be followed by "^10" (line 1 of "<test>").
-    #> 1.5*^ 10
-     : "1.5*" cannot be followed by "^ 10" (line 1 of "<test>").
-
-    ## Issue654
-    #> 1^^2
-     : Requested base 1 in 1^^2 should be between 2 and 36.
-     : Expression cannot begin with "1^^2" (line 1 of "<test>").
-    #> 2^^0101
-     = 5
-    #> 2^^01210
-     : Digit at position 3 in 01210 is too large to be used in base 2.
-     : Expression cannot begin with "2^^01210" (line 1 of "<test>").
-    #> 16^^5g
-     : Digit at position 2 in 5g is too large to be used in base 16.
-     : Expression cannot begin with "16^^5g" (line 1 of "<test>").
-    #> 36^^0123456789abcDEFxyzXYZ
-     = 14142263610074677021975869033659
-    #> 37^^3
-     : Requested base 37 in 37^^3 should be between 2 and 36.
-     : Expression cannot begin with "37^^3" (line 1 of "<test>").
     """
 
     summary_text = "head for real numbers"
@@ -999,7 +875,7 @@ class RealNumberQ(Test):
     >> RealNumberQ[0 * I]
      = True
     >> RealNumberQ[0.0 * I]
-     = True
+     = False
     """
 
     attributes = A_NO_ATTRIBUTES
@@ -1076,12 +952,6 @@ class Sum(IterationFunction, SympyFunction):
     >> Sum[x ^ 2, {x, 1, y}] - y * (y + 1) * (2 * y + 1) / 6
      = 0
 
-    ## >> (-1 + a^n) Sum[a^(k n), {k, 0, m-1}] // Simplify
-    ## = -1 + (a ^ n) ^ m  # this is what I am getting
-    ## = Piecewise[{{m (-1 + a ^ n), a ^ n == 1}, {-1 + (a ^ n) ^ m, True}}]
-
-    #> a=Sum[x^k*Sum[y^l,{l,0,4}],{k,0,4}]]
-     : "a=Sum[x^k*Sum[y^l,{l,0,4}],{k,0,4}]" cannot be followed by "]" (line 1 of "<test>").
 
     ## Issue #302
     ## The sum should not converge since the first term is 1/0.

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -697,7 +697,6 @@ class _BaseFinder(Builtin):
     def eval_with_x_tuple(self, f, xtuple, evaluation: Evaluation, options: dict):
         "%(name)s[f_, xtuple_, OptionsPattern[]]"
         f_val = f.evaluate(evaluation)
-
         if f_val.has_form("Equal", 2):
             f = Expression(SymbolPlus, f_val.elements[0], f_val.elements[1])
 

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -263,14 +263,6 @@ class ComplexInfinity(_SympyConstant):
      = ComplexInfinity
     >> FullForm[ComplexInfinity]
      = DirectedInfinity[]
-
-    ## Issue689
-    #> ComplexInfinity + ComplexInfinity
-     : Indeterminate expression ComplexInfinity + ComplexInfinity encountered.
-     = Indeterminate
-    #> ComplexInfinity + Infinity
-     : Indeterminate expression ComplexInfinity + Infinity encountered.
-     = Indeterminate
     """
 
     summary_text = "infinite complex quantity of undetermined direction"
@@ -302,15 +294,6 @@ class Degree(_MPMathConstant, _NumpyConstant, _SympyConstant):
 
     >> N[\\[Degree]] == N[Degree]
      = True
-
-    #> Cos[Degree[x]]
-     = Cos[Degree[x]]
-
-
-    #> N[Degree]
-     = 0.0174533
-    #> N[Degree, 30]
-     = 0.0174532925199432957692369076849
     """
 
     summary_text = "conversion factor from radians to degrees"
@@ -367,9 +350,6 @@ class E(_MPMathConstant, _NumpyConstant, _SympyConstant):
      = 2.71828
     >> N[E, 50]
      = 2.7182818284590452353602874713526624977572470937000
-
-    #> 5. E
-     = 13.5914
     """
 
     summary_text = "exponential constant E ≃ 2.7182"
@@ -512,16 +492,6 @@ class Infinity(_SympyConstant):
     Use 'Infinity' in sum and limit calculations:
     >> Sum[1/x^2, {x, 1, Infinity}]
      = Pi ^ 2 / 6
-
-    #> FullForm[Infinity]
-     = DirectedInfinity[1]
-    #> (2 + 3.5*I) / Infinity
-     = 0.
-    #> Infinity + Infinity
-     = Infinity
-    #> Infinity / Infinity
-     : Indeterminate expression 0 Infinity encountered.
-     = Indeterminate
     """
 
     sympy_name = "oo"

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -18,7 +18,21 @@ from mathics.core.expression_predefined import (
 from mathics.core.systemsymbols import SymbolIndeterminate
 
 
-@lru_cache(maxsize=1024)
+# Another issue with the lru_cache: for mpmath, mpmath.mpc(0.,0.) and
+# mpmath.mpf(0.) produces the same hash. As a result, depending on
+# what is called first, the output of this function is different.
+#
+# note mmatera: When I start to pass the private doctests
+# to pytests, I realize that WMA evaluates `0. I`  to `Complex[0.,0.]`
+# instead of  `0.`. To fix this incompatibility, I removed from
+# `from_sympy` the lines that convert `mpc(0.,0.)` to `mpf(0.0)`,
+# and then this issue becomes evident.
+#
+# As we decide by now that performance comes after ensuring the compatibility
+# and clarity of the code, I propose here to conserve the right tests,
+# and commented out the cache and the lines that convert mpc(0,0) to MachineReal(0).
+#
+# @lru_cache(maxsize=1024)
 def from_mpmath(
     value: Union[mpmath.mpf, mpmath.mpc],
     precision: Optional[int] = None,
@@ -42,8 +56,8 @@ def from_mpmath(
         # HACK: use str here to prevent loss of precision
         return PrecisionReal(sympy.Float(str(value), precision=precision - 1))
     elif isinstance(value, mpmath.mpc):
-        if value.imag == 0.0:
-            return from_mpmath(value.real, precision=precision)
+        # if value.imag == 0.0:
+        #    return from_mpmath(value.real, precision=precision)
         val_re, val_im = value.real, value.imag
         if mpmath.isinf(val_re):
             if mpmath.isinf(val_im):

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -57,7 +57,7 @@ def from_mpmath(
         return PrecisionReal(sympy.Float(str(value), precision=precision - 1))
     elif isinstance(value, mpmath.mpc):
         # if value.imag == 0.0:
-        #    return from_mpmath(value.real, precision=precision)
+        #   return from_mpmath(value.real, precision=precision)
         val_re, val_im = value.real, value.imag
         if mpmath.isinf(val_re):
             if mpmath.isinf(val_im):

--- a/mathics/format/latex.py
+++ b/mathics/format/latex.py
@@ -234,7 +234,7 @@ def superscriptbox(self, **options):
         base = self.tex_block(tex1, True)
         superidx_to_tex = lookup_conversion_method(self.superindex, "latex")
         superindx = self.tex_block(superidx_to_tex(self.superindex, **options), True)
-        if isinstance(self.superindex, (String, StyleBox)):
+        if len(superindx) == 1 and isinstance(self.superindex, (String, StyleBox)):
             return "%s^%s" % (
                 base,
                 superindx,

--- a/test/builtin/arithmetic/test_basic.py
+++ b/test/builtin/arithmetic/test_basic.py
@@ -174,63 +174,106 @@ def test_directed_infinity_precedence(str_expr, str_expected, msg):
 
 
 @pytest.mark.parametrize(
-    (
-        "str_expr",
-        "str_expected",
-        "msg",
-    ),
+    ("str_expr", "str_expected", "expected_message", "fail_msg"),
     [
-        ("2^0", "1", None),
-        ("(2/3)^0", "1", None),
-        ("2.^0", "1.", None),
-        ("2^1", "2", None),
-        ("(2/3)^1", "2 / 3", None),
-        ("2.^1", "2.", None),
-        ("2^(3)", "8", None),
-        ("(1/2)^3", "1 / 8", None),
-        ("2^(-3)", "1 / 8", None),
-        ("(1/2)^(-3)", "8", None),
-        ("(-7)^(5/3)", "-7 (-7) ^ (2 / 3)", None),
-        ("3^(1/2)", "Sqrt[3]", None),
+        ("2^0", "1", None, None),
+        ("(2/3)^0", "1", None, None),
+        ("2.^0", "1.", None, None),
+        ("2^1", "2", None, None),
+        ("(2/3)^1", "2 / 3", None, None),
+        ("2.^1", "2.", None, None),
+        ("2^(3)", "8", None, None),
+        ("(1/2)^3", "1 / 8", None, None),
+        ("2^(-3)", "1 / 8", None, None),
+        ("(1/2)^(-3)", "8", None, None),
+        ("(-7)^(5/3)", "-7 (-7) ^ (2 / 3)", None, None),
+        ("3^(1/2)", "Sqrt[3]", None, None),
         # WMA do not rationalize numbers
-        ("(1/5)^(1/2)", "Sqrt[5] / 5", None),
+        ("(1/5)^(1/2)", "Sqrt[5] / 5", None, None),
         # WMA do not rationalize numbers
-        ("(3)^(-1/2)", "Sqrt[3] / 3", None),
-        ("(1/3)^(-1/2)", "Sqrt[3]", None),
-        ("(5/3)^(1/2)", "Sqrt[5 / 3]", None),
-        ("(5/3)^(-1/2)", "Sqrt[3 / 5]", None),
-        ("1/Sqrt[Pi]", "1 / Sqrt[Pi]", None),
-        ("I^(2/3)", "(-1) ^ (1 / 3)", None),
+        ("(3)^(-1/2)", "Sqrt[3] / 3", None, None),
+        ("(1/3)^(-1/2)", "Sqrt[3]", None, None),
+        ("(5/3)^(1/2)", "Sqrt[5 / 3]", None, None),
+        ("(5/3)^(-1/2)", "Sqrt[3 / 5]", None, None),
+        ("1/Sqrt[Pi]", "1 / Sqrt[Pi]", None, None),
+        ("I^(2/3)", "(-1) ^ (1 / 3)", None, None),
         # In WMA, the next test would return ``-(-I)^(2/3)``
         # which is less compact and elegant...
         #        ("(-I)^(2/3)", "(-1) ^ (-1 / 3)", None),
-        ("(2+3I)^3", "-46 + 9 I", None),
-        ("(1.+3. I)^.6", "1.46069 + 1.35921 I", None),
-        ("3^(1+2 I)", "3 ^ (1 + 2 I)", None),
-        ("3.^(1+2 I)", "-1.75876 + 2.43038 I", None),
-        ("3^(1.+2 I)", "-1.75876 + 2.43038 I", None),
+        ("(2+3I)^3", "-46 + 9 I", None, None),
+        ("(1.+3. I)^.6", "1.46069 + 1.35921 I", None, None),
+        ("3^(1+2 I)", "3 ^ (1 + 2 I)", None, None),
+        ("3.^(1+2 I)", "-1.75876 + 2.43038 I", None, None),
+        ("3^(1.+2 I)", "-1.75876 + 2.43038 I", None, None),
         # In WMA, the following expression returns
         # ``(Pi/3)^I``. By now, this is handled by
         # sympy, which produces the result
-        ("(3/Pi)^(-I)", "(3 / Pi) ^ (-I)", None),
+        ("(3/Pi)^(-I)", "(3 / Pi) ^ (-I)", None, None),
         # Association rules
         #        ('(a^"w")^2', 'a^(2 "w")', "Integer power of a power with string exponent"),
-        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None),
-        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None),
-        ("(a^2)^(1/2)", "Sqrt[a ^ 2]", None),
-        ("(a^(1/2))^2", "a", None),
-        ("(a^(1/2))^2", "a", None),
-        ("(a^(3/2))^3.", "(a ^ (3 / 2)) ^ 3.", None),
+        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None, None),
+        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None, None),
+        ("(a^2)^(1/2)", "Sqrt[a ^ 2]", None, None),
+        ("(a^(1/2))^2", "a", None, None),
+        ("(a^(1/2))^2", "a", None, None),
+        ("(a^(3/2))^3.", "(a ^ (3 / 2)) ^ 3.", None, None),
         #        ("(a^(1/2))^3.", "a ^ 1.5", "Power associativity rational, real"),
         #        ("(a^(.3))^3.", "a ^ 0.9", "Power associativity for real powers"),
-        ("(a^(1.3))^3.", "(a ^ 1.3) ^ 3.", None),
+        ("(a^(1.3))^3.", "(a ^ 1.3) ^ 3.", None, None),
         # Exponentials involving expressions
-        ("(a^(p-2 q))^3", "a ^ (3 p - 6 q)", None),
-        ("(a^(p-2 q))^3.", "(a ^ (p - 2 q)) ^ 3.", None),
+        ("(a^(p-2 q))^3", "a ^ (3 p - 6 q)", None, None),
+        ("(a^(p-2 q))^3.", "(a ^ (p - 2 q)) ^ 3.", None, None),
+        # Indefinite / ComplexInfinity / Complex powers
+        ("1/0", "ComplexInfinity", "Infinite expression 1 / 0 encountered.", None),
+        (
+            "0 ^ -2",
+            "ComplexInfinity",
+            "Infinite expression 1 / 0 ^ 2 encountered.",
+            None,
+        ),
+        (
+            "0 ^ (-1/2)",
+            "ComplexInfinity",
+            "Infinite expression 1 / Sqrt[0] encountered.",
+            None,
+        ),
+        (
+            "0 ^ -Pi",
+            "ComplexInfinity",
+            "Infinite expression 1 / 0 ^ 3.14159 encountered.",
+            None,
+        ),
+        (
+            "0 ^ (2 I E)",
+            "Indeterminate",
+            "Indeterminate expression 0 ^ (0. + 5.43656 I) encountered.",
+            None,
+        ),
+        (
+            "0 ^ - (Pi + 2 E I)",
+            "ComplexInfinity",
+            "Infinite expression 0 ^ (-3.14159 - 5.43656 I) encountered.",
+            None,
+        ),
+        ("0 ^ 0", "Indeterminate", "Indeterminate expression 0 ^ 0 encountered.", None),
+        ("Sqrt[-3+2. I]", "0.550251 + 1.81735 I", None, None),
+        ("(3/2+1/2I)^2", "2 + 3 I / 2", None, None),
+        ("I ^ I", "(-1) ^ (I / 2)", None, None),
+        ("2 ^ 2.0", "4.", None, None),
+        ("Pi ^ 4.", "97.4091", None, None),
+        ("a ^ b", "a ^ b", None, None),
     ],
 )
-def test_power(str_expr, str_expected, msg):
-    check_evaluation(str_expr, str_expected, failure_message=msg)
+def test_power(str_expr, str_expected, expected_message, fail_msg):
+    if expected_message is None:
+        check_evaluation(str_expr, str_expected, failure_message=fail_msg)
+    else:
+        check_evaluation(
+            str_expr,
+            str_expected,
+            failure_message=fail_msg,
+            expected_messages=[expected_message],
+        )
 
 
 @pytest.mark.parametrize(
@@ -289,6 +332,55 @@ def test_complex(str_expr, str_expected, msg):
             "-1 + (a ^ n) ^ m",
             "according to WMA. Now it fails",
         ),
+        ("1 / 4.0", "0.25", None),
+        ("10 / 3 // FullForm", "Rational[10, 3]", None),
+        ("a / b // FullForm", "Times[a, Power[b, -1]]", None),
+        # Plus
+        ("-2a - 2b", "-2 a - 2 b", None),
+        ("-4+2x+2*Sqrt[3]", "-4 + 2 Sqrt[3] + 2 x", None),
+        ("2a-3b-c", "2 a - 3 b - c", None),
+        ("2a+5d-3b-2c-e", "2 a - 3 b - 2 c + 5 d - e", None),
+        ("1 - I * Sqrt[3]", "1 - I Sqrt[3]", None),
+        ("Head[3 + 2 I]", "Complex", None),
+        # Times
+        ("Times[]// FullForm", "1", None),
+        ("Times[-1]// FullForm", "-1", None),
+        ("Times[-5]// FullForm", "-5", None),
+        ("Times[-5, a]// FullForm", "Times[-5, a]", None),
+        ("-a*b // FullForm", "Times[-1, a, b]", None),
+        ("-(x - 2/3)", "2 / 3 - x", None),
+        ("-x*2", "-2 x", None),
+        ("-(h/2) // FullForm", "Times[Rational[-1, 2], h]", None),
+        ("x / x", "1", None),
+        ("2x^2 / x^2", "2", None),
+        ("3. Pi", "9.42478", None),
+        ("Head[3 * I]", "Complex", None),
+        ("Head[Times[I, 1/2]]", "Complex", None),
+        ("Head[Pi * I]", "Times", None),
+        ("3 * a //InputForm", "3*a", None),
+        ("3 * a //OutputForm", "3 a", None),
+        ("-2.123456789 x", "-2.12346 x", None),
+        ("-2.123456789 I", "0. - 2.12346 I", None),
+        ("N[Pi, 30] * I", "3.14159265358979323846264338328 I", None),
+        ("N[I Pi, 30]", "3.14159265358979323846264338328 I", None),
+        ("N[Pi * E, 30]", "8.53973422267356706546355086955", None),
+        ("N[Pi, 30] * N[E, 30]", "8.53973422267356706546355086955", None),
+        (
+            "N[Pi, 30] * E//{#1, Precision[#1]}&",
+            "{8.53973422267356706546355086955, 30.}",
+            None,
+        ),
+        # Precision
+        (
+            "N[Pi, 30] + N[E, 30]//{#1, Precision[#1]}&",
+            "{5.85987448204883847382293085463, 30.}",
+            None,
+        ),
+        (
+            "N[Sqrt[2], 50]",
+            "1.4142135623730950488016887242096980785696718753769",
+            "N[Sqrt[...]]",
+        ),
         (
             "Sum[i / Log[i], {i, 1, Infinity}]",
             "Sum[i / Log[i], {i, 1, Infinity}]",
@@ -307,7 +399,7 @@ def test_complex(str_expr, str_expected, msg):
     ],
 )
 def test_miscelanea_private_tests(str_expr, str_expected, msg):
-    check_evaluation(str_expr, str_expected, failure_message=msg)
+    check_evaluation(str_expr, str_expected, failure_message=msg, hold_expected=True)
 
 
 @pytest.mark.parametrize(
@@ -330,3 +422,30 @@ def test_miscelanea_private_tests(str_expr, str_expected, msg):
 @pytest.mark.xfail
 def test_miscelanea_private_tests_xfail(str_expr, str_expected, msg):
     check_evaluation(str_expr, str_expected, failure_message=msg)
+
+
+@pytest.mark.parametrize(
+    (
+        "str_expr",
+        "str_expected",
+        "msgs",
+        "failmsg",
+    ),
+    [
+        ("CubeRoot[-5]", "-5 ^ (1 / 3)", None, None),
+        ("CubeRoot[-510000]", "-10 510 ^ (1 / 3)", None, None),
+        ("CubeRoot[-5.1]", "-1.7213", None, None),
+        ("CubeRoot[b]", "b ^ (1 / 3)", None, None),
+        ("CubeRoot[-0.5]", "-0.793701", None, None),
+        (
+            "CubeRoot[3 + 4 I]",
+            "(3 + 4 I) ^ (1 / 3)",
+            ["The parameter 3 + 4 I should be real valued."],
+            None,
+        ),
+    ],
+)
+def test_cuberoot(str_expr, str_expected, msgs, failmsg):
+    check_evaluation(
+        str_expr, str_expected, expected_messages=msgs, failure_message=failmsg
+    )

--- a/test/builtin/atomic/test_numbers.py
+++ b/test/builtin/atomic/test_numbers.py
@@ -266,6 +266,9 @@ def test_accuracy(str_expr, str_expected):
         ('{{a, 2, 3.2`},{2.1``3, 3.2``5, "a"}}', "3."),
         ("{1, 0.}", "MachinePrecision"),
         ("{1, 0.``5}", "0."),
+        ("Re[0.5+2.3 I]", "MachinePrecision"),
+        ("Re[1+2.3 I]", "MachinePrecision"),
+        ("Im[0.5+2.3 I]", "MachinePrecision"),
     ],
 )
 def test_precision(str_expr, str_expected):

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -90,42 +90,6 @@ tests_for_integrate = [
 
 
 @pytest.mark.parametrize(
-    (
-        "str_expr",
-        "str_expected",
-        "msg",
-    ),
-    [
-        (None, None, None),
-        # Private tests from mathics.arithmetic.Complex
-        ("Complex[1, Complex[0, 1]]", "0", "Iterated Complex (1 , I)"),
-        ("Complex[1, Complex[1, 0]]", "1 + I", "Iterated Complex  (1, 1) "),
-        ("Complex[1, Complex[1, 1]]", "I", "Iterated Complex, (1, 1 + I)"),
-        ("Complex[0., 0.]", "0. + 0. I", "build complex 0.+0. I"),
-        ("Complex[10, 0.]", "10. + 0. I", "build complex"),
-        ("Complex[10, 0]", "10", "build complex"),
-        ("1 + 0. I", "1.", None),
-        ("0. + 0. I//FullForm", "Complex[0., 0.]", "WMA compatibility"),
-        ("0. I//FullForm", "Complex[0., 0.]", None),
-        ("1. + 0. I//FullForm", "1.", None),
-        ("0. + 1. I//FullForm", "Complex[0., 1.]", None),
-        ("1. + 0. I//OutputForm", "1.", "Formatted"),
-        ("0. + 1. I//OutputForm", "0. + 1. I", "Formatting 1. I"),
-        ("-2/3-I//FullForm", "Complex[Rational[-2, 3], -1]", "Adding a rational"),
-    ],
-)
-def test_do_complex(str_expr, str_expected, msg):
-    check_evaluation(
-        str_expr,
-        str_expected,
-        failure_message=msg,
-        to_string_expected=True,
-        # to_string_expr=True,
-        hold_expected=True,
-    )
-
-
-@pytest.mark.parametrize(
     "str_expr, str_expected, assert_fail_message, expected_messages",
     tests_for_findminimum,
 )

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -90,6 +90,42 @@ tests_for_integrate = [
 
 
 @pytest.mark.parametrize(
+    (
+        "str_expr",
+        "str_expected",
+        "msg",
+    ),
+    [
+        (None, None, None),
+        # Private tests from mathics.arithmetic.Complex
+        ("Complex[1, Complex[0, 1]]", "0", "Iterated Complex (1 , I)"),
+        ("Complex[1, Complex[1, 0]]", "1 + I", "Iterated Complex  (1, 1) "),
+        ("Complex[1, Complex[1, 1]]", "I", "Iterated Complex, (1, 1 + I)"),
+        ("Complex[0., 0.]", "0. + 0. I", "build complex 0.+0. I"),
+        ("Complex[10, 0.]", "10. + 0. I", "build complex"),
+        ("Complex[10, 0]", "10", "build complex"),
+        ("1 + 0. I", "1.", None),
+        ("0. + 0. I//FullForm", "Complex[0., 0.]", "WMA compatibility"),
+        ("0. I//FullForm", "Complex[0., 0.]", None),
+        ("1. + 0. I//FullForm", "1.", None),
+        ("0. + 1. I//FullForm", "Complex[0., 1.]", None),
+        ("1. + 0. I//OutputForm", "1.", "Formatted"),
+        ("0. + 1. I//OutputForm", "0. + 1. I", "Formatting 1. I"),
+        ("-2/3-I//FullForm", "Complex[Rational[-2, 3], -1]", "Adding a rational"),
+    ],
+)
+def test_do_complex(str_expr, str_expected, msg):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        failure_message=msg,
+        to_string_expected=True,
+        # to_string_expr=True,
+        hold_expected=True,
+    )
+
+
+@pytest.mark.parametrize(
     "str_expr, str_expected, assert_fail_message, expected_messages",
     tests_for_findminimum,
 )

--- a/test/builtin/numbers/test_constants.py
+++ b/test/builtin/numbers/test_constants.py
@@ -4,6 +4,8 @@ Unit tests for mathics.builtins.numbers.constants
 """
 from test.helper import check_evaluation
 
+import pytest
+
 
 def test_Undefined():
     for fn in [
@@ -50,3 +52,47 @@ def test_Undefined():
     ]:
         check_evaluation(f"{fn}[a, Undefined]", "Undefined")
         check_evaluation(f"{fn}[Undefined, b]", "Undefined")
+
+
+# This is a miscelanea of private tests. I put here to make it easier to check
+# where these tests comes from. Then, we can move them to more suitable places.
+@pytest.mark.parametrize(
+    ("expr_str", "expected_str", "fail_msg", "msgs"),
+    [
+        (
+            "ComplexInfinity + ComplexInfinity",
+            "Indeterminate",
+            "Issue689",
+            ["Indeterminate expression ComplexInfinity + ComplexInfinity encountered."],
+        ),
+        (
+            "ComplexInfinity + Infinity",
+            "Indeterminate",
+            "Issue689",
+            ["Indeterminate expression ComplexInfinity + Infinity encountered."],
+        ),
+        ("Cos[Degree[x]]", "Cos[Degree[x]]", "Degree as a function", None),
+        ("N[Degree]//OutputForm", "0.0174533", "Degree", None),
+        ("5. E//OutputForm", "13.5914", "E", None),
+        ("N[Degree, 30]//OutputForm", "0.0174532925199432957692369076849", None, None),
+        ("FullForm[Infinity]", "DirectedInfinity[1]", None, None),
+        ("(2 + 3.5*I) / Infinity", "0. + 0. I", "Complex over Infinity", None),
+        ("Infinity + Infinity", "Infinity", "Infinity plus Infinity", None),
+        (
+            "Infinity / Infinity",
+            "Indeterminate",
+            "Infinity over Infinity",
+            ["Indeterminate expression 0 Infinity encountered."],
+        ),
+    ],
+)
+def test_constants_private(expr_str, expected_str, fail_msg, msgs):
+    check_evaluation(
+        expr_str,
+        expected_str,
+        fail_msg,
+        expected_messages=msgs,
+        hold_expected=True,
+        to_string_expected=True,
+        to_string_expr=True,
+    )

--- a/test/builtin/test_assignment.py
+++ b/test/builtin/test_assignment.py
@@ -355,6 +355,11 @@ def test_set_and_clear_to_fix(str_expr, str_expected, msg):
             "This clears A and B, but not $ContextPath",
             ("Special symbol $ContextPath cannot be cleared.",),
         ),
+        # `This test was in mathics.builtin.arithmetic.Sum`. It is clear that it does not
+        # belongs there. On the other hand, this is something to check at the level of the interpreter,
+        # and is not related with Sum, or Set.
+        # ("a=Sum[x^k*Sum[y^l,{l,0,4}],{k,0,4}]]", "None" , "syntax error",
+        # ('"a=Sum[x^k*Sum[y^l,{l,0,4}],{k,0,4}]" cannot be followed by "]" (line 1 of "<test>").',))
     ],
 )
 def test_set_and_clear_messages(str_expr, str_expected, message, out_msgs):

--- a/test/builtin/test_comparison.py
+++ b/test/builtin/test_comparison.py
@@ -647,3 +647,24 @@ def test_cmp_compare_numbers(str_expr, str_expected, message):
         to_string_expr=True,
         to_string_expected=True,
     )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "message"),
+    [
+        (
+            "{a, b} = {2^10000, 2^10000 + 1}; {a == b, a < b, a <= b}",
+            "{False, True, True}",
+            "Test large Integer comparison bug",
+        ),
+        #        (None, None, None),
+    ],
+)
+def test_misc_private_tests(str_expr, str_expected, message):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        failure_message=message,
+        to_string_expr=True,
+        to_string_expected=True,
+    )

--- a/test/builtin/test_patterns.py
+++ b/test/builtin/test_patterns.py
@@ -5,8 +5,11 @@ Unit tests from mathics.builtin.patterns.
 
 from test.helper import check_evaluation
 
+# Clear all the variables
+
 
 def test_blank():
+    check_evaluation(None, None, None)
     for str_expr, str_expected, message in (
         (
             "g[i] /. _[i] :> a",
@@ -18,6 +21,7 @@ def test_blank():
 
 
 def test_replace_all():
+    check_evaluation(None, None, None)
     for str_expr, str_expected, message in (
         (
             "a == d b + d c /. a_ x_ + a_ y_ -> a (x + y)",

--- a/test/core/parser/test_convert.py
+++ b/test/core/parser/test_convert.py
@@ -58,12 +58,25 @@ class ConvertTests(unittest.TestCase):
         self.check("10*^3", Integer(10000))
         self.check("10*^-3", Rational(1, 100))
         self.check("8^^23*^2", Integer(1216))
+        self.check("2^^0101", Integer(5))
+        self.check(
+            "36^^0123456789abcDEFxyzXYZ", Integer(14142263610074677021975869033659)
+        )
 
         n = random.randint(-sys.maxsize, sys.maxsize)
         self.check(str(n), Integer(n))
 
         n = random.randint(sys.maxsize, sys.maxsize * sys.maxsize)
         self.check(str(n), Integer(n))
+
+        # Requested base 1 in 1^^2 should be between 2 and 36.
+        self.invalid_error(r"1^^2")
+        # Requested base 37 in 37^^3 should be between 2 and 36.
+        self.invalid_error(r"37^^3")
+        # Digit at position 3 in 01210 is too large to be used in base 2.
+        self.invalid_error(r"2^^01210")
+        # "Digit at position 2 in 5g is too large to be used in base 16."
+        self.invalid_error(r"16^^5g")
 
     def testReal(self):
         self.check("1.5", Real("1.5"))
@@ -74,9 +87,20 @@ class ConvertTests(unittest.TestCase):
         self.check("0``3", "0.000`3")
         self.check("0.`3", "0.000`3")
         self.check("0.``3", "0.000``3")
+        ## Mathematica treats zero strangely
         self.check("0.00000000000000000", "0.")
         self.check("0.000000000000000000`", "0.")
         self.check("0.000000000000000000", "0.``18")
+        # Parse *^ notation
+        self.check("1.5×10^24", Real(1.5) * Integer(10) ** Integer(24))
+        self.check("1.5*^+24", Real("1.5e24"))
+        self.check("1.5*^-24", Real("1.5e-24"))
+        ## Don't accept *^ with spaces
+        # > 1.5 *^10
+        # "1.5*" cannot be followed by "^ 10"
+        self.invalid_error("1.5 *^10")
+        # "1.5*" cannot be followed by "^ 10"
+        self.invalid_error("1.5*^ 10")
 
     def testString(self):
         self.check(r'"abc"', String("abc"))

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -1,5 +1,5 @@
-# from .helper import session
 import os
+from test.helper import check_evaluation
 
 from mathics.core.symbols import Symbol
 from mathics.session import MathicsSession
@@ -128,6 +128,123 @@ all_test = {
             "System`TraditionalForm": "-4.3",
             "System`InputForm": "-4.3",
             "System`OutputForm": "-4.3",
+        },
+    },
+    "1. 10^6": {
+        "msg": "very large real number (>10^6)",
+        "text": {
+            "System`InputForm": r"1.000000*^6",
+            "System`OutputForm": "1.×10^6",
+        },
+        "latex": {
+            "System`InputForm": r"1.000000\text{*${}^{\wedge}$}6",
+            "System`OutputForm": r"1.\times 10^6",
+        },
+        "mathml": {},
+    },
+    "1. 10^5": {
+        "msg": "large real number (<10^6)",
+        "text": {
+            "System`InputForm": r"100000.",
+            "System`OutputForm": "100000.",
+        },
+        "latex": {
+            "System`InputForm": r"100000.",
+            "System`OutputForm": "100000.",
+        },
+        "mathml": {},
+    },
+    "-1. 10^6": {
+        "msg": "large negative real number (>10^6)",
+        "text": {
+            "System`InputForm": r"-1.000000*^6",
+            "System`OutputForm": "-1.×10^6",
+        },
+        "latex": {
+            "System`InputForm": r"-1.000000\text{*${}^{\wedge}$}6",
+            "System`OutputForm": r"-1.\times 10^6",
+        },
+        "mathml": {},
+    },
+    "-1. 10^5": {
+        "msg": "large negative real number (<10^6)",
+        "text": {
+            "System`InputForm": r"-100000.",
+            "System`OutputForm": "-100000.",
+        },
+        "latex": {
+            "System`InputForm": r"-100000.",
+            "System`OutputForm": "-100000.",
+        },
+        "mathml": {},
+    },
+    "1. 10^-6": {
+        "msg": "very small real number (<10^-6)",
+        "text": {
+            "System`InputForm": r"1.*^-6",
+            "System`OutputForm": "1.×10^-6",
+        },
+        "latex": {
+            "System`InputForm": r"1.\text{*${}^{\wedge}$}-6",
+            "System`OutputForm": r"1.\times 10^{-6}",
+        },
+        "mathml": {},
+    },
+    "1. 10^-5": {
+        "msg": "small real number (<10^-5)",
+        "text": {
+            "System`InputForm": r"0.00001",
+            "System`OutputForm": "0.00001",
+        },
+        "latex": {
+            "System`InputForm": r"0.00001",
+            "System`OutputForm": "0.00001",
+        },
+        "mathml": {},
+    },
+    "-1. 10^-6": {
+        "msg": "very small negative real number (<10^-6)",
+        "text": {
+            "System`InputForm": r"-1.*^-6",
+            "System`OutputForm": "-1.×10^-6",
+        },
+        "latex": {
+            "System`InputForm": r"-1.\text{*${}^{\wedge}$}-6",
+            "System`OutputForm": r"-1.\times 10^{-6}",
+        },
+        "mathml": {},
+    },
+    "-1. 10^-5": {
+        "msg": "small negative real number (>10^-5)",
+        "text": {
+            "System`InputForm": r"-0.00001",
+            "System`OutputForm": "-0.00001",
+        },
+        "latex": {
+            "System`InputForm": r"-0.00001",
+            "System`OutputForm": "-0.00001",
+        },
+        "mathml": {},
+    },
+    "Complex[1.09*^12,3.]": {
+        "msg": "Complex number",
+        "text": {
+            "System`StandardForm": "1.09*^12+3. I",
+            "System`TraditionalForm": "1.09×10^12+3.⁢I",
+            "System`InputForm": "1.090000000000*^12 + 3.*I",
+            "System`OutputForm": "1.09×10^12 + 3. I",
+        },
+        "mathml": {
+            "System`StandardForm": r"<mrow><mrow><mn>1.09</mn> <mtext>*^</mtext> <mn>12</mn></mrow> <mo>+</mo> <mrow><mn>3.</mn> <mo>&nbsp;</mo> <mi>I</mi></mrow></mrow>",
+            "System`TraditionalForm": r'<mrow><mrow><mn>1.09</mn> <mo>×</mo> <msup><mn>10</mn> <mn>12</mn></msup></mrow> <mo>+</mo> <mrow><mn>3.</mn> <mo form="prefix" lspace="0" rspace="0.2em">⁢</mo> <mi>I</mi></mrow></mrow>',
+            "System`InputForm": r"<mrow><mrow><mtext>1.090000000000</mtext> <mtext>*^</mtext> <mtext>12</mtext></mrow> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mtext>3.</mtext> <mtext>*</mtext> <mi>I</mi></mrow></mrow>",
+            "System`OutputForm": r"<mrow><mrow><mn>1.09</mn> <mo>×</mo> <msup><mn>10</mn> <mn>12</mn></msup></mrow> <mtext>&nbsp;+&nbsp;</mtext> <mrow><mn>3.</mn> <mo>&nbsp;</mo> <mi>I</mi></mrow></mrow>",
+        },
+        "latex": {
+            "System`StandardForm": r"1.09\text{*${}^{\wedge}$}12+3. I",
+            "System`TraditionalForm": r"1.09\times 10^{12}+3. I",
+            "System`InputForm": r"1.090000000000\text{*${}^{\wedge}$}12\text{ + }3.*I",
+            "System`OutputForm": r"1.09\times 10^{12}\text{ + }3. I",
         },
     },
     '"Hola!"': {
@@ -792,3 +909,29 @@ def test_makeboxes_mathml(str_expr, str_expected, form, msg):
     else:
         strresult = format_result.boxes_to_mathml(evaluation=session.evaluation)
         assert strresult == str_expected
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "msg"),
+    [
+        (
+            "OutputForm[Complex[2.0 ^ 40, 3]]",
+            "1.09951×10^12 + 3. I",
+            "OutputForm Complex",
+        ),
+        (
+            "InputForm[Complex[2.0 ^ 40, 3]]",
+            "1.099511627776*^12 + 3.*I",
+            "InputForm Complex",
+        ),
+    ],
+)
+def test_format_private_doctests(str_expr, str_expected, msg):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=msg,
+    )


### PR DESCRIPTION
In this PR, I start to move some private doctests to Pytest. I also propose some extra related tests and check that the expected behavior matches with obtained in WMA.
From this, it came up that we are handling wrong how ```  0. I``` is evaluated: In master, it is evaluated to `0.`, but in WMA, it is evaluated to ```  Complex[0.`, 0.`] ```.
To match this behavior, I had to modify `from_mpmath`, and deactivate its lru_cache.  The problem now with lru_cache is that  `mpmath.mpf(0.)` produces the same hash than `mpmath.mpc(0., 0.)`, which looks wrong.



  