### PR TITLE
Complex cosine distance

### DIFF
--- a/mathics/builtin/distance/numeric.py
+++ b/mathics/builtin/distance/numeric.py
@@ -154,7 +154,7 @@ class CosineDistance(Builtin):
       <dd>returns the angular cosine distance between vectors $u$ and $v$.
     </dl>
 
-    The cosine distance is equivalent to 1 - $u$.Conjugate[$v$] / ('Norm[$u$] Norm[$v$]').
+    The cosine distance is equivalent to 1 - ($u$.Conjugate[$v$]) / ('Norm[$u$] Norm[$v$]').
 
     >> N[CosineDistance[{7, 9}, {71, 89}]]
      = 0.0000759646
@@ -173,6 +173,12 @@ class CosineDistance(Builtin):
     Cosine distance includes a dot product scaled by norms:
     >> CosineDistance[{a, b, c}, {x, y, z}]
      = 1 + (-a Conjugate[x] - b Conjugate[y] - c Conjugate[z]) / (Sqrt[Abs[a] ^ 2 + Abs[b] ^ 2 + Abs[c] ^ 2] Sqrt[Abs[x] ^ 2 + Abs[y] ^ 2 + Abs[z] ^ 2])
+
+    A Cosine distance applied to complex numbers, uses 'Abs[]' for 'Norm[]' and complex multiplication for dot product,
+    1 - $u$ * Conjugate[$v$] / ('Abs[$u$] Abs[$v$]'):
+
+    >> CosineDistance[1+2I, 5]
+     = 1 - (1 / 5 + 2 I / 5) Sqrt[5]
     """
 
     messages = {

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -32,7 +32,6 @@ from mathics.core.attributes import (
 )
 from mathics.core.builtin import Builtin, MPMathFunction, SympyFunction
 from mathics.core.convert.sympy import from_sympy
-from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.number import MACHINE_EPSILON

--- a/mathics/eval/distance/numeric.py
+++ b/mathics/eval/distance/numeric.py
@@ -1,3 +1,5 @@
+from sympy.core.power import Mul, Pow
+
 from mathics.core.atoms import Complex, Integer, Integer0, Real
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
 from mathics.eval.arithmetic import eval_Abs
@@ -14,23 +16,18 @@ def eval_CosineDistance(u, v):
     if isinstance(u, (Complex, Integer, Real)) and isinstance(
         v, (Complex, Integer, Real)
     ):
-        u_val = u.to_python()
-        v_val = v.to_python()
         u_abs = eval_Abs(u)
         if u_abs is None:
             return
         v_abs = eval_Abs(v)
         if v_abs is None:
             return
-        distance = 1 - u_val * v_val.conjugate() / (u_abs.to_sympy() * v_abs.to_sympy())
 
-        # If the input arguments were Integers, preserve that in the result
-        if isinstance(u_val, int) and isinstance(v_val, int):
-            try:
-                if distance == int(distance):
-                    distance = int(distance)
-            except Exception:
-                pass
+        # Do the following, but using SymPy expressions:
+        #   distance = 1 - (u * v.conjugate()) / (abs(u) * abs(v))
+        numerator = Mul(u.to_sympy(), v.to_sympy().conjugate())
+        divisor_product = Mul(u_abs.to_sympy(), v_abs.to_sympy())
+        distance = 1 - numerator * Pow(divisor_product, -1)
         return from_sympy(distance)
 
     sym_u = to_sympy_matrix(u)

--- a/mathics/eval/distance/numeric.py
+++ b/mathics/eval/distance/numeric.py
@@ -28,7 +28,10 @@ def eval_CosineDistance(u, v):
         numerator = Mul(u.to_sympy(), v.to_sympy().conjugate())
         divisor_product = Mul(u_abs.to_sympy(), v_abs.to_sympy())
         distance = 1 - numerator * Pow(divisor_product, -1)
-        return from_sympy(distance)
+        result = from_sympy(distance)
+        if (isinstance(u, Real) or isinstance(v, Real)) and isinstance(result, Integer):
+            result = Real(result.value)
+        return result
 
     sym_u = to_sympy_matrix(u)
     if sym_u is None:

--- a/mathics/eval/distance/numeric.py
+++ b/mathics/eval/distance/numeric.py
@@ -1,6 +1,6 @@
 from mathics.core.atoms import Complex, Integer, Integer0, Real
-from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy, to_sympy_matrix
+from mathics.eval.arithmetic import eval_Abs
 
 
 def eval_CosineDistance(u, v):
@@ -16,7 +16,13 @@ def eval_CosineDistance(u, v):
     ):
         u_val = u.to_python()
         v_val = v.to_python()
-        distance = 1 - u_val * v_val.conjugate() / (abs(u_val) * abs(v_val))
+        u_abs = eval_Abs(u)
+        if u_abs is None:
+            return
+        v_abs = eval_Abs(v)
+        if v_abs is None:
+            return
+        distance = 1 - u_val * v_val.conjugate() / (u_abs.to_sympy() * v_abs.to_sympy())
 
         # If the input arguments were Integers, preserve that in the result
         if isinstance(u_val, int) and isinstance(v_val, int):
@@ -25,7 +31,7 @@ def eval_CosineDistance(u, v):
                     distance = int(distance)
             except Exception:
                 pass
-        return from_python(distance)
+        return from_sympy(distance)
 
     sym_u = to_sympy_matrix(u)
     if sym_u is None:

--- a/test/builtin/distance/test_numeric.py
+++ b/test/builtin/distance/test_numeric.py
@@ -15,7 +15,7 @@ def test_cosine_distance():
             "CosineDistance of an Integers and a Real is 0.0",
             None,
         ),
-        ("CosineDistance[Complex[1, 0], Complex[0, 2]]", "1. + 1 I", None, None),
+        ("CosineDistance[Complex[1, 0], Complex[0, 2]]", "1 + I", None, None),
         (
             "CosineDistance[Complex[5.0, 0], Complex[10, 3]]",
             "0.0421737 + 0.287348 I",


### PR DESCRIPTION
  Switch from using Python's multiply and divide, and abs() of complex numbers  to SymPy's Expr operators for more precise real-number results
