### PR TITLE
Go over package dependencies...

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -898,22 +898,24 @@ class FindRoot(_BaseFinder):
             native_findroot_messages,
             native_findroot_methods,
         )
-
-        methods.update(native_findroot_methods)
-        messages.update(native_findroot_messages)
     except Exception:
         pass
+    else:
+        methods.update(native_findroot_methods)
+        messages.update(native_findroot_messages)
+
     try:
         from mathics.builtin.scipy_utils.optimizers import (
             scipy_findroot_methods,
             update_findroot_messages,
         )
 
+    except Exception:
+        pass
+    else:
         methods.update(scipy_findroot_methods)
         messages = _BaseFinder.messages.copy()
         update_findroot_messages(messages)
-    except Exception:
-        pass
 
 
 # Move to mathics.builtin.domains...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ build-backend = "setuptools.build_meta"
 description = "A general-purpose computer algebra system."
 dependencies = [
     "Mathics-Scanner >= 1.3.0",
-#    "llvmlite",
     "mpmath>=1.2.0",
     "numpy<1.27",
     "palettable",
@@ -23,6 +22,7 @@ dependencies = [
     "pint",
     "python-dateutil",
     "requests",
+    "scipy",
     "setuptools",
     "sympy>=1.11,<1.13",
 ]
@@ -63,6 +63,7 @@ dev = [
 ]
 full = [
     "ipywidgets",
+    "llvmlite",
     "lxml",
     "psutil",
     "pyocr",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,7 +12,6 @@ def get_testdir():
     return osp.realpath(filename)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7 or higher")
 def test_cli():
     script_file = osp.join(get_testdir(), "data", "script.m")
 


### PR DESCRIPTION
* Use try/else to narrow the region of uncertainty
* We no longer need to check for Python 3.7
* add llvm under as a "full" install dependency
* scipy is a dependency; add it