### PR TITLE
adding margins inside the definition block in latex documentation

### DIFF
--- a/mathics/doc/latex/mathics.tex
+++ b/mathics/doc/latex/mathics.tex
@@ -118,13 +118,13 @@
 
 	\vspace{0.5em}%
 	\begin{lrbox}{\@tempboxa}
-          \hspace*{2em}
+          \hspace*{1em}
           \begin{minipage}{0.95\columnwidth}%
 	\nobreak\vspace{0.6em}%
 }{%
 	\nobreak%
 	\vspace{0.6em}%
-      \end{minipage}\hspace*{2em}
+      \end{minipage}\hspace*{1em}
        \end{lrbox}
 	\colorbox{definitions}{\usebox{\@tempboxa}}
 	\vspace{1em}%

--- a/mathics/doc/latex/mathics.tex
+++ b/mathics/doc/latex/mathics.tex
@@ -119,7 +119,7 @@
 	\vspace{0.5em}%
 	\begin{lrbox}{\@tempboxa}
           \hspace*{1em}
-          \begin{minipage}{0.95\columnwidth}%
+          \begin{minipage}{0.9\columnwidth}%
 	\nobreak\vspace{0.6em}%
 }{%
 	\nobreak%

--- a/mathics/doc/latex/mathics.tex
+++ b/mathics/doc/latex/mathics.tex
@@ -117,12 +117,15 @@
 \makeatletter\newenvironment{definitions}{
 
 	\vspace{0.5em}%
-	\begin{lrbox}{\@tempboxa}\begin{minipage}{0.95\columnwidth}%
-	\nobreak\vspace{0.3em}%
+	\begin{lrbox}{\@tempboxa}
+          \hspace*{2em}
+          \begin{minipage}{0.95\columnwidth}%
+	\nobreak\vspace{0.6em}%
 }{%
 	\nobreak%
-	\vspace{0.3em}%
-	\end{minipage}\end{lrbox}
+	\vspace{0.6em}%
+      \end{minipage}\hspace*{2em}
+       \end{lrbox}
 	\colorbox{definitions}{\usebox{\@tempboxa}}
 	\vspace{1em}%
 }\makeatother


### PR DESCRIPTION
This PR adjusts the margins inside the Definition block in the PDF documentation. As a result this:

![imagen](https://github.com/user-attachments/assets/f708e1fc-ce4d-46c7-9daa-de5419813f7a)


looks now like this:
![imagen](https://github.com/user-attachments/assets/1480c4cd-b409-486a-ac61-a388c16cd580)
