### PR TITLE
Remove "sympy_name" in from_sympy() calls:

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -10,7 +10,7 @@ arithmetic operations.
 """
 
 from itertools import product
-from typing import Optional
+from typing import Iterable, Optional
 
 import numpy as np
 import sympy
@@ -442,7 +442,7 @@ class Derivative(PostfixOperator, SympyFunction):
                       The idea of the test is to set `Derivative[n][f]` to `nothing`. Then, the derivative is
                       evaluated. If it is not possible to find an explicit expression for the derivative,
                       then their occurencies are replaced by `nothing`. Therefore, if the resulting expression
-                      if free of `nothing`, then we can use the result. Otherwise, the rule does not work. 
+                      if free of `nothing`, then we can use the result. Otherwise, the rule does not work.
 
                       Differently from `True` and  `False`, `List` does not produce an infinite recurrence,
                       but since is a protected symbol, the following test produces error messages.
@@ -1042,7 +1042,7 @@ class Integrate(SympyFunction):
                 return [elements[0]] + x.elements
         return elements
 
-    def from_sympy(self, sympy_name, elements):
+    def from_sympy(self, elements: Iterable) -> Expression:
         args = []
         for element in elements[1:]:
             if element.has_form("List", 1):

--- a/mathics/builtin/numbers/exp.py
+++ b/mathics/builtin/numbers/exp.py
@@ -11,6 +11,7 @@ import math
 from collections import namedtuple
 from contextlib import contextmanager
 from itertools import chain
+from typing import Iterable
 
 import mpmath
 
@@ -184,7 +185,7 @@ class Exp(MPMathFunction):
     }
     summary_text = "exponential function"
 
-    def from_sympy(self, sympy_name, elements):
+    def from_sympy(self, elements: Iterable) -> Expression:
         return Expression(SymbolPower, SymbolE, elements[0])
 
 

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -1,7 +1,9 @@
 """
 Gamma and Related Functions
 """
+
 import sys
+from typing import Iterable
 
 import mpmath
 import sympy
@@ -326,8 +328,8 @@ class Gamma(MPMathMultiFunction):
     def get_sympy_names(self):
         return ["gamma", "uppergamma", "lowergamma"]
 
-    def from_sympy(self, sympy_name, elements):
-        if sympy_name == "lowergamma":
+    def from_sympy(self, elements: Iterable) -> Expression:
+        if self.sympy_name == "lowergamma":
             # lowergamma(z, x) -> Gamma[z, 0, x]
             z, x = elements
             return Expression(Symbol(self.get_name()), z, Integer0, x)

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -530,7 +530,7 @@ class SympyFunction(SympyObject):
         else:
             return PrecisionReal(sympy_fn.n(d))
 
-    def get_sympy_function(self, elements=None):
+    def get_sympy_function(self, elements=None) -> Optional[Callable]:
         if self.sympy_name:
             return getattr(sympy, self.sympy_name)
         return None
@@ -546,12 +546,13 @@ class SympyFunction(SympyObject):
                 if None in sympy_args:
                     return None
                 sympy_function = self.get_sympy_function(elements)
-                return sympy_function(*sympy_args)
+                if sympy_function is not None:
+                    return sympy_function(*sympy_args)
         except TypeError:
             pass
 
-    def from_sympy(self, sympy_name, elements):
-        return to_expression(self.get_name(), *elements)
+    def from_sympy(self, elements: list) -> Expression:
+        return Expression(Symbol(self.get_name()), *elements)
 
     def prepare_mathics(self, sympy_expr):
         return sympy_expr

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -501,7 +501,7 @@ def old_from_sympy(expr) -> BaseElement:
                 else:
                     margs.append(from_sympy(arg))
             builtin = sympy_to_mathics.get(name)
-            return builtin.from_sympy(name, margs)
+            return builtin.from_sympy(margs)
 
         elif isinstance(expr, sympy.sign):
             name = "Sign"
@@ -517,7 +517,7 @@ def old_from_sympy(expr) -> BaseElement:
         args = [from_sympy(arg) for arg in expr.args]
         builtin = sympy_to_mathics.get(name)
         if builtin is not None:
-            return builtin.from_sympy(name, args)
+            return builtin.from_sympy(args)
         return Expression(Symbol(name), *args)
 
     if isinstance(expr, sympy.Tuple):


### PR DESCRIPTION
Generally, we can get sympy_name from the object.
Previously, we sometimes we had two-parameter "from_sympy()" calls and three-parameter calls where sometiems a parameter might not be used.

Overall, I think this will simplifies things.

Some type annotations were added.