### PR TITLE
handle box errors in graphics and graphics3d

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,9 @@ Compatibility
 * ``*Plot`` does not show messages during the evaluation.
 * ``Range[]`` now handles a negative ``di`` PR #951
 * Improved support for ``DirectedInfinity`` and ``Indeterminate``.
-
+* ``Graphics`` and ``Graphics3D`` including wrong primitives and directives
+  are shown with a pink background. In the Mathics-Django interface, a tooltip
+  error message is also shown.
 
 Internals
 ---
@@ -41,6 +43,7 @@ Bugs
 
 * ``Definitions`` is compatible with ``pickle``.
 * Improved support for ``Quantity`` expressions, including conversions, formatting and arithmetic operations.
+* ``Background`` option for ``Graphics`` and ``Graphics3D`` is operative again.
 * ``Switch[]`` involving ``Infinity`` Issue #956
 * ``Outer[]`` on ``SparseArray`` Issue #939
 * ``ArrayQ[]`` detects ``SparseArray`` PR #947

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -491,6 +491,11 @@ class GraphicsBox(BoxExpression):
         if evaluation is None:
             evaluation = self.evaluation
         elements = GraphicsElements(elements[0], evaluation, neg_y)
+        if hasattr(elements, "background_color"):
+            self.background_color = elements.background_color
+        if hasattr(elements, "tooltip_text"):
+            self.tooltip_text = elements.tooltip_text
+
         axes = []  # to be filled further down
 
         def calc_dimensions(final_pass=True):

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -77,6 +77,10 @@ class Graphics3D(Graphics):
         >> Graphics3D[Polygon[{{0,0,0}, {0,1,1}, {1,0,0}}]]
          = -Graphics3D-
 
+        The 'Background' option allows to set the color of the background:
+        >> Graphics3D[Sphere[], Background->RGBColor[.6, .7, 1.]]:
+         = -Graphics-
+
         In 'TeXForm', 'Graphics3D' creates Asymptote figures:
         >> Graphics3D[Sphere[]] // TeXForm
          = #<--#

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -78,8 +78,8 @@ class Graphics3D(Graphics):
          = -Graphics3D-
 
         The 'Background' option allows to set the color of the background:
-        >> Graphics3D[Sphere[], Background->RGBColor[.6, .7, 1.]]:
-         = -Graphics-
+        >> Graphics3D[Sphere[], Background->RGBColor[.6, .7, 1.]]
+         = -Graphics3D-
 
         In 'TeXForm', 'Graphics3D' creates Asymptote figures:
         >> Graphics3D[Sphere[]] // TeXForm

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -72,8 +72,7 @@ GRAPHICS_OPTIONS = {
 DEFAULT_POINT_FACTOR = 0.005
 
 
-ERROR_BOX_FACE_COLOR = RGBColor(components=[1, 0.3, 0.3, 0.25])
-ERROR_BOX_EDGE_COLOR = RGBColor(components=[1, 0, 0, 1.0])
+ERROR_BACKGROUND_COLOR = RGBColor(components=[1, 0.3, 0.3, 0.25])
 
 
 class CoordinatesError(BoxExpressionError):
@@ -1096,73 +1095,6 @@ class _GraphicsElements:
 
         failed = []
 
-        def build_error_box1(style):
-            error_style = style.klass(
-                style.graphics,
-                edge=ERROR_BOX_EDGE_COLOR,
-                face=ERROR_BOX_FACE_COLOR,
-            )
-            if isinstance(self, GraphicsElements):
-                error_primitive_head = Symbol("PolygonBox")
-                error_primitive_expression = Expression(
-                    error_primitive_head,
-                    from_python([(-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1)]),
-                )
-            else:
-                error_primitive_head = Symbol("Polygon3DBox")
-                error_primitive_expression = Expression(
-                    error_primitive_head,
-                    from_python(
-                        [
-                            (-1, 0, -1),
-                            (1, 0, -1),
-                            (1, 0.01, 1),
-                            (-1, 0.01, 1),
-                            (-1, 0, -1),
-                        ]
-                    ),
-                )
-            error_box = get_class(error_primitive_head)(
-                self, style=error_style, item=error_primitive_expression
-            )
-            error_box.face_color = ERROR_BOX_FACE_COLOR
-            error_box.edge_color = ERROR_BOX_EDGE_COLOR
-            return error_box
-
-        def build_error_box2(style):
-            error_style = style.klass(
-                style.graphics,
-                edge=ERROR_BOX_EDGE_COLOR,
-                face=ERROR_BOX_FACE_COLOR,
-            )
-            if isinstance(self, GraphicsElements):
-                error_primitive_head = Symbol("RectangleBox")
-                error_primitive_expression = Expression(
-                    error_primitive_head,
-                    from_python([-1, -1]),
-                )
-            else:
-                error_primitive_head = Symbol("Cuboid3DBox")
-                error_primitive_expression = Expression(
-                    error_primitive_head,
-                    from_python(
-                        [
-                            (
-                                -1,
-                                -1,
-                                -1,
-                            ),
-                            (1, 1, 1),
-                        ]
-                    ),
-                )
-            error_box = get_class(error_primitive_head)(
-                self, style=style, item=error_primitive_expression
-            )
-            error_box.face_color = ERROR_BOX_FACE_COLOR
-            error_box.edge_color = ERROR_BOX_EDGE_COLOR
-            return error_box
-
         def convert(content, style):
             if content.has_form("List", None):
                 items = content.elements
@@ -1223,7 +1155,7 @@ class _GraphicsElements:
                 [f"{str(h)} is not a valid primitive or directive." for h in failed]
             )
             self.tooltip_text = messages
