### PR TITLE
Lookup streams by user (short) names

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -12,7 +12,7 @@ from io import BytesIO
 # We use the below import for access to variables that may change
 # at runtime.
 import mathics.eval.files_io.files as io_files
-from mathics.core.atoms import Integer, Integer3, String, SymbolString
+from mathics.core.atoms import Integer, String, SymbolString
 from mathics.core.attributes import A_PROTECTED, A_READ_PROTECTED
 from mathics.core.builtin import (
     Builtin,

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -109,13 +109,13 @@ class _OpenAction(Builtin):
             tmpf = tempfile.NamedTemporaryFile(dir=TMP_DIR, delete=False)
             path = String(tmpf.name)
             tmpf.close()
-            return self.eval_path(path, evaluation, options)
+            return self.eval_name(path, evaluation, options)
         else:
             evaluation.message("OpenRead", "argx")
             return
 
-    def eval_path(self, path, evaluation: Evaluation, options: dict):
-        "%(name)s[path_?NotOptionQ, OptionsPattern[]]"
+    def eval_name(self, name, evaluation: Evaluation, options: dict):
+        "%(name)s[name_?NotOptionQ, OptionsPattern[]]"
 
         # Options
         # BinaryFormat
@@ -124,17 +124,18 @@ class _OpenAction(Builtin):
             if not self.mode.endswith("b"):
                 mode += "b"
 
-        if not (isinstance(path, String) and len(path.to_python()) > 2):
-            evaluation.message(self.__class__.__name__, "fstr", path)
+        if not (isinstance(name, String) and len(name.to_python()) > 2):
+            evaluation.message(self.__class__.__name__, "fstr", name)
             return
 
-        path_string = path.get_string_value()
+        name_string = name.get_string_value()
 
-        tmp, is_temporary_file = path_search(path_string)
+        tmp, is_temporary_file = path_search(name_string)
         if tmp is None:
             if mode in ["r", "rb"]:
-                evaluation.message("General", "noopen", path)
+                evaluation.message("General", "noopen", name)
                 return
+            path_string = name_string
         else:
             path_string = tmp
 
@@ -146,19 +147,20 @@ class _OpenAction(Builtin):
             opener = MathicsOpen(
                 path_string,
                 mode=mode,
+                name=name_string,
                 encoding=encoding.value,
                 is_temporary_file=is_temporary_file,
             )
             opener.__enter__(is_temporary_file=is_temporary_file)
             n = opener.n
         except IOError:
-            evaluation.message("General", "noopen", path)
+            evaluation.message("General", "noopen", name)
             return
         except MessageException as e:
             e.message(evaluation)
             return
 
-        return Expression(Symbol(self.stream_type), path, Integer(n))
+        return Expression(Symbol(self.stream_type), name, Integer(n))
 
 
 class Character(Builtin):
@@ -1612,11 +1614,9 @@ class WriteString(Builtin):
 
     def eval(self, channel, expr, evaluation: Evaluation):
         """WriteString[channel_, expr___]"""
+
         if isinstance(channel, String):
-            if channel.value == "stdout":
-                stream = stream_manager.lookup_stream(1)
-            elif channel.value == "stderr":
-                stream = stream_manager.lookup_stream(2)
+            stream = stream_manager.get_stream_by_name(channel.value)
         elif isinstance(channel, Stream):
             stream = channel
         elif isinstance(channel, ListExpression):

--- a/mathics/eval/files_io/read.py
+++ b/mathics/eval/files_io/read.py
@@ -54,7 +54,12 @@ class MathicsOpen(Stream):
     """
 
     def __init__(
-        self, file: str, mode: str = "r", encoding=None, is_temporary_file: bool = False
+        self,
+        path: str,
+        mode: str = "r",
+        name=None,
+        encoding=None,
+        is_temporary_file: bool = False,
     ):
         if encoding is not None:
             encoding = to_python_encoding(encoding)
@@ -64,7 +69,9 @@ class MathicsOpen(Stream):
             elif encoding is None:
                 raise MessageException("General", "charcode", self.encoding)
         self.encoding = encoding
-        super().__init__(file, mode, self.encoding)
+        if name is None:
+            name = path
+        super().__init__(name, mode=mode, path=path, encoding=self.encoding)
         self.is_temporary_file = is_temporary_file
 
         # The following are set in __enter__ and __exit__
@@ -85,8 +92,9 @@ class MathicsOpen(Stream):
 
         # Add to our internal list of streams
         self.stream = stream_manager.add(
-            name=path,
+            name=self.name,
             mode=self.mode,
+            path=path,
             encoding=self.encoding,
             io=self.fp,
             num=stream_manager.next,

--- a/test/builtin/files_io/test_files.py
+++ b/test/builtin/files_io/test_files.py
@@ -443,6 +443,55 @@ def test_streams():
     evaluate("Close[newStream]")
 
 
+def test_write_string():
+    """
+    Check OpenWrite[] and WriteString[] using a path name.
+    """
+    # 1. Create a temporary file name in Python.
+    # 2. Open that for writing in Mathics3 using OpenWrite[].
+    # 3. Write some data to that using WriteString[] and
+    #    close the stream using Close[]
+    # 4. Then back in Python, see that the file was written and
+    #    that it has the data that was written via WriteString[].
+    # 5. Finally, remove the file.
+
+    # 1. Create temporary file name
+    tempfile = NamedTemporaryFile(mode="r", delete=False)
+    tempfile_path = tempfile.name
+
+    # 2. Open that for writing in Mathics3 using OpenWrite[].
+    check_evaluation(
+        str_expr=f'stream = OpenWrite["{tempfile_path}"];',
+        to_string_expr=False,
+        to_string_expected=False,
+    )
+
+    # 3. Write some data to that using WriteString[] and
+    #    close the stream using Close[]
+    text = "testing\n"
+    check_evaluation(
+        str_expr=f'WriteString["{tempfile_path}", "{text}"];',
+        to_string_expr=False,
+        to_string_expected=False,
+    )
+    check_evaluation(
+        str_expr="Close[stream];",
+    )
+
+    # 4. Back in Python, see that the file was written and
+    #    that it has the data that was written via WriteString[].
+
+    assert osp.exists(tempfile_path)
+    assert open(tempfile_path, "r").read() == text
+
+    # 5. Finally, remove the file.
+    try:
+        os.unlink(tempfile_path)
+    except PermissionError:
+        # This can happen in MS Windows
+        pass
+
+
 # rocky: I don't understand what these are supposed to test.
 
 # (


### PR DESCRIPTION
We need to lookup streams opened by the name or string the gives, not the resolved path name. 

This bug was discovered in trying to run Analytica.  <strike>At some point in the vague future, I'll write up a bug report, and possibly tidy this.</strike>

Fixes #1195