### PR TITLE
Remove "precedence" in operator classes...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 CHANGES
 =======
 
+
 New Builtins
 ++++++++++++
 
@@ -11,6 +12,11 @@ Compatibility
 -------------
 
 * ``GetEnvironment`` expanded to handle ``[]`` and ``{var1, var2,...}`` forms
+
+Internals
+---------
+
+Operator precedence has been gone over and is picked up in tables from the Mathics Scanner project.
 
 
 7.0.0
@@ -63,7 +69,7 @@ Compatibility
 
 
 Internals
----
+---------
 
 * ``eval_abs`` and ``eval_sign`` extracted from ``Abs`` and ``Sign`` and added to ``mathics.eval.arithmetic``.
 * Maximum number of digits allowed in a string set to 7000 and can be adjusted using environment variable

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -159,7 +159,6 @@ class Divide(BinaryOperator):
 
     grouping = "Left"
     operator = "/"
-    precedence = 470
 
     rules = {
         "Divide[x_, y_]": "Times[x, Power[y, -1]]",
@@ -208,7 +207,6 @@ class Minus(PrefixOperator):
     }
 
     operator = "-"
-    precedence = 480
 
     rules = {
         "Minus[x_]": "Times[-1, x]",
@@ -283,7 +281,6 @@ class Plus(BinaryOperator, SympyFunction):
     }
 
     operator = "+"
-    precedence = 310
 
     summary_text = "add"
 
@@ -435,7 +432,6 @@ class Power(BinaryOperator, MPMathFunction):
 
     nargs = {2}
     operator = "^"
