### PR TITLE
Combinatorica V0.9 workarounds and expanded tests

### DIFF
--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -217,25 +217,36 @@ class _RandomSelection(_RandomBase):
 # FIXME: This class should be removed and put in a Mathematica V.5 compatibility package
 class Random(Builtin):
     """
-    <url>
-    :WMA link:
-    https://reference.wolfram.com/language/ref/Random.html</url>
-    <dl>
-      <dt>'Random[]'
-      <dd>gives a uniformly distributed pseudorandom Real number in the range 0 to 1.
+     <url>:Randomness:
+     https://en.wikipedia.org/wiki/Randomness</url> (<url>:WMA link:
+     https://reference.wolfram.com/language/ref/Random.html</url>)
+     <dl>
+       <dt>'Random[]'
+       <dd>gives a pseudorandom real number in the range 0 to 1.
 
-      <dt>'Random[$type$, $range$]'
-      <dd>gives a uniformly distributed pseudorandom number of the type \
-          $type$, in the specified interval $range$. Possible types are \
-          'Integer', 'Real' or 'Complex'.
-    </dl>
+       <dt>'Random[$type$, $range$]'
+       <dd>gives a pseudorandom number of the type $type$, in the specified interval $range$.
+           Possible types are 'Integer', 'Real' or 'Complex'.
+     </dl>
 
-    Legacy function. Superseded by RandomReal, RandomInteger and RandomComplex.
+     Legacy function. Superseded by <url>
+     :RandomReal:/doc/reference-of-built-in-symbols/integer-and-number-theoretical-functions/random-number-generation/randomreal
+     </url>, <url>
+    :RandomInteger:/doc/reference-of-built-in-symbols/integer-and-number-theoretical-functions/random-number-generation/randominteger
+     </url>, and <url>
+    :RandomComplex:/doc/reference-of-built-in-symbols/integer-and-number-theoretical-functions/random-number-generation/randomcomplex</url>.
 
+     Four random numbers in the range 0..1:
+     >> Table[Random[], {4}]
+      = ...
+
+     Eight random integers in the range 1..100:
+     >> Table[Random[Integer, {1, 100}], {8}]
+      = ...
     """
 
     rules = {
-        "Random[]": "RandomReal[0, 1]",
+        "Random[]": "RandomReal[]",
         "Random[Integer]": "RandomInteger[]",
         "Random[Integer,  zmax_Integer]": "RandomInteger[zmax]",
         "Random[Integer, {zmin_Integer, zmax_Integer}]": "RandomInteger[{zmin, zmax}]",
@@ -247,7 +258,7 @@ class Random(Builtin):
         "Random[Complex, {zmin_?NumberQ, zmax_?NumberQ}]": "RandomComplex[{zmin, zmax}]",
     }
 
-    summary_text = "pick a random number"
+    summary_text = "pick a random number (legacy function)"
 
 
 class RandomChoice(_RandomSelection):

--- a/mathics/packages/DiscreteMath/CombinatoricaV0.9.m
+++ b/mathics/packages/DiscreteMath/CombinatoricaV0.9.m
@@ -324,6 +324,9 @@ Josephus::usage = "Josephus[n,m] generates the inverse of the permutation define
 
 KSubsets::usage = "KSubsets[l,k] returns all subsets of set l containing exactly k elements, ordered lexicographically."
 
+KSetPartitions::usage = "KSetPartitions[set, k] returns the list of set partitions of set with k blocks. KSetPartitions[n, k] returns the list of set partitions of {1, 2, ..., n} with k blocks. If all set partitions of a set are needed, use the function SetPartitions."
+
+
 K::usage = "K[n] creates a complete graph on n vertices. K[a,b,c,...,k] creates a complete k-partite graph of the prescribed shape."
 
 LabeledTreeToCode::usage = "LabeledTreeToCode[g] reduces the tree g to its Prufer code."
@@ -491,6 +494,8 @@ SamenessRelation::usage = "SamenessRelation[l] constructs a binary relation from
 SelectionSort::usage = "SelectionSort[l,f] sorts list l using ordering function f."
 
 SelfComplementaryQ::usage = "SelfComplementaryQ[g] returns True if graph g is self-complementary, meaning it is isomorphic to its complement."
+
+SetPartitions::usage = "SetPartitions[set] returns the list of set partitions of set. SetPartitions[n] returns the list of set partitions of {1, 2, ..., n}. If all set partitions with a fixed number of subsets are needed use KSetPartitions."
 
 ShakeGraph::usage = "ShakeGraph[g,d] performs a random perturbation of the vertices of graph g, with each vertex moving at most a distance d from its original position."
 