-            self.background_color = ERROR_BOX_FACE_COLOR
+            self.background_color = ERROR_BACKGROUND_COLOR
             logging.warn(messages)
 
     def create_style(self, expr):

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -72,7 +72,7 @@ GRAPHICS_OPTIONS = {
 DEFAULT_POINT_FACTOR = 0.005
 
 
-ERROR_BOX_FACE_COLOR = RGBColor(components=[1, 0, 0, 0.25])
+ERROR_BOX_FACE_COLOR = RGBColor(components=[1, 0.3, 0.3, 0.25])
 ERROR_BOX_EDGE_COLOR = RGBColor(components=[1, 0, 0, 1.0])
 
 
@@ -1213,15 +1213,17 @@ class _GraphicsElements:
                     failed.append(head)
                     continue
 
-            if failed:
-                yield build_error_box2(style)
-                # raise BoxExpressionError(messages)
+            # if failed:
+            #    yield build_error_box2(style)
+            #    raise BoxExpressionError(messages)
 
         self.elements = list(convert(content, self.style_class(self)))
         if failed:
             messages = "\n".join(
                 [f"{str(h)} is not a valid primitive or directive." for h in failed]
             )
+            self.tooltip_text = messages
+            self.background_color = ERROR_BOX_FACE_COLOR
             logging.warn(messages)
 
     def create_style(self, expr):

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -268,6 +268,10 @@ class Graphics(Builtin):
     >> Graphics[Rectangle[]] // ToBoxes // Head
      = GraphicsBox
 
+    The 'Background' option allows to set the color of the background:
+    >> Graphics[{Green, Disk[]}, Background->RGBColor[.6, .7, 1.]]
+     = -Graphics-
+
     In 'TeXForm', 'Graphics' produces Asymptote figures:
     >> Graphics[Circle[]] // TeXForm
      = #<--#

--- a/mathics/format/latex.py
+++ b/mathics/format/latex.py
@@ -551,13 +551,21 @@ def graphics3dbox(self, elements=None, **options) -> str:
                 boundbox_asy += "draw(({0}), {1});\n".format(path, pen)
 
     (height, width) = (400, 400)  # TODO: Proper size
+
+    # Background color
+    if self.background_color:
+        bg_color, opacity = asy_color(self.background_color)
+        background_directive = "background=" + bg_color + ", "
+    else:
+        background_directive = ""
+
     tex = r"""
 \begin{{asy}}
 import three;
 import solids;
 size({0}cm, {1}cm);
 currentprojection=perspective({2[0]},{2[1]},{2[2]});
-currentlight=light(rgb(0.5,0.5,1), specular=red, (2,0,2), (2,2,2), (0,2,2));
+currentlight=light(rgb(0.5,0.5,1), {5}specular=red, (2,0,2), (2,2,2), (0,2,2));
 {3}
 {4}
 \end{{asy}}
@@ -568,6 +576,7 @@ currentlight=light(rgb(0.5,0.5,1), specular=red, (2,0,2), (2,2,2), (0,2,2));
         [vp * max([xmax - xmin, ymax - ymin, zmax - zmin]) for vp in self.viewpoint],
         asy,
         boundbox_asy,
+        background_directive,
     )
     return tex
 

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -308,17 +308,19 @@ def graphics_box(self, elements=None, **options: dict) -> str:
     self.boxwidth = options.get("width", self.boxwidth)
     self.boxheight = options.get("height", self.boxheight)
 
+    tooltip_text = self.tooltip_text if hasattr(self, "tooltip_text") else ""
     if self.background_color is not None:
         # FIXME: tests don't seem to cover this secton of code.
         # Wrap svg_elements in a rectangle
         svg_body = f"""
+        <rect x="{xmin:f}" y="{ymin:f}" width="{self.boxwidth:f}" height="{self.boxheight:f}" style="fill: {self.background_color}"></rect>
             <rect
                  x="{xmin:f}" y="{ymin:f}"
                  width="{self.boxwidth:f}"
                  height="{self.boxheight:f}"
-                 style="fill:{self.background_color.to_css()[0]}
+                 style="fill:{self.background_color.to_css()[0]}"><title>{tooltip_text}</title></rect>
             {svg_body}
-           />"""
+           """
 
     if options.get("noheader", False):
         return svg_body

--- a/test/builtin/drawing/test_plot.py
+++ b/test/builtin/drawing/test_plot.py
@@ -29,6 +29,17 @@ import pytest
         ),
         ("Plot[x*y, {x, -1, 1}]", None, "-Graphics-", None),
         ("Plot3D[z, {x, 1, 20}, {y, 1, 10}]", None, "-Graphics3D-", None),
