### PR TITLE
For unicode operators, remove class assign...

### DIFF
--- a/mathics/builtin/testing_expressions/logic.py
+++ b/mathics/builtin/testing_expressions/logic.py
@@ -275,7 +275,6 @@ class Implies(InfixOperator):
      = a Implies b Implies c
     """
 
-    operator = "\u21D2"
     grouping = "Right"
     summary_text = "logic implication"
 
@@ -393,7 +392,6 @@ class Nand(InfixOperator):
      = True
     """
 
-    operator = "\u22BC"
     rules = {
         "Nand[expr___]": "Not[And[expr]]",
     }


### PR DESCRIPTION
For Unicode operators, remove class assign and get value from JSON.

Operators that are ASCII-only probably needs some coordination with JSON output on the mathicsscanner side.