### PR TITLE
Add CI job for mypy

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,40 @@
+name: Mathics3 (Type checking)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt update -qq && sudo apt install llvm-dev remake
+        python -m pip install --upgrade pip
+        # We can comment out after next Mathics-Scanner release
+        # python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        git clone https://github.com/Mathics3/mathics-scanner.git
+        cd mathics-scanner/
+        pip install -e .
+        cd ..
+
+    - name: Install Mathics with minimum dependencies
+      run: |
+        make develop
+    - name: Run mypy
+      run: |
+        pip install mypy==1.13 sympy==1.12
+        touch ./mathics-scanner/mathics_scanner/py.typed
+        pip install ./mathics-scanner/
+        mypy --install-types --non-interactive mathics

--- a/mathics/__init__.py
+++ b/mathics/__init__.py
@@ -3,7 +3,7 @@
 import platform
 import sys
 from importlib import import_module
-from typing import Dict
+from typing import Dict, Tuple
 
 from mpmath import __version__ as mpmath_version
 from numpy import __version__ as numpy_version
@@ -26,7 +26,7 @@ version_info: Dict[str, str] = {
 
 # optional_software contains a list of Python packages
 # that add functionality but are optional
-optional_software: Dict[str, str] = (
+optional_software: Tuple[str, ...] = (
     "cython",
     "lxml",
     "matplotlib",

--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -7,6 +7,7 @@ no_doc = True
 
 
 from math import atan2, ceil, cos, degrees, floor, log10, pi, sin
+from typing import Optional
 
 from mathics.builtin.box.expression import BoxExpression
 from mathics.builtin.colors.color_directives import (
@@ -48,7 +49,7 @@ SymbolStandardForm = Symbol("StandardForm")
 
 # Note: has to come before _ArcBox
 class _RoundBox(_GraphicsElementBox):
-    face_element = None
+    face_element: Optional[bool] = None
 
     def init(self, graphics, style, item):
         super(_RoundBox, self).init(graphics, item, style)

--- a/mathics/builtin/quantum_mechanics/angular.py
+++ b/mathics/builtin/quantum_mechanics/angular.py
@@ -106,10 +106,10 @@ class PauliMatrix(SympyFunction):
     >> PauliMatrix[1] . PauliMatrix[2] == I PauliMatrix[3]
      = True
 
-    >> MatrixExp[I \[Phi]/2 PauliMatrix[3]]
+    >> MatrixExp[I \\[Phi]/2 PauliMatrix[3]]
      = {{E ^ (I / 2 ϕ), 0}, {0, E ^ ((-I / 2) ϕ)}}
 
-    >> % /. \[Phi] -> 2 Pi
+    >> % /. \\[Phi] -> 2 Pi
      = {{-1, 0}, {0, -1}}
     """
 

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -6,7 +6,7 @@ import math
 import re
 from typing import Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 
-import mpmath  # type: ignore[import-untyped]
+import mpmath
 import sympy
 
 from mathics.core.element import BoxElementMixin, ImmutableValueMixin

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -26,7 +26,7 @@ from typing import (
     cast,
 )
 
-import mpmath  # type: ignore[import-untyped]
+import mpmath
 import pkg_resources
 import sympy
 

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -196,7 +196,7 @@ class Builtin:
     rules: Dict[str, Any] = {}
     formats: Dict[str, Any] = {}
     messages: Dict[str, Any] = {}
-    options: Optional[Dict[str, Any]] = {}
+    options: Dict[str, Any] = {}
     defaults: Dict[Optional[int], str] = {}
 
     def __getnewargs_ex__(self):
@@ -244,7 +244,6 @@ class Builtin:
 
         option_syntax = "Warn"
 
-        assert self.options is not None
         for option, value in self.options.items():
             if option == "$OptionSyntax":
                 option_syntax = value
@@ -518,6 +517,8 @@ class Builtin:
 
 
 class BuiltinElement(Builtin, BaseElement):
+    options: Dict[str, Any]
+
     def __new__(cls, *args, **kwargs):
         new_kwargs = kwargs.copy()
         # In a Builtin element, we never return an Expression object,
@@ -1213,6 +1214,7 @@ class PatternObject(BuiltinElement, BasePattern):
     needs_verbatim = True
 
     arg_counts: List[int] = []
+    options: Dict[str, Any]
 
     def init(self, expr: Expression, evaluation: Optional[Evaluation] = None):
         super().init(expr, evaluation=evaluation)

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -196,7 +196,7 @@ class Builtin:
     rules: Dict[str, Any] = {}
     formats: Dict[str, Any] = {}
     messages: Dict[str, Any] = {}
-    options: Dict[str, Any] = {}
+    options: Optional[Dict[str, Any]] = {}
     defaults: Dict[Optional[int], str] = {}
 
     def __getnewargs_ex__(self):
@@ -244,6 +244,7 @@ class Builtin:
 
         option_syntax = "Warn"
 
+        assert self.options is not None
         for option, value in self.options.items():
             if option == "$OptionSyntax":
                 option_syntax = value

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -3,7 +3,7 @@
 from functools import lru_cache
 from typing import Optional, Union
 
-import mpmath  # type: ignore[import-untyped]
+import mpmath
 import sympy
 
 from mathics.core.atoms import Complex, MachineReal, MachineReal0, PrecisionReal

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -208,8 +208,9 @@ class BaseElement(KeyComparable, ABC):
     Some important subclasses: Atom and Expression.
     """
 
-    options: dict
+    options: Optional[Dict[str, Any]]
     last_evaluated: Any
+    unevaluated: bool
     # this variable holds a function defined in mathics.core.expression that creates an expression
     create_expression: Any
 

--- a/mathics/core/evaluation.py
+++ b/mathics/core/evaluation.py
@@ -172,7 +172,7 @@ class Evaluation:
         self.out: List[_Out] = []
         self.output = output if output else Output()
         self.listeners: Dict[str, List[Callable]] = {}
-        self.options: Optional[tuple] = None
+        self.options: Optional[Dict[str, Any]] = None
         self.predetermined_out = None
 
         self.quiet_all = False

--- a/mathics/core/number.py
+++ b/mathics/core/number.py
@@ -6,7 +6,7 @@ from math import ceil, log
 from sys import float_info
 from typing import List, Optional, Union
 
-import mpmath  # type: ignore[import-untyped]
+import mpmath
 import sympy
 
 from mathics.core.element import BaseElement

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -549,7 +549,7 @@ class DocumentationEntry:
         item = "\n".join(line for line in item.split("\n") if not line.isspace())
         return item
 
-    def get_tests(self) -> List["DocumentationEntry"]:
+    def get_tests(self) -> List["DocTest"]:
         """retrieve a list of tests in the documentation entry"""
         tests = []
         for item in self.items:

--- a/mathics/doc/latex/doc2latex.py
+++ b/mathics/doc/latex/doc2latex.py
@@ -63,7 +63,7 @@ def read_doctest_data(quiet=False) -> Optional[Dict[tuple, dict]]:
         )
     except KeyboardInterrupt:
         print("\nAborted.\n")
-        return
+        return None
 
 
 def get_versions():

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -4,7 +4,7 @@ FIXME: Ditch home-grown and lame parsing and hook into sphinx.
 """
 
 import re
-from typing import Optional
+from typing import Callable, Optional
 
 from mathics.doc.doc_entries import (
     CONSOLE_RE,
@@ -257,11 +257,11 @@ def escape_latex(text):
                 if content.find("/doc/") == 0:
                     slug = "/".join(content.split("/")[2:]).rstrip("/")
                     return "%s \\ref{%s}" % (text, latex_label_safe(slug))
-                    slug = "/".join(content.split("/")[2:]).rstrip("/")
-                    return "%s of section~\\ref{%s}" % (text, latex_label_safe(slug))
+                    # slug = "/".join(content.split("/")[2:]).rstrip("/")
+                    # return "%s of section~\\ref{%s}" % (text, latex_label_safe(slug))
                 else:
                     return "\\href{%s}{%s}" % (content, text)
-                return "\\href{%s}{%s}" % (content, text)
+        return "\\href{%s}{%s}" % (content, text)
 
     text = QUOTATIONS_RE.sub(repl_quotation, text)
     text = HYPERTEXT_RE.sub(repl_hypertext, text)
@@ -646,6 +646,7 @@ class LaTeXDocChapter(DocChapter):
                 short,
             )
 
+        sort_section_function: Callable
         if self.part.is_reference:
             sort_section_function = sorted
         else:
@@ -691,6 +692,7 @@ class LaTeXDocPart(DocPart):
         `output` is not used here but passed along to the bottom-most
         level in getting expected test results.
         """
+        chapter_fn: Callable
         if self.is_reference:
             chapter_fn = sorted_chapters
         else:

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -569,6 +569,8 @@ class LaTeXMathicsDocumentation(MathicsMainDocumentation):
     produce a the documentation in LaTeX format.
     """
 
+    parts: Sequence["LaTeXDocPart"]
+
     def __init__(self):
         super().__init__()
         self.load_documentation_sources()
@@ -629,6 +631,9 @@ class LaTeXMathicsDocumentation(MathicsMainDocumentation):
 
 
 class LaTeXDocChapter(DocChapter):
+    doc: LaTeXDocumentationEntry
+    guide_sections: Sequence["LaTeXDocGuideSection"]
+
     def latex(
         self, doc_data: dict, quiet=False, filter_sections: Optional[str] = None
     ) -> str:
@@ -712,6 +717,8 @@ class LaTeXDocPart(DocPart):
 
 
 class LaTeXDocSection(DocSection):
+    subsections: Sequence["LaTeXDocSubsection"]
+
     def __init__(
         self,
         chapter,
@@ -764,6 +771,8 @@ class LaTeXDocGuideSection(DocGuideSection):
     are examples of Guide Sections, and each contains a number of Sections.
     like NamedColors or Orthogonal Polynomials.
     """
+
+    subsections: Sequence["LaTeXDocSubsection"]
 
     def __init__(
         self,
@@ -827,6 +836,8 @@ class LaTeXDocSubsection(DocSubsection):
     """An object for a Documented Subsection.
     A Subsection is part of a Section.
     """
+
+    subsections: Sequence["LaTeXDocSubsection"]
 
     def __init__(
         self,

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -4,7 +4,7 @@ FIXME: Ditch home-grown and lame parsing and hook into sphinx.
 """
 
 import re
-from typing import Callable, Optional
+from typing import Callable, Optional, Sequence
 
 from mathics.doc.doc_entries import (
     CONSOLE_RE,
@@ -535,6 +535,8 @@ class LaTeXDocumentationEntry(DocumentationEntry):
     Mathics core also uses this in getting usage strings (`??`).
     """
 
+    items: Sequence["LaTeXDocumentationEntry"]
+
     def __init__(self, doc_str: str, title: str, section: Optional[DocSection]):
         super().__init__(doc_str, title, section)
 
@@ -548,7 +550,7 @@ class LaTeXDocumentationEntry(DocumentationEntry):
                 return escape_latex(self.rawdoc)
 
         return "\n".join(
-            item.latex(doc_data) for item in self.items if not item.is_private()
+            item.latex(doc_data) for item in self.items  # if not item.is_private()
         )
 
     def _set_classes(self):

--- a/mathics/doc/structure.py
+++ b/mathics/doc/structure.py
@@ -9,7 +9,7 @@ and extended regular expressions used to parse it.
 import logging
 import re
 from os import environ
-from typing import Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional, Sequence
 
 from mathics import settings
 from mathics.core.builtin import check_requires_list
@@ -17,7 +17,7 @@ from mathics.core.load_builtin import (
     builtins_by_module as global_builtins_by_module,
     mathics3_builtins_modules,
 )
-from mathics.doc.doc_entries import DocumentationEntry, Tests, filter_comments
+from mathics.doc.doc_entries import DocTest, DocumentationEntry, Tests, filter_comments
 from mathics.doc.utils import slugify
 from mathics.eval.pymathics import pymathics_builtins_by_module, pymathics_modules
 
@@ -60,11 +60,12 @@ class DocSection:
         self.chapter = chapter
         self.in_guide = in_guide
         self.installed = installed
-        self.items = []  # tests in section when this is under a guide section
+        # tests in section when this is under a guide section
+        self.items: List[DocTest] = []
         self.operator = operator
         self.slug = slugify(title)
-        self.subsections = []
-        self.subsections_by_slug = {}
+        self.subsections: Sequence[DocSubsection] = []
+        self.subsections_by_slug: Dict[str, DocSubsection] = {}
         self.summary_text = summary_text
         self.tests = None  # tests in section when not under a guide section
         self.title = title
@@ -120,18 +121,22 @@ class DocChapter:
     """
 
     def __init__(
-        self, part: "DocPart", title: str, doc=None, chapter_order: Optional[int] = None
+        self,
+        part: "DocPart",
+        title: str,
+        doc: Optional["DocumentationEntry"] = None,
+        chapter_order: Optional[int] = None,
     ):
         self.chapter_order = chapter_order
         self.doc = doc
-        self.guide_sections = []
+        self.guide_sections: Sequence[DocGuideSection] = []
         self.part = part
         self.title = title
         self.slug = slugify(title)
-        self.sections = []
-        self.sections_by_slug = {}
+        self.sections: List[DocSection] = []
+        self.sections_by_slug: Dict[str, DocSection] = {}
         self.sort_order = None
-        if doc:
+        if self.doc:
             self.doc.set_parent_path(self)
 
         part.chapters_by_slug[self.slug] = self
@@ -203,8 +208,8 @@ class DocPart:
     def __init__(self, documentation: "Documentation", title: str, is_reference=False):
         self.documentation = documentation
         self.title = title
-        self.chapters = []
-        self.chapters_by_slug = {}
+        self.chapters: List[DocChapter] = []
+        self.chapters_by_slug: Dict[str, DocChapter] = {}
         self.is_reference = is_reference
         self.is_appendix = False
         self.slug = slugify(title)
@@ -257,10 +262,10 @@ class Documentation:
         # without defining these attributes as class
         # attributes.
         self._set_classes()
-        self.appendix = []
+        self.appendix: List[DocPart] = []
         self.doc_dir = doc_dir
-        self.parts = []
-        self.parts_by_slug = {}
+        self.parts: Sequence[DocPart] = []
+        self.parts_by_slug: Dict[str, DocPart] = {}
         self.title = title
 
     def _set_classes(self):
@@ -421,7 +426,7 @@ class Documentation:
                 if MATHICS_DEBUG_TEST_CREATE:
                     print(f"DEBUG Gathering tests for Chapter {chapter.title}")
 
-                tests = chapter.doc.get_tests()
+                tests = chapter.doc.get_tests() if chapter.doc else []
                 if tests:
                     yield Tests(part.title, chapter.title, "", tests)
 
@@ -538,6 +543,7 @@ class Documentation:
             part.is_appendix = True
             self.appendix.append(part)
         else:
+            assert isinstance(self.parts, list)
             self.parts.append(part)
         return chapter_order
 
@@ -549,10 +555,10 @@ class DocSubsection:
 
     def __init__(
         self,
-        chapter,
-        section,
-        title,
-        text,
+        chapter: DocChapter,
+        section: DocSection,
+        title: str,
+        text: str,
         operator=None,
         installed=True,
         in_guide=False,
@@ -587,7 +593,7 @@ class DocSubsection:
 
         self.section = section
         self.slug = slugify(title)
-        self.subsections = []
+        self.subsections: Sequence[DocSubsection] = []
         self.title = title
         self.doc.set_parent_path(self)
 

--- a/mathics/doc/structure.py
+++ b/mathics/doc/structure.py
@@ -49,7 +49,7 @@ class DocSection:
 
     def __init__(
         self,
-        chapter,
+        chapter: "DocChapter",
         title: str,
         text: str,
         operator,
@@ -119,7 +119,9 @@ class DocChapter:
     A Chapter is part of a Part[dChapter. It can contain (Guide or plain) Sections.
     """
 
-    def __init__(self, part, title, doc=None, chapter_order: Optional[int] = None):
+    def __init__(
+        self, part: "DocPart", title: str, doc=None, chapter_order: Optional[int] = None
+    ):
         self.chapter_order = chapter_order
         self.doc = doc
         self.guide_sections = []
@@ -198,7 +200,7 @@ class DocPart:
 
     chapter_class = DocChapter
 
-    def __init__(self, documentation, title, is_reference=False):
+    def __init__(self, documentation: "Documentation", title: str, is_reference=False):
         self.documentation = documentation
         self.title = title
         self.chapters = []

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -23,8 +23,13 @@ import mathics
 from mathics import settings, version_string
 from mathics.core.evaluation import Output
 from mathics.core.load_builtin import _builtins, import_and_load_builtins
-from mathics.doc.common_doc import DocGuideSection, DocSection, MathicsMainDocumentation
-from mathics.doc.doc_entries import DocTest, DocTests
+from mathics.doc.doc_entries import DocTest, DocumentationEntry
+from mathics.doc.structure import (
+    DocGuideSection,
+    DocSection,
+    DocSubsection,
+    MathicsMainDocumentation,
+)
 from mathics.doc.utils import load_doctest_data, print_and_log, slugify
 from mathics.eval.pymathics import PyMathicsLoadException, eval_LoadModule
 from mathics.session import MathicsSession
@@ -368,11 +373,11 @@ def section_tests_iterator(
     the user definitions are reset.
     """
     chapter = section.chapter
-    subsections: List[DocSection] = [section]
+    subsections: List[Union[DocumentationEntry, DocSection, DocSubsection]] = [section]
     if chapter.doc:
         subsections = [chapter.doc] + subsections
     if section.subsections:
-        subsections = subsections + section.subsections
+        subsections.extend(section.subsections)
 
     for subsection in subsections:
         if (
@@ -409,11 +414,11 @@ def test_section_in_chapter(
 
     chapter = section.chapter
     index = 0
-    subsections = [section]
+    subsections: List[Union[DocumentationEntry, DocSection, DocSubsection]] = [section]
     if chapter.doc:
         subsections = [chapter.doc] + subsections
     if section.subsections:
-        subsections = subsections + section.subsections
+        subsections.extend(section.subsections)
 
     section_name_for_print = ""
     for doctest in section_tests_iterator(

--- a/mathics/format/asy.py
+++ b/mathics/format/asy.py
@@ -140,7 +140,7 @@ def arcbox(self: _ArcBox, **options) -> str:
         is_face_element=self.face_element,
     )
     command = "filldraw" if self.face_element else "draw"
-    arc_path = create_arc_path(self.face_element, yscale)
+    arc_path = create_arc_path(self.face_element or False, yscale)
     asy = f"""// ArcBox
 {command}({arc_path}, {pen});"""
     # print("### arcbox", asy)
@@ -705,18 +705,18 @@ add_conversion_fn(Sphere3DBox)
 
 
 def tube_3d_box(self: Tube3DBox, **options) -> str:
-    if not (hasattr(self.graphics, "tube_import_added") and self.tube_import_added):
-        self.graphics.tube_import_added = True
-        asy_head = "import tube;\n\n"
-    else:
-        asy_head = ""
+    # if not (hasattr(self.graphics, "tube_import_added") and self.tube_import_added):
+    #     self.graphics.tube_import_added = True
+    #     asy_head = "import tube;\n\n"
+    # else:
+    #     asy_head = ""
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)
     opacity = self.face_opacity
     color_str = build_3d_pen_color(face_color, opacity)
 
     asy = (
-        asy_head
-        + "// Tube3DBox\n draw(tube({0}, scale({1})*unitcircle), {2});".format(
+        # asy_head +
+        "// Tube3DBox\n draw(tube({0}, scale({1})*unitcircle), {2});".format(
             "--".join(
                 "({0},{1},{2})".format(*coords.pos()[0]) for coords in self.points
             ),
@@ -730,7 +730,7 @@ def tube_3d_box(self: Tube3DBox, **options) -> str:
 add_conversion_fn(Tube3DBox, tube_3d_box)
 
 
-def uniform_polyhedron_3d_box(self: RectangleBox, **options) -> str:
+def uniform_polyhedron_3d_box(self: UniformPolyhedron3DBox, **options) -> str:
     # l = self.style.get_line_width(face_element=True)
 
     face_color = self.face_color.to_js() if self.face_color else (1, 1, 1)

--- a/mathics/format/asy_fns.py
+++ b/mathics/format/asy_fns.py
@@ -5,9 +5,11 @@ Asymptote-related functions
 """
 
 from itertools import chain
-from typing import Optional, Type, Union
+from typing import Optional, Union
 
-RealType = Type[Union[int, float]]
+from mathics.builtin.colors.color_directives import _ColorObject
+
+RealType = Union[int, float]
 
 
 def asy_add_bezier_fn(self) -> str:
@@ -94,7 +96,7 @@ def asy_bezier(*segments):
         connect = p[-1:]
 
 
-def asy_color(self):
+def asy_color(self: _ColorObject):
     """Return an asymptote rgba string fragment for object's RGB or RGBA
     value and it opacity (alpha) value"""
     rgba = self.to_rgba()
@@ -106,8 +108,8 @@ def asy_color(self):
 
 
 def asy_create_pens(
-    edge_color: Optional[str] = None,
-    face_color: Optional[str] = None,
+    edge_color: Optional[_ColorObject] = None,
+    face_color: Optional[_ColorObject] = None,
     edge_opacity: Optional[RealType] = None,
     face_opacity: Optional[RealType] = None,
     stroke_width=None,

--- a/mathics/format/mathml.py
+++ b/mathics/format/mathml.py
@@ -303,24 +303,6 @@ def graphicsbox(self, elements=None, **options) -> str:
 add_conversion_fn(GraphicsBox, graphicsbox)
 
 
-def sqrtbox(self, **options):
-    _options = self.box_options.copy()
-    _options.update(options)
-    options = _options
-    if self.index:
-        return "<mroot> %s %s </mroot>" % (
-            lookup_conversion_method(self.radicand, "mathml")(self.radicand, **options),
-            lookup_conversion_method(self.index, "mathml")(self.index, **options),
-        )
-
-    return "<msqrt> %s </msqrt>" % lookup_conversion_method(self.radicand, "mathml")(
-        self.radicand, **options
-    )
-
-
-add_conversion_fn(SqrtBox, sqrtbox)
-
-
 def graphics3dbox(self, elements=None, **options) -> str:
     """Turn the Graphics3DBox into a MathML string"""
     json_repr = self.boxes_to_json(elements, **options)

--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -8,6 +8,7 @@ import os
 import os.path as osp
 import sys
 from pathlib import Path
+from typing import List
 
 import pkg_resources
 
@@ -97,7 +98,7 @@ ENABLE_FILES_MODULE = True
 
 # Rocky: this is probably a hack. LoadModule[] needs to handle
 # whatever it is that setting this thing did.
-default_pymathics_modules = []
+default_pymathics_modules: List[str] = []
 
 character_encoding = os.environ.get(
     "MATHICS_CHARACTER_ENCODING", sys.getdefaultencoding()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,5 +118,9 @@ version = {attr = "mathics.version.__version__"}
 force_union_syntax = true
 
 [[tool.mypy.overrides]]
-module = ["mpmath", "llvmlite.*"]
+module = ["mpmath", "llvmlite.*", "trepan.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["mathics.benchmark", "mathics.builtin.*", "mathics.eval.*", "test.*"]
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,10 @@ include = ["mathics*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "mathics.version.__version__"}
+
+[tool.mypy]
+force_union_syntax = true
+
+[[tool.mypy.overrides]]
+module = ["mpmath", "llvmlite.*"]
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ import os
 import os.path as osp
 import platform
 import sys
+from typing import List
 
 from setuptools import Extension, setup
 from setuptools.command.build_py import build_py as setuptools_build_py
@@ -49,7 +50,7 @@ def get_srcdir():
     return osp.realpath(filename)
 
 
-DEPENDENCY_LINKS = []
+DEPENDENCY_LINKS: List[str] = []
 #     "http://github.com/Mathics3/mathics-scanner/tarball/master#egg=Mathics_Scanner-1.0.0.dev"
 # ]
 
@@ -60,7 +61,7 @@ CMDCLASS = {}
 try:
     if is_PyPy:
         raise ImportError
-    from Cython.Distutils import build_ext
+    from Cython.Distutils import build_ext  # type: ignore[import-not-found]
 except ImportError:
     pass
 else:

--- a/test/consistency-and-style/test_summary_text.py
+++ b/test/consistency-and-style/test_summary_text.py
@@ -3,6 +3,8 @@ import importlib
 import os
 import os.path as osp
 import pkgutil
+from types import ModuleType
+from typing import Dict
 
 import pytest
 
@@ -59,7 +61,7 @@ local_vocabulary = (
 language_tool = None
 if CHECK_GRAMMAR:
     try:
-        import language_tool_python
+        import language_tool_python  # type: ignore[import-not-found]
 
         language_tool = language_tool_python.LanguageToolPublicAPI("en-US")
         # , config={ 'cacheSize': 1000, 'pipelineCaching': True })
@@ -114,7 +116,7 @@ for subdir in module_subdirs:
         module_names.append(f"{subdir}.{modname}")
 
 
-modules = dict()
+modules: Dict[str, ModuleType] = dict()
 for module_name in module_names:
     import_module(module_name)
 
@@ -122,6 +124,7 @@ for module_name in module_names:
 
 
 def check_grammar(text: str):
+    assert language_tool is not None
     matches = language_tool.check(text)
     filtered_matches = []
     if matches:

--- a/test/doc/test_latex.py
+++ b/test/doc/test_latex.py
@@ -107,7 +107,7 @@ def test_chapter():
         "\\section{Numerical Properties}\n"
         "\\label{reference-of-built-in-symbols/testing-expressions/numerical-properties}\n"
         "\\sectionstart\n\n\n\n"
-        "\\subsection{CoprimeQ}\index{CoprimeQ}"
+        "\\subsection{CoprimeQ}\\index{CoprimeQ}"
     )
     latex_section_head = section.latex({}).strip()[: len(expected_latex_section_head)]
 

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -549,8 +549,8 @@ all_test = {
             "System`OutputForm": "<mrow><mi>Integrate</mi> <mo>[</mo> <mrow><mrow><mi>F</mi> <mo>[</mo> <mi>x</mi> <mo>]</mo></mrow> <mtext>,&nbsp;</mtext> <mrow><mo>{</mo> <mrow><mi>x</mi> <mtext>,&nbsp;</mtext> <mi>a</mi> <mtext>,&nbsp;</mtext> <mrow><mi>g</mi> <mo>[</mo> <mi>b</mi> <mo>]</mo></mrow></mrow> <mo>}</mo></mrow></mrow> <mo>]</mo></mrow>",
         },
         "latex": {
-            "System`StandardForm": "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \, dx",
-            "System`TraditionalForm": "\\int_a^{g\\left(b\\right)} F\\left(x\\right) \, dx",
+            "System`StandardForm": "\\int_a^{g\\left[b\\right]} F\\left[x\\right] \\, dx",
+            "System`TraditionalForm": "\\int_a^{g\\left(b\\right)} F\\left(x\\right) \\, dx",
             "System`InputForm": "\\text{Integrate}\\left[F\\left[x\\right], \\left\\{x, a, g\\left[b\\right]\\right\\}\\right]",
             "System`OutputForm": "\\text{Integrate}\\left[F\\left[x\\right], \\left\\{x, a, g\\left[b\\right]\\right\\}\\right]",
         },


### PR DESCRIPTION
I've fixed up the remaining mypy errors outside of:

- `mathics.builtin` and `mathics.eval`: these still have quite a few errors, but are going to be a bigger job to go through than the core modules, and are probably easier to just knock off one by one incrementally
- `test/` which I'd say are lower priority for type checking
- `mathics/benchmark.py`: is this still used? It just crashes when I try to run it

For now I've just set the mypy config to ignore these directories so we can run a CI job to ensure that the other core modules continue to typecheck, but might be better to be a bit more selective.

There were also a couple bits of code I've commented out as they appeared to be dead as best I could tell, but tell me if I'm mistaken.