### PR TITLE
fix #956

### DIFF
--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -486,7 +486,7 @@ class Switch(Builtin):
             evaluation.message("Switch", "argct", "Switch", len(rules) + 1)
             return
         for pattern, value in zip(rules[::2], rules[1::2]):
-            if match(expr, pattern, evaluation):
+            if match(expr, pattern.evaluate(evaluation), evaluation):
                 return value.evaluate(evaluation)
         # return unevaluated Switch when no pattern matches
 

--- a/test/builtin/test_procedural.py
+++ b/test/builtin/test_procedural.py
@@ -89,6 +89,12 @@ def test_nestwhile(str_expr, str_expected):
         ("res=CompoundExpression[]", None, "Null", None),
         ("res", None, "Null", None),
         (
+            "{MatchQ[Infinity,Infinity],Switch[Infinity,Infinity,True,_,False]}",
+            None,
+            "{True, True}",
+            "Issue #956",
+        ),
+        (
             "Clear[f];Clear[g];Clear[h];Clear[i];Clear[n];Clear[res];Clear[z]; ",
             None,
             "Null",


### PR DESCRIPTION
This PR makes that `Switch` evaluates each pattern before the comparison, following the behavior in WMA