### PR TITLE
background documentation and opacity support

### DIFF
--- a/mathics/builtin/box/expression.py
+++ b/mathics/builtin/box/expression.py
@@ -199,6 +199,9 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
         if evaluation:
             default = evaluation.definitions.get_options(self.get_name()).copy()
         else:
+            # If evaluation is not available, load the default values
+            # for the options directly from the class. This requires
+            # to parse the rules.
             from mathics.core.parser import parse_builtin_rule
 
             default = {}
@@ -206,6 +209,8 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
                 option = ensure_context(option)
                 default[option] = parse_builtin_rule(value)
 
+        # Now, update the default options with the options explicitly
+        # included in the elements
         options = ListExpression(*elements).get_option_values(evaluation)
         default.update(options)
         return default

--- a/mathics/builtin/box/expression.py
+++ b/mathics/builtin/box/expression.py
@@ -198,8 +198,6 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
         evaluation = options.get("evaluation", None)
         if evaluation:
             default = evaluation.definitions.get_options(self.get_name()).copy()
-            options = ListExpression(*elements).get_option_values(evaluation)
-            default.update(options)
         else:
             from mathics.core.parser import parse_builtin_rule
 
@@ -207,6 +205,9 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
             for option, value in self.options.items():
                 option = ensure_context(option)
                 default[option] = parse_builtin_rule(value)
+
+        options = ListExpression(*elements).get_option_values(evaluation)
+        default.update(options)
         return default
 
 

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -474,7 +474,10 @@ class GraphicsBox(BoxExpression):
         ):
             self.background_color = None
         else:
-            self.background_color = _ColorObject.create(background)
+            try:
+                self.background_color = _ColorObject.create(background)
+            except ColorError:
+                self.background_color = None
 
         base_width, base_height, size_multiplier, size_aspect = self._get_image_size(
             options, self.graphics_options, max_width

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -372,12 +372,14 @@ class Graphics3DBox(GraphicsBox):
             boxscale,
         ) = self._prepare_elements(elements, options)
 
-        # TODO: Handle alpha channel
-        background = (
-            self.background_color.to_css()[:-1]
-            if self.background_color is not None
-            else "rgbcolor(100%,100%,100%)"
-        )
+        background = "rgba(100%,100%,100%,100%)"
+        if self.background_color:
+            components = self.background_color.to_rgba()
+            if len(components) == 3:
+                background = "rgb(" + ", ".join(f"{100*c}%" for c in components) + ")"
+            else:
+                background = "rgba(" + ", ".join(f"{100*c}%" for c in components) + ")"
+
         tooltip_text = (
             elements.tooltip_text if hasattr(elements, "tooltip_text") else ""
         )

--- a/mathics/builtin/box/graphics3d.py
+++ b/mathics/builtin/box/graphics3d.py
@@ -372,7 +372,7 @@ class Graphics3DBox(GraphicsBox):
             boxscale,
         ) = self._prepare_elements(elements, options)
 
-        background = "rgba(100%,100%,100%,100%)"
+        background = "rgba(100.0%, 100.0%, 100.0%, 100.0%)"
         if self.background_color:
             components = self.background_color.to_rgba()
             if len(components) == 3:

--- a/mathics/builtin/colors/color_directives.py
+++ b/mathics/builtin/colors/color_directives.py
@@ -690,7 +690,6 @@ class RGBColor(_ColorObject):
     def to_rgba(self):
         return self.components
 
-    # rules = {"RGBColor[r, g, b, a]": "{RGBColor[r, g, b], Opacity[a]}"}
     summary_text = "specify an RGB color"
 
 

--- a/mathics/builtin/colors/color_directives.py
+++ b/mathics/builtin/colors/color_directives.py
@@ -690,7 +690,7 @@ class RGBColor(_ColorObject):
     def to_rgba(self):
         return self.components
 
-    rules = {"RGBColor[r, g, b, a]": "{RGBColor[r, g, b], Opacity[a]}"}
+    # rules = {"RGBColor[r, g, b, a]": "{RGBColor[r, g, b], Opacity[a]}"}
     summary_text = "specify an RGB color"
 
 

--- a/mathics/builtin/drawing/drawing_options.py
+++ b/mathics/builtin/drawing/drawing_options.py
@@ -87,16 +87,16 @@ class Background(Builtin):
       <dd>is an option that specifies the color of the background.
     </dl>
 
