### PR TITLE
Update tests for issue #1156

### DIFF
--- a/test/builtin/numbers/test_linalg.py
+++ b/test/builtin/numbers/test_linalg.py
@@ -252,9 +252,7 @@ def test_inverse(str_expr, str_expected, fail_msg, warnings):
         (
             "eigvals /. a[x_, y_] -> x+I*y",
             None,
-            (
-                "{10 - 3 Sqrt[11], 10 + 3 Sqrt[11]}"
-            ),
+            ("{10 - 3 Sqrt[11], 10 + 3 Sqrt[11]}"),
             None,  # "Sympy issue #1156",
         ),
     ],

--- a/test/builtin/numbers/test_linalg.py
+++ b/test/builtin/numbers/test_linalg.py
@@ -212,17 +212,25 @@ def test_inverse(str_expr, str_expected, fail_msg, warnings):
             None,
         ),
         (
-            "A = Array[a, {2,2}]; eigvals=Eigenvalues[A.ConjugateTranspose[A]][[1]]",
+            "A = Array[a, {2,2}]; eigvals=Eigenvalues[A.ConjugateTranspose[A]]",
             None,
             (
-                "-Sqrt[(a[1, 1] Conjugate[a[1, 1]] + a[1, 2] Conjugate[a[1, 2]] "
-                "+ a[2, 1] Conjugate[a[2, 1]] + a[2, 2] Conjugate[a[2, 2]]) ^ 2 "
-                "- 4 (a[1, 1] Conjugate[a[1, 1]] + a[1, 2] Conjugate[a[1, 2]]) "
+                "{-Sqrt[(a[1, 1] Conjugate[a[1, 1]] + a[1, 2] Conjugate[a[1, 2]] + "
+                "a[2, 1] Conjugate[a[2, 1]] + a[2, 2] Conjugate[a[2, 2]]) ^ 2 - "
+                "4 (a[1, 1] Conjugate[a[1, 1]] + a[1, 2] Conjugate[a[1, 2]]) "
+                "(a[2, 1] Conjugate[a[2, 1]] + a[2, 2] Conjugate[a[2, 2]]) + "
+                "4 (a[1, 1] Conjugate[a[2, 1]] + a[1, 2] Conjugate[a[2, 2]]) "
+                "(a[2, 1] Conjugate[a[1, 1]] + a[2, 2] Conjugate[a[1, 2]])] / 2 "
+                "+ a[1, 1] Conjugate[a[1, 1]] / 2 + a[1, 2] Conjugate[a[1, 2]] / 2 + "
+                "a[2, 1] Conjugate[a[2, 1]] / 2 + a[2, 2] Conjugate[a[2, 2]] / 2, "
+                "Sqrt[(a[1, 1] Conjugate[a[1, 1]] + a[1, 2] Conjugate[a[1, 2]] + "
+                "a[2, 1] Conjugate[a[2, 1]] + a[2, 2] Conjugate[a[2, 2]]) ^ 2 - "
+                "4 (a[1, 1] Conjugate[a[1, 1]] + a[1, 2] Conjugate[a[1, 2]]) "
                 "(a[2, 1] Conjugate[a[2, 1]] + a[2, 2] Conjugate[a[2, 2]]) + 4 "
                 "(a[1, 1] Conjugate[a[2, 1]] + a[1, 2] Conjugate[a[2, 2]]) "
-                "(a[2, 1] Conjugate[a[1, 1]] + a[2, 2] Conjugate[a[1, 2]])] / 2 "
-                "+ a[1, 1] Conjugate[a[1, 1]] / 2 + a[1, 2] Conjugate[a[1, 2]] / 2 "
-                "+ a[2, 1] Conjugate[a[2, 1]] / 2 + a[2, 2] Conjugate[a[2, 2]] / 2"
+                "(a[2, 1] Conjugate[a[1, 1]] + a[2, 2] Conjugate[a[1, 2]])] / 2 + "
+                "a[1, 1] Conjugate[a[1, 1]] / 2 + a[1, 2] Conjugate[a[1, 2]] / 2 + "
+                "a[2, 1] Conjugate[a[2, 1]] / 2 + a[2, 2] Conjugate[a[2, 2]] / 2}"
             ),
             None,  # "Sympy issue #1156",
         ),
@@ -235,9 +243,19 @@ def test_inverse(str_expr, str_expected, fail_msg, warnings):
                 "4 a[1, 1] a[2, 2] Conjugate[a[1, 1]] Conjugate[a[2, 2]] - "
                 "4 a[1, 2] a[2, 1] Conjugate[a[1, 2]] Conjugate[a[2, 1]] + "
                 "4 a[1, 1] a[2, 2] Conjugate[a[1, 2]] Conjugate[a[2, 1]] + "
-                "4 a[1, 2] a[2, 1] Conjugate[a[1, 1]] Conjugate[a[2, 2]]] / 2"
+                "4 a[1, 2] a[2, 1] Conjugate[a[1, 1]] Conjugate[a[2, 2]]] / 2 + "
+                "a[1, 1] Conjugate[a[1, 1]] / 2 + a[1, 2] Conjugate[a[1, 2]] / 2 + "
+                "a[2, 1] Conjugate[a[2, 1]] / 2 + a[2, 2] Conjugate[a[2, 2]] / 2"
             ),
-            None,  #            "Sympy issue #1156",
+            None,  # "Sympy issue #1156",
+        ),
+        (
+            "eigvals /. a[x_, y_] -> x+I*y",
+            None,
+            (
+                "{10 - 3 Sqrt[11], 10 + 3 Sqrt[11]}"
+            ),
+            None,  # "Sympy issue #1156",
         ),
     ],
 )


### PR DESCRIPTION
Tests for issue #1156

# Test output

```python
(mathics) ~/git/mathics-core/test/builtin/numbers$ python -m pytest test_linalg.py
=================================================== test session starts ====================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: ~/git/mathics/mathics-core
configfile: pyproject.toml
plugins: anyio-4.6.2.post1, typeguard-4.3.0
collected 32 items

test_linalg.py ................................                                                                      [100%]

===================================================== warnings summary =====================================================
../../../mathics/settings.py:13
  ~/git/mathics/mathics-core/mathics/settings.py:13: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../../mathics/core/parser/convert.py:41
test/builtin/numbers/test_linalg.py::test_inverse[None-None-None-None]
  ~/git/mathics/mathics-core/mathics/core/parser/convert.py:41: DeprecationWarning: invalid escape sequence '\!'
    return s.encode("raw_unicode_escape").decode("unicode_escape")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== 32 passed, 3 warnings in 6.09s ==============================================
```
