### PR TITLE
Fix required test in doctests

### DIFF
--- a/mathics/doc/common_doc.py
+++ b/mathics/doc/common_doc.py
@@ -498,9 +498,9 @@ class DocSection:
         title: str,
         text: str,
         operator,
-        installed=True,
-        in_guide=False,
-        summary_text="",
+        installed: bool = True,
+        in_guide: bool = False,
+        summary_text: str = "",
     ):
         self.chapter = chapter
         self.in_guide = in_guide
@@ -537,6 +537,12 @@ class DocSection:
 
     def __str__(self) -> str:
         return f"    == {self.title} ==\n{self.doc}"
+
+    def get_tests(self):
+        """yield tests"""
+        if self.installed:
+            for test in self.doc.get_tests():
+                yield test
 
 
 # DocChapter has to appear before DocGuideSection which uses it.
@@ -781,7 +787,8 @@ class Documentation:
         "section_object" is either a Python module or a Class object instance.
         """
         if section_object is not None:
-            installed = check_requires_list(getattr(section_object, "requires", []))
+            required_libs = getattr(section_object, "requires", [])
+            installed = check_requires_list(required_libs) if required_libs else True
             # FIXME add an additional mechanism in the module
             # to allow a docstring and indicate it is not to go in the
             # user manual
@@ -823,22 +830,12 @@ class Documentation:
         operator=None,
         in_guide=False,
     ):
-        installed = check_requires_list(getattr(instance, "requires", []))
-
-        # FIXME add an additional mechanism in the module
-        # to allow a docstring and indicate it is not to go in the
-        # user manual
-
         """
         Append a subsection for ``instance`` into ``section.subsections``
         """
-        installed = True
-        for package in getattr(instance, "requires", []):
-            try:
-                importlib.import_module(package)
-            except ImportError:
-                installed = False
-                break
+
+        required_libs = getattr(instance, "requires", [])
+        installed = check_requires_list(required_libs) if required_libs else True
 
         # FIXME add an additional mechanism in the module
         # to allow a docstring and indicate it is not to go in the
@@ -1293,6 +1290,12 @@ class DocSubsection:
 
     def __str__(self) -> str:
         return f"=== {self.title} ===\n{self.doc}"
+
+    def get_tests(self):
+        """yield tests"""
+        if self.installed:
+            for test in self.doc.get_tests():
+                yield test
 
 
 class MathicsMainDocumentation(Documentation):

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# FIXME: combine with same thing in Django
+# FIXME: combine with same thing in Mathics Django
 """
 Does 2 things which can either be done independently or
 as a pipeline:
@@ -43,11 +43,6 @@ class TestOutput(Output):
 
 
 # Global variables
-definitions = None
-documentation = None
-check_partial_elapsed_time = False
-logfile = None
-
 
 # FIXME: After 3.8 is the minimum Python we can turn "str" into a Literal
 SEP: str = "-" * 70 + "\n"

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -302,7 +302,7 @@ def test_section_in_chapter(
                 continue
 
             DEFINITIONS.reset_user_definitions()
-            for test in subsection.doc.get_tests():
+            for test in subsection.get_tests():
                 # Get key dropping off test index number
                 key = list(test.key)[1:-1]
                 if prev_key != key:
@@ -365,7 +365,7 @@ def test_section_in_chapter(
     else:
         if include_subsections is None or section.title in include_subsections:
             DEFINITIONS.reset_user_definitions()
-            for test in section.doc.get_tests():
+            for test in section.get_tests():
                 # Get key dropping off test index number
                 key = list(test.key)[1:-1]
                 if prev_key != key:


### PR DESCRIPTION
After the last changes in the documentation system, `requires` was not taken into account in docpipeline. This PR fixes that.