### PR TITLE
Minor things noticed in looking over the code

### DIFF
--- a/mathics/builtin/exp_structure/general.py
+++ b/mathics/builtin/exp_structure/general.py
@@ -8,7 +8,7 @@ from mathics.core.builtin import BinaryOperator, Builtin, Predefined
 from mathics.core.exceptions import InvalidLevelspecError
 from mathics.core.expression import Evaluation, Expression
 from mathics.core.list import ListExpression
-from mathics.core.rules import Pattern
+from mathics.core.rules import BasePattern
 from mathics.core.symbols import Atom, SymbolFalse, SymbolTrue
 from mathics.core.systemsymbols import SymbolMap
 from mathics.eval.parts import python_levelspec, walk_levels
@@ -114,7 +114,7 @@ class FreeQ(Builtin):
     def eval(self, expr, form, evaluation: Evaluation):
         "FreeQ[expr_, form_]"
 
-        form = Pattern.create(form)
+        form = BasePattern.create(form)
         if expr.is_free(form, evaluation):
             return SymbolTrue
         else:

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -13,7 +13,7 @@ from itertools import permutations
 from mathics.builtin.box.layout import RowBox
 from mathics.core.atoms import Integer, is_integer_rational_or_real
 from mathics.core.attributes import A_HOLD_FIRST, A_LISTABLE, A_LOCKED, A_PROTECTED
-from mathics.core.builtin import Builtin, IterationFunction, Pattern
+from mathics.core.builtin import BasePattern, Builtin, IterationFunction
 from mathics.core.convert.expression import to_expression
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.element import ElementsProperties
@@ -431,7 +431,7 @@ class Reap(Builtin):
         "Reap[expr_, {patterns___}, f_]"
 
         patterns = patterns.get_sequence()
-        sown = [(Pattern.create(pattern), []) for pattern in patterns]
+        sown = [(BasePattern.create(pattern), []) for pattern in patterns]
 
         def listener(e, tag):
             result = False

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -33,7 +33,7 @@ from mathics.core.expression_predefined import (
     MATHICS3_NEG_INFINITY,
 )
 from mathics.core.list import ListExpression
