### PR TITLE
Disable int to string conversion limit

### DIFF
--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -4,6 +4,7 @@
 import base64
 import math
 import re
+import sys
 from typing import Optional, Type, Union
 
 import mpmath
@@ -28,6 +29,9 @@ from mathics.core.symbols import (
     symbol_set,
 )
 from mathics.core.systemsymbols import SymbolFullForm, SymbolInfinity, SymbolInputForm
+
+# Disable integer to string conversion length limit.
+sys.set_int_max_str_digits(0)
 
 # Imperical number that seems to work.
 # We have to be able to match mpmath values with sympy values


### PR DESCRIPTION
`Factorial[5000]` gives the crash:

```
...
  File "/home/kjc/mathics-core/mathics/core/rules.py", line 269, in do_replace
    return self.function(evaluation=evaluation, **vars_noctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kjc/mathics-core/mathics/builtin/makeboxes.py", line 360, in eval_general
    return expr.atom_to_boxes(f, evaluation)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kjc/mathics-core/mathics/core/atoms.py", line 239, in atom_to_boxes
    return self.make_boxes(f.get_name())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kjc/mathics-core/mathics/core/atoms.py", line 249, in make_boxes
    return String(str(self._value))
                  ^^^^^^^^^^^^^^^^
ValueError: Exceeds the limit (7000 digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit
```

The [limit](https://stackoverflow.com/questions/73693104/valueerror-exceeds-the-limit-4300-for-integer-string-conversion) was introduced in Python 3.11 to prevent DoS attacks. That problem doesn't apply in Mathics case. This PR removes the limit.