### PR TITLE
Track Combinatorica v201 and v091

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -36,6 +36,8 @@ jobs:
         git submodule update
         remake -x develop
         cd mathics/packages/Combinatorica-repo
-        git pull origin HEAD
+        # If Combinatorica repo changes, we may need the below altered
+        # with a branch name, (not HEAD) for testing.
+        # git pull origin HEAD
         pip install -e .[dev]
         remake -x check

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -36,6 +36,6 @@ jobs:
         git submodule update
         remake -x develop
         cd mathics/packages/Combinatorica-repo
-        git pull origin rename-combinatorica-files
+        git pull origin HEAD
         pip install -e .[dev]
         remake -x check

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -36,5 +36,6 @@ jobs:
         git submodule update
         remake -x develop
         cd mathics/packages/Combinatorica-repo
+        git pull origin rename-combinatorica-files
         pip install -e .[dev]
         remake -x check


### PR DESCRIPTION
This draft is not really for merging but for testing that if we merge https://github.com/Mathics3/Mathics3-Combinatorica/pull/5, then we won't break Mathics-core. 

After Combinatorica is changed, we would then change the  "package.yml" file of this draft to pull from "master" rather than a branch.