### PR TITLE
Improve cosine distance

### DIFF
--- a/mathics/builtin/distance/numeric.py
+++ b/mathics/builtin/distance/numeric.py
@@ -2,9 +2,8 @@
 Numerical Data
 """
 
-from mathics.core.atoms import Integer0, Integer2
+from mathics.core.atoms import Integer2
 from mathics.core.builtin import Builtin
-from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
 from mathics.core.expression import Evaluation, Expression
 from mathics.core.symbols import SymbolAbs, SymbolDivide, SymbolPlus, SymbolPower
 from mathics.core.systemsymbols import (
@@ -13,6 +12,7 @@ from mathics.core.systemsymbols import (
     SymbolSubtract,
     SymbolTotal,
 )
+from mathics.eval.distance import eval_CosineDistance
 
 
 def _norm_calc(head, u, v, evaluation: Evaluation):
@@ -171,19 +171,7 @@ class CosineDistance(Builtin):
     def eval(self, u, v, evaluation: Evaluation):
         "CosineDistance[u_, v_]"
 
-        # We follow pretty much what is done in Symja in ClusteringFunctions.java for this:
-        # https://github.com/axkr/symja_android_library/blob/master/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ClusteringFunctions.java#L377-L386
-
-        sym_u = to_sympy_matrix(u)
-        sym_v = to_sympy_matrix(v)
-        u_norm = sym_u.norm()
-        if u_norm == 0:
-            return Integer0
-        v_norm = sym_v.norm()
-        if v_norm == 0:
-            return Integer0
-
-        return from_sympy(1 - sym_u.dot(sym_v.conjugate()) / (u_norm * v_norm))
+        return eval_CosineDistance(u, v)
 
 
 class EuclideanDistance(Builtin):

--- a/mathics/builtin/distance/numeric.py
+++ b/mathics/builtin/distance/numeric.py
@@ -150,14 +150,20 @@ class CosineDistance(Builtin):
     >> N[CosineDistance[{7, 9}, {71, 89}]]
      = 0.0000759646
 
-    >> CosineDistance[{0, 0}, {x, y}]
+    When the length of either vector is 0, the result is 0:
+    >> CosineDistance[{0.0, 0.0}, {x, y}]
      = 0
 
     >> CosineDistance[{1, 0}, {x, y}]
      = 1 - Conjugate[x] / Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2]
 
-    >> CosineDistance[{a, b}, {c, d}]
-     = 1 + (-a Conjugate[c] - b Conjugate[d]) / (Sqrt[Abs[a] ^ 2 + Abs[b] ^ 2] Sqrt[Abs[c] ^ 2 + Abs[d] ^ 2])
+    The order of the vectors influences the result:
+    >> CosineDistance[{x, y}, {1, 0}]
+     = 1 - x / Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2]
+
+    Cosine distance inclues a dot product scaled by norms:
+    >> CosineDistance[{a, b, c}, {x, y, z}]
+     = 1 + (-a Conjugate[x] - b Conjugate[y] - c Conjugate[z]) / (Sqrt[Abs[a] ^ 2 + Abs[b] ^ 2 + Abs[c] ^ 2] Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2 + Abs[z] ^ 2])
     """
 
     summary_text = "cosine distance"

--- a/mathics/eval/distance.py
+++ b/mathics/eval/distance.py
@@ -2,7 +2,8 @@
 Distance-related evaluation functions and exception classes
 """
 
-from mathics.core.atoms import Integer, Real
+from mathics.core.atoms import Integer, Integer0, Real
+from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
 
 
 class IllegalDataPoint(Exception):
@@ -31,6 +32,24 @@ def dist_repr(p) -> tuple:
         else:
             dist_p = repr_p = p.elements
     return dist_p, repr_p
+
+
+def eval_CosineDistance(u, v):
+    "CosineDistance[u_, v_]"
+
+    # We follow pretty much what is done in Symja in ClusteringFunctions.java for this:
+    # https://github.com/axkr/symja_android_library/blob/master/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ClusteringFunctions.java#L377-L386
+
+    sym_u = to_sympy_matrix(u)
+    sym_v = to_sympy_matrix(v)
+    u_norm = sym_u.norm()
+    if u_norm == 0:
+        return Integer0
+    v_norm = sym_v.norm()
+    if v_norm == 0:
+        return Integer0
+
+    return from_sympy(1 - sym_u.dot(sym_v.conjugate()) / (u_norm * v_norm))
 
 
 def to_real_distance(d):

--- a/mathics/eval/distance.py
+++ b/mathics/eval/distance.py
@@ -2,7 +2,8 @@
 Distance-related evaluation functions and exception classes
 """
 
-from mathics.core.atoms import Integer, Integer0, Real
+from mathics.core.atoms import Complex, Integer, Integer0, Real
+from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
 
 
@@ -39,9 +40,23 @@ def eval_CosineDistance(u, v):
 
     # We follow pretty much what is done in Symja in ClusteringFunctions.java for this:
     # https://github.com/axkr/symja_android_library/blob/master/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ClusteringFunctions.java#L377-L386
+    # Some extensions for degenerate cases have been added.
+
+    # Handle some degenerate cases
+    if isinstance(u, (Complex, Integer, Real)) and isinstance(
+        v, (Complex, Integer, Real)
+    ):
+        u_val = u.to_python()
+        v_val = v.to_python()
+        distance = 1 - u_val * v_val.conjugate() / (abs(u_val) * abs(v_val))
+        return from_python(distance)
 
     sym_u = to_sympy_matrix(u)
+    if sym_u is None:
+        return
     sym_v = to_sympy_matrix(v)
+    if sym_v is None:
+        return
     u_norm = sym_u.norm()
     if u_norm == 0:
         return Integer0


### PR DESCRIPTION
Handle CosineDistance more correctly in symbolic computations that should use Conjugate. Code adapted from https://github.com/axkr/symja_android_library/blob/master/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ClusteringFunctions.java#L377-L386

However, we also add the situation where arguments are numeric scalars, and we check for mismatched vector lengths.

Some tweaking of code for conversion to/from Complex has been done. 

TODO: more tests. 

There is a bit more that could be done, but this is getting large already. 

Fixes #1197