### PR TITLE
Noticed another ` _apply` that should be `eval_xxx`

### DIFF
--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -230,6 +230,7 @@ class General(Builtin):
         "ssym": "`1` is not a symbol or a string.",
         "stream": "`1` is not string, InputStream[], or OutputStream[]",
         "string": "String expected.",
+        "strse": "String or list of strings expected at position `1` in `2`.",
         "sym": "Argument `1` at position `2` is expected to be a symbol.",
         "tag": "Rule for `1` can only be attached to `2`.",
         "take": "Cannot take positions `1` through `2` in `3`.",

--- a/mathics/builtin/string/charcodes.py
+++ b/mathics/builtin/string/charcodes.py
@@ -65,9 +65,6 @@ class ToCharacterCode(Builtin):
      = -Graphics-
     """
 
-    messages = {
-        "strse": "String or list of strings expected at position `1` in `2`.",
-    }
     summary_text = "convert a string to a list of character codes"
 
     def _encode(self, string, encoding, evaluation: Evaluation):

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -39,6 +39,7 @@ from mathics.core.systemsymbols import (
 )
 from mathics.eval.makeboxes import format_element
 from mathics.eval.parts import convert_seq, python_seq
+from mathics.eval.strings import eval_StringFind
 
 
 class StringDrop(Builtin):
@@ -197,7 +198,6 @@ class StringInsert(Builtin):
      = 1.234.567.890.123.456"""
 
     messages = {
-        "strse": "String or list of strings expected at position `1` in `2`.",
         "string": "String expected at position `1` in `2`.",
         "ins": "Cannot insert at position `1` in `2`.",
         "psl": "Position specification `1` in `2` is not a machine-sized integer or a list of machine-sized integers.",
@@ -402,7 +402,6 @@ class StringPosition(Builtin):
     """
 
     messages = {
-        "strse": "String or list of strings expected at position `1` in `2`.",
         "overall": "Overlaps -> All option is not currently implemented in Mathics.",
         "innf": "Non-negative integer or Infinity expected at position `2` in `1`.",
     }
@@ -576,7 +575,7 @@ class StringReplace(_StringFind):
     def eval(self, string, rule, n, evaluation: Evaluation, options: dict):
         "%(name)s[string_, rule_, OptionsPattern[%(name)s], n_:System`Private`Null]"
         # this pattern is a slight hack to get around missing Shortest/Longest.
-        return self._apply(string, rule, n, evaluation, options, False)
+        return eval_StringFind(self, string, rule, n, evaluation, options, False)
 
 
 class StringReverse(Builtin):
@@ -750,7 +749,6 @@ class StringSplit(Builtin):
     """
 
     messages = {
-        "strse": "String or list of strings expected at position `1` in `2`.",
         "pysplit": "As of Python 3.5 re.split does not handle empty pattern matches.",
     }
 
@@ -862,20 +860,21 @@ class StringTake(Builtin):
     """
 
     messages = {
-        "strse": "String or list of strings expected at position 1.",
         # FIXME: mseqs should be: Sequence specification (+n, -n, {+n}, {-n}, {m, n}, or {m, n, s}) or a list
         # of sequence specifications expected at position 2 in
         "mseqs": "Integer or a list of sequence specifications expected at position 2.",
+        # FIXME: we can't used stre from General because we do not have the expr context
+        "strse": "String or list of strings expected at position 1.",
         "take": 'Cannot take positions `1` through `2` in "`3`".',
     }
 
     summary_text = "sub-string from a range of positions"
 
-    def eval(self, string, seqspec, evaluation):
+    def eval(self, string: String, seqspec, evaluation: Evaluation):
         "StringTake[string_String, seqspec_]"
         result = string.get_string_value()
         if result is None:
-            evaluation.message("StringTake", "strse")
+            evaluation.message("StringTake", "strse", Integer1, string)
             return
 
         if isinstance(seqspec, Integer):

--- a/mathics/builtin/string/patterns.py
+++ b/mathics/builtin/string/patterns.py
@@ -20,6 +20,7 @@ from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolFalse, SymbolTrue
+from mathics.eval.strings import eval_StringFind
 
 SymbolStringMatchQ = Symbol("StringMatchQ")
 SymbolStringExpression = Symbol("StringExpression")
@@ -230,7 +231,7 @@ class StringCases(_StringFind):
     def eval(self, string, rule, n, evaluation: Evaluation, options: dict):
         "%(name)s[string_, rule_, OptionsPattern[%(name)s], n_:System`Private`Null]"
         # this pattern is a slight hack to get around missing Shortest/Longest.
-        return self._apply(string, rule, n, evaluation, options, True)
+        return eval_StringFind(self, string, rule, n, evaluation, options, True)
 
 
 class StringExpression(BinaryOperator):
@@ -306,10 +307,6 @@ class StringFreeQ(Builtin):
 
     """
 
-    messages = {
-        "strse": "String or list of strings expected at position `1` in `2`.",
-    }
-
     options = {
         "IgnoreCase": "False",
     }
@@ -356,10 +353,6 @@ class StringMatchQ(Builtin):
     options = {
         "IgnoreCase": "False",
         "SpellingCorrections": "None",
-    }
-
-    messages = {
-        "strse": "String or list of strings expected at position `1` in `2`.",
     }
 
     rules = {

--- a/mathics/eval/strings.py
+++ b/mathics/eval/strings.py
@@ -1,11 +1,17 @@
 """
 String-related evaluation functions.
 """
+import re
 
-from mathics.core.atoms import String
+from mathics.core.atoms import Integer1, Integer3, String
+from mathics.core.convert.expression import to_mathics_list
+from mathics.core.convert.regex import to_regex
 from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation
-from mathics.core.symbols import Symbol
+from mathics.core.expression import Expression
+from mathics.core.expression_predefined import MATHICS3_INFINITY
+from mathics.core.list import ListExpression
+from mathics.core.symbols import Symbol, SymbolTrue
 from mathics.eval.makeboxes import format_element
 
 
@@ -16,3 +22,77 @@ def eval_ToString(
     boxes = format_element(expr, evaluation, form, encoding=encoding)
     text = boxes.boxes_to_text(evaluation=evaluation)
     return String(text)
+
+
+def eval_StringFind(self, string, rule, n, evaluation, options, cases):
+    if n.sameQ(Symbol("System`Private`Null")):
+        expr = Expression(Symbol(self.get_name()), string, rule)
+        n = None
+    else:
+        expr = Expression(Symbol(self.get_name()), string, rule, n)
+
+    # convert string
+    if isinstance(string, ListExpression):
+        py_strings = [stri.get_string_value() for stri in string.elements]
+        if None in py_strings:
+            evaluation.message(self.get_name(), "strse", Integer1, expr)
+            return
+    else:
+        py_strings = string.get_string_value()
+        if py_strings is None:
+            evaluation.message(self.get_name(), "strse", Integer1, expr)
+            return
+
+    # convert rule
+    def convert_rule(r):
+        if r.has_form("Rule", None) and len(r.elements) == 2:
+            py_s = to_regex(r.elements[0], show_message=evaluation.message)
+            if py_s is None:
+                evaluation.message(
+                    "StringExpression", "invld", r.elements[0], r.elements[0]
+                )
+                return
+            py_sp = r.elements[1]
+            return py_s, py_sp
+        elif cases:
+            py_s = to_regex(r, show_message=evaluation.message)
+            if py_s is None:
+                evaluation.message("StringExpression", "invld", r, r)
+                return
+            return py_s, None
+
+        evaluation.message(self.get_name(), "srep", r)
+        return
+
+    if rule.has_form("List", None):
+        py_rules = [convert_rule(r) for r in rule.elements]
+    else:
+        py_rules = [convert_rule(rule)]
+    if None in py_rules:
+        return None
+
+    # convert n
+    if n is None:
+        py_n = 0
+    elif n.sameQ(MATHICS3_INFINITY):
+        py_n = 0
+    else:
+        py_n = n.get_int_value()
+        if py_n is None or py_n < 0:
+            evaluation.message(self.get_name(), "innf", Integer3, expr)
+            return
+
+    # flags
+    flags = re.MULTILINE
+    if options["System`IgnoreCase"] is SymbolTrue:
+        flags = flags | re.IGNORECASE
+
+    if isinstance(py_strings, list):
+        return to_mathics_list(
+            *[
+                self._find(py_stri, py_rules, py_n, flags, evaluation)
+                for py_stri in py_strings
+            ]
+        )
+    else:
+        return self._find(py_strings, py_rules, py_n, flags, evaluation)


### PR DESCRIPTION
Something I noticed during debugging something else. In looking at tracebacks, names in context are a bit more visible, making it easier when names reflect what's going on.

Also, an error message added to General and duplication in classes removed. 