### PR TITLE
A second pass at redoing load_builtin.py

### DIFF
--- a/mathics/data/.gitignore
+++ b/mathics/data/.gitignore
@@ -1,2 +1,3 @@
 /doc_latex_data.pcl
+/doctest_latex_data.pcl
 /op-tables.json

--- a/mathics/doc/latex/.gitignore
+++ b/mathics/doc/latex/.gitignore
@@ -1,5 +1,6 @@
 /core-version.tex
 /doc_latex_data.pcl
+/documentation.log
 /documentation.tex
 /documentation.tex-before-sed
 /images/


### PR DESCRIPTION
Second pass at making it possible to load a single module inside `mathics.builti`  rather than all modules at once.
 
* the loop updating ``display_operators_set`` is now done inside module import rather than its own independent loop.    
*  `add_builtins_from_builtin_module()` isolated from inside `add_builtins_from_builtin_modules()` so that we can eventually remove  the latter.
*  More type annotations, docstrings and comments.