-    The specification must be a 'Color' or 'Automatic':
+    The specification must be a Color specification or 'Automatic':
 
     >> Graphics3D[{Arrow[{{0,0,0},{1,0,1},{0,-1,0},{1,1,1}}]}, Background -> Red]
      = -Graphics3D-
 
-    Other values for this option are neglected. For example, this prevent to
-    combine a color with an opacity. To get that effect, the color must
-    be specified with an alpha channel:
+    Notice that opacity cannot be specified by passing a 'List' containing 'Opacity' \
+    together with a color specification like '{Red, Opacity[.1]}'. Use a color \
+    directive with an alpha channel instead:
 
-    >> Graphics[{Disk[]}, Background -> RGBColor[0,0,1,.2]]
+    >> Plot[{Sin[x], Cos[x], x / 3}, {x, -Pi, Pi}, Background -> RGBColor[0.5, .5, .5, 0.1]]
      = -Graphics-
 
     """

--- a/mathics/builtin/drawing/drawing_options.py
+++ b/mathics/builtin/drawing/drawing_options.py
@@ -78,6 +78,32 @@ class Axis(Builtin):
     summary_text = "graph option value to fill plot from curve to the axis"
 
 
+class Background(Builtin):
+    """
+    <url>:WMA link:https://reference.wolfram.com/language/ref/Background.html</url>
+
+    <dl>
+      <dt>'Background'
+      <dd>is an option that specifies the color of the background.
+    </dl>
+
+    The specification must be a 'Color' or 'Automatic':
+
+    >> Graphics3D[{Arrow[{{0,0,0},{1,0,1},{0,-1,0},{1,1,1}}]}, Background -> Red]
+     = -Graphics3D-
+
+    Other values for this option are neglected. For example, this prevent to
+    combine a color with an opacity. To get that effect, the color must
+    be specified with an alpha channel:
+
+    >> Graphics[{Disk[]}, Background -> RGBColor[0,0,1,.2]]
+     = -Graphics-
+
+    """
+
+    summary_text = "graphic option for the color of the background"
+
+
 class Bottom(Builtin):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/Bottom.html</url>

--- a/mathics/format/latex.py
+++ b/mathics/format/latex.py
@@ -354,6 +354,8 @@ def graphicsbox(self, elements=None, **options) -> str:
 
     if self.background_color is not None:
         color, opacity = asy_color(self.background_color)
+        if opacity is not None:
+            color = color + f"+opacity({opacity})"
         asy_background = "filldraw(%s, %s);" % (asy_box, color)
     else:
         asy_background = ""

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -312,13 +312,21 @@ def graphics_box(self, elements=None, **options: dict) -> str:
     if self.background_color is not None:
         # FIXME: tests don't seem to cover this secton of code.
         # Wrap svg_elements in a rectangle
+
+        background = "rgba(100%,100%,100%,100%)"
+        if self.background_color:
+            components = self.background_color.to_rgba()
+            if len(components) == 3:
+                background = "rgb(" + ", ".join(f"{100*c}%" for c in components) + ")"
+            else:
+                background = "rgba(" + ", ".join(f"{100*c}%" for c in components) + ")"
+
         svg_body = f"""
-        <rect x="{xmin:f}" y="{ymin:f}" width="{self.boxwidth:f}" height="{self.boxheight:f}" style="fill: {self.background_color}"></rect>
             <rect
                  x="{xmin:f}" y="{ymin:f}"
                  width="{self.boxwidth:f}"
                  height="{self.boxheight:f}"
