### PR TITLE
making llvmlite to be optional

### DIFF
--- a/mathics/builtin/compilation.py
+++ b/mathics/builtin/compilation.py
@@ -49,18 +49,18 @@ class Compile(Builtin):
 
 
     >> cf = Compile[{x, y}, x + 2 y]
-     = CompiledFunction[{x, y}, x + 2 y, -CompiledCode-]
+     = CompiledFunction[{x, y}, x + 2 y, ...]
     >> cf[2.5, 4.3]
      = 11.1
 
     >> cf = Compile[{{x, _Real}}, Sin[x]]
-     = CompiledFunction[{x}, Sin[x], -CompiledCode-]
+     = CompiledFunction[{x}, Sin[x], ...]
     >> cf[1.4]
      = 0.98545
 
     Compile supports basic flow control:
     >> cf = Compile[{{x, _Real}, {y, _Integer}}, If[x == 0.0 && y <= 0, 0.0, Sin[x ^ y] + 1 / Min[x, 0.5]] + 0.5]
-     = CompiledFunction[{x, y}, ..., -CompiledCode-]
+     = CompiledFunction[{x, y}, ...]
     >> cf[3.5, 2]
      = 2.18888
 
@@ -78,7 +78,6 @@ class Compile(Builtin):
         "fdup": "Duplicate parameter `1` found in `2`.",
     }
 
-    requires = ("llvmlite",)
     summary_text = "compile an expression"
 
     def eval(self, vars, expr, evaluation: Evaluation):
@@ -172,7 +171,7 @@ class CompiledFunction(Builtin):
     </dl>
 
     >> sqr = Compile[{x}, x x]
-     = CompiledFunction[{x}, x ^ 2, -CompiledCode-]
+     = CompiledFunction[{x}, x ^ 2, ...]
     >> Head[sqr]
      = CompiledFunction
     >> sqr[2]

--- a/mathics/compile/__init__.py
+++ b/mathics/compile/__init__.py
@@ -15,8 +15,9 @@ except ImportError:
     has_llvmlite = False
 
 
+from .base import CompileArg, CompileError
+from .types import *
+
 if has_llvmlite:
-    from .base import CompileArg, CompileError
     from .compile import _compile
     from .ir import IRGenerator
-    from .types import *

--- a/mathics/compile/types.py
+++ b/mathics/compile/types.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from llvmlite import ir
+try:
+    from llvmlite import ir
 
-int_type = ir.IntType(64)
-real_type = ir.DoubleType()
-bool_type = ir.IntType(1)
-void_type = ir.VoidType()
+    int_type = ir.IntType(64)
+    real_type = ir.DoubleType()
+    bool_type = ir.IntType(1)
+    void_type = ir.VoidType()
+except:
+    int_type = int
+    real_type = float
+    bool_type = bool
+    void_type = type(None)

--- a/mathics/core/convert/function.py
+++ b/mathics/core/convert/function.py
@@ -22,6 +22,10 @@ try:
     }
 except ImportError:
     use_llvm = False