-from mathics.core.rules import Pattern
+from mathics.core.rules import BasePattern
 from mathics.core.symbols import (
     Atom,
     Symbol,
@@ -549,11 +549,11 @@ class _CoefficientHandler(Builtin):
             else:
                 return [([], expr)]
         if len(var_exprs) == 1:
-            target_pat = Pattern.create(var_exprs[0])
+            target_pat = BasePattern.create(var_exprs[0])
             var_pats = [target_pat]
         else:
-            target_pat = Pattern.create(Expression(SymbolAlternatives, *var_exprs))
-            var_pats = [Pattern.create(var) for var in var_exprs]
+            target_pat = BasePattern.create(Expression(SymbolAlternatives, *var_exprs))
+            var_pats = [BasePattern.create(var) for var in var_exprs]
 
         # ###### Auxiliary functions #########
         def key_powers(lst: list) -> Union[int, float]:
@@ -1172,7 +1172,7 @@ class Expand(_Expand):
             return
 
         if target:
-            kwargs["pattern"] = Pattern.create(target)
+            kwargs["pattern"] = BasePattern.create(target)
         kwargs["evaluation"] = evaluation
         return expand(expr, True, False, **kwargs)
 
@@ -1235,7 +1235,7 @@ class ExpandAll(_Expand):
             return
 
         if target:
-            kwargs["pattern"] = Pattern.create(target)
+            kwargs["pattern"] = BasePattern.create(target)
         kwargs["evaluation"] = evaluation
         return expand(expr, numer=True, denom=True, deep=True, **kwargs)
 

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -46,7 +46,7 @@ from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.number import MACHINE_EPSILON, dps
-from mathics.core.rules import Pattern
+from mathics.core.rules import BasePattern
 from mathics.core.symbols import (
     BaseElement,
     Symbol,
@@ -228,7 +228,7 @@ class D(SympyFunction):
         if f == x:
             return Integer1
 
-        x_pattern = Pattern.create(x)
+        x_pattern = BasePattern.create(x)
         if f.is_free(x_pattern, evaluation):
             return Integer0
 
@@ -1917,7 +1917,7 @@ class SeriesData(Builtin):
             nummax.get_int_value(),
             den.get_int_value(),
         )
-        x_pattern = Pattern.create(x)
+        x_pattern = BasePattern.create(x)
         incompat_series = []
         max_exponent = Integer(int(series[2] / series[3] + 1))
         if coeff.get_head() is SymbolSequence:
@@ -2263,7 +2263,7 @@ class Solve(Builtin):
         vars = []
         vars_sympy = []
         for var, var_sympy in zip(all_vars, all_vars_sympy):
-            pattern = Pattern.create(var)
+            pattern = BasePattern.create(var)
             if not eqs.is_free(pattern, evaluation):
                 vars.append(var)
                 vars_sympy.append(var_sympy)

--- a/mathics/builtin/patterns.py
+++ b/mathics/builtin/patterns.py
@@ -37,9 +37,6 @@ Options using 'OptionsPattern' and 'OptionValue':
 The attributes 'Flat', 'Orderless', and 'OneIdentity' affect pattern matching.
 """
 
-# This tells documentation how to sort this module
-sort_order = "mathics.builtin.rules-and-patterns"
-
 from typing import Callable, List, Optional as OptionalType, Tuple, Union
 
 from mathics.core.atoms import Integer, Number, Rational, Real, String
@@ -63,11 +60,14 @@ from mathics.core.evaluation import Evaluation
 from mathics.core.exceptions import InvalidLevelspecError
 from mathics.core.expression import Expression, SymbolVerbatim
 from mathics.core.list import ListExpression
-from mathics.core.pattern import Pattern, StopGenerator
+from mathics.core.pattern import BasePattern, StopGenerator
 from mathics.core.rules import Rule
 from mathics.core.symbols import Atom, Symbol, SymbolList, SymbolTrue
 from mathics.core.systemsymbols import SymbolBlank, SymbolDefault, SymbolDispatch
 from mathics.eval.parts import python_levelspec
+
+# This tells documentation how to sort this module
+sort_order = "mathics.builtin.rules-and-patterns"
 
 
 class Rule_(BinaryOperator):
@@ -159,7 +159,7 @@ def create_rules(
     if any_lists:
         all_lists = True
         for item in rules:
-            if not item.get_head() is SymbolList:
+            if item.get_head() is not SymbolList:
                 all_lists = False
                 break
 
@@ -568,7 +568,7 @@ class PatternTest(BinaryOperator, PatternObject):
             "System`NonNegative": self.match_nonnegative,
         }
 
-        self.pattern = Pattern.create(expr.elements[0], evaluation=evaluation)
+        self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
         self.test = expr.elements[1]
         testname = self.test.get_name()
         self.test_name = testname
@@ -765,7 +765,8 @@ class Alternatives(BinaryOperator, PatternObject):
     ) -> None:
         super(Alternatives, self).init(expr, evaluation=evaluation)
         self.alternatives = [
-            Pattern.create(element, evaluation=evaluation) for element in expr.elements
+            BasePattern.create(element, evaluation=evaluation)
+            for element in expr.elements
         ]
 
     def match(self, yield_func, expression, vars, evaluation, **kwargs):
@@ -826,11 +827,11 @@ class Except(PatternObject):
         self, expr: Expression, evaluation: OptionalType[Evaluation] = None
     ) -> None:
         super(Except, self).init(expr, evaluation=evaluation)
-        self.c = Pattern.create(expr.elements[0])
+        self.c = BasePattern.create(expr.elements[0])
         if len(expr.elements) == 2:
-            self.p = Pattern.create(expr.elements[1], evaluation=evaluation)
+            self.p = BasePattern.create(expr.elements[1], evaluation=evaluation)
         else:
-            self.p = Pattern.create(Expression(SymbolBlank), evaluation=evaluation)
+            self.p = BasePattern.create(Expression(SymbolBlank), evaluation=evaluation)
 
     def match(self, yield_func, expression, vars, evaluation, **kwargs):
         def except_yield_func(vars, rest):
@@ -910,7 +911,7 @@ class HoldPattern(PatternObject):
         self, expr: Expression, evaluation: OptionalType[Evaluation] = None
     ) -> None:
         super(HoldPattern, self).init(expr, evaluation=evaluation)
-        self.pattern = Pattern.create(expr.elements[0], evaluation=evaluation)
+        self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
 
     def match(self, yield_func, expression, vars, evaluation, **kwargs):
         # for new_vars, rest in self.pattern.match(
@@ -919,7 +920,7 @@ class HoldPattern(PatternObject):
         self.pattern.match(yield_func, expression, vars, evaluation)
 
 
-class Pattern_(PatternObject):
+class Pattern(PatternObject):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/Pattern.html</url>
 
@@ -995,9 +996,9 @@ class Pattern_(PatternObject):
         varname = expr.elements[0].get_name()
         if varname is None or varname == "":
             self.error("patvar", expr)
-        super(Pattern_, self).init(expr, evaluation=evaluation)
+        super(Pattern, self).init(expr, evaluation=evaluation)
         self.varname = varname
-        self.pattern = Pattern.create(expr.elements[1], evaluation=evaluation)
+        self.pattern = BasePattern.create(expr.elements[1], evaluation=evaluation)
 
     def __repr__(self):
         return "<Pattern: %s>" % repr(self.pattern)
@@ -1099,7 +1100,7 @@ class Optional(BinaryOperator, PatternObject):
         self, expr: Expression, evaluation: OptionalType[Evaluation] = None
     ) -> None:
         super(Optional, self).init(expr, evaluation=evaluation)
-        self.pattern = Pattern.create(expr.elements[0], evaluation=evaluation)
+        self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
         if len(expr.elements) == 2:
             self.default = expr.elements[1]
         else:
@@ -1400,7 +1401,7 @@ class Repeated(PostfixOperator, PatternObject):
         min: int = 1,
         evaluation: OptionalType[Evaluation] = None,
     ):
-        self.pattern = Pattern.create(expr.elements[0], evaluation=evaluation)
+        self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
         self.max = None
         self.min = min
         if len(expr.elements) == 2:
@@ -1552,9 +1553,9 @@ class Condition(BinaryOperator, PatternObject):
         # if (expr.elements[0].get_head_name() == "System`Condition" and
         #    len(expr.elements[0].elements) == 2):
         #    self.test = Expression(SymbolAnd, self.test, expr.elements[0].elements[1])
-        #    self.pattern = Pattern.create(expr.elements[0].elements[0])
+        #    self.pattern = BasePattern.create(expr.elements[0].elements[0])
         # else:
-        self.pattern = Pattern.create(expr.elements[0], evaluation=evaluation)
+        self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
 
     def match(
         self,

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -54,7 +54,7 @@ from mathics.core.interrupt import BreakInterrupt, ContinueInterrupt, ReturnInte
 from mathics.core.list import ListExpression
 from mathics.core.number import PrecisionValueError, dps, get_precision, min_prec
 from mathics.core.parser.util import PyMathicsDefinitions, SystemDefinitions
-from mathics.core.pattern import Pattern
+from mathics.core.pattern import BasePattern
 from mathics.core.rules import FunctionApplyRule, Rule
 from mathics.core.symbols import (
     BaseElement,
@@ -1131,7 +1131,7 @@ class PatternArgumentError(PatternError):
         super().__init__(name, "argr", count, expected)
 
 
-class PatternObject(BuiltinElement, Pattern):
+class PatternObject(BuiltinElement, BasePattern):
     needs_verbatim = True
 
     arg_counts: List[int] = []
@@ -1142,9 +1142,10 @@ class PatternObject(BuiltinElement, Pattern):
             if len(expr.elements) not in self.arg_counts:
                 self.error_args(len(expr.elements), *self.arg_counts)
         self.expr = expr
-        self.head = Pattern.create(expr.head, evaluation=evaluation)
+        self.head = BasePattern.create(expr.head, evaluation=evaluation)
         self.elements = [
-            Pattern.create(element, evaluation=evaluation) for element in expr.elements
+            BasePattern.create(element, evaluation=evaluation)
+            for element in expr.elements
         ]
 
     def error(self, tag, *args):

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -1,9 +1,11 @@
 # cython: language_level=3
 # cython: profile=False
 # -*- coding: utf-8 -*-
-"""
-Core to Mathics3 is are patterns which match symbol expressions. While there are built-in function which allow
-users to match parts of expressions, patterns are also used in applying of transformation rules and deciding functiosn get applied.
+"""Core to Mathics3 is are patterns which match symbolic expressions. A pattern are built up in a custon pattern notation.
+The parts of a pattern are called "Pattern Objects".
+
+While there is a built-in function which allows users to match parts of expressions, patterns are also used in applying of transformation
+rules and deciding functions that get applied.
 
 See also: mathics.core.rules and https://reference.wolfram.com/language/tutorial/PatternsAndTransformationRules.html
 """
@@ -115,7 +117,7 @@ class BasePattern(ABC):
     # Also, when the initial Definitions object for the evaluation
     # context is created, many rules must be created without an
     # evaluation context available. For that case, we still
-    # must be able to create Patten objects without the evaluation context.
+    # must be able to create Pattern objects without the evaluation context.
     #
     # In any case, just by caching the attributes in the first use of
     # the pattern there is a win ~5% in performance.
@@ -128,7 +130,7 @@ class BasePattern(ABC):
     # ===========================
     #
     # Notice also that the case of `Alternatives` is a corner case,
-    # where attributes are readed at the moment of the rule application:
+    # where attributes are read at the moment of the rule application:
     #
     # For example, in WMA, let's consider this example
     # ```
@@ -261,7 +263,7 @@ class BasePattern(ABC):
         fully: bool = True,
     ) -> bool:
         """returns True if `expression` matches self or we have
-        reached the end fo the matches, and False if it does not.
+        reached the end of the matches, and False if it does not.
         """
 
         if vars_dict is None:

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -2,11 +2,14 @@
 # cython: profile=False
 # -*- coding: utf-8 -*-
 """
-Basic classes for Patterns
+Core to Mathics3 is are patterns which match symbol expressions. While there are built-in function which allow
+users to match parts of expressions, patterns are also used in applying of transformation rules and deciding functiosn get applied.
 
+See also: mathics.core.rules and https://reference.wolfram.com/language/tutorial/PatternsAndTransformationRules.html
 """
 
 
