### PR TITLE
Another mini operator refactor

### DIFF
--- a/mathics/builtin/functional/apply_fns_to_lists.py
+++ b/mathics/builtin/functional/apply_fns_to_lists.py
@@ -69,7 +69,6 @@ class Apply(InfixOperator):
     """
 
     summary_text = "apply a function to a list, at specified levels"
-    operator = "@@"
     grouping = "Right"
 
     options = {
@@ -128,7 +127,6 @@ class Map(InfixOperator):
     """
 
     summary_text = "map a function over a list, at specified levels"
-    operator = "/@"
     grouping = "Right"
 
     options = {

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -322,7 +322,6 @@ class MessageName(InfixOperator):
     default_formats = False
     formats: typing.Dict[str, Any] = {}
     messages = {"messg": "Message cannot be set to `1`. It must be set to a string."}
-    summary_text = "message identifyier"
     operator = "::"
     rules = {
         "MakeBoxes[MessageName[symbol_Symbol, tag_String], "
@@ -333,6 +332,7 @@ class MessageName(InfixOperator):
             'RowBox[{MakeBoxes[symbol, InputForm], "::", tag}]'
         ),
     }
+    summary_text = "associate a message name with a tag"
 
     def eval(self, symbol: Symbol, tag: String, evaluation: Evaluation):
         "MessageName[symbol_Symbol, tag_String]"

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -321,7 +321,6 @@ class StringJoin(InfixOperator):
     """
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED
-    operator = "<>"
     summary_text = "join strings together"
 
     def eval(self, items, evaluation):

--- a/mathics/builtin/string/patterns.py
+++ b/mathics/builtin/string/patterns.py
@@ -248,7 +248,6 @@ class StringExpression(InfixOperator):
     """
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED
-    operator = "~~"
 
     messages = {
         "invld": "Element `1` is not a valid string or pattern element in `2`.",

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -114,7 +114,6 @@ class Dot(InfixOperator):
      = a . b
     """
 
-    operator = "."
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED
 
     rules = {

--- a/mathics/builtin/testing_expressions/equality_inequality.py
+++ b/mathics/builtin/testing_expressions/equality_inequality.py
@@ -468,7 +468,6 @@ class Equal(_EqualityOperator, _SympyComparison):
     """
 
     grouping = "None"
-    operator = "=="
     summary_text = "numerical equality"
     sympy_name = "Eq"
 
@@ -503,7 +502,6 @@ class Greater(_ComparisonOperator, _SympyComparison):
      = True
     """
 
-    operator = ">"
     summary_text = "greater than"
     sympy_name = "StrictGreaterThan"
 
@@ -522,7 +520,6 @@ class GreaterEqual(_ComparisonOperator, _SympyComparison):
     </dl>
     """
 
-    operator = ">="
     summary_text = "greater than or equal to"
     sympy_name = "GreaterThan"
 
@@ -600,7 +597,6 @@ class Less(_ComparisonOperator, _SympyComparison):
      = 1 < 3 < x < 2
     """
 
-    operator = "<"
     summary_text = "less than"
     sympy_name = "StrictLessThan"
 
@@ -623,7 +619,6 @@ class LessEqual(_ComparisonOperator, _SympyComparison):
 
     """
 
-    operator = "<="
     summary_text = "less than or equal to"
     sympy_name = "LessThan"  # in contrast to StrictLessThan
 
@@ -748,7 +743,6 @@ class SameQ(_ComparisonOperator):
     """
 
     grouping = "None"  # Indeterminate grouping: Neither left nor right
-    operator = "==="
 
     summary_text = "literal symbolic identity"
 
@@ -842,7 +836,6 @@ class Unequal(_EqualityOperator, _SympyComparison):
      = {True, True, True}
     """
 
-    operator = "!="
     summary_text = "numerical inequality"
     sympy_name = "Ne"
 
@@ -884,7 +877,6 @@ class UnsameQ(_ComparisonOperator):
     """
 
     grouping = "None"  # Indeterminate grouping: Neither left nor right
-    operator = "=!="
 
     summary_text = "not literal symbolic identity"
 

--- a/mathics/builtin/testing_expressions/logic.py
+++ b/mathics/builtin/testing_expressions/logic.py
@@ -89,7 +89,6 @@ class And(InfixOperator):
     """
 
     attributes = A_FLAT | A_HOLD_ALL | A_ONE_IDENTITY | A_PROTECTED
-    operator = "&&"
     summary_text = "logic conjunction"
     #    rules = {
     #        "And[a_]": "a",
@@ -210,7 +209,6 @@ class Equivalent(InfixOperator):
     """
 
     attributes = A_ORDERLESS | A_PROTECTED
-    operator = "\u29E6"
     summary_text = "logic equivalence"
 
     def eval(self, args, evaluation: Evaluation):
@@ -379,7 +377,7 @@ class Or(InfixOperator):
             return SymbolFalse
 
 
-class Nand(Builtin):
+class Nand(InfixOperator):
     """
     <url>:WMA link:
     https://reference.wolfram.com/language/ref/Nand.html</url>
@@ -402,7 +400,7 @@ class Nand(Builtin):
     summary_text = "negation of logic conjunction"
 
 
-class Nor(Builtin):
+class Nor(InfixOperator):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/Nor.html</url>
 
@@ -417,7 +415,6 @@ class Nor(Builtin):
      = False
     """
 
-    operator = "\u22BD"
     rules = {
         "Nor[expr___]": "Not[Or[expr]]",
     }
@@ -492,7 +489,6 @@ class Xor(InfixOperator):
     """
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_ORDERLESS | A_PROTECTED
-    operator = "\u22BB"
     summary_text = "logic (exclusive) disjunction"
 
     def eval(self, args, evaluation: Evaluation):

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -1426,14 +1426,14 @@ def add_no_meaning_builtin_classes(
             mathics3_format_function_name,
         )
 
-        # FIXME: Right now, precedence for infix operators is listed in
-        # JSON only for infix operators. Extend table generation in the same way
-        # for prefix and postfix, and then extend the code below to
-        # assign operator precedences for prefix and postfix operators.
         if affix == "infix":
             mathics.core.parser.operators.flat_binary_ops[
                 operator_name
             ] = operator_tuple[1]
+        elif affix == "postfix":
+            mathics.core.parser.operators.postfix_ops[operator_name] = operator_tuple[1]
+        elif affix == "prefix":
+            mathics.core.parser.operators.prefix_ops[operator_name] = operator_tuple[1]
 
         # Put the newly-created Builtin class inside the module under
         # mathics.builtin.no_meaning.xxx.


### PR DESCRIPTION
Set operator precedence for  no-meaning prefix and posftix operators

Remove some  `operator =`  assignments in some Operator classes so we use the operator symbols from JSON.

A lot more work is needed here. This is just the first step.
 