### PR TITLE
Misc doctest and pytrest fixes

### DIFF
--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -161,10 +161,6 @@ class TestStatus:
         self.prev_key = []
         self.quiet = quiet
 
-    def find_texdata_folder(self):
-        """Generate a folder for texdata"""
-        return self.textdatafolder
-
     def mark_as_failed(self, key):
         """Mark a key as failed"""
         self.failed_sections.add(key)
@@ -200,7 +196,7 @@ class TestStatus:
 def test_case(
     test: DocTest,
     test_pipeline: DocTestPipeline,
-    fail: Optional[Callable] = lambda x: False,
+    fail: Callable,
 ) -> bool:
     """
     Run a single test cases ``test``. Return True if test succeeds and False if it
@@ -735,7 +731,7 @@ def save_doctest_data(doctest_pipeline: DocTestPipeline):
     i = 0
     for key in output_data:
         i = i + 1
-        doctest_pipeline.print_and_log("{key}, {output_data[key]}")
+        doctest_pipeline.print_and_log(f"{key}, {output_data[key]}")
         if i > 9:
             break
     with open(doctest_latex_data_path, "wb") as output_file:
@@ -913,6 +909,7 @@ def main():
     test_pipeline = DocTestPipeline(args, output_format="latex", data_path=data_path)
     test_status = test_pipeline.status
 
+    start_time = None
     if args.sections:
         include_sections = set(args.sections.split(","))
         exclude_subsections = set(args.exclude.split(","))

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -674,7 +674,7 @@ def show_report(test_pipeline):
             test_pipeline.print_and_log(f"  - {section} in {part} / {chapter}")
 
     if test_parameters.data_path is not None and (
-        test_status.failed == 0 or test_parameters.doc_even_if_error
+        test_status.failed == 0 or test_parameters.keep_going
     ):
         save_doctest_data(test_pipeline)
         return

--- a/test/builtin/files_io/test_importexport.py
+++ b/test/builtin/files_io/test_importexport.py
@@ -220,8 +220,6 @@ if not (os.environ.get("CI", False) or sys.platform in ("win32",)):
             "$Failed",
             None,
         ),
-        ## Empty elems
-        ('Export["123.txt", 1+x, {}]', None, "123.txt", None),
         ## FORMATS
         ## ASCII text
         ('FileFormat["ExampleData/BloodToilTearsSweat.txt"]', None, "Text", None),
@@ -259,12 +257,20 @@ def test_inividually():
     # Test Export where we cannot infer the export type from the file extension;
     # here it is: ".jcp".
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jcp") as tmp:
-        filename = osp.join(tmp.name, "123.jcp")
+        filename = tmp.name
         expr = f'Export["{filename}", 1+x,' + "{}]"
         result = evaluate(expr)
         outs = [out.text for out in session.evaluation.out]
         assert result == SymbolFailed
         assert outs == [f"Cannot infer format of file {filename}."]
+
+    # Check that exporting with an empty list of elements is okay.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt") as tmp:
+        filename = tmp.name
+        expr = f'Export["{filename}", 1+x' + "{}]"
+        result = evaluate(expr)
+        outs = [out.text for out in session.evaluation.out]
+        assert outs == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix some doctest and pytest bugs...

test.parameters.{doc_even_if_error,keep_going}:
*  `doc_even_if_error` is not defined; `keep_going is`.

mathics/docpipeline.py:
*  remove find_texdata_folder(): it is not used and it also refers to a nonexistent class element

*   `test_case(... fail: Optional[]...= ...)` allows an explicit None to be passed. `None` was not tested for in using ` fail()`. Make parameter not optional

* call to doctest_pripile.print_and_log missing f-string specifier.  Not sure why we need the for loop.
* start_time needs to be initialized

test/builtin/files_io/test_importexport.py:
 * test was pollutes local file system with `123.txt`. Ideally *None* of the tests would work in the local filesystem; a _temporary_ file system is okay though.
