### PR TITLE
Doc code another round of tiny changes 2

### DIFF
--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -4,7 +4,7 @@ A module and library that assists in organizing document data
 located in static files and docstrings from
 Mathics3 Builtin Modules. Builtin Modules are written in Python and
 reside either in the Mathics3 core (mathics.builtin) or are packaged outside,
-e.g. pymathics.natlang.
+in Mathics3 Modules e.g. pymathics.natlang.
 
 This data is stored in a way that facilitates:
 * organizing information to produce a LaTeX file
@@ -35,7 +35,7 @@ import pkgutil
 import re
 from os import environ, getenv, listdir
 from types import ModuleType
-from typing import Callable, Iterator, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from mathics import settings
 from mathics.core.builtin import check_requires_list
@@ -694,13 +694,9 @@ class Documentation:
 
         return None
 
-    def get_tests(self, want_sorting=False):
+    def get_tests(self):
         for part in self.parts:
-            if want_sorting:
-                chapter_collection_fn = lambda x: sorted_chapters(x)
-            else:
-                chapter_collection_fn = lambda x: x
-            for chapter in chapter_collection_fn(part.chapters):
+            for chapter in sorted_chapters(part.chapters):
                 tests = chapter.doc.get_tests()
                 if tests:
                     yield Tests(part.title, chapter.title, "", tests)
@@ -1046,6 +1042,10 @@ class MathicsMainDocumentation(Documentation):
         section.subsections.append(subsection)
 
     def doc_chapter(self, module, part, builtins_by_module) -> Optional[DocChapter]:
+        """
+        Build documentation structure for a "Chapter" - reference section which
+        might be a Mathics Module.
+        """
         modules_seen = set([])
 
         title, text = get_module_doc(module)
@@ -1130,8 +1130,8 @@ class MathicsMainDocumentation(Documentation):
 
     def doc_part(self, title, modules, builtins_by_module, start):
         """
-        Produce documentation for a "Part" - reference section or
-        possibly Pymathics modules
+        Build documentation structure for a "Part" - Reference
+        section or collection of Mathics3 Modules.
         """
 
         builtin_part = self.part_class(self, title, is_reference=start)
@@ -1143,20 +1143,9 @@ class MathicsMainDocumentation(Documentation):
         # packages inside ``mathics.builtin``.
         modules_seen = set([])
 
-        want_sorting = True
-        if want_sorting:
-            module_collection_fn = lambda x: sorted(
-                modules,
-                key=lambda module: module.sort_order
-                if hasattr(module, "sort_order")
-                else module.__name__,
-            )
-        else:
-            module_collection_fn = lambda x: x
-
         def filter_toplevel_modules(module_list):
             """
-            Keep just the modules at the top level
+            Keep just the modules at the top level.
             """
             if len(module_list) == 0:
                 return module_list
@@ -1176,7 +1165,12 @@ class MathicsMainDocumentation(Documentation):
         # which can be decomposed in the way proposed in #984.
 
         modules = filter_toplevel_modules(modules)
-        for module in module_collection_fn(modules):
+        for module in sorted(
+            modules,
+            key=lambda module: module.sort_order
+            if hasattr(module, "sort_order")
+            else module.__name__,
+        ):
             if skip_module_doc(module, modules_seen):
                 continue
             chapter = self.doc_chapter(module, builtin_part, builtins_by_module)

--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -1160,7 +1160,7 @@ class MathicsMainDocumentation(Documentation):
             """
             if len(module_list) == 0:
                 return module_list
-              
+
             modules_and_levels = sorted(
                 ((module.__name__.count("."), module) for module in module_list),
                 key=lambda x: x[0],
@@ -1174,7 +1174,7 @@ class MathicsMainDocumentation(Documentation):
         #
         # Also, this provides a more deterministic way to walk the module hierarchy,
         # which can be decomposed in the way proposed in #984.
-        
+
         modules = filter_toplevel_modules(modules)
         for module in module_collection_fn(modules):
             if skip_module_doc(module, modules_seen):

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -251,7 +251,6 @@ def test_chapters(
     stop_on_failure=False,
     generate_output=False,
     reload=False,
-    want_sorting=False,
     keep_going=False,
 ):
     failed = 0
@@ -294,7 +293,6 @@ def test_sections(
     stop_on_failure=False,
     generate_output=False,
     reload=False,
-    want_sorting=False,
     keep_going=False,
 ):
     failed = 0
@@ -354,7 +352,6 @@ def test_all(
     texdatafolder=None,
     doc_even_if_error=False,
     excludes=[],
-    want_sorting=False,
 ):
     if not quiet:
         print(f"Testing {version_string}")
@@ -371,7 +368,7 @@ def test_all(
         total = failed = skipped = 0
         failed_symbols = set()
         output_data = {}
-        for tests in documentation.get_tests(want_sorting=want_sorting):
+        for tests in documentation.get_tests():
             sub_total, sub_failed, sub_skipped, symbols, index = test_tests(
                 tests,
                 index,
@@ -608,21 +605,6 @@ def main():
         action="store_true",
         help="print cache statistics",
     )
-    # FIXME: historically was weird interacting going on with
-    # mathics when tests in sorted order. Possibly a
-    # mpmath precsion reset bug.
-    # We see a noticeable 2 minute delay in processing.
-    # WHile the problem is in Mathics itself rather than
-    # sorting, until we get this fixed, use
-    # sort as an option only. For normal testing we don't
-    # want it for speed. But for document building which is
-    # rarely done, we do want sorting of the sections and chapters.
-    parser.add_argument(
-        "--want-sorting",
-        dest="want_sorting",
-        action="store_true",
-        help="Sort chapters and sections",
-    )
     global logfile
 
     args = parser.parse_args()
@@ -635,7 +617,7 @@ def main():
         logfile = open(args.logfilename, "wt")
 
     global documentation
-    documentation = MathicsMainDocumentation(want_sorting=args.want_sorting)
+    documentation = MathicsMainDocumentation()
 
     # LoadModule Mathics3 modules
     if args.pymathics:
@@ -686,7 +668,6 @@ def main():
                 count=args.count,
                 doc_even_if_error=args.keep_going,
                 excludes=excludes,
-                want_sorting=args.want_sorting,
             )
             end_time = datetime.now()
             print("Tests took ", end_time - start_time)


### PR DESCRIPTION
This PR continues #990 by moving the inner loop that loads chapters in `MathicsMainDocumentation.doc_part` to a new method `MathicsMainDocumentation.doc_chapter`. With this change, the "on the fly" loading of documentation for Pymathics modules loaded in a Django session now is possible (and is implemented in https://github.com/Mathics3/mathics-django/pull/201)