### PR TITLE
Fix ArrayQ for SparseArray

### DIFF
--- a/mathics/builtin/testing_expressions/list_oriented.py
+++ b/mathics/builtin/testing_expressions/list_oriented.py
@@ -8,9 +8,9 @@ from mathics.core.evaluation import Evaluation
 from mathics.core.exceptions import InvalidLevelspecError
 from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, SymbolFalse, SymbolTrue
-from mathics.core.systemsymbols import SymbolSparseArray, SymbolSubsetQ
+from mathics.core.systemsymbols import SymbolSubsetQ #, SymbolSparseArray
 from mathics.eval.parts import python_levelspec
-from mathics.eval.testing_expressions import check_ArrayQ, check_SparseArrayQ
+from mathics.eval.testing_expressions import check_ArrayQ #, check_SparseArrayQ
 
 
 class ArrayQ(Builtin):
@@ -39,14 +39,6 @@ class ArrayQ(Builtin):
      = False
     >> ArrayQ[{{a, b}, {c, d}}, 2, SymbolQ]
      = True
-    >> ArrayQ[SparseArray[{{1, 2} -> a, {2, 1} -> b}]]
-     = True
-    >> ArrayQ[SparseArray[{{1, 2} -> a, {2, 1} -> b}], 1]
-     = False
-    >> ArrayQ[SparseArray[{{1, 2} -> a, {2, 1} -> b}], 2, SymbolQ]
-     = False
-    >> ArrayQ[SparseArray[{{1, 1} -> a, {1, 2} -> b}], 2, SymbolQ]
-     = True
     """
 
     rules = {
@@ -59,8 +51,8 @@ class ArrayQ(Builtin):
     def eval(self, expr, pattern, test, evaluation: Evaluation):
         "ArrayQ[expr_, pattern_, test_]"
 
-        if not isinstance(expr, Atom) and expr.head.sameQ(SymbolSparseArray):
-            return check_SparseArrayQ(expr, pattern, test, evaluation)
+        # if not isinstance(expr, Atom) and expr.head.sameQ(SymbolSparseArray):
+        #    return check_SparseArrayQ(expr, pattern, test, evaluation)
 
         return check_ArrayQ(expr, pattern, test, evaluation)
 

--- a/mathics/builtin/testing_expressions/list_oriented.py
+++ b/mathics/builtin/testing_expressions/list_oriented.py
@@ -8,9 +8,9 @@ from mathics.core.evaluation import Evaluation
 from mathics.core.exceptions import InvalidLevelspecError
 from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, SymbolFalse, SymbolTrue
-from mathics.core.systemsymbols import SymbolSubsetQ #, SymbolSparseArray
+from mathics.core.systemsymbols import SymbolSubsetQ  # , SymbolSparseArray
 from mathics.eval.parts import python_levelspec
-from mathics.eval.testing_expressions import check_ArrayQ #, check_SparseArrayQ
+from mathics.eval.testing_expressions import check_ArrayQ  # , check_SparseArrayQ
 
 
 class ArrayQ(Builtin):

--- a/mathics/eval/testing_expressions.py
+++ b/mathics/eval/testing_expressions.py
@@ -2,13 +2,15 @@ from typing import Optional
 
 import sympy
 
-from mathics.core.atoms import Complex, Integer0, Integer1, IntegerM1
+from mathics.core.atoms import Complex, Integer, Integer0, Integer1, IntegerM1
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
-from mathics.core.systemsymbols import SymbolDirectedInfinity
+from mathics.core.rules import Pattern
+from mathics.core.symbols import SymbolFalse, SymbolTimes, SymbolTrue
+from mathics.core.systemsymbols import SymbolDirectedInfinity, SymbolSparseArray
 
 
 def do_cmp(x1, x2) -> Optional[int]:
-
     # don't attempt to compare complex numbers
     for x in (x1, x2):
         # TODO: Send message General::nord
@@ -99,3 +101,64 @@ def expr_min(elements):
 
 def is_number(sympy_value) -> bool:
     return hasattr(sympy_value, "is_number") or isinstance(sympy_value, sympy.Float)
+
+
+def check_ArrayQ(expr, pattern, test, evaluation: Evaluation):
+    "Check if expr is an Array which test yields true for each of its elements."
+
+    pattern = Pattern.create(pattern)
+
+    dims = [len(expr.get_elements())]  # to ensure an atom is not an array
+
+    def check(level, expr):
+        if not expr.has_form("List", None):
+            test_expr = Expression(test, expr)
+            if test_expr.evaluate(evaluation) != SymbolTrue:
+                return False
+            level_dim = None
+        else:
+            level_dim = len(expr.elements)
+
+        if len(dims) > level:
+            if dims[level] != level_dim:
+                return False
+        else:
+            dims.append(level_dim)
+        if level_dim is not None:
+            for element in expr.elements:
+                if not check(level + 1, element):
+                    return False
+        return True
+
+    if not check(0, expr):
+        return SymbolFalse
+
+    depth = len(dims) - 1  # None doesn't count
+    if not pattern.does_match(Integer(depth), evaluation):
+        return SymbolFalse
+
+    return SymbolTrue
+
+
+def check_SparseArrayQ(expr, pattern, test, evaluation: Evaluation):
+    "Check if expr is a SparseArray which test yields true for each of its elements."
+
+    if not expr.head.sameQ(SymbolSparseArray):
+        return SymbolFalse
+
+    pattern = Pattern.create(pattern)
+    dims, default_value, rules = expr.elements[1:]
+    if not pattern.does_match(Integer(len(dims.elements)), evaluation):
+        return SymbolFalse
+
+    array_size = Expression(SymbolTimes, *dims.elements).evaluate(evaluation)
+    if array_size.value > len(rules.elements):  # expr is not full
+        test_expr = Expression(test, default_value)  # test default value
+        if test_expr.evaluate(evaluation) != SymbolTrue:
+            return SymbolFalse
+    for rule in rules.elements:
+        test_expr = Expression(test, rule.elements[-1])
+        if test_expr.evaluate(evaluation) != SymbolTrue:
+            return SymbolFalse
+
+    return SymbolTrue


### PR DESCRIPTION
At present ``ArrayQ`` returns ``False`` for ``SparseArray`` (which is inconsistent with Mathematica). This (draft) PR will fix this problem. 

It's also a preparation for ``TensorProduct`` that I plan to bring in in a few weeks, which will make rules of ``TensorProduct`` clearer.

For me there are two things of concern about this (draft) PR:
1. ``ArrayQ`` (``MatrixQ``) has been used throught out Mathics3. Though all tests have been passed, numerous problems may occur (e.g. ``Transpose[a_SparseArray]``, which returns the same expression as input now, but will cause an ``AttributeError`` in this PR). In a way this reminds us that there's still quite a bit to be done about ``SparseArrays``.
2. Rules like ``"ArrayQ[expr_]": "ArrayQ[expr, _, True&]"`` don't look efficient, all the evaluation on pattern matching and ``True&`` can be omitted entirely. Actually I've seen quite a few rules in Mathics3 like this: replacing a simple function with a more complicated but more general function. While these rules are unlikely to affect order-of-magnitude efficiencies, this issue may still worth attention.