### PR TITLE
fix doctest for MaxLengthStringConversion in Pyston

### DIFF
--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -59,7 +59,7 @@ class MaxLengthIntStringConversion(Predefined):
 
     Show the default value of '$MaxLengthIntStringConversion':
     >> $MaxLengthIntStringConversion
-     = 7000
+     = ...
 
     500! is a 1135-digit number:
     >> 500! //ToString//StringLength


### PR DESCRIPTION
Just a tiny adjustment to avoid a failure of the doctest in Pyston 3.8