### PR TITLE
fixing make doc-data

### DIFF
--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -447,9 +447,17 @@ class DocTest:
 
 
 # FIXME: Turn into a NamedTuple?
+
+# Looking at https://github.com/mathics/Mathics/blob/eba5c22990fae01cd2579d13bbeabcfdb5221426/mathics/doc/doc.py
+#
+# The class Test was used to yield tests from the Documentation.get_tests() function,
+# while DocTests was used as items in the Doc object (now DocText). It is possible that Tests should subclass DocTests.
+#
+#
+#
 class Tests:
     """
-    A group of tests in the same section or subsection.
+    A group of tests in the same section or subsection of the Documentation.
     """
 
     def __init__(

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -803,7 +803,6 @@ class DocSection:
                                     new_items,
                                 )
                                 yield self.tests
-                                1 / 0
                     return
 
                 for subsection in section.subsections:


### PR DESCRIPTION
@rocky 
This is the first bunch of silly changes. Most of them does not have any effect, but could help to clarify the code:
* Use `logging` for warnings
* Avoid monkey patch objects of the `DocTests` class.  
* Check what is the class of the input parameter `tests` in `mathics.docpipeline.create_output` and `mathics.docpipeline.test_tests`. The mixture of types was responsible for a failure here, when a generator was passed instead of a `Tests` object.
* The parameter `format_output` in `mathics.docpipeline.test_case` should not be there: all the reference results are given in `text` form, so the evaluation must be always formatted as `text`.

With the last two changes, make doc-data is working now.