### PR TITLE
More Unary and Binary operators from JSON

### DIFF
--- a/mathics/builtin/assignments/assign_binaryop.py
+++ b/mathics/builtin/assignments/assign_binaryop.py
@@ -61,7 +61,6 @@ class AddTo(InfixOperator, InplaceInfixOperator):
 
     attributes = A_HOLD_FIRST | A_PROTECTED
     grouping = "Right"
-    operator = "+="
 
     operator_symbol = SymbolPlus
     return_before_value: bool = True
@@ -120,7 +119,6 @@ class Decrement(InplaceInfixOperator, InfixOperator, PostfixOperator):
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
     increment_symbol = IntegerM1
-    operator = "--"
     operator_symbol = SymbolPlus
 
     returns_updated_value = False
@@ -206,7 +204,6 @@ class Increment(InplaceInfixOperator, InfixOperator, PostfixOperator):
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
     increment_symbol = Integer1
-    operator = "++"
     operator_symbol = SymbolPlus
     returns_updated_value: bool = False
     summary_text = (
@@ -297,7 +294,6 @@ class PreIncrement(InplaceInfixOperator, PrefixOperator):
     """
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
-    operator = "++"
     operator_symbol = SymbolPlus
     return_before_value: bool = False
 
@@ -326,7 +322,6 @@ class SubtractFrom(InfixOperator):
 
     attributes = A_HOLD_FIRST | A_PROTECTED
     grouping = "Right"
-    operator = "-="
 
     rules = {
         "x_ -= dx_": "x = x - dx",
@@ -353,7 +348,6 @@ class TimesBy(InfixOperator):
     #> Clear[a]
     """
 
-    operator = "*="
     attributes = A_HOLD_FIRST | A_PROTECTED
     grouping = "Right"
 

--- a/mathics/builtin/assignments/assign_binaryop.py
+++ b/mathics/builtin/assignments/assign_binaryop.py
@@ -241,7 +241,6 @@ class PreDecrement(InplaceInfixOperator, PrefixOperator):
 
     attributes = A_HOLD_FIRST | A_PROTECTED | A_READ_PROTECTED
     increment_symbol = IntegerM1
-    operator = "--"
     operator_symbol = SymbolPlus
     returns_updated_value: bool = True
     summary_text = "decrease the value by one and assigns that returning the new value"

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -423,7 +423,6 @@ class Information(PrefixOperator):
 
     attributes = A_HOLD_ALL | A_SEQUENCE_HOLD | A_PROTECTED | A_READ_PROTECTED
     messages = {"notfound": "Expression `1` is not a symbol"}
-    operator = "??"
     options = {
         "LongForm": "True",
     }

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -361,7 +361,6 @@ class Get(PrefixOperator):
     ## >> << "VectorAnalysis`"
     """
 
-    operator = "<<"
     options = {
         "Trace": "False",
     }
@@ -566,7 +565,6 @@ class Put(InfixOperator):
     S> DeleteFile[filename]
     """
 
-    operator = ">>"
     summary_text = "write an expression to a file"
 
     def eval(self, exprs, filename, evaluation):

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -659,7 +659,6 @@ class PutAppend(InfixOperator):
     >> DeleteFile["factorials"];
     """
 
-    operator = ">>>"
     summary_text = "append an expression to a file"
 
     def eval(self, exprs, filename, evaluation):

--- a/mathics/builtin/functional/application.py
+++ b/mathics/builtin/functional/application.py
@@ -91,7 +91,6 @@ class Function(PostfixOperator, SympyFunction):
     to the function body.
     """
 
-    operator = "&"
     attributes = A_HOLD_ALL | A_PROTECTED
 
     messages = {
@@ -196,8 +195,6 @@ class Slot(SympyFunction, PrefixOperator):
 
     attributes = A_N_HOLD_ALL | A_PROTECTED
 
-    operator = "#"  # FIXME generate this automatically
-
     rules = {
         "Slot[]": "Slot[1]",
         "MakeBoxes[Slot[n_Integer?NonNegative],"
@@ -236,8 +233,6 @@ class SlotSequence(PrefixOperator, Builtin):
     """
 
     attributes = A_N_HOLD_ALL | A_PROTECTED
-
-    operator = "##"  # FIXME generate this automatically
 
     rules = {
         "SlotSequence[]": "SlotSequence[1]",

--- a/mathics/builtin/functional/apply_fns_to_lists.py
+++ b/mathics/builtin/functional/apply_fns_to_lists.py
@@ -71,8 +71,6 @@ class Apply(InfixOperator):
     summary_text = "apply a function to a list, at specified levels"
     grouping = "Right"
 
-    operator = "@@"  # FIXME generate this automatically
-
     options = {
         "Heads": "False",
     }

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -231,7 +231,6 @@ class Postfix(PostfixOperator):
     """
 
     grouping = "Left"
-    operator = "//"
     operator_display = None
     summary_text = "postfix form"
 

--- a/mathics/builtin/layout.py
+++ b/mathics/builtin/layout.py
@@ -321,7 +321,6 @@ class Prefix(PrefixOperator):
     """
 
     grouping = "Right"
-    operator = "@"
     operator_display = None
     summary_text = "prefix form"
 

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -1624,7 +1624,6 @@ class Span(InfixOperator):
      = Span[1, 3]
     """
 
-    operator = ";;"
     summary_text = "general specification for spans or blocks of elements"
 
 

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -324,7 +324,6 @@ class MessageName(InfixOperator):
     default_formats = False
     formats: typing.Dict[str, Any] = {}
     messages = {"messg": "Message cannot be set to `1`. It must be set to a string."}
-    operator = "::"
     rules = {
         "MakeBoxes[MessageName[symbol_Symbol, tag_String], "
         "f:StandardForm|TraditionalForm|OutputForm]": (

--- a/mathics/builtin/no_meaning/infix_extra.py
+++ b/mathics/builtin/no_meaning/infix_extra.py
@@ -44,8 +44,6 @@ class DirectedEdge(InfixOperator):
 
     attributes = A_NO_ATTRIBUTES
     default_formats = False  # Don't use any default format rules. Instead, see belo.
-
-    operator = "→"
     summary_text = 'DirectedEdge infix operator "→"'
 
 
@@ -82,6 +80,4 @@ class UndirectedEdge(InfixOperator):
 
     attributes = A_NO_ATTRIBUTES
     default_formats = False  # Don't use any default format rules. Instead, see belo.
-
-    operator = "↔"
     summary_text = 'UndirectedEdge infix operator "↔"'

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -411,7 +411,6 @@ class Derivative(PostfixOperator, SympyFunction):
 
     attributes = A_N_HOLD_ALL
     default_formats = False
-    operator = "'"
     rules = {
         "MakeBoxes[Derivative[n__Integer][f_], "
         "  form:StandardForm|TraditionalForm]": (

--- a/mathics/builtin/patterns/composite.py
+++ b/mathics/builtin/patterns/composite.py
@@ -470,7 +470,6 @@ class Repeated(PostfixOperator, PatternObject):
         )
     }
 
-    operator = ".."
     summary_text = "match to one or more occurrences of a pattern"
 
     def init(
@@ -550,7 +549,6 @@ class RepeatedNull(Repeated):
      = t
     """
 
-    operator = "..."
     summary_text = "match to zero or more occurrences of a pattern"
 
     def init(

--- a/mathics/builtin/patterns/defaults.py
+++ b/mathics/builtin/patterns/defaults.py
@@ -67,7 +67,6 @@ class Optional(InfixOperator, PatternObject):
         "MakeBoxes[Verbatim[Optional][Verbatim[Pattern][symbol_Symbol, Verbatim[_]]], f:StandardForm|TraditionalForm|InputForm|OutputForm]": 'MakeBoxes[symbol, f] <> "_."',
         "MakeBoxes[Verbatim[Optional][Verbatim[_]], f:StandardForm|TraditionalForm|InputForm|OutputForm]": '"_."',
     }
-    operator = ":"
     summary_text = "an optional argument with a default value"
 
     def init(

--- a/mathics/builtin/patterns/restrictions.py
+++ b/mathics/builtin/patterns/restrictions.py
@@ -49,7 +49,6 @@ class Condition(InfixOperator, PatternObject):
     arg_counts = [2]
     # Don't know why this has attribute HoldAll in Mathematica
     attributes = A_HOLD_REST | A_PROTECTED
-    operator = "/;"
     summary_text = "conditional definition"
 
     def init(
@@ -106,7 +105,6 @@ class PatternTest(InfixOperator, PatternObject):
     """
 
     arg_counts = [2]
-    operator = "?"
     summary_text = "match to a pattern conditioned to a test result"
 
     def init(

--- a/mathics/builtin/patterns/rules.py
+++ b/mathics/builtin/patterns/rules.py
@@ -512,6 +512,9 @@ class Rule_(InfixOperator):
     grouping = "Right"
     name = "Rule"
     needs_verbatim = True
+
+    # FIXME: if we remove this we have problems.
+    # We should be able to get this from JSON.
     operator = "->"
     summary_text = "a replacement rule"
 

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -202,7 +202,6 @@ class CompoundExpression(InfixOperator):
     """
 
     attributes = A_HOLD_ALL | A_PROTECTED | A_READ_PROTECTED
-    operator = ";"
 
     summary_text = "execute expressions in sequence"
 

--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -168,7 +168,6 @@ class Factorial(PostfixOperator, MPMathFunction):
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
 
     mpmath_name = "factorial"
-    operator = "!"
     summary_text = "factorial"
 
 
@@ -201,7 +200,6 @@ class Factorial2(PostfixOperator, MPMathFunction):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
-    operator = "!!"
     mpmath_name = "fac2"
     sympy_name = "factorial2"
     messages = {

--- a/mathics/builtin/testing_expressions/logic.py
+++ b/mathics/builtin/testing_expressions/logic.py
@@ -348,7 +348,6 @@ class Or(InfixOperator):
     """
 
     attributes = A_FLAT | A_HOLD_ALL | A_ONE_IDENTITY | A_PROTECTED
-    operator = "||"
     summary_text = "logic (inclusive) disjunction"
 
     #    rules = {
@@ -437,6 +436,8 @@ class Not(PrefixOperator):
      = !b
     """
 
+    # FIXME: If we remove this we pick up unicode unconditionally
+    # which wew don't want to do.
     operator = "!"
 
     rules = {

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -1315,6 +1315,18 @@ class UnaryOperator(Operator):
     def __init__(self, format_function, *args, **kwargs):
         super().__init__(*args, **kwargs)
         name = self.get_name(short=True)
+
+        # Pick up operator string from JSON table if
+        # it appears there.
+        if self.operator is None:
+            operator_string = self.get_operator()
+            if operator_string:
+                self.operator = operator_string
+            # else:
+            #     if self.operator is None:
+            #         breakpoint()
+            #     print("FIX UP", self.operator, name)
+
         self.precedence = self.get_precedence(name)
         if self.needs_verbatim:
             name = f"Verbatim[{name}"


### PR DESCRIPTION
Remove hard-coded operator precedences and pull from YAML tables from scanner project (via JSON).