### PR TITLE
allow setting In/Out prefix...

### DIFF
--- a/mathics/main.py
+++ b/mathics/main.py
@@ -65,10 +65,21 @@ def show_echo(query, evaluation):
 
 
 class TerminalShell(MathicsLineFeeder):
-    def __init__(self, definitions, colors, want_readline, want_completion):
+    def __init__(
+        self,
+        definitions,
+        colors,
+        want_readline,
+        want_completion,
+        autoload=False,
+        in_prefix: str = "In",
+        out_prefix: str = "Out",
+    ):
         super(TerminalShell, self).__init__("<stdin>")
         self.input_encoding = locale.getpreferredencoding()
         self.lineno = 0
+        self.in_prefix = in_prefix
+        self.out_prefix = out_prefix
 
         # Try importing readline to enable arrow keys support etc.
         self.using_readline = False
@@ -129,7 +140,8 @@ class TerminalShell(MathicsLineFeeder):
 
         self.incolors, self.outcolors = term_colors
         self.definitions = definitions
-        autoload_files(definitions, get_srcdir(), "autoload-cli")
+        if autoload:
+            autoload_files(definitions, get_srcdir(), "autoload-cli")
 
     def get_last_line_number(self):
         return self.definitions.get_line_no()
@@ -137,17 +149,21 @@ class TerminalShell(MathicsLineFeeder):
     def get_in_prompt(self):
         next_line_number = self.get_last_line_number() + 1
         if self.lineno > 0:
-            return " " * len("In[{0}]:= ".format(next_line_number))
+            return " " * len("{0}[{1}]:= ".format(self.in_prefix, next_line_number))
         else:
-            return "{1}In[{2}{0}{3}]:= {4}".format(next_line_number, *self.incolors)
+            return "{2}{0}[{3}{1}{4}]:= {5}".format(
+                self.in_prefix, next_line_number, *self.incolors
+            )
 
     def get_out_prompt(self, form=None):
         line_number = self.get_last_line_number()
         if form:
-            return "{2}Out[{3}{0}{4}]//{1}= {5}".format(
-                line_number, form, *self.outcolors
+            return "{3}{0}[{4}{1}{5}]//{2}= {6}".format(
+                self.out_prefix, line_number, form, *self.outcolors
             )
-        return "{1}Out[{2}{0}{3}]= {4}".format(line_number, *self.outcolors)
+        return "{2}{0}[{3}{1}{4}]= {5}".format(
+            self.out_prefix, line_number, *self.outcolors
+        )
 
     def to_output(self, text, form=None):
         line_number = self.get_last_line_number()
@@ -247,6 +263,26 @@ class TerminalOutput(Output):
 
     def out(self, out):
         return self.shell.out_callback(out)
+
+
+def eval_loop(feeder: MathicsFileLineFeeder, shell: TerminalShell):
+    """
+    A read eval/loop for things having file input `feeder`.
+    `shell` is a shell session
+    """
+    try:
+        while not feeder.empty():
+            evaluation = Evaluation(
+                shell.definitions,
+                output=TerminalOutput(shell),
+                catch_interrupt=False,
+            )
+            query = evaluation.parse_feeder(feeder)
+            if query is None:
+                continue
+            evaluation.evaluate(query, timeout=settings.TIMEOUT)
+    except KeyboardInterrupt:
+        print("\nKeyboardInterrupt")
 
 
 def main() -> int:
@@ -403,43 +439,19 @@ Please contribute to Mathics!""",
         args.colors,
         want_readline=not (args.no_readline),
         want_completion=not (args.no_completion),
+        autoload=True,
     )
 
     if args.initfile:
         feeder = MathicsFileLineFeeder(args.initfile)
-        try:
-            while not feeder.empty():
-                evaluation = Evaluation(
-                    shell.definitions,
-                    output=TerminalOutput(shell),
-                    catch_interrupt=False,
-                )
-                query = evaluation.parse_feeder(feeder)
-                if query is None:
-                    continue
-                evaluation.evaluate(query, timeout=settings.TIMEOUT)
-        except KeyboardInterrupt:
-            print("\nKeyboardInterrupt")
-
+        eval_loop(feeder, shell)
         definitions.set_line_no(0)
 
     if args.FILE is not None:
         set_input_var(args.FILE.name)
         definitions.set_inputfile(args.FILE.name)
         feeder = MathicsFileLineFeeder(args.FILE)
-        try:
-            while not feeder.empty():
-                evaluation = Evaluation(
-                    shell.definitions,
-                    output=TerminalOutput(shell),
-                    catch_interrupt=False,
-                )
-                query = evaluation.parse_feeder(feeder)
-                if query is None:
-                    continue
-                evaluation.evaluate(query, timeout=settings.TIMEOUT)
-        except KeyboardInterrupt:
-            print("\nKeyboardInterrupt")
+        eval_loop(feeder, shell)
 
         if args.persist:
             definitions.set_line_no(0)


### PR DESCRIPTION
The Mathics3 debugger has the abilty to go back into a Mathics session in the middle of debugging.

To separate what is done inside a debug sesssion from what is done outside in the interactive session we set "In[]" to be "Debug In[]" and Out[] to be "Debug Out[]".

Also we DRY the eval loop of main()