@@ -1060,6 +1065,38 @@ KSubsets[l_List,k_Integer?Positive] :=
 		Map[(Prepend[#,First[l]])&, KSubsets[Rest[l],k-1]],
 		KSubsets[Rest[l],k]
 	]
+
+(* From combinatorica 2.0.0 *)
+KSetPartitions[{}, 0] := {{}}
+KSetPartitions[s_List, 0] := {}
+KSetPartitions[s_List, k_Integer] := {} /; (k > Length[s])
+KSetPartitions[s_List, k_Integer] := {Map[{#} &, s]} /; (k === Length[s])
+KSetPartitions[s_List, k_Integer] :=
+       Block[{$RecursionLimit = 512},
+             Join[Map[Prepend[#, {First[s]}] &, KSetPartitions[Rest[s], k - 1]],
+                  Flatten[
+                     Map[Table[Prepend[Delete[#, j], Prepend[#[[j]], s[[1]]]],
+                              {j, Length[#]}
+                         ]&,
+                         KSetPartitions[Rest[s], k]
+                     ], 1
+                  ]
+             ]
+       ] /; (k > 0) && (k < Length[s])
+
+KSetPartitions[0, 0] := {{}}
+KSetPartitions[0, k_Integer?Positive] := {}
+KSetPartitions[n_Integer?Positive, 0] := {}
+KSetPartitions[n_Integer?Positive, k_Integer?Positive] := KSetPartitions[Range[n], k]
+
+
+SetPartitions[{}] := {{}}
+SetPartitions[s_List] := Flatten[Table[KSetPartitions[s, i], {i, Length[s]}], 1]
+
+SetPartitions[0] := {{}}
+SetPartitions[n_Integer?Positive] := SetPartitions[Range[n]]
+
+(* end *)
 
 NextKSubset[set_List,subset_List] :=
 	Take[set,Length[subset]] /; (Take[set,-Length[subset]] === subset)
@@ -3329,8 +3366,9 @@ IsomorphicQ,
 IsomorphismQ,
 Isomorphism,
 Josephus,
-KSubsets,
 K,
+KSetPartitions,
+KSubsets,
 LabeledTreeToCode,
 LastLexicographicTableau,
 LexicographicPermutations,
@@ -3414,6 +3452,7 @@ Runs,
 SamenessRelation,
 SelectionSort,
 SelfComplementaryQ,
+SetPartitions,
 ShakeGraph,
 ShortestPathSpanningTree,
 ShortestPath,

--- a/mathics/packages/DiscreteMath/CombinatoricaV0.9.m
+++ b/mathics/packages/DiscreteMath/CombinatoricaV0.9.m
@@ -1133,10 +1133,18 @@ Partitions[0,_] := { {} }
 Partitions[n_Integer,1] := { Table[1,{n}] }
 Partitions[_,0] := {}
 
+(* FIXME: Below the If[] is added to fold in the rule:
+   Partitions[0,_] := { {} }
+from above. That rule
+is taking precedence over the above in Mathematica, but not in
+Mathics3.
+ *)
 Partitions[n_Integer,maxpart_Integer] :=
-	Join[
-		Map[(Prepend[#,maxpart])&, Partitions[n-maxpart,maxpart]],
-		Partitions[n,maxpart-1]
+	If[n<0, {}, (* rocky added If *)
+	   Join[
+		   Map[(Prepend[#,maxpart])&, Partitions[n-maxpart,maxpart]],
+		   Partitions[n,maxpart-1]
+	   ]
 	]
 
 NextPartition[p_List] := Join[Drop[p,-1],{Last[p]-1,1}]  /; (Last[p] > 1)

--- a/mathics/packages/DiscreteMath/CombinatoricaV0.9.m
+++ b/mathics/packages/DiscreteMath/CombinatoricaV0.9.m
@@ -1219,7 +1219,7 @@ RandomPartition[n_Integer?Positive] :=
   Module[{mult = Table[0, {n}], j, d, r=n, z},
     While[ (r > 0),
       d = 1;  j = 0;
-      z = RandomReal[] r PartitionsP[r];
+      z = Random[] r PartitionsP[r];
       While [z >= 0,
          j++;
          If [r-j*d < 0, {j=1; d++;}];
@@ -2144,7 +2144,7 @@ CodeToLabeledTree[l_List] :=
 	]
 
 RandomTree[n_Integer?Positive] :=
-	RadialEmbedding[CodeToLabeledTree[ Table[RandomInteger[{1,n}],{n-2}] ], 1]
+	RadialEmbedding[CodeToLabeledTree[ Table[Random[Integer,{1,n}],{n-2}] ], 1]
 
 RandomGraph[n_Integer,p_] := RandomGraph[n,p,{1,1}]
 
@@ -2154,7 +2154,7 @@ RandomGraph[n_Integer,p_,range_List] :=
 			Join[
 				Table[0,{i}],
 				Table[
-					If[RandomReal[]<p, RandomInteger[range], 0],
+					If[Random[Real]<p, Random[Integer,range], 0],
 					{n-i}
 				]
 			],
@@ -2176,13 +2176,13 @@ NthPair[n_Integer] :=
 		{n - Binomial[i-1,2], i}
 	]
 
-RandomVertices[n_Integer] := Table[{RandomReal[], RandomReal[]}, {n}]
+RandomVertices[n_Integer] := Table[{Random[], Random[]}, {n}]
 RandomVertices[g_Graph] := Graph[ Edges[g], RandomVertices[V[g]] ]
 
 RandomGraph[n_Integer,p_,range_List,Directed] :=
 	RemoveSelfLoops[
 		Graph[
-			Table[If[RandomReal[]<p,RandomInteger[range],0],{n},{n}],
+			Table[If[Random[Real]<p,Random[Integer,range],0],{n},{n}],
 			CircularVertices[n]
 		]
 	]

--- a/test/package/test_combinatorica.py
+++ b/test/package/test_combinatorica.py
@@ -569,11 +569,11 @@ def test_combinatorica_rest():
             "2",
             "BinarySearch - find where key is a list",
         ),
-        # (
-        #     "SetPartitions[3]",
-        #     "{{{1, 2, 3}}, {{1}, {2, 3}}, {{1, 2}, {3}}, {{1, 3}, {2}}, {{1}, {2}, {3}}}",
-        #     "SetPartitions"
-        # ),
+        (
+            "SetPartitions[3]",
+            "{{{1, 2, 3}}, {{1}, {2, 3}}, {{1, 2}, {3}}, {{1, 3}, {2}}, {{1}, {2}, {3}}}",
+            "SetPartitions",
+        ),
         (
             "TransposePartition[{8, 6, 4, 4, 3, 1}]",
             "{6, 5, 5, 4, 2, 2, 1, 1}",

--- a/test/package/test_combinatorica.py
+++ b/test/package/test_combinatorica.py
@@ -525,20 +525,11 @@ def test_2_1_to_2_3():
             "{{7}, {6, 1}, {5, 2}, {4, 3}, {4, 2, 1}}",
             "Bijections between Partitions 2.1.3, Page 56",
         ),
-<<<<<<< HEAD
-        # RandomPartition gives an error of trying to modify a List head.
-        # (
-        #     "{DurfeeSquare[p=RandomPartition[20]], DurfeeSquare[TransposePartition[p]]}",
-        #     "{42, 42}",
-        #     "Counting Partitions 2.1.3, Page 57",
-        # ),
-=======
         (
             "DurfeeSquare[p=RandomPartition[20]] == DurfeeSquare[TransposePartition[p]]",
             "True",
             "Counting Partitions 2.1.3, Page 57",
         ),
->>>>>>> 88059faff0d505f168058017e9f0f3efc7934ab6
         (
             "{PartitionsP[10], NumberOfPartitions[10]}",
             "{42, 42}",

--- a/test/package/test_combinatorica.py
+++ b/test/package/test_combinatorica.py
@@ -489,12 +489,51 @@ def test_combinations_1_5():
 def test_2_1_to_2_3():
     for str_expr, str_expected, message in (
         (
-            # 2.1.1 uses Partitions which is broken
-            # 2.1.2 Ferrers Diagrams can't be tested easily and robustly here
-            # easily
-            # 2.1.3 uses Partitions which is broken
-            "PartitionsP[10]",
-            "NumberOfPartitions[10]",
+            "Partitions[6]",
+            "{{6}, {5, 1}, {4, 2}, {4, 1, 1}, {3, 3}, "
+            "{3, 2, 1}, {3, 1, 1, 1}, {2, 2, 2}, {2, 2, 1, 1}, "
+            "{2, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1}}",
+            "Generating Partitions 2.1.1, Page 52",
+        ),
+        (
+            "Partitions[6, 3]",
+            "{{3, 3}, {3, 2, 1}, {3, 1, 1, 1}, {2, 2, 2}, "
+            "{2, 2, 1, 1}, {2, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1}}",
+            "Generating Partitions 2.1.1, Page 52",
+        ),
+        (
+            "Length[Partitions[10]]",
+            "42",
+            "Generating Partitions 2.1.1, Page 52",
+        ),
+        # 2.1.2 Ferrers Diagrams can't be tested easily and robustly here
+        # easily
+        # (
+        #     "(p=Table[1,{6}]; Table[p=NextPartition[p], {NumberOfPartitions[6]}])",
+        #     "{{6}, {5, 1}, {4, 2}, {4, 1, 1}, {3, 3}, "
+        #     "{3, 2, 1}, {3, 1, 1, 1}, {2, 2, 2}, {2, 2, 1, 1}, "
+        #      "{2, 1, 1, 1, 1}, {1, 1, 1, 1, 1, 1}}",
+        #     "Generating Partitions 2.1.1, Page 52",
+        # ),
+        (
+            "Select[Partitions[7], (Apply[And,Map[OddQ, #]])&]",
+            "{{7}, {5, 1, 1}, {3, 3, 1}, {3, 1, 1, 1, 1}, " "{1, 1, 1, 1, 1, 1, 1}}",
+            "Bijections between Partitions 2.1.3, Page 56",
+        ),
+        (
+            "Select[Partitions[7], (Length[#] == Length[Union[#]])&]",
+            "{{7}, {6, 1}, {5, 2}, {4, 3}, {4, 2, 1}}",
+            "Bijections between Partitions 2.1.3, Page 56",
+        ),
+        # RandomPartition gives an error of trying to modify a List head.
+        # (
+        #     "{DurfeeSquare[p=RandomPartition[20]], DurfeeSquare[TransposePartition[p]]}",
+        #     "{42, 42}",
+        #     "Counting Partitions 2.1.3, Page 57",
+        # ),
+        (
+            "{PartitionsP[10], NumberOfPartitions[10]}",
+            "{42, 42}",
             "Counting Partitions 2.1.4, Page 57",
         ),
         (
@@ -503,14 +542,24 @@ def test_2_1_to_2_3():
             "Random Compositions 2.2.1, Page 60",
         ),
         (
-            "TableauQ[{{1,2,5}, {3,4,5}, {6}}]",
-            "True",
-            "Young Tableau 2.3, Page 64",
+            "Compositions[6,3]",
+            "{{0, 0, 6}, {0, 1, 5}, {0, 2, 4}, {0, 3, 3}, "
+            "{0, 4, 2}, {0, 5, 1}, {0, 6, 0}, {1, 0, 5}, {1, 1, 4}, "
+            "{1, 2, 3}, {1, 3, 2}, {1, 4, 1}, {1, 5, 0}, {2, 0, 4}, "
+            "{2, 1, 3}, {2, 2, 2}, {2, 3, 1}, {2, 4, 0}, {3, 0, 3}, "
+            "{3, 1, 2}, {3, 2, 1}, {3, 3, 0}, {4, 0, 2}, {4, 1, 1}, "
+            "{4, 2, 0}, {5, 0, 1}, {5, 1, 0}, {6, 0, 0}}",
+            "Generating Compositions 2.2.2, Page 61",
         ),
         (
-            "TableauQ[{{1,2,5,9,10}, {5,4,7,13}, {4,8,12},{11}}]",
-            "False",
-            "Young Tableau 2.3, Page 64",
+            "(c = {0, 0, 6}; Table[c = NextComposition[c], {28}])",
+            "{{6, 0, 0}, {5, 1, 0}, {4, 2, 0}, {3, 3, 0}, "
+            "{2, 4, 0}, {1, 5, 0}, {0, 6, 0}, {5, 0, 1}, {4, 1, 1}, "
+            "{3, 2, 1}, {2, 3, 1}, {1, 4, 1}, {0, 5, 1}, {4, 0, 2}, "
+            "{3, 1, 2}, {2, 2, 2}, {1, 3, 2}, {0, 4, 2}, {3, 0, 3}, "
+            "{2, 1, 3}, {1, 2, 3}, {0, 3, 3}, {2, 0, 4}, {1, 1, 4}, "
+            "{0, 2, 4}, {1, 0, 5}, {0, 1, 5}, {0, 0, 6}}",
+            "Generating Compositions 2.2.2, Page 62",
         ),
         # Need to not evaluate expected which reformats \n's
         #         (
@@ -522,6 +571,16 @@ def test_2_1_to_2_3():
         #             "False",
         #             "Young Tableau 2.3, Page 63",
         #         ),
+        (
+            "TableauQ[{{1,2,5}, {3,4,5}, {6}}]",
+            "True",
+            "Young Tableau 2.3, Page 64",
+        ),
+        (
+            "TableauQ[{{1,2,5,9,10}, {5,4,7,13}, {4,8,12},{11}}]",
+            "False",
+            "Young Tableau 2.3, Page 64",
+        ),
     ):
         check_evaluation(str_expr, str_expected, message)
 


### PR DESCRIPTION
SetPartitions[]`  and `KSetPartitions[]` from Combinatorica workin V2.0 (In V.09 it is not broken, it is just altogether missing.)  

So copy the 2.0.0 code into V0.9