### PR TITLE
Change dl margin space to match vspace length

### DIFF
--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -25,7 +25,7 @@ mathics.pdf: mathics.tex documentation.tex logo-text-nodrop.pdf logo-heptatom.pd
 
 #: File containing version information
 version-info.tex: doc2latex.py
-	$(PYTHON) doc2latex.py $(MATHICS3_MODULE_OPTION )&& $(BASH) ./sed-hack.sh
+	$(PYTHON) doc2latex.py $(MATHICS3_MODULE_OPTION) && $(BASH) ./sed-hack.sh
 
 #: Build test PDF
 mathics-test.pdf: mathics-test.tex testing.tex

--- a/mathics/doc/latex/mathics.tex
+++ b/mathics/doc/latex/mathics.tex
@@ -117,7 +117,7 @@
 
 	\vspace{0.5em}%
 	\begin{lrbox}{\@tempboxa}
-          \hspace*{1em}
+          \hspace*{0.6em}
           \begin{minipage}{0.9\columnwidth}%
 	\nobreak\vspace{0.6em}%
 }{%
@@ -126,7 +126,7 @@
       \end{minipage}\hspace*{1em}
        \end{lrbox}
 	\colorbox{definitions}{\usebox{\@tempboxa}}
-	\vspace{1em}%
+	\vspace{0.6em}%
 }\makeatother
 
 \newcommand{\dt}[1]{#1%


### PR DESCRIPTION
Looking at the grey margin space around definition lists, it is still a little too large. 0.6em matches the vspace.

Somewhere I read a design principle that one should try reduce the overall number of different kinds of spacing.