### PR TITLE
Misc tweaks...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,17 @@
 CHANGES
 =======
 
+New Builtins
+++++++++++++
+
+* ``SetEnvironment``
+
+Compatibility
+-------------
+
+* ``GetEnvironment`` expanded to handle ``[]`` and ``{var1, var2,...}`` forms
+
+
 7.0.0
 -----
 

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -231,9 +231,11 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
                 elements = sub_expr.elements
                 if target_pat:
                     elements = [
-                        element
-                        if element.is_free(target_pat, evaluation)
-                        else _expand(element)
+                        (
+                            element
+                            if element.is_free(target_pat, evaluation)
+                            else _expand(element)
+                        )
                         for element in elements
                     ]
                 else:
@@ -248,9 +250,11 @@ def expand(expr, numer=True, denom=False, deep=False, **kwargs):
                     elements = sub_expr.elements
                     if target_pat:
                         elements = [
-                            element
-                            if element.is_free(target_pat, evaluation)
-                            else _expand(element)
+                            (
+                                element
+                                if element.is_free(target_pat, evaluation)
+                                else _expand(element)
+                            )
                             for element in elements
                         ]
                     else:
@@ -335,9 +339,11 @@ def get_exponents_sorted(expr, var) -> list:
             # find exponent of terms multiplied with functions: sin, cos, log, exp, ...
             # e.g: x^3 * Sin[x^2] should give 3
             muls = [
-                term.as_coeff_mul(x)[1]
-                if term.as_coeff_mul(x)[1]
-                else (sympy.Integer(0),)
+                (
+                    term.as_coeff_mul(x)[1]
+                    if term.as_coeff_mul(x)[1]
+                    else (sympy.Integer(0),)
+                )
                 for term in coeff.as_ordered_terms()
             ]
             expos = [term.as_coeff_exponent(x)[1] for mul in muls for term in mul]

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -508,7 +508,7 @@ class PartitionsP(SympyFunction):
     )
 
     def eval(self, n, evaluation: Evaluation):
-        "PartitionsP[n_Integer]"
+        """PartitionsP[n_Integer]"""
         return super().eval(n, evaluation)
 
 

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -8,9 +8,7 @@ from typing import Optional, Type, Union
 
 import sympy
 from sympy import Symbol as Sympy_Symbol, false as SympyFalse, true as SympyTrue
-
-# Import the singleton class
-from sympy.core.numbers import S
+from sympy.core.singleton import S
 
 from mathics.core.atoms import (
     MATHICS3_COMPLEX_I,

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -14,7 +14,11 @@ from mathics.core.element import (
 # I put this constants here instead of inside `mathics.core.convert.sympy`
 # to avoid a circular reference. Maybe they should be in its own module.
 
-sympy_symbol_prefix = "_Mathics_User_"
+# Prefix used for Sympy variables.
+# We wan t this to be short to keep variable names short.
+# In tracing values, long names make output messy.
+sympy_symbol_prefix = "_m_"
+
 sympy_slot_prefix = "_Mathics_Slot_"
 
 

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -14,11 +14,7 @@ from mathics.core.element import (
 # I put this constants here instead of inside `mathics.core.convert.sympy`
 # to avoid a circular reference. Maybe they should be in its own module.
 
-# Prefix used for Sympy variables.
-# We wan t this to be short to keep variable names short.
-# In tracing values, long names make output messy.
-sympy_symbol_prefix = "_m_"
-
+sympy_symbol_prefix = "_Mathics_User_"
 sympy_slot_prefix = "_Mathics_Slot_"
 
 

--- a/test/core/test_sympy_python_convert.py
+++ b/test/core/test_sympy_python_convert.py
@@ -42,10 +42,10 @@ class SympyConvert(unittest.TestCase):
         self.compare_to_mathics(mathics_expr, sympy_expr)
 
     def testSymbol(self):
-        self.compare(Symbol("Global`x"), sympy.Symbol("_Mathics_User_Global`x"))
+        self.compare(Symbol("Global`x"), sympy.Symbol("_mg`x"))
         self.compare(
-            Symbol("_Mathics_User_x"),
-            sympy.Symbol("_Mathics_User_System`_Mathics_User_x"),
+            Symbol("_mu_x"),
+            sympy.Symbol("_mu`x"),
         )
 
     def testReal(self):

--- a/test/core/test_sympy_python_convert.py
+++ b/test/core/test_sympy_python_convert.py
@@ -42,10 +42,10 @@ class SympyConvert(unittest.TestCase):
         self.compare_to_mathics(mathics_expr, sympy_expr)
 
     def testSymbol(self):
-        self.compare(Symbol("Global`x"), sympy.Symbol("_mg`x"))
+        self.compare(Symbol("Global`x"), sympy.Symbol("_Mathics_User_Global`x"))
         self.compare(
-            Symbol("_mu_x"),
-            sympy.Symbol("_mu`x"),
+            Symbol("_Mathics_User_x"),
+            sympy.Symbol("_Mathics_User_System`_Mathics_User_x"),
         )
 
     def testReal(self):


### PR DESCRIPTION
(These were noticed in working on event tracing)

`mathics/builtin/numbers/algebra.py`: black changes its autoformatting

`mathics/builtin/numbers/numbertheory.py`: some linting prefers triples quotes for docstrings

`mathics/core/convert/sympy.py`: use accurate location for singleton class. This reduces unnecessary sympy imports

`CHANGES.rst`: document recent SetEnvironment addition and GetEnvironment changes

`test/builtin/numbers/__init__.py`:  needed if testing in this directory is done separately.