-                 style="fill:{self.background_color.to_css()[0]}"><title>{tooltip_text}</title></rect>
+                 style="fill:{background}"><title>{tooltip_text}</title></rect>
             {svg_body}
            """
 

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -1,15 +1,13 @@
 import os
-from test.helper import check_evaluation
+from test.helper import check_evaluation, session
+
+import pytest
 
 from mathics.core.symbols import Symbol
 from mathics.session import MathicsSession
 
-session = MathicsSession()
-
 # from mathics.core.builtin import BoxConstruct, Predefined
 
-
-import pytest
 
 #
 #  Aim of the tests:

--- a/test/format/test_svg.py
+++ b/test/format/test_svg.py
@@ -1,7 +1,8 @@
 import re
+from test.helper import session
 
 from mathics.builtin.makeboxes import MakeBoxes
-from mathics.core.atoms import Integer0, Integer1
+from mathics.core.atoms import Integer0, Integer1, Real
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.formatter import lookup_method
@@ -10,16 +11,39 @@ from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolPoint
 from mathics.session import MathicsSession
 
-session = MathicsSession(add_builtin=True, catch_interrupt=False)
-evaluation = Evaluation(session.definitions)
+evaluation = session.evaluation
 
 GraphicsSymbol = Symbol("Graphics")
 ListSymbol = Symbol("List")
+
+DISK_TEST_EXPR = Expression(
+    Symbol("Disk")
+)  # , ListExpression(Integer0, Integer0), Integer1)
+COLOR_RED = Expression(Symbol("RGBColor"), Integer1, Integer0, Integer0)
+COLOR_RED_ALPHA = Expression(
+    Symbol("RGBColor"), Integer1, Integer0, Integer0, Real(0.25)
+)
+
 
 svg_wrapper_pat = r"""\s*<svg width="[0-9.]+px" height="[0-9.]+px" xmlns:svg="http://www.w3.org/2000/svg"
 \s*xmlns="http://www.w3.org/2000/svg"
 \s*version="1\.1"
 """
+
+
+# TODO: consider replace the following functions by something that parses SVG and produce a better
+# structure, like a dict, containing information about the size, background and the primitives.
+
+
+def extract_svg_background(svg):
+    matches = re.match(svg_wrapper_pat, svg)
+    assert matches
+    svg = svg[len(matches.group(0)) :]
+    rest_re = r"^\s+viewBox=(.*)\s+((?s:[<].*))<!--GraphicsElements-->((?s:.*))"
+    parts_match = re.match(rest_re, svg)
+    if parts_match:
+        return parts_match.groups()[1].strip().replace("\n", " ")
+    return ""
 
 
 def extract_svg_body(svg):
@@ -32,7 +56,6 @@ def extract_svg_body(svg):
     )
     assert view_inner_match
     inner_svg = view_inner_match.group(1)
-    print(inner_svg)
     return inner_svg
 
 
@@ -41,7 +64,6 @@ def get_svg(expression):
     boxes = MakeBoxes(expression).evaluate(evaluation)
 
     # Would be nice to DRY this boilerplate from boxes_to_mathml
-
     elements = boxes._elements
     elements, calc_dimensions = boxes._prepare_elements(
         elements, options=options, neg_y=True
@@ -82,7 +104,6 @@ def test_svg_point():
 
     # Circles are implemented as ellipses with equal major and minor axes.
     # Check for that.
-    print(inner_svg)
     matches = re.match(r'^<circle cx="(\S+)" cy="(\S+)"', inner_svg)
     assert matches
     assert matches.group(1) == matches.group(2)
@@ -108,6 +129,44 @@ def test_svg_arrowbox():
     # arrow_polygon = inner_svg[len(matches.group(0)) - 1 :]
     # matches = re.match(r'^<polygon points=".+"\s+style=".*"\s*/>', arrow_polygon)
     # assert matches
+
+
+def test_svg_background():
+
+    # If not specified, the background is empty
+    expression = Expression(
+        GraphicsSymbol,
+        DISK_TEST_EXPR,
+    ).evaluate(evaluation)
+    svg = get_svg(expression)
+    assert extract_svg_background(svg) == ""
+
+    # Other possibilities...
+    def check(expr, result):
+        svg = get_svg(expression)
+        background_svg = extract_svg_background(svg)
+        matches = re.match(r'[<]rect(.*)style="(.*)"(.*[>])[<]/rect[>]', background_svg)
+        assert matches
+        background_fill = matches.groups()[1]
+        assert background_fill == result
+
+    # RGB color
+    expression = Expression(
+        GraphicsSymbol,
+        DISK_TEST_EXPR,
+        Expression(Symbol("Rule"), Symbol("System`Background"), COLOR_RED),
+    ).evaluate(evaluation)
+
+    check(expression, "fill:rgb(100.0%, 0.0%, 0.0%)")
+
+    # RGBA color
+    expression = Expression(
+        GraphicsSymbol,
+        DISK_TEST_EXPR,
+        Expression(Symbol("Rule"), Symbol("System`Background"), COLOR_RED_ALPHA),
+    ).evaluate(evaluation)
+
+    check(expression, "fill:rgba(100.0%, 0.0%, 0.0%, 25.0%)")
 
 
 def test_svg_bezier_curve():


### PR DESCRIPTION
This PR adds the entry for `Background` in the documentation and provides support for opacity in SVG and json graphics.