### PR TITLE
Match WMA nocatch msg better and check...

### DIFF
--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -506,6 +506,47 @@ class Switch(Builtin):
         # return unevaluated Switch when no pattern matches
 
 
+class Throw(Builtin):
+    """
+    <url>:WMA link:
+    https://reference.wolfram.com/language/ref/Throw.html</url>
+
+    <dl>
+      <dt>'Throw[`value`]'
+      <dd> stops evaluation and returns `value` as the value of the nearest \
+           enclosing 'Catch'.
+
+      <dt>'Catch[`value`, `tag`]'
+      <dd> is caught only by `Catch[expr,form]`, where tag matches form.
+    </dl>
+
+    Using Throw can affect the structure of what is returned by a function:
+
+    >> NestList[#^2 + 1 &, 1, 7]
+     = ...
+    >> Catch[NestList[If[# > 1000, Throw[#], #^2 + 1] &, 1, 7]]
+     = 458330
+
+    >> Throw[1]
+     : Uncaught Throw[1] returned to top level.
+     = Hold[Throw[1]]
+    """
+
+    messages = {
+        "nocatch": "Uncaught `1` returned to top level.",
+    }
+
+    summary_text = "throw an expression to be caught by a surrounding 'Catch'"
+
+    def eval(self, value, evaluation: Evaluation):
+        "Throw[value_]"
+        raise WLThrowInterrupt(value)
+
+    def eval_with_tag(self, value, tag, evaluation: Evaluation):
+        "Throw[value_, tag_]"
+        raise WLThrowInterrupt(value, tag)
+
+
 class Which(Builtin):
     """
     <url>
@@ -609,43 +650,3 @@ class While(Builtin):
             except ReturnInterrupt as e:
                 return e.expr
         return SymbolNull
-
-
-class Throw(Builtin):
-    """
-    <url>:WMA link:
-    https://reference.wolfram.com/language/ref/Throw.html</url>
-
-    <dl>
-      <dt>'Throw[`value`]'
-      <dd> stops evaluation and returns `value` as the value of the nearest \
-           enclosing 'Catch'.
-
-      <dt>'Catch[`value`, `tag`]'
-      <dd> is caught only by `Catch[expr,form]`, where tag matches form.
-    </dl>
-
-    Using Throw can affect the structure of what is returned by a function:
-
-    >> NestList[#^2 + 1 &, 1, 7]
-     = ...
-    >> Catch[NestList[If[# > 1000, Throw[#], #^2 + 1] &, 1, 7]]
-     = 458330
-
-    X> Throw[1]
-      = Null
-    """
-
-    messages = {
-        "nocatch": "Uncaught `1` returned to top level.",
-    }
-
-    summary_text = "throw an expression to be caught by a surrounding 'Catch'"
-
-    def eval(self, value, evaluation: Evaluation):
-        "Throw[value_]"
-        raise WLThrowInterrupt(value)
-
-    def eval_with_tag(self, value, tag, evaluation: Evaluation):
-        "Throw[value_, tag_]"
-        raise WLThrowInterrupt(value, tag)

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -309,19 +309,14 @@ class Evaluation:
                 else:
                     raise
             except WLThrowInterrupt as ti:
-                if ti.tag:
-                    self.exc_result = Expression(
-                        SymbolHold, Expression(SymbolThrow, ti.value, ti.tag)
-                    )
-                else:
-                    self.exc_result = Expression(
-                        SymbolHold, Expression(SymbolThrow, ti.value)
-                    )
-                self.message("Throw", "nocatch", self.exc_result)
-            #            except OverflowError:
-            #                print("Catch the overflow")
-            #                self.message("General", "ovfl")
-            #                self.exc_result = Expression(SymbolOverflow)
+                msg_expr = (
+                    Expression(SymbolThrow, ti.value, ti.tag)
+                    if ti.tag
+                    else Expression(SymbolThrow, ti.value)
+                )
+                self.message("Throw", "nocatch", msg_expr)
+                self.exc_result = Expression(SymbolHold, msg_expr)
+
             except BreakInterrupt:
                 self.message("Break", "nofdw")
                 self.exc_result = Expression(SymbolHold, Expression(SymbolBreak))


### PR DESCRIPTION
* mathics/builtin/procedural.py: add doctest check for error message; correct class sorting
* mathics/core/evaluation.py; wrap result in Hold, but not the message

@mmatera it looks like you added the Throw error handling code a while ago (4 years ago?). 

 I am in the slow process of going over https://github.com/Mathics3/mathics-core/pull/new/match-Hold-error-msg  and noticed this. 