### PR TITLE
More changes to Graphics (part2)

### DIFF
--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -2,10 +2,6 @@
 """
 Boxing Symbols for 2D Graphics
 """
-# Docs are not yet ready for prime time. Maybe after release 6.0.0.
-no_doc = True
-
-
 from math import atan2, ceil, cos, degrees, floor, log10, pi, sin
 from typing import Optional
 
@@ -42,6 +38,9 @@ from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolTrue
 from mathics.core.systemsymbols import SymbolAutomatic, SymbolTraditionalForm
 from mathics.eval.makeboxes import format_element
+
+# Docs are not yet ready for prime time. Maybe after release 6.0.0.
+no_doc = True
 
 SymbolRegularPolygonBox = Symbol("RegularPolygonBox")
 SymbolStandardForm = Symbol("StandardForm")

--- a/mathics/builtin/drawing/graphics_internals.py
+++ b/mathics/builtin/drawing/graphics_internals.py
@@ -3,17 +3,18 @@
 # No external builtins appear here.
 # Also no docstring which may confuse the doc system
 
+from abc import ABC
 
 from mathics.builtin.box.expression import BoxExpression
 from mathics.core.builtin import BuiltinElement
 from mathics.core.exceptions import BoxExpressionError
 from mathics.core.symbols import Symbol, system_symbols_dict
 
-# Signals to Mathics doc processing not to include this module in its documentation.
+# Signals to Mathics3 doc processing not to include this module in its documentation.
 no_doc = True
 
 
-class _GraphicsDirective(BuiltinElement):
+class _GraphicsDirective(BuiltinElement, ABC):
     def init(self, graphics, item=None):
         if item is not None and not item.has_form(self.get_name(), None):
             raise BoxExpressionError
@@ -24,7 +25,7 @@ class _GraphicsDirective(BuiltinElement):
         return klass(graphics, item)
 
 
-class _GraphicsElementBox(BoxExpression):
+class _GraphicsElementBox(BoxExpression, ABC):
     def init(self, graphics, item=None, style=None, opacity=1.0):
         if item is not None and not item.has_form(self.get_name(), None):
             raise BoxExpressionError

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -276,9 +276,9 @@ class Graphics(Builtin):
      = #<--#
      . \begin{asy}
      . usepackage("amsmath");
-     . size(5.8556cm, 5.8333cm);
-     . draw(ellipse((175,175),175,175), rgb(0, 0, 0)+linewidth(0.66667));
-     . clip(box((-0.33333,0.33333), (350.33,349.67)));
+     . size(5.8445cm, 5.8333cm);
+     . draw(ellipse((175,175),175,175), rgb(0, 0, 0)+linewidth(0.33333));
+     . clip(box((-0.16667,0.16667), (350.17,349.83)));
      . \end{asy}
     """
 
@@ -1038,15 +1038,15 @@ class Style:
     def get_option(self, name):
         return self.options.get(name, None)
 
-    def get_line_width(self, face_element=True):
+    def get_line_width(self, face_element=True) -> float:
         if self.graphics.pixel_width is None:
-            return 0
+            return 0.0
         edge_style, _ = self.get_style(
             _Thickness, default_to_faces=face_element, consider_forms=face_element
         )
         if edge_style is None:
-            return 0
-        return edge_style.get_thickness()
+            return 0.0
+        return edge_style.get_thickness() / 2.0
 
 
 def _flatten(elements):
@@ -1161,7 +1161,7 @@ class _GraphicsElements:
             )
             self.tooltip_text = messages
             self.background_color = ERROR_BACKGROUND_COLOR
-            logging.warn(messages)
+            logging.warning(messages)
 
     def create_style(self, expr):
         style = self.style_class(self)

--- a/mathics/format/svg.py
+++ b/mathics/format/svg.py
@@ -106,10 +106,10 @@ def arcbox(self, **options) -> str:
 
     def path(closed):
         if closed:
-            yield "M %f,%f" % (x, y)
-            yield "L %f,%f" % (sx, sy)
+            yield f"M {x:f},{y:f}"
+            yield f"L {sx:f},{sy:f}"
         else:
-            yield "M %f,%f" % (sx, sy)
+            yield f"M {sx:f},{sy:f}"
 
         yield "A %f,%f,0,%d,0,%f,%f" % (rx, ry, large_arc, ex, ey)
 
@@ -124,7 +124,7 @@ def arcbox(self, **options) -> str:
         edge_opacity=self.edge_opacity,
         face_opacity=self.face_opacity,
     )
-    svg = '<path d="%s" style="%s" />' % (" ".join(path(self.face_element)), style)
+    svg = f"<path d=\"{' '.join(path(self.face_element))}\" style=\"{style}\" />"
     # print("_Arcbox: ", svg)
     return svg
 
@@ -211,7 +211,7 @@ def density_plot_box(self, **options):
         b = (colors[0][2] + colors[1][2] + colors[2][1]) / 3
         mid_color = r"rgb(%f, %f, %f)" % (r * 255, g * 255, b * 255)
 
-        points = " ".join("%f,%f" % (point[0], point[1]) for point in triangle)
+        points = " ".join(f"{point[0]:f},{point[1]:f}" for point in triangle)
         svg_data.append(f'<polygon points="{points}" fill="{mid_color}" />')
 
     svg = "\n".join(svg_data)
@@ -542,13 +542,7 @@ def _roundbox(self):
         edge_opacity=self.edge_opacity,
         face_opacity=self.face_opacity,
     )
-    svg = '<ellipse cx="%f" cy="%f" rx="%f" ry="%f" style="%s" />' % (
-        x,
-        y,
-        rx,
-        ry,
-        style,
-    )
+    svg = f'<ellipse cx="{x:f}" cy="{y:f}" rx="{rx:f}" ry="{ry:f}" style="{style}" />'
     # print("_RoundBox: ", svg)
     return svg
 
@@ -569,9 +563,9 @@ def wrap_svg_body(
     svg_str = f"""
 <svg width="{box_width}px" height="{box_height}px" xmlns:svg="http://www.w3.org/2000/svg"
             xmlns="http://www.w3.org/2000/svg"
-            version="1.1"
             viewBox="{x_min:f} {y_min:f} {box_width:f}, {box_height:f}">
     {svg_body}
 </svg>
 """
+    # print(svg_str)
     return svg_str

--- a/test/format/test_svg.py
+++ b/test/format/test_svg.py
@@ -3,13 +3,11 @@ from test.helper import session
 
 from mathics.builtin.makeboxes import MakeBoxes
 from mathics.core.atoms import Integer0, Integer1, Real
-from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.formatter import lookup_method
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolPoint
-from mathics.session import MathicsSession
 
 evaluation = session.evaluation
 
@@ -27,7 +25,6 @@ COLOR_RED_ALPHA = Expression(
 
 svg_wrapper_pat = r"""\s*<svg width="[0-9.]+px" height="[0-9.]+px" xmlns:svg="http://www.w3.org/2000/svg"
 \s*xmlns="http://www.w3.org/2000/svg"
-\s*version="1\.1"
 """
 
 


### PR DESCRIPTION
 graphics.py:
* Reduce default asy line width
* Add a return type annotation
* remove deprecated logging.warn
    
asy.py:
* Remove math mode in text label
    
 svg.py
 * Remove deprecated version number in <svg> tag.
 * Convert to format strings