### PR TITLE
Move private doctests to pytest11

### DIFF
--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -49,9 +49,6 @@ class Check(Builtin):
      : Infinite expression 1 / 0 encountered.
      = err
 
-    #> Check[1^0, err]
-     = 1
-
     Check only for specific messages:
     >> Check[Sin[0^0], err, Sin::argx]
      : Indeterminate expression 0 ^ 0 encountered.
@@ -61,49 +58,7 @@ class Check(Builtin):
      : Infinite expression 1 / 0 encountered.
      = err
 
-    #> Check[1 + 2]
-     : Check called with 1 argument; 2 or more arguments are expected.
-     = Check[1 + 2]
 
-    #> Check[1 + 2, err, 3 + 1]
-     : Message name 3 + 1 is not of the form symbol::name or symbol::name::language.
-     = Check[1 + 2, err, 3 + 1]
-
-    #> Check[1 + 2, err, hello]
-     : Message name hello is not of the form symbol::name or symbol::name::language.
-     = Check[1 + 2, err, hello]
-
-    #> Check[1/0, err, Compile::cpbool]
-     : Infinite expression 1 / 0 encountered.
-     = ComplexInfinity
-
-    #> Check[{0^0, 1/0}, err]
-     : Indeterminate expression 0 ^ 0 encountered.
-     : Infinite expression 1 / 0 encountered.
-     = err
-
-    #> Check[0^0/0, err, Power::indet]
-     : Indeterminate expression 0 ^ 0 encountered.
-     : Infinite expression 1 / 0 encountered.
-     = err
-
-    #> Check[{0^0, 3/0}, err, Power::indet]
-     : Indeterminate expression 0 ^ 0 encountered.
-     : Infinite expression 1 / 0 encountered.
-     = err
-
-    #> Check[1 + 2, err, {a::b, 2 + 5}]
-     : Message name 2 + 5 is not of the form symbol::name or symbol::name::language.
-     = Check[1 + 2, err, {a::b, 2 + 5}]
-
-    #> Off[Power::infy]
-    #> Check[1 / 0, err]
-     = ComplexInfinity
-
-    #> On[Power::infy]
-    #> Check[1 / 0, err]
-     : Infinite expression 1 / 0 encountered.
-     = err
     """
 
     attributes = A_HOLD_ALL | A_PROTECTED
@@ -175,10 +130,6 @@ class Failed(Predefined):
     <dt>'$Failed'
         <dd>is returned by some functions in the event of an error.
     </dl>
-
-    #> Get["nonexistent_file.m"]
-     : Cannot open nonexistent_file.m.
-     = $Failed
     """
 
     summary_text = "retrieved result for failed evaluations"
@@ -406,12 +357,6 @@ class Off(Builtin):
     >> Off[Power::indet, Syntax::com]
     >> {0 ^ 0,}
      = {Indeterminate, Null}
-
-    #> Off[1]
-     :  Message name 1 is not of the form symbol::name or symbol::name::language.
-    #> Off[Message::name, 1]
-
-    #> On[Power::infy, Power::indet, Syntax::com]
     """
 
     attributes = A_HOLD_ALL | A_PROTECTED
@@ -457,11 +402,6 @@ class On(Builtin):
      = ComplexInfinity
     """
 
-    # TODO
-    """
-    #> On[f::x]
-     : Message f::x not found.
-    """
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "turn on a message for printing"
 
@@ -523,9 +463,6 @@ class Quiet(Builtin):
      : Hello
      = 2 x
 
-    #> Quiet[expr, All, All]
-     : Arguments 2 and 3 of Quiet[expr, All, All] should not both be All.
-     = Quiet[expr, All, All]
     >> Quiet[x + x, {a::b}, {a::b}]
      : In Quiet[x + x, {a::b}, {a::b}] the message name(s) {a::b} appear in both the list of messages to switch off and the list of messages to switch on.
      = Quiet[x + x, {a::b}, {a::b}]
@@ -638,73 +575,6 @@ class Syntax(Builtin):
 
     >> 1.5``
      : "1.5`" cannot be followed by "`" (line 1 of "<test>").