+from abc import ABC
 from itertools import chain
 from typing import Callable, List, Optional, Tuple, Union
 
@@ -75,9 +78,9 @@ class StopGenerator_Pattern(StopGenerator):
     """
 
 
-class Pattern:
+class Pattern(ABC):
     """
-    This is the base class for Mathics Pattern objects.
+    This is the base class for Mathics3 Pattern objects.
 
     A Pattern is a way to represent classes of expressions.
     For example, ``F[x_Symbol]`` is a pattern which matches an expression whose
@@ -121,8 +124,8 @@ class Pattern:
     # to specialize the match method.
     #
     #
-    # Corner case: `Alternaties`
-    # ==========================
+    # Corner case: `Alternatives`
+    # ===========================
     #
     # Notice also that the case of `Alternatives` is a corner case,
     # where attributes are readed at the moment of the rule application:
@@ -227,9 +230,9 @@ class Pattern:
         expression: BaseElement,
         vars_dict: dict,
         evaluation: Evaluation,
-        head: Symbol = None,
-        element_index: int = None,
-        element_count: int = None,
+        head: Optional[Symbol] = None,
+        element_index: Optional[int] = None,
+        element_count: Optional[int] = None,
         fully: bool = True,
     ):
         """
@@ -255,8 +258,8 @@ class Pattern:
         vars_dict: Optional[dict] = None,
         fully: bool = True,
     ) -> bool:
-        """
-        returns True if `expression` matches self.
+        """returns True if `expression` matches self or we have
+        reached the end fo the matches, and False if it does not.
         """
 
         if vars_dict is None:

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -73,12 +73,12 @@ class StopGenerator_ExpressionPattern_match(StopGenerator):
 
 class StopGenerator_Pattern(StopGenerator):
     """
-    Exception raised when  Pattern matches
+    Exception raised when  BasePattern matches
     an expression.
     """
 
 
