### PR TITLE
sympy  1.13 compatibility

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -507,7 +507,7 @@ class DirectedInfinity(SympyFunction):
                 else:
                     normalized_direction = direction / Abs(direction)
             elif isinstance(ndir, Complex):
-                re, im = ndir.value
+                re, im = ndir.real, ndir.imag
                 if abs(re.value**2 + im.value**2 - 1.0) < 1.0e-9:
                     normalized_direction = direction
                 else:

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -581,13 +581,13 @@ class PrimePi(SympyFunction):
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
     mpmath_name = "primepi"
     summary_text = "amount of prime numbers less than or equal"
-    sympy_name = "ntheory.primepi"
+    sympy_name = "primepi"
 
     # TODO: Traditional Form
 
     def eval(self, n, evaluation: Evaluation):
         "PrimePi[n_?NumericQ]"
-        result = sympy.ntheory.primepi(eval_N(n, evaluation).to_python())
+        result = sympy.primepi(eval_N(n, evaluation).to_python())
         return Integer(result)
 
 

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -719,10 +719,17 @@ class Complex(Number):
 
         if isinstance(real, MachineReal) and not isinstance(imag, MachineReal):
             imag = imag.round()
-        if isinstance(imag, MachineReal) and not isinstance(real, MachineReal):
+            prec = FP_MANTISA_BINARY_DIGITS
+        elif isinstance(imag, MachineReal) and not isinstance(real, MachineReal):
             real = real.round()
+            prec = FP_MANTISA_BINARY_DIGITS
+        else:
+            prec = min(
+                (u for u in (x.get_precision() for x in (real, imag)) if u is not None),
+                default=None,
+            )
 
-        value = (real, imag)
+        value = (real, imag, prec)
         self = cls._complex_numbers.get(value)
         if self is None:
             self = super().__new__(cls)
@@ -732,7 +739,7 @@ class Complex(Number):
             self._value = value
 
             # Cache object so we don't allocate again.
-            # self._complex_numbers[value] = self
+            self._complex_numbers[value] = self
 
             # Set a value for self.__hash__() once so that every time
             # it is used this is fast. Note that in contrast to the

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -732,7 +732,7 @@ class Complex(Number):
             self._value = value
 
             # Cache object so we don't allocate again.
-            self._complex_numbers[value] = self
+            # self._complex_numbers[value] = self
 
             # Set a value for self.__hash__() once so that every time
             # it is used this is fast. Note that in contrast to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "python-dateutil",
     "requests",
     "setuptools",
-    "sympy==1.11",
+    "sympy>=1.8",
 ]
 requires-python = ">=3.7"
 readme = "README.rst"


### PR DESCRIPTION
And here we have a partial compatibility patch. The root of the issues seems to be the change in which comparisons between `sympy.Float` and `float` are done from sympy 1.13.
It breaks several things, including the cache mechanism for complex numbers. This draft makes it works by disabling the cache.