### PR TITLE
apply_rule -> apply_function ...

### DIFF
--- a/mathics/builtin/trace.py
+++ b/mathics/builtin/trace.py
@@ -33,7 +33,9 @@ from mathics.core.rules import BuiltinRule
 from mathics.core.symbols import SymbolFalse, SymbolNull, SymbolTrue, strip_context
 
 
-def traced_apply_rule(self, expression, vars, options: dict, evaluation: Evaluation):
+def traced_apply_function(
+    self, expression, vars, options: dict, evaluation: Evaluation
+):
     if options and self.check_options:
         if not self.check_options(options, evaluation):
             return None
@@ -185,7 +187,7 @@ class TraceBuiltins(_TraceBase):
     """
 
     definitions_copy: Definitions
-    apply_rule_copy: Callable
+    apply_function_copy: Callable
 
     function_stats: "defaultdict" = defaultdict(
         lambda: {"count": 0, "elapsed_milliseconds": 0.0}
@@ -238,19 +240,19 @@ class TraceBuiltins(_TraceBase):
     @staticmethod
     def enable_trace(evaluation) -> None:
         if TraceBuiltins.traced_definitions is None:
-            TraceBuiltins.apply_rule_copy = BuiltinRule.apply_rule
+            TraceBuiltins.apply_function_copy = BuiltinRule.apply_function
             TraceBuiltins.definitions_copy = evaluation.definitions
 
-            # Replaces apply_rule by the custom one
-            BuiltinRule.apply_rule = traced_apply_rule
-            # Create new definitions uses the new apply_rule
+            # Replaces apply_function by the custom one
+            BuiltinRule.apply_function = traced_apply_function
+            # Create new definitions uses the new apply_function
             evaluation.definitions = Definitions(add_builtin=True)
         else:
             evaluation.definitions = TraceBuiltins.definitions_copy
 
     @staticmethod
     def disable_trace(evaluation) -> None:
-        BuiltinRule.apply_rule = TraceBuiltins.apply_rule_copy
+        BuiltinRule.apply_function = TraceBuiltins.apply_function_copy
         evaluation.definitions = TraceBuiltins.definitions_copy
 
     def eval(self, expr, evaluation, options={}):

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 
 from mathics import __version__, license_string, settings, version_string
-from mathics.builtin.trace import TraceBuiltins, traced_apply_rule
+from mathics.builtin.trace import TraceBuiltins, traced_apply_function
 from mathics.core.atoms import String
 from mathics.core.definitions import Definitions, Symbol, autoload_files
 from mathics.core.evaluation import Evaluation, Output
@@ -385,7 +385,7 @@ Please contribute to Mathics!""",
         extension_modules = default_pymathics_modules
 
     if args.trace_builtins:
-        BuiltinRule.apply_rule = traced_apply_rule
+        BuiltinRule.apply_rule = traced_apply_function
 
         def dump_tracing_stats():
             TraceBuiltins.dump_tracing_stats(sort_by="count", evaluation=None)


### PR DESCRIPTION
Change `apply_rule()` -> to `apply_function()` when that is what is is; (and not when it is not).

Also mark BaseRule an abstract class, and go over docstrings in mathics.core.rules

@mmatera I think i now understand what you were getting at when we were discussion replacement name for `do_replace()`.  Both functions are definitely apply functions. We could call the method `apply()`. I think though being specific and explicit increases clarity and reduces potential confusion.