+        (
+            "Graphics[{Disk[]}, Background->RGBColor[1,.1,.1]]//TeXForm//ToString",
+            None,
+            (
+                '\n\\begin{asy}\nusepackage("amsmath");\nsize(5.8333cm, 5.8333cm);\n'
+                "filldraw(box((0,0), (350,350)), rgb(1, 0.1, 0.1));\n"
+                "filldraw(ellipse((175,175),175,175), rgb(0, 0, 0), nullpen);\n"
+                "clip(box((0,0), (350,350)));\n\\end{asy}\n"
+            ),
+            "Background 2D",
+        ),
         ## MaxRecursion Option
         (
             "Plot3D[0, {x, -2, 2}, {y, -2, 2}, MaxRecursion -> 0]",
@@ -85,6 +96,34 @@ import pytest
             None,
             "\n\\begin{asy}\nimport three;\nimport solids;\nsize(6.6667cm, 6.6667cm);",
             None,
+        ),
+        (
+            "Graphics3D[{Sphere[]}, Background->RGBColor[1,.1,.1]]//TeXForm//ToString",
+            None,
+            (
+                "\n\\begin{asy}\n"
+                "import three;\n"
+                "import solids;\n"
+                "size(6.6667cm, 6.6667cm);\n"
+                "currentprojection=perspective(2.6,-4.8,4.0);\n"
+                "currentlight=light(rgb(0.5,0.5,1), background=rgb(1, 0.1, 0.1), specular=red, (2,0,2), (2,2,2), (0,2,2));\n"
+                "// Sphere3DBox\n"
+                "draw(surface(sphere((0, 0, 0), 1)), rgb(1,1,1)+opacity(1));\n"
+                "draw(((-1,-1,-1)--(1,-1,-1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,1,-1)--(1,1,-1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,-1,1)--(1,-1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,1,1)--(1,1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,-1,-1)--(-1,1,-1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((1,-1,-1)--(1,1,-1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,-1,1)--(-1,1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((1,-1,1)--(1,1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,-1,-1)--(-1,-1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((1,-1,-1)--(1,-1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((-1,1,-1)--(-1,1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "draw(((1,1,-1)--(1,1,1)), rgb(0.4, 0.4, 0.4)+linewidth(1));\n"
+                "\\end{asy}\n"
+            ),
+            "Background 3D",
         ),
         (
             "Graphics3D[Point[Table[{Sin[t], Cos[t], 0}, {t, 0, 2. Pi, Pi / 15.}]]] // TeXForm//ToString",


### PR DESCRIPTION
Here we go with a proposal to address #964. The idea is that when an invalid graphics primitive is processed, a pink rectangle is drawn instead. Notice that in WMA no error message is shown in the client. Just the pink background is shown in the image, plus a tooltip in the notebook interface.