### PR TITLE
Refactor some inplace ops for error handling...

### DIFF
--- a/mathics/builtin/assignments/assign_binaryop.py
+++ b/mathics/builtin/assignments/assign_binaryop.py
@@ -92,11 +92,29 @@ class Decrement(InplaceInfixOperator, InfixOperator, PostfixOperator):
       <dd>decrements $x$ by 1, returning the original value of $x$.
     </dl>
 
-    >> a = 5;
-    X> a--
+    >> a = 5; a--
      = 5
-    X> a
+    >> a
      = 4
+
+    Decrement a numerical value:
+
+    >> a = 1.6; a--; a
+     = 0.6
+
+    Decrement all values in a list:
+
+    >> a = {1, 3, 5}
+     = {1, 3, 5}
+
+    >> a--; a
+     = {0, 2, 4}
+
+    Compare with <url>:PreDecrement:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/predecrement
+    </url> which returns the value before updating, and <url>:Increment:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/increment
+    </url> which goes the other way.
     """
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
@@ -149,14 +167,41 @@ class Increment(InplaceInfixOperator, InfixOperator, PostfixOperator):
       <dd>increments $x$ by 1, returning the original value of $x$.
     </dl>
 
-    >> a = 2;
-    >> a++
-     = 2
+    >> a = 1; a++
+     = 1
     >> a
-     = 3
+     = 2
+
+    Increment a numeric value:
+
+    >> a = 1.5; a++
+     = 1.5
+
+    >> a
+     = 2.5
+
+    Increment a symbolic value:
+
+    >> y = 2 x; y++; y
+     = 1 + 2 x
+
+    Increment all values in a list:
+
+    >> x = {1, 3, 5}
+     = {1, 3, 5}
+
+    x++; x
+     = {2, 4, 6}
+
     Grouping of 'Increment', 'PreIncrement' and 'Plus':
     >> ++++a+++++2//Hold//FullForm
      = Hold[Plus[PreIncrement[PreIncrement[Increment[Increment[a]]]], 2]]
+
+    Compare with <url>:PreIncrement:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/preincrement
+    </url> which returns the value before update.
+
+    #> Clear[a, x, y]
     """
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
@@ -167,33 +212,6 @@ class Increment(InplaceInfixOperator, InfixOperator, PostfixOperator):
     summary_text = (
         "increases the value by one and assigns that returning the original value"
     )
-
-
-class PreIncrement(InplaceInfixOperator, PrefixOperator):
-    """
-    <url>:WMA link:
-    https://reference.wolfram.com/language/ref/PreIncrement.html</url>
-
-    <dl>
-      <dt>'PreIncrement[$x$]'
-      <dt>'++$x$'
-      <dd>increments $x$ by 1, returning the new value of $x$.
-    </dl>
-
-    '++$a$' is equivalent to '$a$ = $a$ + 1':
-    >> a = 2;
-    >> ++a
-     = 3
-    >> a
-     = 3
-    """
-
-    attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
-    operator = "++"
-    operator_symbol = SymbolPlus
-    return_before_value: bool = False
-
-    summary_text = "increase the value by one and assigns that returning the new value"
 
 
 class PreDecrement(InplaceInfixOperator, PrefixOperator):
@@ -214,6 +232,14 @@ class PreDecrement(InplaceInfixOperator, PrefixOperator):
      = 1
     >> a
      = 1
+
+    Compare with <url>:Decrement:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/decrement
+    </url> which returns the updated value, and <url>:Increment:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/increment
+    </url> which goes the other way.
+
+    #> Clear[a]
     """
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
@@ -222,6 +248,60 @@ class PreDecrement(InplaceInfixOperator, PrefixOperator):
     operator_symbol = SymbolPlus
     returns_updated_value: bool = True
     summary_text = "decrease the value by one and assigns that returning the new value"
+
+
+class PreIncrement(InplaceInfixOperator, PrefixOperator):
+    """
+    <url>:WMA link:
+    https://reference.wolfram.com/language/ref/PreIncrement.html</url>
+
+    <dl>
+      <dt>'PreIncrement[$x$]'
+      <dt>'++$x$'
+      <dd>increments $x$ by 1, returning the new value of $x$.
+    </dl>
+
+    '++$a$' is equivalent to '$a$ = $a$ + 1':
+    >> a = 2
+     = 2
+
+    >> ++a
+     = 3
+
+    >> a
+     = 3
+
+    PreIncrement a numeric value:
+
+    >> a + 1.6
+     = 4.6
+
+
+    PreIncrement a symbolic value:
+
+    #> Clear[x, y]
+
+    >> y = x; ++y
+     = 1 + x
+
+    >> y
+     = 1 + x
+
+    Compare with <url>:Increment:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/increment
+    </url> which returns the updated value, and <url>:PreDecrement:
+    /doc/reference-of-built-in-symbols/assignments/in-place-binary-assignment-operator/predecrement
+    </url> which goes the other way.
+
+    #> Clear[a, x, y]
+    """
+
+    attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
+    operator = "++"
+    operator_symbol = SymbolPlus
+    return_before_value: bool = False
+
+    summary_text = "increase the value by one and assigns that returning the new value"
 
 
 class SubtractFrom(InfixOperator):
@@ -240,6 +320,8 @@ class SubtractFrom(InfixOperator):
      = 8
     >> a
      = 8
+
+    #> Clear[a]
     """
 
     attributes = A_HOLD_FIRST | A_PROTECTED
