### PR TITLE
SameQ[]  and Expression module tweaks

### DIFF
--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12' '3.11']
+        python-version: ['3.12', '3.11']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12' '3.11', '3.8', '3.9', '3.10']
+        python-version: ['3.12', '3.11', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -5,7 +5,7 @@
 Here we have the base class and related function for element inside an Expression.
 """
 
-
+from abc import ABC
 from typing import Any, Optional, Tuple
 
 from mathics.core.attributes import A_NO_ATTRIBUTES
@@ -193,7 +193,7 @@ class KeyComparable:
         ) or self.get_sort_key() != other.get_sort_key()
 
 
-class BaseElement(KeyComparable):
+class BaseElement(KeyComparable, ABC):
     """
     This is the base class from which all other Expressions are
     derived from.  If you think of an Expression as tree-like, then a
@@ -290,7 +290,7 @@ class BaseElement(KeyComparable):
     def get_int_value(self):
         return None
 
-    def get_lookup_name(self):
+    def get_lookup_name(self) -> str:
         """
         Returns symbol name of leftmost head. This method is used
         to determine which definition must be asked for rules
@@ -398,7 +398,7 @@ class BaseElement(KeyComparable):
     def is_inexact(self) -> bool:
         return self.get_precision() is not None
 
-    def sameQ(self, rhs) -> bool:
+    def sameQ(self, rhs: "BaseElement") -> bool:
         """Mathics SameQ"""
         return id(self) == id(rhs)
 

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -88,11 +88,11 @@ symbols_arithmetic_operations = symbol_set(
 )
 
 
-def expression_sameQ(self, other):
+def eval_SameQ(self, other):
     """
-    Iterative implementation of SameQ.
+    Iterative implementation of SameQ[].
 
-    Ttree traversal comparison between `self` and `other`.
+    Tree traversal comparison between `self` and `other`.
     Return `True` if both tree structures are equal.
 
     This non-recursive implementation reduces the Python stack needed
@@ -1446,7 +1446,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
             return True
 
         # All this stuff maybe should be in mathics.eval.expression
-        return expression_sameQ(self, other)
+        return eval_SameQ(self, other)
 
     def sequences(self):
         cache = self._cache


### PR DESCRIPTION
@mmatera looked the code over and do not find anything wrong with it. 

I made some small changes to the docstring comment and addressed some of the lint errors my editor is telling me about.

We can't use generators here since there we access and then "rewind" sometimes. And this _is_ essentially a version without the tail recursions.  So I've removed the comments concerning doubt.

If you have the example that caused the failure on 3.12 without this change, it would be interesting to benchmark just this test inside a Mathics3 session to see if there's any difference in execution time. 

Other comments I'll put in the specific code changes in this PR.