-class Pattern(ABC):
+class BasePattern(ABC):
     """
     This is the base class for Mathics3 Pattern objects.
 
@@ -90,11 +90,11 @@ class Pattern(ABC):
 
     expr: BaseElement
 
-    # TODO: In WMA, when a Pattern is created, the attributes
+    # TODO: In WMA, when a BasePattern is created, the attributes
     # from the head are read from the evaluation context and
     # stored as a part of a rule.
     #
-    # As Patterns are nested structures, the factory not only needs
+    # As BasePatterns are nested structures, the factory not only needs
     # the attributes of the head, but also the full evaluation context
     # which is needed to create patterns for its elements.
     #
@@ -165,7 +165,9 @@ class Pattern(ABC):
     #
     #
     @staticmethod
-    def create(expr: BaseElement, evaluation: Optional[Evaluation] = None) -> "Pattern":
+    def create(
+        expr: BaseElement, evaluation: Optional[Evaluation] = None
+    ) -> "BasePattern":
         """
         If ``expr`` is listed in ``pattern_object``  return the pattern found there.
         Otherwise, if ``expr`` is an ``Atom``, create and return  ``AtomPattern`` for ``expr``.
@@ -310,7 +312,7 @@ class Pattern(ABC):
         return self.expr.sameQ(other.expr)
 
 
-class AtomPattern(Pattern):
+class AtomPattern(BasePattern):
     """
     A pattern that matches with an atom.
     """
@@ -390,7 +392,7 @@ class AtomPattern(Pattern):
 #    pass
 
 
-class ExpressionPattern(Pattern):
+class ExpressionPattern(BasePattern):
     """
     Pattern that matches with an Expression.
     """
@@ -407,8 +409,8 @@ class ExpressionPattern(Pattern):
             None if evaluation is None else head.get_attributes(evaluation.definition)
         )
         self.__set_pattern_attributes__(attributes)
