### PR TITLE
Bugfix in `With`: Return evaluated result

### DIFF
--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -712,5 +712,4 @@ class With(Builtin):
 
         vars = dict(get_scoping_vars(vars, "With", evaluation))
         result = expr.replace_vars(vars)
-        result.evaluate(evaluation)
-        return result
+        return result.evaluate(evaluation)

--- a/test/builtin/test_scoping.py
+++ b/test/builtin/test_scoping.py
@@ -58,3 +58,22 @@ def test_private_doctests_scoping(str_expr, msgs, str_expected, fail_msg):
         failure_message=fail_msg,
         expected_messages=msgs,
     )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "msgs", "str_expected", "fail_msg"),
+    [
+        ("Block[{i = 0}, With[{}, Module[{j = i}, Set[i, i+1]; j]]]", None, "0", None),
+    ],
+)
+def test_scoping_constructs(str_expr, msgs, str_expected, fail_msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=fail_msg,
+        expected_messages=msgs,
+    )


### PR DESCRIPTION
# Problem
```mathematica
Block[{i = 0}, With[{}, Module[{j = i}, Set[i, i+1]; j]]]
```` 
returns `1` whereas the correct answer is `0`. This is because, `With` evaluates the `Module` expression but erroneously returns the unevaluated version, triggering a second evaluation.

# Fix
The fix is to return the evaluated version. With the fix, the above code returns `0` as expected.
