### PR TITLE
Fix gather tests and start adding pytests

### DIFF
--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -345,9 +345,11 @@ def gather_tests(
             if tests is None:
                 tests = test_collection_constructor()
             tests.tests.append(test)
-        if tests is not None:
-            items.append(tests)
-            tests = None
+
+    # After the loop finishes, add the last bunch of tests
+    if tests is not None:
+        items.append(tests)
+        tests = None
     return items
 
 
@@ -369,8 +371,8 @@ class DocTest:
       `|`  Prints output.
     """
 
-    def __init__(self, index, testcase, key_prefix: tuple):
-        def strip_sentinal(line):
+    def __init__(self, index: int, testcase: List[str], key_prefix: tuple):
+        def strip_sentinal(line: str):
             """Remove END_LINE_SENTINAL from the end of a line if it appears.
 
             Some editors like to strip blanks at the end of a line.
@@ -470,6 +472,7 @@ class DocChapter:
     """An object for a Documented Chapter.
     A Chapter is part of a Part[dChapter. It can contain (Guide or plain) Sections.
     """
+
     def __init__(self, part, title, doc):
         self.doc = doc
         self.guide_sections = []
@@ -674,6 +677,7 @@ class DocTests:
     subsection.
     Access ``tests`` to get these.
     """
+
     def __init__(self):
         self._tests = []
         self.text = ""
@@ -1317,8 +1321,15 @@ class XMLDoc:
     Mathics core also uses this in getting usage strings (`??`).
     """
 
-    def __init__(self, doc_str: str, title: str, section: [DocSection],
-                 doctests_class=DocTests, doctest_class=DocTest, doctext_class=DocText):
+    def __init__(
+        self,
+        doc_str: str,
+        title: str,
+        section: [DocSection],
+        doctests_class=DocTests,
+        doctest_class=DocTest,
+        doctext_class=DocText,
+    ):
         self.title = title
         chapter = section.chapter
         part = chapter.part
@@ -1326,7 +1337,9 @@ class XMLDoc:
         key_prefix = (part.title, chapter.title, title)
 
         self.rawdoc = doc_str
-        self.items = gather_tests(self.rawdoc, doctests_class, doctest_class, doctext_class, key_prefix)
+        self.items = gather_tests(
+            self.rawdoc, doctests_class, doctest_class, doctext_class, key_prefix
+        )
 
     def __str__(self) -> str:
         return "\n".join(str(item) for item in self.items)

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -862,6 +862,27 @@ mathics3_module_part: Optional[DocPart] = None
 
 
 class Documentation:
+    """
+    `Documentation` describes an object containing the whole documentation system.
+
+    Documentation
+        |
+        +--------0> Parts
+                      |
+                      +-----0> Chapters
+                                 |
+                                 +-----0>Sections
+                                           |
+                                           +------0> SubSections
+
+    (with 0>) meaning "agregation".
+    Each element contains a title, a collection of elements of the following class
+    in the hierarchy. Parts, Chapters, Sections and SubSections contains a doc_xml
+    attribute describing the content to be presented after the title, and before
+    the elements of the subsequent terms in the hierarchy.
+
+    """
+
     def __init__(self):
         self.doc_class = XMLDoc
         self.doc_dir = settings.DOC_DIR
@@ -1313,7 +1334,17 @@ class DocText:
 
 
 class XMLDoc:
-    """A class to hold our internal XML-like format data for test sections or subsections.
+    """
+    Describes the contain of an entry in the documentation system, as a
+    sequence (list) of items of the clase  `DocText` and `DocTests`.
+    `DocText` items contains an internal XML-like formatted text. `DocTests` entries
+    contain one or more `DocTest` element.
+
+    Each level of the Documentation hierarchy contains an XMLDoc, describing the
+    content after the title and before the elements of the next level. For example,
+    in `DocChapter`, `DocChapter.doc_xml` contains the text comming after the title
+    of the chapter, and before the sections in `DocChapter.sections`.
+
     Specialized classes like LaTeXDoc or and DjangoDoc provide methods for
     getting formatted output. For LaTeXDoc ``latex()`` is added while for
     DjangoDoc ``html()`` is added

--- a/test/doc/test_common.py
+++ b/test/doc/test_common.py
@@ -1,3 +1,8 @@
+"""
+Pytests for the documentation system. Basic functions and classes.
+"""
+
+from mathics.core.evaluation import Message, Print
 from mathics.doc.common_doc import DocTest, DocTests, DocText, Tests, gather_tests
 
 DOCTEST_ENTRY = """
@@ -36,18 +41,7 @@ DOCTEST_ENTRY = """
 def test_gather_tests():
     """Check the behavioir of gather_tests"""
 
-    base_expected_types = [
-        DocText,
-        DocTests,
-        DocText,
-        DocTests,
-        DocText,
-        DocTests,
-        DocText,
-        DocTests,
-        DocText,
-        DocTests,
-    ]
+    base_expected_types = [DocText, DocTests] * 5
     cases = [
         (
             DOCTEST_ENTRY[133:],
@@ -86,7 +80,7 @@ def test_gather_tests():
 
 
 def test_create_doctest():
-    """DocTest"""
+    """initializing DocTest"""
 
     key = (
         "Part title",
@@ -100,8 +94,58 @@ def test_create_doctest():
                 "private": False,
                 "ignore": False,
                 "result": "4",
+                "outs": [],
+                "key": key + (1,),
             },
-        }
+        },
+        {
+            "test": ["#", "2+2", "\n    = 4"],
+            "properties": {
+                "private": True,
+                "ignore": False,
+                "result": "4",
+                "outs": [],
+                "key": key + (1,),
+            },
+        },
+        {
+            "test": ["S", "2+2", "\n    = 4"],
+            "properties": {
+                "private": False,
+                "ignore": False,
+                "result": "4",
+                "outs": [],
+                "key": key + (1,),
+            },
+        },
+        {
+            "test": ["X", 'Print["Hola"]', "| Hola"],
+            "properties": {
+                "private": False,
+                "ignore": True,
+                "result": None,
+                "outs": [Print("Hola")],
+                "key": key + (1,),
+            },
+        },
+        {
+            "test": [
+                ">",
+                "1 / 0",
+                "\n : Infinite expression 1 / 0 encountered.\n ComplexInfinity",
+            ],
+            "properties": {
+                "private": False,
+                "ignore": False,
+                "result": None,
+                "outs": [
+                    Message(
+                        symbol="", text="Infinite expression 1 / 0 encountered.", tag=""
+                    )
+                ],
+                "key": key + (1,),
+            },
+        },
     ]
     for index, test_case in enumerate(test_cases):
         doctest = DocTest(1, test_case["test"], key)

