### PR TITLE
Handle setting $Input and $InputFileName during Get[]

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -13,6 +13,7 @@ from io import BytesIO
 from mathics_scanner import TranslateError
 
 import mathics
+import mathics.eval.files_io.files as eval_files
 from mathics.core.atoms import Integer, String, SymbolString
 from mathics.core.attributes import A_PROTECTED, A_READ_PROTECTED
 from mathics.core.builtin import (
@@ -53,7 +54,6 @@ INPUT_VAR = ""
 
 SymbolInputStream = Symbol("InputStream")
 SymbolOutputStream = Symbol("OutputStream")
-SymbolPath = Symbol("$Path")
 
 # TODO: Improve docs for these Read[] arguments.
 
@@ -392,56 +392,6 @@ class Get(PrefixOperator):
     def eval(self, path, evaluation: Evaluation, options: dict):
         "Get[path_String, OptionsPattern[Get]]"
 
-        def eval_inner(self, path, evaluation: Evaluation, options: dict):
-            def check_options(options):
-                # Options
-                # TODO Proper error messages
-
-                result = {}
-                trace_get = evaluation.parse("Settings`$TraceGet")
-                if (
-                    options["System`Trace"].to_python()
-                    or trace_get.evaluate(evaluation) is SymbolTrue
-                ):
-                    import builtins
-
-                    result["TraceFn"] = builtins.print
-                else:
-                    result["TraceFn"] = None
-
-                return result
-
-            py_options = check_options(options)
-            trace_fn = py_options["TraceFn"]
-            result = None
-            pypath = path.get_string_value()
-            definitions = evaluation.definitions
-            mathics.core.streams.PATH_VAR = SymbolPath.evaluate(evaluation).to_python(
-                string_quotes=False
-            )
-            try:
-                if trace_fn:
-                    trace_fn(pypath)
-                with MathicsOpen(pypath, "r") as f:
-                    feeder = MathicsFileLineFeeder(f, trace_fn)
-                    while not feeder.empty():
-                        try:
-                            query = parse(definitions, feeder)
-                        except TranslateError:
-                            return SymbolNull
-                        finally:
-                            feeder.send_messages(evaluation)
-                        if query is None:  # blank line / comment
-                            continue
-                        result = query.evaluate(evaluation)
-            except IOError:
-                evaluation.message("General", "noopen", path)
-                return SymbolFailed
-            except MessageException as e:
-                e.message(evaluation)
-                return SymbolFailed
-            return result
-
         # wrap actual evaluation to handle setting $Input
         # and $InputFileName
         global INPUT_VAR
@@ -456,7 +406,7 @@ class Get(PrefixOperator):
 
         # perform the actual evaluation
         try:
-            return eval_inner(self, path, evaluation, options)
+            return eval_files.eval_Get_inner(self, path, evaluation, options)
         finally:
             # always restore input paths of calling context
             INPUT_VAR = outer_input_var

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -61,6 +61,11 @@ SymbolPath = Symbol("$Path")
 # ## it can be moved somewhere else.
 
 
+def set_input_var(input_string):
+    global INPUT_VAR
+    INPUT_VAR = input_string
+
+
 class Input_(Predefined):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/Input_.html</url>
@@ -387,54 +392,75 @@ class Get(PrefixOperator):
     def eval(self, path, evaluation: Evaluation, options: dict):
         "Get[path_String, OptionsPattern[Get]]"
 
-        def check_options(options):
-            # Options
-            # TODO Proper error messages
+        def eval_inner(self, path, evaluation: Evaluation, options: dict):
+            def check_options(options):
+                # Options
+                # TODO Proper error messages
 
-            result = {}
-            trace_get = evaluation.parse("Settings`$TraceGet")
-            if (
-                options["System`Trace"].to_python()
-                or trace_get.evaluate(evaluation) is SymbolTrue
-            ):
-                import builtins
+                result = {}
+                trace_get = evaluation.parse("Settings`$TraceGet")
+                if (
+                    options["System`Trace"].to_python()
+                    or trace_get.evaluate(evaluation) is SymbolTrue
+                ):
+                    import builtins
 
-                result["TraceFn"] = builtins.print
-            else:
-                result["TraceFn"] = None
+                    result["TraceFn"] = builtins.print
+                else:
+                    result["TraceFn"] = None
 
+                return result
+
+            py_options = check_options(options)
+            trace_fn = py_options["TraceFn"]
+            result = None
+            pypath = path.get_string_value()
+            definitions = evaluation.definitions
+            mathics.core.streams.PATH_VAR = SymbolPath.evaluate(evaluation).to_python(
+                string_quotes=False
+            )
+            try:
+                if trace_fn:
+                    trace_fn(pypath)
+                with MathicsOpen(pypath, "r") as f:
+                    feeder = MathicsFileLineFeeder(f, trace_fn)
+                    while not feeder.empty():
+                        try:
+                            query = parse(definitions, feeder)
+                        except TranslateError:
+                            return SymbolNull
+                        finally:
+                            feeder.send_messages(evaluation)
+                        if query is None:  # blank line / comment
+                            continue
+                        result = query.evaluate(evaluation)
+            except IOError:
+                evaluation.message("General", "noopen", path)
+                return SymbolFailed
+            except MessageException as e:
+                e.message(evaluation)
+                return SymbolFailed
             return result
 
-        py_options = check_options(options)
-        trace_fn = py_options["TraceFn"]
-        result = None
-        pypath = path.get_string_value()
+        # wrap actual evaluation to handle setting $Input
+        # and $InputFileName
+        global INPUT_VAR
         definitions = evaluation.definitions
-        mathics.core.streams.PATH_VAR = SymbolPath.evaluate(evaluation).to_python(
-            string_quotes=False
-        )
+        # store input paths of calling context
+        outer_input_var = INPUT_VAR
+        outer_inputfile = definitions.get_inputfile()
+        # set new input paths
+        pypath = path.get_string_value()
+        INPUT_VAR = pypath
+        definitions.set_inputfile(pypath)
+
+        # perform the actual evaluation
         try:
-            if trace_fn:
-                trace_fn(pypath)
-            with MathicsOpen(pypath, "r") as f:
-                feeder = MathicsFileLineFeeder(f, trace_fn)
-                while not feeder.empty():
-                    try:
-                        query = parse(definitions, feeder)
-                    except TranslateError:
-                        return SymbolNull
-                    finally:
-                        feeder.send_messages(evaluation)
-                    if query is None:  # blank line / comment
-                        continue
-                    result = query.evaluate(evaluation)
-        except IOError:
-            evaluation.message("General", "noopen", path)
-            return SymbolFailed
-        except MessageException as e:
-            e.message(evaluation)
-            return SymbolFailed
-        return result
+            return eval_inner(self, path, evaluation, options)
+        finally:
+            # always restore input paths of calling context
+            INPUT_VAR = outer_input_var
+            definitions.set_inputfile(outer_inputfile)
 
     def eval_default(self, filename, evaluation):
         "Get[filename_]"

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -264,7 +264,7 @@ class Definitions:
         self.clear_cache()
 
     def set_inputfile(self, dir) -> None:
-        self.inputfile = dir
+        self.inputfile = os.path.abspath(dir)
 
     def get_builtin_names(self):
         return set(self.builtin)

--- a/mathics/eval/files_io/files.py
+++ b/mathics/eval/files_io/files.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# cython: language_level=3
+
+"""
+files-related evaluation functions
+"""
+
+import os.path as osp
+
+from mathics_scanner import TranslateError
+
+import mathics
+from mathics.core.builtin import MessageException
+from mathics.core.evaluation import Evaluation
+from mathics.core.parser import MathicsFileLineFeeder, parse
+from mathics.core.read import MathicsOpen
+from mathics.core.symbols import Symbol, SymbolFullForm, SymbolNull, SymbolTrue
+from mathics.core.systemsymbols import (
+    SymbolFailed,
+    SymbolHold,
+    SymbolInputForm,
+    SymbolOutputForm,
+    SymbolReal,
+)
+
+SymbolPath = Symbol("$Path")
+
+
+# Reads a file and evaluates each expression, returning only the last one.
+def eval_Get_inner(self, path, evaluation: Evaluation, options: dict):
+    def check_options(options):
+        # Options
+        # TODO Proper error messages
+
+        result = {}
+        trace_get = evaluation.parse("Settings`$TraceGet")
+        if (
+            options["System`Trace"].to_python()
+            or trace_get.evaluate(evaluation) is SymbolTrue
+        ):
+            import builtins
+
+            result["TraceFn"] = builtins.print
+        else:
+            result["TraceFn"] = None
+
+        return result
+
+    py_options = check_options(options)
+    trace_fn = py_options["TraceFn"]
+    result = None
+    pypath = path.get_string_value()
+    definitions = evaluation.definitions
+    mathics.core.streams.PATH_VAR = SymbolPath.evaluate(evaluation).to_python(
+        string_quotes=False
+    )
+    try:
+        if trace_fn:
+            trace_fn(pypath)
+        with MathicsOpen(pypath, "r") as f:
+            feeder = MathicsFileLineFeeder(f, trace_fn)
+            while not feeder.empty():
+                try:
+                    query = parse(definitions, feeder)
+                except TranslateError:
+                    return SymbolNull
+                finally:
+                    feeder.send_messages(evaluation)
+                if query is None:  # blank line / comment
+                    continue
+                result = query.evaluate(evaluation)
+    except IOError:
+        evaluation.message("General", "noopen", path)
+        return SymbolFailed
+    except MessageException as e:
+        e.message(evaluation)
+        return SymbolFailed
+    return result

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 
 from mathics import __version__, license_string, settings, version_string
+from mathics.builtin.files_io.files import set_input_var
 from mathics.builtin.trace import TraceBuiltins, traced_do_replace
 from mathics.core.atoms import String
 from mathics.core.definitions import Definitions, Symbol, autoload_files
@@ -423,6 +424,7 @@ Please contribute to Mathics!""",
         definitions.set_line_no(0)
 
     if args.FILE is not None:
+        set_input_var(args.FILE.name)
         definitions.set_inputfile(args.FILE.name)
         feeder = MathicsFileLineFeeder(args.FILE)
         try:


### PR DESCRIPTION
Currently the global variables `$Input` and `$InputFileName` are not set correctly. This pull request fixes this.

### Description of the bug
#### Steps to reproduce
- Create a file `script.m` with contents  
```
Print["Input: ",$Input]
Print["InputFileName: ", $InputFileName]
```
- Within mathics execute: `Get["script.m"]`
- or call the script from the command line `mathics script.m`

#### Observed output on mathics as of commit 430b1f47840fa064a8e324f8f2b759fb1db1bef3
Using `Get` the global variables are not set at all.
```
In[1]:= Get["script.m"]
Script Input: 
Script InputFileName: 
Out[1]= None
```

From the command line `InputFileName` is set, but not the full path. `Input` is still unset.
```
Script Input: 
Script InputFileName: script.m
```

#### Expected output
```
In[1]:= Get["script.m"]                                                        
Input: script.m
InputFileName: /full/path/to/script.m
```