-    precedence = 590
 
     rules = {
         "Power[]": "1",
@@ -556,8 +552,6 @@ class Subtract(BinaryOperator):
     grouping = "Left"
 
     operator = "-"
-    precedence = 310
-    precedence_parse = 311
     rules = {
         "Subtract[x_, y_]": "Plus[x, Times[-1, y]]",
     }
@@ -623,7 +617,6 @@ class Times(BinaryOperator, SympyFunction):
     operator = "*"
     operator_display = " "
 
-    precedence = 400
     rules = {}
 
     # FIXME Note this is deprecated in 1.11

--- a/mathics/builtin/assignments/assign_binaryop.py
+++ b/mathics/builtin/assignments/assign_binaryop.py
@@ -165,7 +165,6 @@ class PreIncrement(PrefixOperator):
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
     operator = "++"
-    precedence = 660
 
     rules = {
         "++x_": "x = x + 1",
@@ -195,7 +194,6 @@ class PreDecrement(PrefixOperator):
     """
 
     operator = "--"
-    precedence = 660
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
 
     rules = {
@@ -225,7 +223,6 @@ class SubtractFrom(BinaryOperator):
     attributes = A_HOLD_FIRST | A_PROTECTED
     grouping = "Right"
     operator = "-="
-    precedence = 100
 
     rules = {
         "x_ -= dx_": "x = x - dx",
@@ -251,7 +248,6 @@ class TimesBy(BinaryOperator):
     """
 
     operator = "*="
-    precedence = 100
     attributes = A_HOLD_FIRST | A_PROTECTED
     grouping = "Right"
 

--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -169,7 +169,6 @@ class Set(BinaryOperator, _SetOperator):
     }
 
     operator = "="
-    precedence = 40
 
     summary_text = "assign a value"
 
@@ -372,7 +371,6 @@ class UpSet(BinaryOperator, _SetOperator):
     attributes = A_HOLD_FIRST | A_PROTECTED | A_SEQUENCE_HOLD
     grouping = "Right"
     operator = "^="
-    precedence = 40
 
     summary_text = (
         "set value and associate the assignment with symbols that occur at level one"

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -190,7 +190,6 @@ class Remove(Builtin):
 
     attributes = A_HOLD_ALL | A_LOCKED | A_PROTECTED
 
-    precedence = 670
     summary_text = "remove the definition of a symbol"
 
     def eval(self, symb, evaluation):
@@ -256,7 +255,6 @@ class Unset(PostfixOperator):
         "norep": "Assignment on `2` for `1` not found.",
         "usraw": "Cannot unset raw object `1`.",
     }
-    precedence = 670
     summary_text = "unset a value of the LHS"
 
     def eval(self, expr, evaluation):

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -427,7 +427,6 @@ class InterpretationBox(PrefixOperator):
     """
 
     operator = "\\!"
-    precedence = 670
     summary_text = "interpret boxes as an expression"
 
     def eval(self, boxes, evaluation: Evaluation):

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -236,7 +236,6 @@ class Definition(Builtin):
     """
 
     attributes = A_HOLD_ALL | A_PROTECTED
-    precedence = 670
     summary_text = "give values of a symbol in a form that can be stored in a package"
 
     def format_definition(self, symbol, evaluation, grid=True):
@@ -428,7 +427,6 @@ class Information(PrefixOperator):
     options = {
         "LongForm": "True",
     }
-    precedence = 0
     summary_text = "get information about all assignments for a symbol"
 
     def format_definition(self, symbol, evaluation, options, grid=True):

--- a/mathics/builtin/exp_structure/general.py
+++ b/mathics/builtin/exp_structure/general.py
@@ -33,7 +33,6 @@ class MapApply(BinaryOperator):
 
     grouping = "Right"
     operator = "@@@"
-    precedence = 620
 
     rules = {
         "MapApply[f_, expr_]": "Apply[f, expr, {1}]",

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -377,7 +377,6 @@ class Get(PrefixOperator):
     options = {
         "Trace": "False",
     }
-    precedence = 720
     summary_text = "read in a file and evaluate commands in it"
 
     def eval(self, path: String, evaluation: Evaluation, options: dict):
@@ -567,7 +566,6 @@ class Put(BinaryOperator):
     """
 
     operator = ">>"
-    precedence = 30
     summary_text = "write an expression to a file"
 
     def eval(self, exprs, filename, evaluation):
@@ -663,7 +661,6 @@ class PutAppend(BinaryOperator):
     """
 
     operator = ">>>"
-    precedence = 30
     summary_text = "append an expression to a file"
 
     def eval(self, exprs, filename, evaluation):

--- a/mathics/builtin/functional/application.py
+++ b/mathics/builtin/functional/application.py
@@ -86,7 +86,6 @@ class Function(PostfixOperator):
     """
 
     operator = "&"
-    precedence = 90
     attributes = A_HOLD_ALL | A_PROTECTED
 
     messages = {

--- a/mathics/builtin/functional/apply_fns_to_lists.py
+++ b/mathics/builtin/functional/apply_fns_to_lists.py
@@ -70,7 +70,6 @@ class Apply(BinaryOperator):
 
     summary_text = "apply a function to a list, at specified levels"
     operator = "@@"
-    precedence = 620
     grouping = "Right"
 
     options = {
@@ -130,7 +129,6 @@ class Map(BinaryOperator):
 
     summary_text = "map a function over a list, at specified levels"
     operator = "/@"
-    precedence = 620
     grouping = "Right"
 
     options = {

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -236,7 +236,6 @@ class Postfix(BinaryOperator):
     grouping = "Left"
     operator = "//"
     operator_display = None
-    precedence = 70
     summary_text = "postfix form"
 
 
@@ -327,7 +326,6 @@ class Prefix(BinaryOperator):
     grouping = "Right"
     operator = "@"
     operator_display = None
-    precedence = 640
     summary_text = "prefix form"
 
 

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -1479,7 +1479,6 @@ class Span(BinaryOperator):
     """
 
     operator = ";;"
-    precedence = 305
     summary_text = "general specification for spans or blocks of elements"
 
 

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -322,7 +322,6 @@ class MessageName(BinaryOperator):
     messages = {"messg": "Message cannot be set to `1`. It must be set to a string."}
     summary_text = "message identifyier"
     operator = "::"
-    precedence = 750
     rules = {
         "MakeBoxes[MessageName[symbol_Symbol, tag_String], "
         "f:StandardForm|TraditionalForm|OutputForm]": (

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -403,7 +403,6 @@ class Derivative(PostfixOperator, SympyFunction):
     attributes = A_N_HOLD_ALL
     default_formats = False
     operator = "'"
-    precedence = 670
     rules = {
         "MakeBoxes[Derivative[n__Integer][f_], "
         "  form:StandardForm|TraditionalForm]": (
@@ -1752,7 +1751,6 @@ class SeriesData(Builtin):
 
     # TODO: Implement sum, product and composition of series
 
-    precedence = 1000
     summary_text = "power series of a variable about a point"
 
     def eval_reduce(

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -97,7 +97,6 @@ class Rule_(BinaryOperator):
 
     name = "Rule"
     operator = "->"
-    precedence = 120
     attributes = A_SEQUENCE_HOLD | A_PROTECTED
     grouping = "Right"
     needs_verbatim = True
@@ -122,7 +121,6 @@ class RuleDelayed(BinaryOperator):
     attributes = A_SEQUENCE_HOLD | A_HOLD_REST | A_PROTECTED
     needs_verbatim = True
     operator = ":>"
-    precedence = 120
     summary_text = "a rule that keeps the replacement unevaluated"
 
 
@@ -335,7 +333,6 @@ class ReplaceAll(BinaryOperator):
     grouping = "Left"
     needs_verbatim = True
     operator = "/."
-    precedence = 110
 
     messages = {
         "reps": "`1` is not a valid replacement rule.",
@@ -391,7 +388,6 @@ class ReplaceRepeated(BinaryOperator):
     grouping = "Left"
     needs_verbatim = True
     operator = "//."
-    precedence = 110
 
     messages = {
         "reps": "`1` is not a valid replacement rule.",
@@ -544,7 +540,6 @@ class PatternTest(BinaryOperator, PatternObject):
 
     arg_counts = [2]
     operator = "?"
-    precedence = 680
     summary_text = "match to a pattern conditioned to a test result"
 
     def init(
@@ -763,7 +758,6 @@ class Alternatives(BinaryOperator, PatternObject):
     arg_counts = None
     needs_verbatim = True
     operator = "|"
-    precedence = 160
     summary_text = "match to any of several patterns"
 
     def init(
@@ -1097,7 +1091,6 @@ class Optional(BinaryOperator, PatternObject):
         "MakeBoxes[Verbatim[Optional][Verbatim[_]], f:StandardForm|TraditionalForm|InputForm|OutputForm]": '"_."',
     }
     operator = ":"
-    precedence = 140
     summary_text = "an optional argument with a default value"
 
     def init(
@@ -1381,7 +1374,6 @@ class Repeated(PostfixOperator, PatternObject):
     }
 
     operator = ".."
-    precedence = 170
     summary_text = "match to one or more occurrences of a pattern"
 
     def init(
@@ -1451,7 +1443,6 @@ class RepeatedNull(Repeated):
     """
 
     operator = "..."
-    precedence = 170
     summary_text = "match to zero or more occurrences of a pattern"
 
     def init(
@@ -1533,7 +1524,6 @@ class Condition(BinaryOperator, PatternObject):
     # Don't know why this has attribute HoldAll in Mathematica
     attributes = A_HOLD_REST | A_PROTECTED
     operator = "/;"
-    precedence = 130
     summary_text = "conditional definition"
 
     def init(

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -171,7 +171,6 @@ class CompoundExpression(BinaryOperator):
 
     attributes = A_HOLD_ALL | A_PROTECTED | A_READ_PROTECTED
     operator = ";"
-    precedence = 10
 
     summary_text = "execute expressions in sequence"
 

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -164,7 +164,6 @@ class Factorial(PostfixOperator, MPMathFunction):
 
     mpmath_name = "factorial"
     operator = "!"
-    precedence = 610
     summary_text = "factorial"
 
 
@@ -198,7 +197,6 @@ class Factorial2(PostfixOperator, MPMathFunction):
 
     attributes = A_NUMERIC_FUNCTION | A_PROTECTED
     operator = "!!"
-    precedence = 610
     mpmath_name = "fac2"
     sympy_name = "factorial2"
     messages = {

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -322,7 +322,6 @@ class StringJoin(BinaryOperator):
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED
     operator = "<>"
-    precedence = 600
     summary_text = "join strings together"
 
     def eval(self, items, evaluation):

--- a/mathics/builtin/string/patterns.py
+++ b/mathics/builtin/string/patterns.py
@@ -248,7 +248,6 @@ class StringExpression(BinaryOperator):
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED
     operator = "~~"
-    precedence = 135
 
     messages = {
         "invld": "Element `1` is not a valid string or pattern element in `2`.",

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -115,7 +115,6 @@ class Dot(BinaryOperator):
     """
 
     operator = "."
-    precedence = 490
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED
 
     rules = {
@@ -186,7 +185,7 @@ class Outer(Builtin):
     Outer product of two matrices:
     >> Outer[Times, {{a, b}, {c, d}}, {{1, 2}, {3, 4}}]
      = {{{{a, 2 a}, {3 a, 4 a}}, {{b, 2 b}, {3 b, 4 b}}}, {{{c, 2 c}, {3 c, 4 c}}, {{d, 2 d}, {3 d, 4 d}}}}
-    
+
     Outer product of two sparse arrays:
     >> Outer[Times, SparseArray[{{1, 2} -> a, {2, 1} -> b}], SparseArray[{{1, 2} -> c, {2, 1} -> d}]]
      = SparseArray[Automatic, {2, 2, 2, 2}, 0, {{1, 2, 1, 2} -> a c, {1, 2, 2, 1} -> a d, {2, 1, 1, 2} -> b c, {2, 1, 2, 1} -> b d}]
@@ -194,11 +193,11 @@ class Outer(Builtin):
     'Outer' of multiple lists:
     >> Outer[f, {a, b}, {x, y, z}, {1, 2}]
      = {{{f[a, x, 1], f[a, x, 2]}, {f[a, y, 1], f[a, y, 2]}, {f[a, z, 1], f[a, z, 2]}}, {{f[b, x, 1], f[b, x, 2]}, {f[b, y, 1], f[b, y, 2]}, {f[b, z, 1], f[b, z, 2]}}}
-    
+
     'Outer' converts input sparse arrays to lists if f=!=Times, or if the input is a mixture of sparse arrays and lists:
     >> Outer[f, SparseArray[{{1, 2} -> a, {2, 1} -> b}], SparseArray[{{1, 2} -> c, {2, 1} -> d}]]
      = {{{{f[0, 0], f[0, c]}, {f[0, d], f[0, 0]}}, {{f[a, 0], f[a, c]}, {f[a, d], f[a, 0]}}}, {{{f[b, 0], f[b, c]}, {f[b, d], f[b, 0]}}, {{f[0, 0], f[0, c]}, {f[0, d], f[0, 0]}}}}
-    
+
     >> Outer[Times, SparseArray[{{1, 2} -> a, {2, 1} -> b}], {c, d}]
      = {{{0, 0}, {a c, a d}}, {{b c, b d}, {0, 0}}}
 

--- a/mathics/builtin/testing_expressions/equality_inequality.py
+++ b/mathics/builtin/testing_expressions/equality_inequality.py
@@ -51,7 +51,6 @@ operators = {
 
 
 class _InequalityOperator(BinaryOperator):
-    precedence = 290
     grouping = "NonAssociative"
 
     @staticmethod
@@ -750,7 +749,6 @@ class SameQ(_ComparisonOperator):
 
     grouping = "None"  # Indeterminate grouping: Neither left nor right
     operator = "==="
-    precedence = 290
 
     summary_text = "literal symbolic identity"
 
@@ -887,7 +885,6 @@ class UnsameQ(_ComparisonOperator):
 
     grouping = "None"  # Indeterminate grouping: Neither left nor right
     operator = "=!="
-    precedence = 290
 
     summary_text = "not literal symbolic identity"
 

--- a/mathics/builtin/testing_expressions/logic.py
+++ b/mathics/builtin/testing_expressions/logic.py
@@ -90,7 +90,6 @@ class And(BinaryOperator):
 
     attributes = A_FLAT | A_HOLD_ALL | A_ONE_IDENTITY | A_PROTECTED
     operator = "&&"
-    precedence = 215
     summary_text = "logic conjunction"
     #    rules = {
     #        "And[a_]": "a",
@@ -212,7 +211,6 @@ class Equivalent(BinaryOperator):
 
     attributes = A_ORDERLESS | A_PROTECTED
     operator = "\u29E6"
-    precedence = 205
     summary_text = "logic equivalence"
 
     def eval(self, args, evaluation: Evaluation):
@@ -280,7 +278,6 @@ class Implies(BinaryOperator):
     """
 
     operator = "\u21D2"
-    precedence = 200
     grouping = "Right"
     summary_text = "logic implication"
 
@@ -355,7 +352,6 @@ class Or(BinaryOperator):
 
     attributes = A_FLAT | A_HOLD_ALL | A_ONE_IDENTITY | A_PROTECTED
     operator = "||"
-    precedence = 215
     summary_text = "logic (inclusive) disjunction"
 
     #    rules = {
@@ -447,7 +443,6 @@ class Not(PrefixOperator):
     """
 
     operator = "!"
-    precedence = 230
 
     rules = {
         "Not[True]": "False",
@@ -498,7 +493,6 @@ class Xor(BinaryOperator):
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_ORDERLESS | A_PROTECTED
     operator = "\u22BB"
-    precedence = 215
     summary_text = "logic (exclusive) disjunction"
 
     def eval(self, args, evaluation: Evaluation):


### PR DESCRIPTION
Removes setting class variable precedence. This is now controlled from the Mathics Scanner project. 

Duplicating information can lead to inconsistency and confusion. 