### PR TITLE
Fix Derivative issue discussed in #971

### DIFF
--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -349,6 +349,7 @@ class Locked(Predefined):
      = 3
     """
 
+    attributes = A_PROTECTED | A_LOCKED
     summary_text = "keep all attributes locked (settable but not clearable)"
 
 

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -7,7 +7,7 @@ import typing
 from typing import Any
 
 from mathics.core.atoms import String
-from mathics.core.attributes import A_HOLD_ALL, A_HOLD_FIRST, A_PROTECTED
+from mathics.core.attributes import A_HOLD_ALL, A_HOLD_FIRST, A_LOCKED, A_PROTECTED
 from mathics.core.builtin import BinaryOperator, Builtin, Predefined
 from mathics.core.evaluation import Evaluation, Message as EvaluationMessage
 from mathics.core.expression import Expression
@@ -26,6 +26,7 @@ class Aborted(Predefined):
     </dl>
     """
 
+    attributes = A_LOCKED | A_PROTECTED
     summary_text = "return value for aborted evaluations"
     name = "$Aborted"
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -486,9 +486,10 @@ class Derivative(PostfixOperator, SympyFunction):
         super(Derivative, self).__init__(*args, **kwargs)
 
     def eval_locked_symbols(self, n, **kwargs):
-        """Derivative[n__Integer][Alternatives[True|False]]"""
-        # Prevents the evaluation for List, True and False
-        # as function names. See
+        """Derivative[n__Integer][Alternatives[True|False|Symbol|TooBig|$Aborted|Removed|Locked]]"""
+        # Prevents the evaluation for True, False, and other Locked symbols
+        # as function names. This produces a recursion error in the evaluation rule for Derivative.
+        # See
         # https://github.com/Mathics3/mathics-core/issues/971#issuecomment-1902814462
         # in issue #971
         # An alternative would be to reformulate the long rule.

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -486,7 +486,7 @@ class Derivative(PostfixOperator, SympyFunction):
         super(Derivative, self).__init__(*args, **kwargs)
 
     def eval_locked_symbols(self, n, **kwargs):
-        """Derivative[n__Integer][Alternatives[True|False|Symbol|TooBig|$Aborted|Removed|Locked]]"""
+        """Derivative[n__Integer][Alternatives[True|False|Symbol|TooBig|$Aborted|Removed|Locked|$PrintLiteral|$Off]]"""
         # Prevents the evaluation for True, False, and other Locked symbols
         # as function names. This produces a recursion error in the evaluation rule for Derivative.
         # See

--- a/test/builtin/numbers/test_calculus.py
+++ b/test/builtin/numbers/test_calculus.py
@@ -278,6 +278,14 @@ def test_private_doctests_optimization(str_expr, msgs, str_expected, fail_msg):
             "x E ^ (-1 / x ^ 2) + Sqrt[Pi] Erf[1 / x]",
             None,
         ),
+        ("True'", None, "True'", None),
+        ("False'", None, "False'", None),
+        ("List'", None, "{1}&", None),
+        ("1'", None, "0&", None),
+        ("-1.4'", None, "-(0&)", None),
+        ("(2/3)'", None, "0&", None),
+        ("I'", None, "0&", None),
+        ("Derivative[0,0,1][List]", None, "{0, 0, 1}&", None),
     ],
 )
 def test_private_doctests_calculus(str_expr, msgs, str_expected, fail_msg):


### PR DESCRIPTION
This PR prevents ``True'``, ``False'`` and ``List'`` be evaluated producing the error reported in #971. Comments explaining how the rule for evaluating `Derivative` over anonymous functions works was added.