### PR TITLE
`setup.py`: Build `op-tables.json` as part of "build_py"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [build-system]
 requires = [
     "setuptools>=61.2",
-    "cython>=0.15.1; implementation_name!='pypy'"
+    "cython>=0.15.1; implementation_name!='pypy'",
+    # For mathics-generate-json-table
+    "Mathics-Scanner >= 1.3.0",
 ]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "Mathics3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,46 +79,9 @@ mathics = "mathics.main:main"
 
 [tool.setuptools]
 include-package-data = false
-packages = [
-    "mathics",
-    "mathics.algorithm",
-    "mathics.compile",
-    "mathics.core",
-    "mathics.core.convert",
-    "mathics.core.parser",
-    "mathics.builtin",
-    "mathics.builtin.arithfns",
-    "mathics.builtin.assignments",
-    "mathics.builtin.atomic",
-    "mathics.builtin.binary",
-    "mathics.builtin.box",
-    "mathics.builtin.colors",
-    "mathics.builtin.distance",
-    "mathics.builtin.exp_structure",
-    "mathics.builtin.drawing",
-    "mathics.builtin.fileformats",
-    "mathics.builtin.files_io",
-    "mathics.builtin.forms",
-    "mathics.builtin.functional",
-    "mathics.builtin.image",
-    "mathics.builtin.intfns",
-    "mathics.builtin.list",
-    "mathics.builtin.matrices",
-    "mathics.builtin.numbers",
-    "mathics.builtin.numpy_utils",
-    "mathics.builtin.pymimesniffer",
-    "mathics.builtin.pympler",
-    "mathics.builtin.quantum_mechanics",
-    "mathics.builtin.scipy_utils",
-    "mathics.builtin.specialfns",
-    "mathics.builtin.statistics",
-    "mathics.builtin.string",
-    "mathics.builtin.testing_expressions",
-    "mathics.builtin.vectors",
-    "mathics.eval",
-    "mathics.doc",
-    "mathics.format",
-]
+
+[tool.setuptools.packages.find]
+include = ["mathics*"]
 
 [tool.setuptools.package-data]
 "mathics" = [

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ import platform
 import sys
 
 from setuptools import Extension, setup
+from setuptools.command.build_py import build_py as setuptools_build_py
 
 log = logging.getLogger(__name__)
 
@@ -95,6 +96,24 @@ else:
         #     for module in modules
         # )
         CMDCLASS = {"build_ext": build_ext}
+
+
+class build_py(setuptools_build_py):
+    def run(self):
+        os.system(
+            "mathics-generate-json-table"
+            " --field=ascii-operator-to-symbol"
+            " --field=ascii-operator-to-unicode"
+            " --field=ascii-operator-to-wl-unicode"
+            " --field=operator-to-ascii"
+            " --field=operator-to-unicode"
+            " -o mathics/data/op-tables.json"
+        )
+        self.distribution.package_data["mathics"].append("data/op-tables.json")
+        setuptools_build_py.run(self)
+
+
+CMDCLASS["build_py"] = build_py
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -100,15 +100,16 @@ else:
 
 class build_py(setuptools_build_py):
     def run(self):
-        os.system(
-            "mathics-generate-json-table"
-            " --field=ascii-operator-to-symbol"
-            " --field=ascii-operator-to-unicode"
-            " --field=ascii-operator-to-wl-unicode"
-            " --field=operator-to-ascii"
-            " --field=operator-to-unicode"
-            " -o mathics/data/op-tables.json"
-        )
+        if not os.path.exists("mathics/data/op-tables.json"):
+            os.system(
+                "mathics-generate-json-table"
+                " --field=ascii-operator-to-symbol"
+                " --field=ascii-operator-to-unicode"
+                " --field=ascii-operator-to-wl-unicode"
+                " --field=operator-to-ascii"
+                " --field=operator-to-unicode"
+                " -o mathics/data/op-tables.json"
+            )
         self.distribution.package_data["mathics"].append("data/op-tables.json")
         setuptools_build_py.run(self)
 


### PR DESCRIPTION
This makes it possible to install mathics directly from the repo, using `pip install git+https://github.com/Mathics3/mathics-core`

Also updating the definition of the Python packages in `pyproject.toml`.