--- a/test/doc/test_common.py
+++ b/test/doc/test_common.py
@@ -1,0 +1,109 @@
+from mathics.doc.common_doc import DocTest, DocTests, DocText, Tests, gather_tests
+
+DOCTEST_ENTRY = """
+    <dl>
+      <dt>'TestSymbol'
+      <dd>it is just a test example of docstring entry
+    </dl>
+
+    A doctest with a result value
+    >> 2 + 2
+     = 4
+
+    Two consuecutive tests:
+    >> a={1,2,3}
+     = {1, 2, 3}
+    >> Tr[a]
+     = 6
+
+    A doctest without a result value
+    >> Print["Hola"]
+     | Hola
+
+    A private doctest without a result, followed
+    by a private doctest with a result
+    #> Null
+    #> 2+2
+     = 4
+    A private doctest with a message
+    #> 1/0 
+     : 
+     = ComplexInfinity
+
+"""
+
+
+def test_gather_tests():
+    """Check the behavioir of gather_tests"""
+
+    base_expected_types = [
+        DocText,
+        DocTests,
+        DocText,
+        DocTests,
+        DocText,
+        DocTests,
+        DocText,
+        DocTests,
+        DocText,
+        DocTests,
+    ]
+    cases = [
+        (
+            DOCTEST_ENTRY[133:],
+            base_expected_types[1:],
+        ),
+        (
+            DOCTEST_ENTRY + "\n\n And a last paragraph\n with two lines.\n",
+            base_expected_types + [DocText],
+        ),
+        (
+            DOCTEST_ENTRY,
+            base_expected_types,
+        ),
+    ]
+
+    for case, list_expected_types in cases:
+        result = gather_tests(
+            case,
+            DocTests,
+            DocTest,
+            DocText,
+            (
+                "part example",
+                "chapter example",
+                "section example",
+            ),
+        )
+        assert isinstance(result, list)
+        assert len(list_expected_types) == len(result)
+        assert all([isinstance(t, cls) for t, cls in zip(result, list_expected_types)])
+
+    tests = [t for t in result if isinstance(t, DocTests)]
+    num_tests = [len(t.tests) for t in tests]
+    assert len(tests) == 5
+    assert all([t == l for t, l in zip(num_tests, [1, 2, 1, 2, 1])])
+
+
+def test_create_doctest():
+    """DocTest"""
+
+    key = (
+        "Part title",
+        "Chapter Title",
+        "Section Title",
+    )
+    test_cases = [
+        {
+            "test": [">", "2+2", "\n    = 4"],
+            "properties": {
+                "private": False,
+                "ignore": False,
+                "result": "4",
+            },
+        }
+    ]
+    for index, test_case in enumerate(test_cases):
+        doctest = DocTest(1, test_case["test"], key)
+        for property_key, value in test_case["properties"].items():
+            assert getattr(doctest, property_key) == value


### PR DESCRIPTION
This PR fixes an indentation error in `gather_tests`, and starts adding some pytests for the documentation system.