### PR TITLE
Go over number format boxing

### DIFF
--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from mathics.builtin.box.layout import GridBox, RowBox, to_boxes
 from mathics.builtin.forms.base import FormBaseClass
-from mathics.builtin.makeboxes import MakeBoxes, number_form
+from mathics.builtin.makeboxes import MakeBoxes, NumberForm_to_String
 from mathics.builtin.tensors import get_dimensions
 from mathics.core.atoms import (
     Integer,
@@ -481,7 +481,7 @@ class NumberForm(_NumberForm):
 
         if py_n is not None:
             py_options["_Form"] = form.get_name()
-            return number_form(expr, py_n, None, evaluation, py_options)
+            return NumberForm_to_String(expr, py_n, None, evaluation, py_options)
         return Expression(SymbolMakeBoxes, expr, form)
 
     def eval_makeboxes_n(self, expr, n, form, evaluation, options={}):
@@ -501,7 +501,7 @@ class NumberForm(_NumberForm):
 
         if isinstance(expr, (Integer, Real)):
             py_options["_Form"] = form.get_name()
-            return number_form(expr, py_n, None, evaluation, py_options)
+            return NumberForm_to_String(expr, py_n, None, evaluation, py_options)
         return Expression(SymbolMakeBoxes, expr, form)
 
     def eval_makeboxes_nf(self, expr, n, f, form, evaluation, options={}):
@@ -523,7 +523,7 @@ class NumberForm(_NumberForm):
 
         if isinstance(expr, (Integer, Real)):
             py_options["_Form"] = form.get_name()
-            return number_form(expr, py_n, py_f, evaluation, py_options)
+            return NumberForm_to_String(expr, py_n, py_f, evaluation, py_options)
         return Expression(SymbolMakeBoxes, expr, form)
 
 

--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -376,6 +376,10 @@ class _NumberForm(Builtin):
 
 class NumberForm(_NumberForm):
     """
+    <url>
+      :WMA link:
+      https://reference.wolfram.com/language/ref/NumberForm.html</url>
+
     <dl>
       <dt>'NumberForm[$expr$, $n$]'
       <dd>prints a real number $expr$ with $n$-digits of precision.
@@ -387,8 +391,12 @@ class NumberForm(_NumberForm):
     >> NumberForm[N[Pi], 10]
      = 3.141592654
 
-    >> NumberForm[N[Pi], {10, 5}]
+    >> NumberForm[N[Pi], {10, 6}]
+     = 3.141593
+
+    >> NumberForm[N[Pi]]
      = 3.14159
+
     """
 
     options = {

--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -10,7 +10,7 @@
 # than applicable to all kinds of expressions.
 
 """
-Forms which appear in '$OutputForms'.
+Form Functions
 """
 import re
 from math import ceil

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -111,7 +111,7 @@ def real_to_tuple_info(real: Real, digits: Optional[int]) -> Tuple[str, int, boo
         else:
             assert value >= 0
             is_nonnegative = True
-        # Set exponent. ``exponent`` is actual, ``pexp`` of ``number_form()`` is printed.
+        # Set exponent. ``exponent`` is actual, ``pexp`` of ``NumberForm_to_string()`` is printed.
         if "e" in s:
             s, exponent = s.split("e")
             exponent = int(exponent)
@@ -136,8 +136,9 @@ def real_to_tuple_info(real: Real, digits: Optional[int]) -> Tuple[str, int, boo
     return s, exponent, is_nonnegative
 
 
-# FIXME the return type should be a NumberForm, not a String.
-def number_form(
+# FIXME: the return type should be a NumberForm, not a String.
+# when this is fixed, rename the function.
+def NumberForm_to_String(
     value: Union[Real, Integer],
     digits: Optional[int],
     digits_after_decimal_point: Optional[int],
@@ -145,9 +146,7 @@ def number_form(
     options: dict,
 ) -> String:
     """
-    Converts a Real or Integer value to a String.  FIXME: the
-    return type is currently a String here, but it in WMA I think the
-    corresponding code would return a NumberForm type.
+    Converts a Real or Integer value to a String.
 
     ``digits`` is the number of digits of precision and
     ``digits_after_decimal_point`` is the number of digits after the

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-Low level Format definitions
+Low-level Format definitions
 """
 
-from typing import Union
+from typing import Optional, Tuple, Union
 
 import mpmath
 
@@ -27,16 +27,22 @@ from mathics.eval.makeboxes import (
 )
 
 
-def int_to_s_exp(expr, n):
-    n = expr.get_int_value()
-    if n < 0:
-        nonnegative = 0
-        s = str(-n)
+def int_to_tuple_info(integer: Integer) -> Tuple[str, int, bool]:
+    """
+    Convert ``integer`` to a tuple representing that value. The tuple consists of:
+    * the string absolute value of ``integer``.
+    * the exponent, base 10, to be used, and
+    * True if the value is nonnegative or False otherwise.
+    """
+    value = integer.value
+    if value < 0:
+        is_nonnegative = False
+        value = -value
     else:
-        nonnegative = 1
-        s = str(n)
-    exp = len(s) - 1
-    return s, exp, nonnegative
+        is_nonnegative = True
+    s = str(value)
+    exponent = len(s) - 1
+    return s, exponent, is_nonnegative
 
 
 # FIXME: op should be a string, so remove the Union.
@@ -65,94 +71,119 @@ def make_boxes_infix(
     return Expression(SymbolRowBox, ListExpression(*result))
 
 
-def real_to_s_exp(expr, n):
-    if expr.is_zero:
+def real_to_tuple_info(real: Real, digits: Optional[int]) -> Tuple[str, int, bool]:
+    """
+    Convert ``real`` to a tuple representing that value. The tuple consists of:
+    * the string absolute value of ``integer`` with decimal point removed from the string;
+      the position of the decimal point is determined by the exponent below,
+    * the exponent, base 10, to be used, and
+    * True if the value is nonnegative or False otherwise.
+
+    If ``digits`` is None, we use the default precision.
+    """
+    if real.is_zero:
         s = "0"
-        if expr.is_machine_precision():
-            exp = 0
+        if real.is_machine_precision():
+            exponent = 0
         else:
-            p = expr.get_precision()
-            exp = -dps(p)
-        nonnegative = 1
+            p = real.get_precision()
+            exponent = -dps(p)
+        is_nonnegative = True
     else:
-        if n is None:
-            if expr.is_machine_precision():
-                value = expr.get_float_value()
+        if digits is None:
+            if real.is_machine_precision():
+                value = real.value
                 s = repr(value)
             else:
-                with mpmath.workprec(expr.get_precision()):
-                    value = expr.to_mpmath()
-                    s = mpmath.nstr(value, dps(expr.get_precision()) + 1)
+                with mpmath.workprec(real.get_precision()):
+                    value = real.to_mpmath()
+                    s = mpmath.nstr(value, dps(real.get_precision()) + 1)
         else:
-            with mpmath.workprec(expr.get_precision()):
-                value = expr.to_mpmath()
-                s = mpmath.nstr(value, n)
+            with mpmath.workprec(real.get_precision()):
+                value = real.to_mpmath()
+                s = mpmath.nstr(value, digits)
 
-        # sign prefix
+        # Set sign prefix.
         if s[0] == "-":
             assert value < 0
-            nonnegative = 0
+            is_nonnegative = False
             s = s[1:]
         else:
             assert value >= 0
-            nonnegative = 1
-        # exponent (exp is actual, pexp is printed)
+            is_nonnegative = True
+        # Set exponent. ``exponent`` is actual, ``pexp`` of ``number_form()`` is printed.
         if "e" in s:
-            s, exp = s.split("e")
-            exp = int(exp)
+            s, exponent = s.split("e")
+            exponent = int(exponent)
             if len(s) > 1 and s[1] == ".":
                 # str(float) doesn't always include '.' if 'e' is present.
                 s = s[0] + s[2:].rstrip("0")
         else:
-            exp = s.index(".") - 1
-            s = s[: exp + 1] + s[exp + 2 :].rstrip("0")
+            exponent = s.index(".") - 1
+            s = s[: exponent + 1] + s[exponent + 2 :].rstrip("0")
 
-            # consume leading '0's.
+            # Normalize exponent: remove leading '0's after the decimal point
+            # and adjust the exponent accordingly.
             i = 0
-            while s[i] == "0":
+            while i < len(s) and s[i] == "0":
                 i += 1
-                exp -= 1
+                exponent -= 1
             s = s[i:]
 
-        # add trailing zeros for precision reals
-        if n is not None and not expr.is_machine_precision() and len(s) < n:
-            s = s + "0" * (n - len(s))
-    return s, exp, nonnegative
+        # Add trailing zeros for precision reals.
+        if digits is not None and not real.is_machine_precision() and len(s) < digits:
+            s = s + "0" * (digits - len(s))
+    return s, exponent, is_nonnegative
 
 
-def number_form(expr, n, f, evaluation: Evaluation, options: dict):
+# FIXME the return type should be a NumberForm, not a String.
+def number_form(
+    value: Union[Real, Integer],
+    digits: Optional[int],
+    digits_after_decimal_point: Optional[int],
+    evaluation: Evaluation,
+    options: dict,
+) -> String:
     """
-    Converts a Real or Integer instance to Boxes.
+    Converts a Real or Integer value to a String. FIXME: the return should be a Numberform.
 
-    n digits of precision with f (can be None) digits after the decimal point.
-    evaluation (can be None) is used for messages.
+    ``digits`` is the number of digits of precision and
+    ``digits_after_decimal_point`` is the number of digits after the
+    decimal point.  ``evaluation`` is used for messages.
 
-    The allowed options are python versions of the options permitted to
+    The allowed options are Python versions of the options permitted to
     NumberForm and must be supplied. See NumberForm or Real.make_boxes
     for correct option examples.
+
+    If ``digits`` is None, use the default precision.  If
+    ``digits_after_decimal_points`` is None, use all the digits we get
+    from the converted number, that is, otherwise the number may be
+    padded on the right-hand side with zeros.
     """
 
-    assert isinstance(n, int) and n > 0 or n is None
-    assert f is None or (isinstance(f, int) and f >= 0)
+    assert isinstance(digits, int) and digits > 0 or digits is None
+    assert digits_after_decimal_point is None or (
+        isinstance(digits_after_decimal_point, int) and digits_after_decimal_point >= 0
+    )
 
     is_int = False
-    if isinstance(expr, Integer):
-        assert n is not None
-        s, exp, nonnegative = int_to_s_exp(expr, n)
-        if f is None:
+    if isinstance(value, Integer):
+        assert digits is not None
+        s, exp, is_nonnegative = int_to_tuple_info(value)
+        if digits_after_decimal_point is None:
             is_int = True
-    elif isinstance(expr, Real):
-        if n is not None:
-            n = min(n, dps(expr.get_precision()) + 1)
-        s, exp, nonnegative = real_to_s_exp(expr, n)
-        if n is None:
-            n = len(s)
+    elif isinstance(value, Real):
+        if digits is not None:
+            digits = min(digits, dps(value.get_precision()) + 1)
+        s, exp, is_nonnegative = real_to_tuple_info(value, digits)
+        if digits is None:
+            digits = len(s)
     else:
         raise ValueError("Expected Real or Integer.")
 
-    assert isinstance(n, int) and n > 0
+    assert isinstance(digits, int) and digits > 0
 
-    sign_prefix = options["NumberSigns"][nonnegative]
+    sign_prefix = options["NumberSigns"][1 if is_nonnegative else 0]
 
     # round exponent to ExponentStep
     rexp = (exp // options["ExponentStep"]) * options["ExponentStep"]
@@ -197,14 +228,18 @@ def number_form(expr, n, f, evaluation: Evaluation, options: dict):
         return number
 
     # pad with NumberPadding
-    if f is not None:
-        if len(right) < f:
+    if digits_after_decimal_point is not None:
+        if len(right) < digits_after_decimal_point:
             # pad right
-            right = right + (f - len(right)) * options["NumberPadding"][1]
-        elif len(right) > f:
+            right = (
+                right
+                + (digits_after_decimal_point - len(right))
+                * options["NumberPadding"][1]
+            )
+        elif len(right) > digits_after_decimal_point:
             # round right
             tmp = int(left + right)
-            tmp = _round(tmp, f - len(right))
+            tmp = _round(tmp, digits_after_decimal_point - len(right))
             tmp = str(tmp)
             left, right = tmp[: exp + 1], tmp[exp + 1 :]
 
@@ -226,8 +261,8 @@ def number_form(expr, n, f, evaluation: Evaluation, options: dict):
     left_padding = 0
     max_sign_len = max(len(options["NumberSigns"][0]), len(options["NumberSigns"][1]))
     i = len(sign_prefix) + len(left) + len(right) - max_sign_len
-    if i < n:
-        left_padding = n - i
+    if i < digits:
+        left_padding = digits - i
     elif len(sign_prefix) < max_sign_len:
         left_padding = max_sign_len - len(sign_prefix)
     left_padding = left_padding * options["NumberPadding"][0]

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -145,7 +145,9 @@ def number_form(
     options: dict,
 ) -> String:
     """
-    Converts a Real or Integer value to a String. FIXME: the return should be a Numberform.
+    Converts a Real or Integer value to a String.  FIXME: the
+    return type is currently a String here, but it in WMA I think the
+    corresponding code would return a NumberForm type.
 
     ``digits`` is the number of digits of precision and
     ``digits_after_decimal_point`` is the number of digits after the

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -446,14 +446,14 @@ class MachineReal(Real):
         return True
 
     def make_boxes(self, form):
-        from mathics.builtin.makeboxes import number_form
+        from mathics.builtin.makeboxes import NumberForm_to_String
 
         _number_form_options["_Form"] = form  # passed to _NumberFormat
         if form in ("System`InputForm", "System`FullForm"):
             n = None
         else:
             n = 6
-        return number_form(self, n, None, None, _number_form_options)
+        return NumberForm_to_String(self, n, None, None, _number_form_options)
 
     @property
     def is_zero(self) -> bool:
@@ -555,10 +555,10 @@ class PrecisionReal(Real):
         return self.value.is_zero
 
     def make_boxes(self, form):
-        from mathics.builtin.makeboxes import number_form
+        from mathics.builtin.makeboxes import NumberForm_to_String
 
         _number_form_options["_Form"] = form  # passed to _NumberFormat
-        return number_form(
+        return NumberForm_to_String(
             self, dps(self.get_precision()), None, None, _number_form_options
         )
 

--- a/test/builtin/test_makeboxes.py
+++ b/test/builtin/test_makeboxes.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-from test.helper import check_evaluation, session
+from test.helper import check_evaluation
 
 import pytest
-from mathics_scanner.errors import IncompleteSyntaxError
 
 # To check the progress in the improvement of formatting routines, set this variable to 1.
 # Otherwise, the tests are going to be skipped.

--- a/test/builtin/test_number_form.py
+++ b/test/builtin/test_number_form.py
@@ -1,0 +1,49 @@
+import pytest
+import sympy
+
+from mathics.builtin.makeboxes import int_to_tuple_info, real_to_tuple_info
+from mathics.core.atoms import Integer, Integer0, Integer1, IntegerM1, Real
+
+# from packaging.version import Version
+
+
+@pytest.mark.parametrize(
+    ("integer", "expected", "exponent", "is_nonnegative"),
+    [
+        (Integer0, "0", 0, True),
+        (Integer1, "1", 0, True),
+        (IntegerM1, "1", 0, False),
+        (Integer(999), "999", 2, True),
+        (Integer(1000), "1000", 3, True),
+        (Integer(-9999), "9999", 3, False),
+        (Integer(-10000), "10000", 4, False),
+    ],
+)
+def test_int_to_tuple_info(
+    integer: Integer, expected: str, exponent: int, is_nonnegative: bool
+):
+    assert int_to_tuple_info(integer) == (expected, exponent, is_nonnegative)
+
+
+@pytest.mark.parametrize(
+    ("real", "digits", "expected", "exponent", "is_nonnegative"),
+    [
+        # Using older uncorrected version of Real()
+        # (
+        #     (Real(sympy.Float(0.0, 10)), 10, "0", -10, True)
+        #     if Version(sympy.__version__) < Version("1.13.0")
+        #     else (Real(sympy.Float(0.0, 10)), 10, "0000000000", -1, True)
+        # ),
+        (Real(sympy.Float(0.0, 10)), 10, "0", -10, True),
+        (Real(0), 1, "0", 0, True),
+        (Real(0), 2, "0", 0, True),
+        (Real(0.1), 2, "1", -1, True),
+        (Real(0.12), 2, "12", -1, True),
+        (Real(-0.12), 2, "12", -1, False),
+        (Real(3.141593), 10, "3141593", 0, True),
+    ],
+)
+def test_real_to_tuple_info(
+    real: Real, digits: int, expected: str, exponent: int, is_nonnegative: bool
+):
+    assert real_to_tuple_info(real, digits) == (expected, exponent, is_nonnegative)


### PR DESCRIPTION
pyproject.toml: we don't support sympy 1.13.1 just yet
makeboxes.py: Add annotations, docstrings and remove ambiguity
test_number_for.py: test changed routines
output.py: More NumberForm docstring examples