### PR TITLE
Minimum Python version supported is 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "setuptools",
     "sympy>=1.8",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 readme = "README.rst"
 license = {text = "GPL"}
 keywords = ["Mathematica", "Wolfram", "Interpreter", "Shell", "Math", "CAS"]


### PR DESCRIPTION
MathicsScanner currently supports 3.8 or greater in order to support Sympy 1.11. And MathicsScanner is a prerequiste of this package.