@@ -267,6 +349,8 @@ class TimesBy(InfixOperator):
      = 20
     >> a
      = 20
+
+    #> Clear[a]
     """
 
     operator = "*="

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -129,9 +129,6 @@ class AppendTo(Builtin):
 
     attributes = A_HOLD_FIRST | A_PROTECTED
 
-    messages = {
-        "rvalue": "`1` is not a variable with a value, so its value cannot be changed.",
-    }
     summary_text = "add an element at the end of an stored list or expression"
 
     def eval(self, s, element, evaluation):
@@ -1344,7 +1341,6 @@ class PrependTo(Builtin):
     attributes = A_HOLD_FIRST | A_PROTECTED
 
     messages = {
-        "rvalue": "`1` is not a variable with a value, so its value cannot be changed.",
         "normal": "Nonatomic expression expected at position 1 in `1`.",
     }
     summary_text = "add an element at the beginning of an stored list or expression"

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -224,6 +224,7 @@ class General(Builtin):
         "pspec": (
             "Part specification `1` is neither an integer nor " "a list of integer."
         ),
+        "rvalue": "`1` is not a variable with a value, so its value cannot be changed.",
         "seqs": "Sequence specification expected, but got `1`.",
         "setp": "Part assignment to `1` could not be made",
         "setps": "`1` in the part assignment is not a symbol.",

--- a/mathics/eval/assignments/assign_binaryop.py
+++ b/mathics/eval/assignments/assign_binaryop.py
@@ -1,0 +1,30 @@
+"""
+evaluation functions associated with the mathics.builtin.assign_binary_op
+module.
+"""
+from mathics.core.evaluation import Evaluation
+from mathics.core.expression import Expression
+from mathics.core.systemsymbols import SymbolSet
+
+
+def eval_inplace_op(
+    self, x, operator, increment, returns_updated_value: bool, evaluation: Evaluation
+):
+    """
+    Perform: Set[x, operator[x, increment]]
+
+    For example if operator is + and increment is 1, perform x += 1
+
+    If returns_updated_value is True, return the value after performing
+    the update operation. Otherwise return the value before it was
+    modified.
+    """
+    value_before_update = x.evaluate(evaluation)
+    if x == value_before_update:
+        evaluation.message(self.__class__.__name__, "rvalue", x)
+        return
+
+    updated_value = Expression(
+        SymbolSet, x, Expression(operator, x, increment).evaluate(evaluation)
+    ).evaluate(evaluation)
+    return updated_value if returns_updated_value else value_before_update

--- a/test/builtin/assignments/__init__.py
+++ b/test/builtin/assignments/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for test.builtin.assignments"""

--- a/test/builtin/assignments/test_assign_binaryop.py
+++ b/test/builtin/assignments/test_assign_binaryop.py
@@ -22,3 +22,11 @@ def test_uninitialized():
                 "a is not a variable with a value, so its value cannot be changed.",
             ),
         ),
+
+
+def test_predecrement():
+    check_evaluation(
+        "--5",
+        "--5",
+        failure_message="PreDecrement::rvalue: 5 is not a variable with a value, so its value cannot be changed.",
+    )

--- a/test/builtin/assignments/test_assign_binaryop.py
+++ b/test/builtin/assignments/test_assign_binaryop.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtins.assignments.assign_binaryop
+"""
+
+from test.helper import check_evaluation, session
+
+
+def test_uninitialized():
+    session.evaluate("Clear[a]")
+    for inplace_operator, str_expected in (
+        ("Decrement", "a--"),
+        ("Increment", "a++"),
+        ("PreDecrement", "--a"),
+        ("PreIncrement", "++a"),
+    ):
+        check_evaluation(
+            str_expr=f"{inplace_operator}[a]",
+            str_expected=str_expected,
+            to_string_expr=True,
+            expected_messages=(
+                "a is not a variable with a value, so its value cannot be changed.",
+            ),
+        ),

--- a/test/builtin/test_assignment.py
+++ b/test/builtin/test_assignment.py
@@ -375,12 +375,6 @@ def test_set_and_clear_messages(str_expr, str_expected, message, out_msgs):
     )
 
 
-def test_predecrement():
-    check_evaluation(
-        "--5", "4", failure_message="Set::setraw: Cannot assign to raw object 5."
-    )
-
-
 def test_assign_list():
     check_evaluation("G[x_Real]=x^2; a={G[x]}; {x=1.; a, x=.; a}", "{{1.}, {G[x]}}")
 


### PR DESCRIPTION
* Add an eval_ function for common inplace operators.
* Remove the use of rewrite rules which don't handle initialized variables properly.
* Add test for uninitialized variables in Increment/Decrement routines.

Fixes #1205