### PR TITLE
Implement `Breakpoint[]`

### DIFF
--- a/mathics/__init__.py
+++ b/mathics/__init__.py
@@ -68,3 +68,8 @@ This program comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions.
 See the documentation for the full license."""
+
+
+# Disabled breakpoint
+def disabled_breakpoint():
+    print("Hit disabled breakpoint.")

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -882,12 +882,12 @@ class Breakpoint(Builtin):
            variable `PYTHONBREAKPOINT` can be utilized.
     </dl>
 
+    >> (* Test with a dummy breakpoint. *)
+    >> SetEnvironment["PYTHONBREAKPOINT" -> "mathics.docpipeline.dummy_breakpoint"]
+    Out[1]= SetEnvironment[PYTHONBREAKPOINT → mathics.docpipeline.dummy_breakpoint]
     >> Breakpoint[]
-    --Return--
-    > mathics/builtin/system.py(891)eval()->None
-    -> breakpoint()
-    (Pdb) c
-    Out[1]= Breakpoint[]
+    Dummy breakpoint() reached! Returning.
+    Out[2]= Breakpoint[]
     """
 
     summary_text = "invoke a Python breakpoint()"

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -885,8 +885,7 @@ class Breakpoint(Builtin):
     </dl>
 
     >> (* Test with a disabled breakpoint. *)
-    >> In[1]:= SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"]
-    Out[1]= SetEnvironment[PYTHONBREAKPOINT → mathics.disabled_breakpoint]
+    >> In[1]:= SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"];
     >> Breakpoint[]
     Hit disabled breakpoint.
     Out[2]= Breakpoint[]

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -877,7 +877,7 @@ class Breakpoint(Builtin):
     """
     <dl>
       <dt>'Breakpoint[]'
-      <dd> Invoke a Python breakpoint. By default, the python debugger \
+      <dd> Invoke a Python breakpoint. By default, the Python debugger \
            (pdb) is loaded. For loading other debuggers, the Python environment \
            variable `PYTHONBREAKPOINT` can be utilized.
     </dl>
@@ -890,7 +890,7 @@ class Breakpoint(Builtin):
     Out[1]= Breakpoint[]
     """
 
-    summary_text = "invoke a Python breakpoint"
+    summary_text = "invoke a Python breakpoint()"
 
     def eval(self, evaluation: Evaluation):
         "Breakpoint[]"

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -885,7 +885,7 @@ class Breakpoint(Builtin):
     </dl>
 
     >> (* Test with a disabled breakpoint. *)
-    >> In[1]:= SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"];
+    >> SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"];
     >> Breakpoint[]
     Hit disabled breakpoint.
     Out[2]= Breakpoint[]

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -875,6 +875,8 @@ class Share(Builtin):
 
 class Breakpoint(Builtin):
     """
+    ## <url>:trace native symbol:</url>
+
     <dl>
       <dt>'Breakpoint[]'
       <dd> Invoke a Python breakpoint. By default, the Python debugger \

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -888,7 +888,7 @@ class Breakpoint(Builtin):
     >> SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"];
     >> Breakpoint[]
     = Hit disabled breakpoint.
-    Out[2]= Breakpoint[]
+    = Breakpoint[]
     """
 
     summary_text = "invoke a Python breakpoint()"

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -887,7 +887,7 @@ class Breakpoint(Builtin):
     >> (* Test with a disabled breakpoint. *)
     >> SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"];
     >> Breakpoint[]
-    Hit disabled breakpoint.
+    = Hit disabled breakpoint.
     Out[2]= Breakpoint[]
     """
 

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -884,11 +884,11 @@ class Breakpoint(Builtin):
            variable `PYTHONBREAKPOINT` can be utilized.
     </dl>
 
-    >> (* Test with a dummy breakpoint. *)
-    >> SetEnvironment["PYTHONBREAKPOINT" -> "mathics.docpipeline.dummy_breakpoint"]
-    Out[1]= SetEnvironment[PYTHONBREAKPOINT → mathics.docpipeline.dummy_breakpoint]
+    >> (* Test with a disabled breakpoint. *)
+    >> In[1]:= SetEnvironment["PYTHONBREAKPOINT" -> "mathics.disabled_breakpoint"]
+    Out[1]= SetEnvironment[PYTHONBREAKPOINT → mathics.disabled_breakpoint]
     >> Breakpoint[]
-    Dummy breakpoint() reached! Returning.
+    Hit disabled breakpoint.
     Out[2]= Breakpoint[]
     """
 

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -871,3 +871,28 @@ class Share(Builtin):
         else:
             gc.collect()
             return Integer0
+
+
+class Breakpoint(Builtin):
+    """
+    <dl>
+      <dt>'Breakpoint[]'
+      <dd> Invoke a Python breakpoint. By default, the python debugger \
+           (pdb) is loaded. For loading other debuggers, the Python environment \
+           variable `PYTHONBREAKPOINT` can be utilized.
+    </dl>
+
+    >> Breakpoint[]
+    --Return--
+    > mathics/builtin/system.py(891)eval()->None
+    -> breakpoint()
+    (Pdb) c
+    Out[1]= Breakpoint[]
+    """
+
+    summary_text = "invoke a Python breakpoint"
+
+    def eval(self, evaluation: Evaluation):
+        "Breakpoint[]"
+
+        breakpoint()

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -60,11 +60,6 @@ TestParameters = namedtuple(
 )
 
 
-# Dummy breakpoint for doctests
-def dummy_breakpoint():
-    print("Dummy breakpoint() reached! Returning.")
-
-
 class TestOutput(Output):
     """Output class for tests"""
 

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -60,6 +60,11 @@ TestParameters = namedtuple(
 )
 
 
+# Dummy breakpoint for doctests
+def dummy_breakpoint():
+    print("Dummy breakpoint() reached! Returning.")
+
+
 class TestOutput(Output):
     """Output class for tests"""
 


### PR DESCRIPTION
This PR implements the `Breakpoint[]` functionality discussed in issue #1172.

With this implementation, it is possible to invoke a Python breakpoint from the mathics command line for debugging. Alternative debuggers can be loaded by setting the relevant Python environment variable `PYTHONBREAKPOINT`. 

Please feel free to edit the description text.