### PR TITLE
Fixing single \Mathics in docstrings

### DIFF
--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -7,7 +7,7 @@ While a definition like 'cube[$x_$] = $x$^3' gives a way to specify \
 specify general properties of functions and symbols. This is \
 independent of the parameters they take and the values they produce.
 
-The builtin-attributes having a predefined meaning in \Mathics which \
+The builtin-attributes having a predefined meaning in \\Mathics which \
 are described below.
 
 However in contrast to \Mathematica, you can set any symbol as an attribute.

--- a/mathics/builtin/attributes.py
+++ b/mathics/builtin/attributes.py
@@ -10,7 +10,7 @@ independent of the parameters they take and the values they produce.
 The builtin-attributes having a predefined meaning in \\Mathics which \
 are described below.
 
-However in contrast to \Mathematica, you can set any symbol as an attribute.
+However in contrast to \\Mathematica, you can set any symbol as an attribute.
 """
 
 # This tells documentation how to sort this module

--- a/mathics/builtin/box/__init__.py
+++ b/mathics/builtin/box/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Boxing modules.
 
 Boxes are added in formatting \Mathics Expressions.

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -3,7 +3,7 @@
 """
 Importing and Exporting
 
-Many kinds data formats can be read into \Mathics. Variable <url>
+Many kinds data formats can be read into \\Mathics. Variable <url>
 :$ExportFormats:
 /doc/reference-of-built-in-symbols/inputoutput-files-and-filesystem/importing-and-exporting/$exportformats</url> \
 contains a list of file formats that are supported by <url>

--- a/mathics/builtin/vectors/__init__.py
+++ b/mathics/builtin/vectors/__init__.py
@@ -8,7 +8,7 @@ row or column of a matrix.
 In computer science, it is an array data structure consisting of collection \
 of elements identified by at least on array index or key.
 
-In \Mathics vectors as are Lists. One never needs to distinguish between row \
+In \\Mathics vectors as are Lists. One never needs to distinguish between row \
 and column vectors. As with other objects vectors can mix number and symbolic elements.
 
 Vectors can be long, dense, or sparse.


### PR DESCRIPTION
This PR fixes some possible misunderstood escaped characters, which now produce a warning.