### PR TITLE
Fix one more test that pollutes the filesystem

### DIFF
--- a/test/builtin/files_io/test_files.py
+++ b/test/builtin/files_io/test_files.py
@@ -169,6 +169,12 @@ def test_close():
             "Close[{OutputStream, MathicsNonExampleFile}]",
             "",
         ),
+        (
+            "Delete[MathicsNonExampleFile]",
+            None,
+            "Delete[MathicsNonExampleFile]",
+            "",
+        ),
         ## writing to dir
         ("x >>> /var/", ("Cannot open /var/.",), "x >>> /var/", ""),
         ## writing to read only file


### PR DESCRIPTION
Ideally, we should be setting $InitialDirectory to $TempoarayDirectory as well. We should not be writing into $InitialDirectory which is not guaranteed to be writable.