-
-    #> (x]
-     : "(x" cannot be followed by "]" (line 1 of "<test>").
-
-    #> (x,)
-     : "(x" cannot be followed by ",)" (line 1 of "<test>").
-
-    #> {x]
-     : "{x" cannot be followed by "]" (line 1 of "<test>").
-
-    #> f[x)
-     : "f[x" cannot be followed by ")" (line 1 of "<test>").
-
-    #> a[[x)]
-     : "a[[x" cannot be followed by ")]" (line 1 of "<test>").
-
-    #> x /: y , z
-     : "x /: y " cannot be followed by ", z" (line 1 of "<test>").
-
-    #> a :: 1
-     : "a :: " cannot be followed by "1" (line 1 of "<test>").
-
-    #> a ? b ? c
-     : "a ? b " cannot be followed by "? c" (line 1 of "<test>").
-
-    #> \:000G
-     : 4 hexadecimal digits are required after \: to construct a 16-bit character (line 1 of "<test>").
-     : Expression cannot begin with "\:000G" (line 1 of "<test>").
-
-    #> \:000
-     : 4 hexadecimal digits are required after \: to construct a 16-bit character (line 1 of "<test>").
-     : Expression cannot begin with "\:000" (line 1 of "<test>").
-
-    #> \009
-     : 3 octal digits are required after \ to construct an 8-bit character (line 1 of "<test>").
-     : Expression cannot begin with "\009" (line 1 of "<test>").
-
-    #> \00
-     : 3 octal digits are required after \ to construct an 8-bit character (line 1 of "<test>").
-     : Expression cannot begin with "\00" (line 1 of "<test>").
-
-    #> \.0G
-     : 2 hexadecimal digits are required after \. to construct an 8-bit character (line 1 of "<test>").
-     : Expression cannot begin with "\.0G" (line 1 of "<test>").
-
-    #> \.0
-     : 2 hexadecimal digits are required after \. to construct an 8-bit character (line 1 of "<test>").
-     : Expression cannot begin with "\.0" (line 1 of "<test>").
-
-    #> "abc \[fake]"
-     : Unknown unicode longname "fake" (line 1 of "<test>").
-     = abc \[fake]
-
-    #> a ~ b + c
-     : "a ~ b " cannot be followed by "+ c" (line 1 of "<test>").
-
-    #> {1,}
-     : Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "<test>").
-     = {1, Null}
-    #> {, 1}
-     : Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "<test>").
-     = {Null, 1}
-    #> {,,}
-     : Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "<test>").
-     : Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "<test>").
-     : Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "<test>").
-     = {Null, Null, Null}
     """
 
     # Extension: MMA does not provide lineno and filename in its error messages

--- a/mathics/builtin/options.py
+++ b/mathics/builtin/options.py
@@ -306,11 +306,6 @@ class Options(Builtin):
     >> f[x, n -> 3]
      = x ^ 3
 
-    #> f[x_, OptionsPattern[f]] := x ^ OptionValue["m"];
-    #> Options[f] = {"m" -> 7};
-    #> f[x]
-     = x ^ 7
-
     Delayed option rules are evaluated just when the corresponding 'OptionValue' is called:
     >> f[a :> Print["value"]] /. f[OptionsPattern[{}]] :> (OptionValue[a]; Print["between"]; OptionValue[a]);
      | value
@@ -334,18 +329,6 @@ class Options(Builtin):
     >> Options[a + b] = {a -> b}
      : Argument a + b at position 1 is expected to be a symbol.
      = {a -> b}
-
-    #> f /: Options[f] = {a -> b}
-     = {a -> b}
-    #> Options[f]
-     = {a :> b}
-    #> f /: Options[g] := {a -> b}
-     : Rule for Options can only be attached to g.
-     = $Failed
-
-    #> Options[f] = a /; True
-     : a /; True is not a valid list of option rules.
-     = a /; True
     """
 
     summary_text = "the list of optional arguments and their default values"

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -216,15 +216,6 @@ class Context_(Predefined):
 
     >> $Context
     = Global`
-
-    #> InputForm[$Context]
-    = "Global`"
-
-    ## Test general context behaviour
-    #> Plus === Global`Plus
-     = False
-    #> `Plus === Global`Plus
-     = True
     """
 
     messages = {"cxset": "`1` is not a valid context name ending in `."}
@@ -548,9 +539,6 @@ class Unique(Predefined):
     Create a unique symbol whose name begins with x:
     >> Unique["x"]
     = x...
-
-    #> Unique[{}]
-    = {}
 
     ## FIXME: include the rest of these in test/builtin/test-unique.py
     ## Each use of Unique[symbol] increments $ModuleNumber:

--- a/test/builtin/test_messages.py
+++ b/test/builtin/test_messages.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests from mathics.builtin.messages.
+"""
+
+
+from test.helper import check_evaluation, session
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "msgs", "str_expected", "fail_msg"),
+    [
+        ("Check[1^0, err]", None, "1", None),
+        (
+            "Check[1 + 2]",
+            ("Check called with 1 argument; 2 or more arguments are expected.",),
+            "Check[1 + 2]",
+            None,
+        ),
+        (
+            "Check[1 + 2, err, 3 + 1]",
+            (
+                "Message name 3 + 1 is not of the form symbol::name or symbol::name::language.",
+            ),
+            "Check[1 + 2, err, 3 + 1]",
+            None,
+        ),
+        (
+            "Check[1 + 2, err, hello]",
+            (
+                "Message name hello is not of the form symbol::name or symbol::name::language.",
+            ),
+            "Check[1 + 2, err, hello]",
+            None,
+        ),
+        (
+            "Check[1/0, err, Compile::cpbool]",
+            ("Infinite expression 1 / 0 encountered.",),
+            "ComplexInfinity",
+            None,
+        ),
+        (
+            "Check[{0^0, 1/0}, err]",
+            (
+                "Indeterminate expression 0 ^ 0 encountered.",
+                "Infinite expression 1 / 0 encountered.",
+            ),
+            "err",
+            None,
+        ),
+        (
+            "Check[0^0/0, err, Power::indet]",
+            (
+                "Indeterminate expression 0 ^ 0 encountered.",
+                "Infinite expression 1 / 0 encountered.",
+            ),
+            "err",
+            None,
+        ),
+        (
+            "Check[{0^0, 3/0}, err, Power::indet]",
+            (
+                "Indeterminate expression 0 ^ 0 encountered.",
+                "Infinite expression 1 / 0 encountered.",
+            ),
+            "err",
+            None,
+        ),
+        (
+            "Check[1 + 2, err, {a::b, 2 + 5}]",
+            (
+                "Message name 2 + 5 is not of the form symbol::name or symbol::name::language.",
+            ),
+            "Check[1 + 2, err, {a::b, 2 + 5}]",
+            None,
+        ),
+        ("Off[Power::infy];Check[1 / 0, err]", None, "ComplexInfinity", None),
+        (
+            "On[Power::infy];Check[1 / 0, err]",
+            ("Infinite expression 1 / 0 encountered.",),
+            "err",
+            None,
+        ),
+        (
+            'Get["nonexistent_file.m"]',
+            ("Cannot open nonexistent_file.m.",),
+            "$Failed",
+            None,
+        ),
+        (
+            "Off[1]",
+            (
+                "Message name 1 is not of the form symbol::name or symbol::name::language.",
+            ),
+            None,
+            None,
+        ),
+        ("Off[Message::name, 1]", None, None, None),
+        (
+            "On[Power::infy, Power::indet, Syntax::com];Quiet[expr, All, All]",
+            ("Arguments 2 and 3 of Quiet[expr, All, All] should not both be All.",),
+            "Quiet[expr, All, All]",
+            None,
+        ),
+        (
+            "{1,}",
+            (
+                'Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "").',
+            ),
+            "{1, Null}",
+            None,
+        ),
+        (
+            "{, 1}",
+            (
+                'Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "").',
+            ),
+            "{Null, 1}",
+            None,
+        ),
+        (
+            "{,,}",
+            (
+                'Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "").',
+                'Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "").',
+                'Warning: comma encountered with no adjacent expression. The expression will be treated as Null (line 1 of "").',
+            ),
+            "{Null, Null, Null}",
+            None,
+        ),
+        # TODO:
+        #  ("On[f::x]", ("Message f::x not found.",), None, None),
+    ],
+)
+def test_private_doctests_messages(str_expr, msgs, str_expected, fail_msg):
+    """These tests check the behavior the module messages"""
+
+    def eval_expr(expr_str):
+        query = session.evaluation.parse(expr_str)
+        res = session.evaluation.evaluate(query)
+        session.evaluation.stopped = False
+        return res
+
+    res = eval_expr(str_expr)
+    if msgs is None:
+        assert len(res.out) == 0
+    else:
+        assert len(res.out) == len(msgs)
+        for li1, li2 in zip(res.out, msgs):
+            assert li1.text == li2
+
+    assert res.result == str_expected