-        self.head = Pattern.create(head)
-        self.elements = [Pattern.create(element) for element in expr.elements]
+        self.head = BasePattern.create(head)
+        self.elements = [BasePattern.create(element) for element in expr.elements]
 
     def __set_pattern_attributes__(self, attributes):
         if attributes is None or self.attributes is not None:

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -57,7 +57,7 @@ from typing import Callable, Optional
 from mathics.core.element import BaseElement, KeyComparable
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
-from mathics.core.pattern import Pattern, StopGenerator
+from mathics.core.pattern import BasePattern, StopGenerator
 from mathics.core.symbols import strip_context
 
 
@@ -98,7 +98,7 @@ class BaseRule(KeyComparable, ABC):
         system: bool = False,
         evaluation: Optional[Evaluation] = None,
     ) -> None:
-        self.pattern = Pattern.create(pattern, evaluation=evaluation)
+        self.pattern = BasePattern.create(pattern, evaluation=evaluation)
         self.system = system
 
     def apply(

--- a/mathics/eval/numbers/calculus/series.py
+++ b/mathics/eval/numbers/calculus/series.py
@@ -6,7 +6,7 @@ from mathics.core.atoms import Integer, Integer0, Rational
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
-from mathics.core.rules import Pattern
+from mathics.core.rules import BasePattern
 from mathics.core.symbols import Atom, Symbol, SymbolPlus, SymbolPower, SymbolTimes
 from mathics.core.systemsymbols import (
     SymbolComplexInfinity,
@@ -372,7 +372,7 @@ def build_series(f, x, x0, n, evaluation):
     vars = {
         x_name: x0,
     }
-    x_pattern = Pattern.create(x)
+    x_pattern = BasePattern.create(x)
 
     if f.is_free(x_pattern, evaluation):
         print(x, " not in ", f)

--- a/mathics/eval/patterns.py
+++ b/mathics/eval/patterns.py
@@ -1,5 +1,5 @@
 from mathics.core.evaluation import Evaluation
-from mathics.core.pattern import Pattern, StopGenerator
+from mathics.core.pattern import BasePattern, StopGenerator
 
 
 class _StopGeneratorMatchQ(StopGenerator):
@@ -8,10 +8,10 @@ class _StopGeneratorMatchQ(StopGenerator):
 
 class Matcher:
     def __init__(self, form):
-        if isinstance(form, Pattern):
+        if isinstance(form, BasePattern):
             self.form = form
         else:
-            self.form = Pattern.create(form)
+            self.form = BasePattern.create(form)
 
     def match(self, expr, evaluation: Evaluation):
         def yield_func(vars, rest):

--- a/mathics/eval/testing_expressions.py
+++ b/mathics/eval/testing_expressions.py
@@ -5,7 +5,7 @@ import sympy
 from mathics.core.atoms import Complex, Integer, Integer0, Integer1, IntegerM1
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
-from mathics.core.rules import Pattern
+from mathics.core.rules import BasePattern
 from mathics.core.symbols import SymbolFalse, SymbolTimes, SymbolTrue
 from mathics.core.systemsymbols import SymbolDirectedInfinity, SymbolSparseArray
 
@@ -112,7 +112,7 @@ def is_number(sympy_value) -> bool:
 def check_ArrayQ(expr, pattern, test, evaluation: Evaluation):
     "Check if expr is an Array which test yields true for each of its elements."
 
-    pattern = Pattern.create(pattern)
+    pattern = BasePattern.create(pattern)
 
     dims = [len(expr.get_elements())]  # to ensure an atom is not an array
 
@@ -152,7 +152,7 @@ def check_SparseArrayQ(expr, pattern, test, evaluation: Evaluation):
     if not expr.head.sameQ(SymbolSparseArray):
         return SymbolFalse
 
-    pattern = Pattern.create(pattern)
+    pattern = BasePattern.create(pattern)
     dims, default_value, rules = expr.elements[1:]
     if not pattern.does_match(Integer(len(dims.elements)), evaluation):
         return SymbolFalse


### PR DESCRIPTION
Here are some minor things noticed in looking over this module.

There is something that greatly bothers me that isn't fixed though. 

In this module, the base class is named `Pattern`. Elsewhere, base classes are prefaced with `Base`. For example, `BaseElement`,  `BaseRule`, or `BaseForm`.  

And then, because of this, the builtin function `Pattern[]` in module `mathics.builtin.pattern` uses the class name `Pattern_`.

To me, all of this feels like a gratuitous complication (even though I imagine this was due to sloppiness). 

