### PR TITLE
Disallow using older setuptools...

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.2",
+    "setuptools>=70.0.0", # CVE-2024-38335 recommends this
     "cython>=0.15.1; implementation_name!='pypy'",
     # For mathics-generate-json-table
     "Mathics-Scanner >= 1.3.0",
@@ -24,9 +24,9 @@ dependencies = [
     "python-dateutil",
     "requests",
     "setuptools",
-    "sympy>=1.8",
+    "sympy>=1.11,<1.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.8" # Sympy 1.11 is supported only down to 3.8
 readme = "README.rst"
 license = {text = "GPL"}
 keywords = ["Mathematica", "Wolfram", "Interpreter", "Shell", "Math", "CAS"]
@@ -38,7 +38,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
which is reported to be highly vulnerable.
Make Python 3.8 be the minimum-allowed Python since sympy 1.11 needs at least 3.8.