+    bool_type = bool
+    int_type = int
+    real_type = float
+
     permitted_types = {
         Expression(SymbolBlank, SymbolInteger): int,
         Expression(SymbolBlank, SymbolReal): float,

--- a/mathics/eval/distance.py
+++ b/mathics/eval/distance.py
@@ -1,6 +1,7 @@
 """
 Distance-related evaluation functions and exception classes
 """
+
 from mathics.core.atoms import Integer, Real
 
 

--- a/mathics/eval/drawing/plot.py
+++ b/mathics/eval/drawing/plot.py
@@ -111,8 +111,11 @@ def compile_quiet_function(expr, arg_names, evaluation, list_is_expected: bool):
     expr: Optional[Type[BaseElement]] = Expression(SymbolN, expr).evaluate(evaluation)
 
     def quiet_f(*args):
+        old_quiet_all = evaluation.quiet_all
+        evaluation.quiet_all = True
         vars = {arg_name: Real(arg) for arg_name, arg in zip(arg_names, args)}
         value = dynamic_scoping(expr.evaluate, vars, evaluation)
+        evaluation.quiet_all = old_quiet_all
         if list_is_expected:
             if value.has_form("List", None):
                 value = [extract_pyreal(item) for item in value.elements]

--- a/mathics/eval/files_io/read.py
+++ b/mathics/eval/files_io/read.py
@@ -248,12 +248,14 @@ def read_list_from_types(read_types):
     # TODO: look for a better implementation handling "Hold[Expression]".
     #
     read_types = (
-        SymbolHoldExpression
-        if (
-            typ.get_head_name() == "System`Hold"
-            and typ.elements[0].get_name() == "System`Expression"
+        (
+            SymbolHoldExpression
+            if (
+                typ.get_head_name() == "System`Hold"
+                and typ.elements[0].get_name() == "System`Expression"
+            )
+            else typ
         )
-        else typ
         for typ in read_types
     )
 

--- a/mathics/eval/hyperbolic.py
+++ b/mathics/eval/hyperbolic.py
@@ -1,6 +1,7 @@
 """
 Mathics3 builtins from mathics.core.numbers.hyperbolic
 """
+
 from sympy import Symbol as SympySymbol
 
 from mathics.core.convert.sympy import from_sympy

--- a/mathics/eval/strings.py
+++ b/mathics/eval/strings.py
@@ -1,6 +1,7 @@
 """
 String-related evaluation functions.
 """
+
 from mathics.core.atoms import String
 from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 description = "A general-purpose computer algebra system."
 dependencies = [
     "Mathics-Scanner >= 1.3.0",
-    "llvmlite",
+#    "llvmlite",
     "mpmath>=1.2.0",
     "numpy<1.27",
     "palettable",

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -6,3 +6,4 @@ pyocr # Used for TextRecognize
 scikit-image >= 0.17 # FindMinimum can use this; used by Image as well
 unidecode # Used in Transliterate
 wordcloud >= 1.9.3 # Used in builtin/image.py by WordCloud(). Previous versions assume "image.textsize" which no longer exists
+llvmlite # Used for llvm compiling

--- a/test/builtin/atomic/test_strings2.py
+++ b/test/builtin/atomic/test_strings2.py
@@ -64,7 +64,7 @@ def test_string_split():
         (
             'StringSplit["This is a sentence, which goes on.",  Except[WordCharacter] ..]',
             "{This, is, a, sentence, which, goes, on}",
-        )
+        ),
         # #  FIXME: these forms are not implemented yet:
         # ('StringSplit["11a22b3", _?LetterQ]', '{11, 22, 3}'),
         # ('StringSplit["a b::c d::e f g", "::" -> "--"]'), '{a, b, --, c d, --, e f g}'),

--- a/test/builtin/test_compilation.py
+++ b/test/builtin/test_compilation.py
@@ -9,7 +9,13 @@ from test.helper import check_evaluation, evaluate
 
 import pytest
 
+from mathics.compile import has_llvmlite
 
+
+@pytest.mark.skipif(
+    not has_llvmlite,
+    reason="requires llvmlite",
+)
 @pytest.mark.parametrize(
     ("str_expr", "msgs", "str_expected", "fail_msg"),
     [

--- a/test/builtin/test_compile.py
+++ b/test/builtin/test_compile.py
@@ -42,6 +42,10 @@ if has_llvmlite:
     )
 
 
+@pytest.mark.skipif(
+    not has_llvmlite,
+    reason="requires llvmlite",
+)
 def test_compile_code():
     for str_expr, x, res in [
         ("Sin[x]", 1.5, 0.997495),
@@ -60,6 +64,10 @@ def test_compile_code():
         assert abs(y - res) < 1.0e-6
 
 
+@pytest.mark.skipif(
+    not has_llvmlite,
+    reason="requires llvmlite",
+)
 def test_builtin_fns_with_symbols_1():
     for str_expr, x, res in [
         ("Sin[x]", 1.5, 0.997495),

--- a/test/consistency-and-style/test_duplicate_builtins.py
+++ b/test/consistency-and-style/test_duplicate_builtins.py
@@ -4,6 +4,7 @@ Checks that builtin functions do not get redefined.
 In the past when reorganizing builtin functions we sometimes
 had missing or duplicate built-in functions definitions.
 """
+
 import os
 
 import pytest

--- a/test/doc/test_common.py
+++ b/test/doc/test_common.py
@@ -1,6 +1,7 @@
 """
 Pytests for the documentation system. Basic functions and classes.
 """
+
 import os.path as osp
 
 from mathics.core.evaluation import Message, Print

--- a/test/doc/test_doctests.py
+++ b/test/doc/test_doctests.py
@@ -1,6 +1,7 @@
 """
 Pytests for the documentation system. Basic functions and classes.
 """
+
 import os.path as osp
 
 from mathics.core.evaluation import Message, Print

--- a/test/doc/test_latex.py
+++ b/test/doc/test_latex.py
@@ -1,6 +1,7 @@
 """
 Pytests for the documentation system. Basic functions and classes.
 """
+
 import os.path as osp
 
 from mathics.core.evaluation import Message, Print


### PR DESCRIPTION
Following the requirement in #1099, this PR makes the dependency in llvm-lite optional.
Notice that the "Action Tests" here still run over the full installation, which includes this library.