--- a/test/builtin/test_options.py
+++ b/test/builtin/test_options.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests from mathics.builtin.options.
+"""
+
+
+from test.helper import check_evaluation, session
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "msgs", "str_expected", "fail_msg"),
+    [
+        (
+            (
+                'f[x_, OptionsPattern[f]] := x ^ OptionValue["m"];'
+                'Options[f] = {"m" -> 7};f[x]'
+            ),
+            None,
+            "x ^ 7",
+            None,
+        ),
+        ("f /: Options[f] = {a -> b}", None, "{a -> b}", None),
+        ("Options[f]", None, "{a :> b}", None),
+        (
+            "f /: Options[g] := {a -> b}",
+            ("Rule for Options can only be attached to g.",),
+            "$Failed",
+            None,
+        ),
+        (
+            "Options[f] = a /; True",
+            ("a /; True is not a valid list of option rules.",),
+            "a /; True",
+            None,
+        ),
+    ],
+)
+def test_private_doctests_options(str_expr, msgs, str_expected, fail_msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=fail_msg,
+        expected_messages=msgs,
+    )

--- a/test/builtin/test_scoping.py
+++ b/test/builtin/test_scoping.py
@@ -2,8 +2,9 @@
 """
 Unit tests from mathics.builtin.scoping.
 """
+from test.helper import check_evaluation, session
 
-from test.helper import session
+import pytest
 
 from mathics.core.symbols import Symbol
 
@@ -34,3 +35,26 @@ def test_unique():
         assert (
             symbol not in symbol_set
         ), "Unique[{symbol_prefix}] should return different symbols; {symbol.name} is duplicated"
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "msgs", "str_expected", "fail_msg"),
+    [
+        ("InputForm[$Context]", None, '"Global`"', None),
+        ## Test general context behaviour
+        ("Plus === Global`Plus", None, "False", None),
+        ("`Plus === Global`Plus", None, "True", None),
+        ("Unique[{}]", None, "{}", None),
+    ],
+)
+def test_private_doctests_scoping(str_expr, msgs, str_expected, fail_msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=fail_msg,
+        expected_messages=msgs,
+    )

--- a/test/core/parser/test_parser.py
+++ b/test/core/parser/test_parser.py
@@ -75,6 +75,7 @@ class AssocTests(ParserTests):
 
     def test_nonassoc(self):
         self.invalid_error("a ? b ? c")
+        self.invalid_error("a ~ b + c")
 
     def test_Function(self):
         self.check("a==b&", "Function[Equal[a, b]]")
@@ -119,6 +120,13 @@ class AtomTests(ParserTests):
         self.check("- 1", "-1")
         self.check("- - 1", "Times[-1, -1]")
         self.check("x=.01", "x = .01")
+        self.scan_error(r"\:000G")
+        self.scan_error(r"\:000")
+        self.scan_error(r"\009")
+        self.scan_error(r"\00")
+        self.scan_error(r"\.0G")
+        self.scan_error(r"\.0")
+        self.scan_error(r"\.0G")
 
     def testNumberBase(self):
         self.check_number("8^^23")
@@ -156,6 +164,7 @@ class AtomTests(ParserTests):
         self.check(r'"a\"b\\c"', String(r"a\"b\\c"))
         self.incomplete_error(r'"\"')
         self.invalid_error(r'\""')
+        self.invalid_error(r"abc \[fake]")
 
     def testAccuracy(self):
         self.scan_error("1.5``")
@@ -832,6 +841,16 @@ class IncompleteTests(ParserTests):
         self.incomplete_error("f[x")  # bktmcp
         self.incomplete_error("{x")  # bktmcp
         self.incomplete_error("f[[x")  # bktmcp
+
+    def testBracketMismatch(self):
+        self.invalid_error("(x]")  # sntxf
+        self.invalid_error("(x,)")  # sntxf
+        self.invalid_error("{x]")  # sntxf
+        self.invalid_error("f{x)")  # sntxf
+        self.invalid_error("a[[x)]")  # sntxf
+
+        self.invalid_error("x /: y , z")  # sntxf
+        self.invalid_error("a :: 1")  # sntxf
 
     def testBracketIncompleteInvalid(self):
         self.invalid_error("(x,")


### PR DESCRIPTION
Another bunch of private doctests converted in pytests. Maybe the most drastic change here regarding the tests is that with these changes, the content of the syntax error messages is not tested anymore. 