### PR TITLE
Adjust sizes and text to match Mathematica better?

### DIFF
--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -411,7 +411,7 @@ class _Size(_GraphicsDirective):
     def init(self, graphics, item=None, value=None):
         super(_Size, self).init(graphics, item)
         if item is not None:
-            self.value = item.elements[0].round_to_float()
+            self.value = item.elements[0].round_to_float() * 0.7
         elif value is not None:
             self.value = value
         else:

--- a/mathics/format/asy.py
+++ b/mathics/format/asy.py
@@ -417,12 +417,11 @@ def inset_box(self, **options) -> str:
         edge_color=self.color, edge_opacity=opacity_value, fontsize=font_size
     )
     asy = """// InsetBox
-label("$%s$", (%s,%s), (%s,%s), %s);\n""" % (
+label("$%s$", (%s,%s), %s, %s);\n""" % (
         content,
         x,
         y,
-        -self.opos[0],
-        -self.opos[1],
+        "align=SW",
         pen,
     )
     return asy

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -387,6 +387,7 @@ def inset_box(self, **options) -> str:
             font_color=self.color,
             edge_color=self.color,
             face_color=self.color,
+            stroke_width=0.2,
             opacity=self.opacity.opacity,
         )
         text_pos_opts = f'x="{x}" y="{y}" ox="{self.opos[0]}" oy="{self.opos[1]}"'

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -4,7 +4,6 @@ from test.helper import check_evaluation, session
 import pytest
 
 from mathics.core.symbols import Symbol
-from mathics.session import MathicsSession
 
 # from mathics.core.builtin import BoxConstruct, Predefined
 
@@ -724,7 +723,16 @@ all_test = {
         #    "System`OutputForm": '<mglyph width="350px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMnB4IiBoZWlnaHQ9IjJweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9Ii0xLjAwMDAwMCAtMS4wMDAwMDAgMi4wMDAwMDAgMi4wMDAwMDAiPgogICAgICAgICAgICAgICAgPCEtLUdyYXBoaWNzRWxlbWVudHMtLT4KPC9zdmc+Cg=="/>',
         # },
         "latex": {
-            "System`StandardForm": '\n\\begin{asy}\nusepackage("amsmath");\nsize(5.8333cm, 5.8333cm);\n\n\nclip(box((-1,-1), (1,1)));\n\n\\end{asy}\n',
+            "System`StandardForm": """
+\\begin{asy}
+usepackage("amsmath");
+size(5.8333cm, 5.8333cm);
+
+
+clip(box((-1,-1), (1,1)));
+
+\\end{asy}
+""",
             "System`TraditionalForm": '\n\\begin{asy}\nusepackage("amsmath");\nsize(5.8333cm, 5.8333cm);\n\n\nclip(box((-1,-1), (1,1)));\n\n\\end{asy}\n',
             "System`InputForm": "\\text{Graphics}\\left[\\left\\{\\right\\}\\right]",
             "System`OutputForm": '\n\\begin{asy}\nusepackage("amsmath");\nsize(5.8333cm, 5.8333cm);\n\n\nclip(box((-1,-1), (1,1)));\n\n\\end{asy}\n',
@@ -745,10 +753,37 @@ all_test = {
         #     "System`OutputForm": '<mglyph width="294px" height="350px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjEzNi41MDAwMDAgMTYyLjUwMDAwMCAyMS4wMDAwMDAgMjUuMDAwMDAwIj4KICAgICAgICAgICAgICAgIDwhLS1HcmFwaGljc0VsZW1lbnRzLS0+Cjx0ZXh0IHg9IjE0Ny4wIiB5PSIxNzUuMCIgb3g9IjAiIG95PSIwIiBmb250LXNpemU9IjEwcHgiIHN0eWxlPSJ0ZXh0LWFuY2hvcjplbmQ7IGRvbWluYW50LWJhc2VsaW5lOmhhbmdpbmc7IHN0cm9rZTogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBzdHJva2Utb3BhY2l0eTogMTsgZmlsbDogcmdiKDAuMDAwMDAwJSwgMC4wMDAwMDAlLCAwLjAwMDAwMCUpOyBmaWxsLW9wYWNpdHk6IDE7IGNvbG9yOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IG9wYWNpdHk6IDEuMCI+YV5iPC90ZXh0Pgo8L3N2Zz4K"/>',
         # },
         "latex": {
-            "System`StandardForm": '\n\\begin{asy}\nusepackage("amsmath");\nsize(4.9cm, 5.8333cm);\n\n// InsetBox\nlabel("$a^b$", (147.0,175.0), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((136.5,162.5), (157.5,187.5)));\n\n\\end{asy}\n',
-            "System`TraditionalForm": '\n\\begin{asy}\nusepackage("amsmath");\nsize(4.9cm, 5.8333cm);\n\n// InsetBox\nlabel("$a^b$", (147.0,175.0), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((136.5,162.5), (157.5,187.5)));\n\n\\end{asy}\n',
+            "System`StandardForm": """
+\\begin{asy}
+usepackage("amsmath");
+size(4.9cm, 5.8333cm);
+
+// InsetBox\nlabel("$a^b$", (147.0,175.0), align=SW, rgb(0, 0, 0)+fontsize(3));
+
+clip(box((136.5,162.5), (157.5,187.5)));
+
+\\end{asy}
+""",
+            "System`TraditionalForm": """
+\\begin{asy}
+usepackage("amsmath");
+size(4.9cm, 5.8333cm);
+
+// InsetBox\nlabel("$a^b$", (147.0,175.0), align=SW, rgb(0, 0, 0)+fontsize(3));
+
+clip(box((136.5,162.5), (157.5,187.5)));
+
+\\end{asy}
+""",
             "System`InputForm": "\\text{Graphics}\\left[\\left\\{\\text{Text}\\left[\\text{Power}\\left[a, b\\right], \\left\\{0, 0\\right\\}\\right]\\right\\}\\right]",
-            "System`OutputForm": '\n\\begin{asy}\nusepackage("amsmath");\nsize(4.9cm, 5.8333cm);\n\n// InsetBox\nlabel("$a^b$", (147.0,175.0), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((136.5,162.5), (157.5,187.5)));\n\n\\end{asy}\n',
+            "System`OutputForm": """
+\\begin{asy}\nusepackage("amsmath");
+size(4.9cm, 5.8333cm);
+
+// InsetBox\nlabel("$a^b$", (147.0,175.0), align=SW, rgb(0, 0, 0)+fontsize(3));
+
+clip(box((136.5,162.5), (157.5,187.5)));\n\n\\end{asy}
+""",
         },
     },
     "TableForm[{Graphics[{Text[a^b,{0,0}]}], Graphics[{Text[a^b,{0,0}]}]}]": {
@@ -766,10 +801,26 @@ all_test = {
         #     "System`OutputForm": '<mtable columnalign="center">\n<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n<mtr><mtd columnalign="center"><mglyph width="147px" height="175px" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEuMHB4IiBoZWlnaHQ9IjI1LjBweCIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICAgICAgICAgICAgIHZlcnNpb249IjEuMSIKICAgICAgICAgICAgICAgIHZpZXdCb3g9IjYzLjAwMDAwMCA3NS4wMDAwMDAgMjEuMDAwMDAwIDI1LjAwMDAwMCI+CiAgICAgICAgICAgICAgICA8IS0tR3JhcGhpY3NFbGVtZW50cy0tPgo8dGV4dCB4PSI3My41IiB5PSI4Ny41IiBveD0iMCIgb3k9IjAiIGZvbnQtc2l6ZT0iMTBweCIgc3R5bGU9InRleHQtYW5jaG9yOmVuZDsgZG9taW5hbnQtYmFzZWxpbmU6aGFuZ2luZzsgc3Ryb2tlOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IHN0cm9rZS1vcGFjaXR5OiAxOyBmaWxsOiByZ2IoMC4wMDAwMDAlLCAwLjAwMDAwMCUsIDAuMDAwMDAwJSk7IGZpbGwtb3BhY2l0eTogMTsgY29sb3I6IHJnYigwLjAwMDAwMCUsIDAuMDAwMDAwJSwgMC4wMDAwMDAlKTsgb3BhY2l0eTogMS4wIj5hXmI8L3RleHQ+Cjwvc3ZnPgo="/></mtd></mtr>\n</mtable>',
         # },
         "latex": {
-            "System`StandardForm": '\\begin{array}{c} \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\\\ \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\end{array}',
-            "System`TraditionalForm": '\\begin{array}{c} \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\\\ \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\end{array}',
-            "System`InputForm": "\\text{TableForm}\\left[\\left\\{\\text{Graphics}\\left[\\left\\{\\text{Text}\\left[\\text{Power}\\left[a, b\\right], \\left\\{0, 0\\right\\}\\right]\\right\\}\\right], \\text{Graphics}\\left[\\left\\{\\text{Text}\\left[\\text{Power}\\left[a, b\\right], \\left\\{0, 0\\right\\}\\right]\\right\\}\\right]\\right\\}\\right]",
-            "System`OutputForm": '\\begin{array}{c} \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\\\ \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), (0,0), rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\end{array}',
+            "System`StandardForm": """\\begin{array}{c} \n\\begin{asy}
+usepackage("amsmath");
+size(2.45cm, 2.9167cm);
+
+// InsetBox\nlabel("$a^b$", (73.5,87.5), align=SW, rgb(0, 0, 0)+fontsize(3));
+
+clip(box((63,75), (84,100)));
+
+\\end{asy}
+\\\\ \n\\begin{asy}
+usepackage("amsmath");
+size(2.45cm, 2.9167cm);
+
+// InsetBox\nlabel("$a^b$", (73.5,87.5), align=SW, rgb(0, 0, 0)+fontsize(3));
+
+clip(box((63,75), (84,100)));
+
+\\end{asy}
+\\end{array}""",
+            "System`TraditionalForm": """\\begin{array}{c} \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), align=SW, rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\\\ \n\\begin{asy}\nusepackage("amsmath");\nsize(2.45cm, 2.9167cm);\n\n// InsetBox\nlabel("$a^b$", (73.5,87.5), align=SW, rgb(0, 0, 0)+fontsize(3));\n\nclip(box((63,75), (84,100)));\n\n\\end{asy}\n\\end{array}""",
         },
     },
 }


### PR DESCRIPTION
graphics.py: Reduce size on PointSize, Thickness, AbsoluteThickness
svg.py: reduced thickness of text in InsetBox

I have been looking at graphs in Implementing Discrete Mathematics and noticed for a while that dots shown in Mathics3  seem a bit too big compared to what they are in the text, and text for axes is too bold. 

Here is an attempt to make this look more like what is printed in this book. 

For comparison with change: examples of dot sizes: 

Before:

![image](https://github.com/user-attachments/assets/5a2ede1b-3220-4877-a509-8b177c3265c8)

Proposed change:

![image](https://github.com/user-attachments/assets/3448f59d-1b0b-40c2-a126-a4da5520c15a)

And text in axes of graphs. Before: 

![image](https://github.com/user-attachments/assets/41636e1f-c8c2-462e-8a71-8bea4b96b7aa)



Proposed change: 

![image](https://github.com/user-attachments/assets/632d00ab-1066-4d71-973d-2bf892f8cede)

Since I don't have access to anything that draws corresponding Mathematica graphs I rely on you to let me know if this is closer.

Note this is not about whether one is aesthetically better than the other, but instead, whether this matches what Mathematica does. The examples are all taken from the Django gallery. 

