### PR TITLE
Removing the  to the return value in Definitions.get_definition

### DIFF
--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -14,6 +14,7 @@ from mathics.core.attributes import (
 from mathics.core.builtin import Builtin, InfixOperator
 from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation
+from mathics.core.expression import Expression
 from mathics.core.symbols import Symbol, SymbolNull
 from mathics.core.systemsymbols import SymbolFailed
 from mathics.eval.assignments import eval_assign
@@ -270,14 +271,14 @@ class TagSet(Builtin):
         self,
         f: BaseElement,
         lhs: BaseElement,
-        rhs: BaseElement,
+        rhs,
         evaluation: Evaluation,
     ) -> Optional[BaseElement]:
         "f_ /: lhs_ = rhs_"
 
         tag_name = f.get_name()
         if not tag_name:
-            evaluation.message(self.get_name(), "sym", tag, 1)
+            evaluation.message(self.get_name(), "sym", f, 1)
             return None
 
         rhs = rhs.evaluate(evaluation)

--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -2,14 +2,8 @@
 """
 Forms of Assignment
 """
+from typing import Optional
 
-
-from mathics.core.assignment import (
-    ASSIGNMENT_FUNCTION_MAP,
-    AssignmentException,
-    assign_store_rules_by_tag,
-    normalize_lhs,
-)
 from mathics.core.atoms import String
 from mathics.core.attributes import (
     A_HOLD_ALL,
@@ -18,45 +12,16 @@ from mathics.core.attributes import (
     A_SEQUENCE_HOLD,
 )
 from mathics.core.builtin import Builtin, InfixOperator
-from mathics.core.symbols import SymbolNull
+from mathics.core.element import BaseElement
+from mathics.core.evaluation import Evaluation
+from mathics.core.symbols import Symbol, SymbolNull
 from mathics.core.systemsymbols import SymbolFailed
+from mathics.eval.assignments import eval_assign
 from mathics.eval.pymathics import PyMathicsLoadException, eval_LoadModule
 
 
-class _SetOperator:
-    """
-
-    This is the base class for assignment Builtin operators.
-
-    Special cases are determined by the head of the expression. Then
-    they are processed by specific routines, which are poke from
-    the ``ASSIGNMENT_FUNCTION_MAP`` dict.
-    """
-
-    # FIXME:
-    # Assignment is determined by the LHS.
-    # Are there a larger patterns or natural groupings that we are missing?
-    # For example, it might be that it
-    # we can key off of some attributes or other properties of the
-    # LHS of a builtin, instead of listing all of the builtins in that class
-    # (which may miss some).
-    # Below, we key on a string, but Symbol is more correct.
-
-    def assign(self, lhs, rhs, evaluation, tags=None, upset=False):
-        lhs, lookup_name = normalize_lhs(lhs, evaluation)
-        try:
-            # Using a builtin name, find which assignment procedure to perform,
-            # and then call that function.
-            assignment_func = ASSIGNMENT_FUNCTION_MAP.get(lookup_name, None)
-            if assignment_func:
-                return assignment_func(self, lhs, rhs, evaluation, tags, upset)
-
-            return assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset)
-        except AssignmentException:
-            return False
-
-
-# Placing this here is a bit weird, but it is not clear where else is better suited for this right now.
+# Placing this here is a bit weird, but it is not clear where else is better
+# suited for this right now.
 class LoadModule(Builtin):
     """
     ## <url>:mathics native for pymathics:</url>
@@ -88,13 +53,13 @@ class LoadModule(Builtin):
         except PyMathicsLoadException:
             evaluation.message(self.name, "notmathicslib", module)
             return SymbolFailed
-        except Exception as e:
-            evaluation.message(self.get_name(), "loaderror", String(str(e)))
+        except ImportError as exception:
+            evaluation.message(self.get_name(), "loaderror", String(str(exception)))
             return SymbolFailed
         return module
 
 
-class Set(InfixOperator, _SetOperator):
+class Set(InfixOperator):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/Set.html</url>
 
@@ -105,7 +70,8 @@ class Set(InfixOperator, _SetOperator):
       <dd>evaluates $value$ and assigns it to $expr$.
 
       <dt>{$s1$, $s2$, $s3$} = {$v1$, $v2$, $v3$}
-      <dd>sets multiple symbols ($s1$, $s2$, ...) to the corresponding values ($v1$, $v2$, ...).
+      <dd>sets multiple symbols ($s1$, $s2$, ...) to the corresponding \
+          values ($v1$, $v2$, ...).
     </dl>
 
     'Set' can be used to give a symbol a value:
@@ -173,7 +139,7 @@ class Set(InfixOperator, _SetOperator):
     def eval(self, lhs, rhs, evaluation):
         "lhs_ = rhs_"
 
-        self.assign(lhs, rhs, evaluation)
+        eval_assign(self, lhs, rhs, evaluation)
         return rhs
 
 
@@ -189,7 +155,9 @@ class SetDelayed(Set):
       <dd>assigns $value$ to $expr$, without evaluating $value$.
     </dl>
 
-    'SetDelayed' is like 'Set', except it has attribute 'HoldAll', thus it does not evaluate the right-hand side immediately, but evaluates it when needed.
+    'SetDelayed' is like 'Set', except it has attribute 'HoldAll', thus it \
+        does not evaluate the right-hand side immediately, but evaluates \
+            it when needed.
 
     >> Attributes[SetDelayed]
      = {HoldAll, Protected, SequenceHold}
@@ -248,16 +216,18 @@ class SetDelayed(Set):
 
     summary_text = "test a delayed value; used in defining functions"
 
-    def eval(self, lhs, rhs, evaluation):
+    def eval(
+        self, lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
+    ) -> Symbol:
         "lhs_ := rhs_"
 
-        if self.assign(lhs, rhs, evaluation):
+        if eval_assign(self, lhs, rhs, evaluation):
             return SymbolNull
-        else:
-            return SymbolFailed
+
+        return SymbolFailed
 
 
-class TagSet(Builtin, _SetOperator):
+class TagSet(Builtin):
     """
     <url>:WMA link:https://reference.wolfram.com/language/ref/TagSet.html</url>
 
@@ -277,7 +247,8 @@ class TagSet(Builtin, _SetOperator):
     >> UpValues[square]
      = {HoldPattern[area[square[s_]]] :> s ^ 2}
 
-    The symbol $f$ must appear as the ultimate head of $lhs$ or as the head of an element in $lhs$:
+    The symbol $f$ must appear as the ultimate head of $lhs$ or as the head \
+        of an element in $lhs$:
     >> x /: f[g[x]] = 3;
      : Tag x not found or too deep for an assigned rule.
     >> g /: f[g[x]] = 3;
@@ -290,18 +261,27 @@ class TagSet(Builtin, _SetOperator):
     messages = {
         "tagnfd": "Tag `1` not found or too deep for an assigned rule.",
     }
-    summary_text = "assign a value to an expression, associating the corresponding assignment with the a symbol"
+    summary_text = (
+        "assign a value to an expression, associating the "
+        "corresponding assignment with the a symbol"
+    )
 
-    def eval(self, f, lhs, rhs, evaluation):
+    def eval(
+        self,
+        f: BaseElement,
+        lhs: BaseElement,
+        rhs: BaseElement,
+        evaluation: Evaluation,
+    ) -> Optional[BaseElement]:
         "f_ /: lhs_ = rhs_"
 
-        name = f.get_name()
-        if not name:
-            evaluation.message(self.get_name(), "sym", f, 1)
-            return
+        tag_name = f.get_name()
+        if not tag_name:
+            evaluation.message(self.get_name(), "sym", tag, 1)
+            return None
 
         rhs = rhs.evaluate(evaluation)
-        self.assign(lhs, rhs, evaluation, tags=[name])
+        eval_assign(self, lhs, rhs, evaluation, tags=[tag_name])
         return rhs
 
 
@@ -319,30 +299,40 @@ class TagSetDelayed(TagSet):
     """
 
     attributes = A_HOLD_ALL | A_PROTECTED | A_SEQUENCE_HOLD
-    summary_text = "assign a delayed value to an expression, associating the corresponding assignment with the a symbol"
+    summary_text = (
+        "assign a delayed value to an expression, associating "
+        "the corresponding assignment with the a symbol"
+    )
 
-    def eval(self, f, lhs, rhs, evaluation):
+    def eval(
+        self,
+        f: BaseElement,
+        lhs: BaseElement,
+        rhs: BaseElement,
+        evaluation: Evaluation,
+    ) -> Optional[Symbol]:
         "f_ /: lhs_ := rhs_"
 
-        name = f.get_name()
-        if not name:
+        tag_name = f.get_name()
+        if not tag_name:
             evaluation.message(self.get_name(), "sym", f, 1)
-            return
+            return None
 
-        if self.assign(lhs, rhs, evaluation, tags=[name]):
+        if eval_assign(self, lhs, rhs, evaluation, tags=[tag_name]):
             return SymbolNull
-        else:
-            return SymbolFailed
+
+        return SymbolFailed
 
 
-class UpSet(InfixOperator, _SetOperator):
+class UpSet(InfixOperator):
     """
     <url>:WMA link:
          https://reference.wolfram.com/language/ref/UpSet.html</url>
 
     <dl>
       <dt>$f$[$x$] ^= $expression$
-      <dd>evaluates $expression$ and assigns it to the value of $f$[$x$], associating the value with $x$.
+      <dd>evaluates $expression$ and assigns it to the value of $f$[$x$], \
+          associating the value with $x$.
     </dl>
 
     'UpSet' creates an upvalue:
@@ -368,10 +358,12 @@ class UpSet(InfixOperator, _SetOperator):
         "set value and associate the assignment with symbols that occur at level one"
     )
 
-    def eval(self, lhs, rhs, evaluation):
+    def eval(
+        self, lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
+    ) -> Optional[BaseElement]:
         "lhs_ ^= rhs_"
 
-        self.assign(lhs, rhs, evaluation, upset=True)
+        eval_assign(self, lhs, rhs, evaluation, upset=True)
         return rhs
 
 
@@ -384,7 +376,8 @@ class UpSetDelayed(UpSet):
        <dt>'UpSetDelayed[$expression$, $value$]'
 
        <dt>'$expression$ ^:= $value$'
-       <dd>assigns $expression$ to the value of $f$[$x$] (without evaluating $expression$), associating the value with $x$.
+       <dd>assigns $expression$ to the value of $f$[$x$] \
+           (without evaluating $expression$), associating the value with $x$.
     </dl>
 
     >> a[b] ^:= x
@@ -396,12 +389,17 @@ class UpSetDelayed(UpSet):
     """
 
     attributes = A_HOLD_ALL | A_PROTECTED | A_SEQUENCE_HOLD
-    summary_text = "set a delayed value and associate the assignment with symbols that occur at level one"
+    summary_text = (
+        "set a delayed value and associate the assignment "
+        "with symbols that occur at level one"
+    )
 
-    def eval(self, lhs, rhs, evaluation):
+    def eval(
+        self, lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
+    ) -> Symbol:
         "lhs_ ^:= rhs_"
 
-        if self.assign(lhs, rhs, evaluation, upset=True):
+        if eval_assign(self, lhs, rhs, evaluation, upset=True):
             return SymbolNull
-        else:
-            return SymbolFailed
+
+        return SymbolFailed

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -6,7 +6,7 @@ Symbolic data. Every symbol has a unique name, exists in a certain context \
 or namespace, and can have a variety of type of values and attributes.
 """
 import re
-from typing import Callable
+from typing import Callable, List
 
 from mathics_scanner.tokeniser import is_symbol_name
 
@@ -52,16 +52,19 @@ from mathics.core.systemsymbols import (
 from mathics.doc.online import online_doc_string
 
 
-def show_definitions(symbol: Symbol, evaluation: Evaluation) -> list:
+def show_definitions(symbol: Symbol, evaluation: Evaluation) -> List[Expression]:
     """Return a list of lines describing the definition of `symbol`"""
     lines = []
 
-    def print_rule(
+    def show_rule(
         rule: Rule,
         up: bool = False,
         lhs: Callable = lambda k: k,
         rhs: Callable = lambda r: r,
     ):
+        """
+        Add a line showing `rule`
+        """
         evaluation.check_stopped()
         if isinstance(rule, Rule):
             r = rhs(
@@ -78,21 +81,21 @@ def show_definitions(symbol: Symbol, evaluation: Evaluation) -> list:
                 )
             )
 
-    def print_rules(definition: Definition):
+    def show_rules(definition: Definition):
         """
-        Print all the rules associated
+        Add to the description all the rules associated
         to a definition object
         """
         for rule in definition.ownvalues:
-            print_rule(rule)
+            show_rule(rule)
         for rule in definition.downvalues:
-            print_rule(rule)
+            show_rule(rule)
         for rule in definition.subvalues:
-            print_rule(rule)
+            show_rule(rule)
         for rule in definition.upvalues:
-            print_rule(rule, up=True)
+            show_rule(rule, up=True)
         for rule in definition.nvalues:
-            print_rule(rule)
+            show_rule(rule)
         formats = sorted(definition.formatvalues.items())
         for format, rules in formats:
             for rule in rules:
@@ -107,7 +110,7 @@ def show_definitions(symbol: Symbol, evaluation: Evaluation) -> list:
                         )
                     return Expression(SymbolInputForm, expr)
 
-                print_rule(rule, lhs=lhs, rhs=rhs)
+                show_rule(rule, lhs=lhs, rhs=rhs)
 
     name = symbol.get_name()
     if not name:
@@ -130,12 +133,12 @@ def show_definitions(symbol: Symbol, evaluation: Evaluation) -> list:
 
     if not A_READ_PROTECTED & attributes:
         try:
-            print_rules(evaluation.definitions.get_user_definition(name, create=False))
+            show_rules(evaluation.definitions.get_user_definition(name, create=False))
         except KeyError:
             pass
 
     for rule in all.defaultvalues:
-        print_rule(rule)
+        show_rule(rule)
     if all.options:
         options = sorted(all.options.items())
         lines.append(

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -6,7 +6,7 @@ Symbolic data. Every symbol has a unique name, exists in a certain context \
 or namespace, and can have a variety of type of values and attributes.
 """
 import re
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from mathics_scanner.tokeniser import is_symbol_name
 
@@ -54,7 +54,7 @@ from mathics.doc.online import online_doc_string
 
 def gather_and_format_definition_rules(
     symbol: Symbol, evaluation: Evaluation
-) -> List[Expression]:
+) -> Optional[List[Expression]]:
     """Return a list of lines describing the definition of `symbol`"""
     lines = []
 
@@ -484,11 +484,11 @@ class Names(Builtin):
 
     summary_text = "find a list of symbols with names matching a pattern"
 
-    def eval(self, pattern, evaluation):
+    def eval(self, pattern, evaluation: Evaluation):
         "Names[pattern_]"
         headname = pattern.get_head_name()
         if headname == "System`StringExpression":
-            pattern = re.compile(to_regex(pattern, show_message=evaluation.messages))
+            pattern = re.compile(to_regex(pattern, show_message=evaluation.message))
         else:
             pattern = pattern.get_string_value()
 

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -306,7 +306,9 @@ class Definition(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "give values of a symbol in a form that can be stored in a package"
 
-    def format_definition(self, symbol, evaluation: Evaluation, grid: bool = True):
+    def format_definition(
+        self, symbol: Symbol, evaluation: Evaluation, grid: bool = True
+    ) -> Symbol:
         "StandardForm,TraditionalForm,OutputForm: Definition[symbol_]"
 
         lines = show_definitions(symbol, evaluation)
@@ -323,7 +325,7 @@ class Definition(Builtin):
 
         return SymbolNull
 
-    def format_definition_input(self, symbol, evaluation):
+    def format_definition_input(self, symbol: Symbol, evaluation: Evaluation) -> Symbol:
         "InputForm: Definition[symbol_]"
         return self.format_definition(symbol, evaluation, grid=False)
 
@@ -406,7 +408,9 @@ class Information(PrefixOperator):
     }
     summary_text = "get information about all assignments for a symbol"
 
-    def format_information(self, symbol, evaluation, options, grid=True):
+    def format_information(
+        self, symbol: Symbol, evaluation: Evaluation, options: dict, grid: bool = True
+    ) -> Symbol:
         "StandardForm,TraditionalForm,OutputForm: Information[symbol_, OptionsPattern[Information]]"
         ret = SymbolNull
         lines = []
@@ -438,7 +442,9 @@ class Information(PrefixOperator):
                     evaluation.print_out(Expression(SymbolInputForm, line))
         return ret
 
-    def format_information_input(self, symbol, evaluation: Evaluation, options: dict):
+    def format_information_input(
+        self, symbol: Symbol, evaluation: Evaluation, options: dict
+    ) -> Symbol:
         "InputForm: Information[symbol_, OptionsPattern[Information]]"
         self.format_information(symbol, evaluation, options, grid=False)
         ret = SymbolNull

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -270,7 +270,12 @@ class Definition(Builtin):
             evaluation.message("Definition", "sym", symbol, 1)
             return
         attributes = evaluation.definitions.get_attributes(name)
-        definition = evaluation.definitions.get_user_definition(name, create=False)
+        try:
+            definition = evaluation.definitions.get_user_definition(name, create=False)
+        except KeyError:
+            # TODO: avoid to assign None to a definition variable.
+            definition = None
+
         all = evaluation.definitions.get_definition(name)
         if attributes:
             attributes_list = attributes_bitset_to_list(attributes)

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -43,46 +43,13 @@ from mathics.core.systemsymbols import (
     SymbolDefinition,
     SymbolFormat,
     SymbolGrid,
-    SymbolInfix,
     SymbolInputForm,
     SymbolLeft,
     SymbolOptions,
     SymbolRule,
     SymbolSet,
 )
-
-
-def _get_usage_string(symbol, evaluation, is_long_form: bool):
-    """
-    Returns a python string with the documentation associated to a given symbol.
-    """
-    definition = evaluation.definitions.get_definition(symbol.name)
-    ruleusage = definition.get_values_list("messages")
-    usagetext = None
-
-    # First look at user definitions:
-    for rulemsg in ruleusage:
-        if rulemsg.pattern.expr.elements[1].__str__() == '"usage"':
-            usagetext = rulemsg.replace.value
-
-    if not is_long_form and usagetext:
-        return usagetext
-
-    builtins = evaluation.definitions.builtin
-    pymathics = evaluation.definitions.pymathics
-    bio = pymathics.get(definition.name) or builtins.get(definition.name)
-
-    if bio is not None:
-        from mathics.doc.doc_entries import DocumentationEntry
-
-        docstr = bio.builtin.__class__.__doc__
-        title = bio.builtin.__class__.__name__
-        if docstr is None:
-            return usagetext
-        docstr = docstr[docstr.find("<dl>") : (docstr.find("</dl>") + 6)]
-        usagetext = DocumentationEntry(docstr, title).text()
-        usagetext = re.sub(r"\$([0-9a-zA-Z]*)\$", r"\1", usagetext)
-    return usagetext
+from mathics.doc.online import online_doc_string
 
 
 def show_definitions(symbol: Symbol, evaluation: Evaluation) -> list:
@@ -448,7 +415,7 @@ class Information(PrefixOperator):
             return ret
         # Print the "usage" message if available.
         is_long_form = self.get_option(options, "LongForm", evaluation).to_python()
-        usagetext = _get_usage_string(symbol, evaluation, is_long_form)
+        usagetext = online_doc_string(symbol, evaluation, is_long_form)
         if usagetext is not None:
             lines.append(usagetext)
 

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -140,7 +140,7 @@ def gather_and_format_definition_rules(
             pass
 
     for rule in all.defaultvalues:
-        show_rule(rule)
+        format_rule(rule)
     if all.options:
         options = sorted(all.options.items())
         lines.append(
@@ -425,7 +425,7 @@ class Information(PrefixOperator):
         # Print the "usage" message if available.
         is_long_form = self.get_option(options, "LongForm", evaluation).to_python()
         usagetext = online_doc_string(symbol, evaluation, is_long_form)
-        if usagetext is not None:
+        if usagetext:
             lines.append(usagetext)
 
         if is_long_form:

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -5,8 +5,8 @@ Symbol Handling
 Symbolic data. Every symbol has a unique name, exists in a certain context \
 or namespace, and can have a variety of type of values and attributes.
 """
-
 import re
+from typing import Callable
 
 from mathics_scanner.tokeniser import is_symbol_name
 
@@ -59,36 +59,134 @@ def _get_usage_string(symbol, evaluation, is_long_form: bool):
     definition = evaluation.definitions.get_definition(symbol.name)
     ruleusage = definition.get_values_list("messages")
     usagetext = None
-    import re
 
     # First look at user definitions:
     for rulemsg in ruleusage:
         if rulemsg.pattern.expr.elements[1].__str__() == '"usage"':
             usagetext = rulemsg.replace.value
-    if usagetext is not None:
-        # Maybe, if htmltout is True, we should convert
-        # the value to a HTML form...
+
+    if not is_long_form and usagetext:
         return usagetext
-    # Otherwise, look at the pymathics, and builtin docstrings:
+
     builtins = evaluation.definitions.builtin
     pymathics = evaluation.definitions.pymathics
-    bio = pymathics.get(definition.name)
-    if bio is None:
-        bio = builtins.get(definition.name)
+    bio = pymathics.get(definition.name) or builtins.get(definition.name)
 
     if bio is not None:
-        if not is_long_form and hasattr(bio.builtin.__class__, "summary_text"):
-            return bio.builtin.__class__.summary_text
-        from mathics.doc.common_doc import XMLDOC
+        from mathics.doc.doc_entries import DocumentationEntry
 
         docstr = bio.builtin.__class__.__doc__
         title = bio.builtin.__class__.__name__
         if docstr is None:
-            return None
-        usagetext = XMLDOC(docstr, title).text(0)
+            return usagetext
+        docstr = docstr[docstr.find("<dl>") : (docstr.find("</dl>") + 6)]
+        usagetext = DocumentationEntry(docstr, title).text()
         usagetext = re.sub(r"\$([0-9a-zA-Z]*)\$", r"\1", usagetext)
-        return usagetext
-    return None
+    return usagetext
+
+
+def show_definitions(symbol: Symbol, evaluation: Evaluation) -> list:
+    """Return a list of lines describing the definition of `symbol`"""
+    lines = []
+
+    def print_rule(
+        rule: Rule,
+        up: bool = False,
+        lhs: Callable = lambda k: k,
+        rhs: Callable = lambda r: r,
+    ):
+        evaluation.check_stopped()
+        if isinstance(rule, Rule):
+            r = rhs(
+                rule.replace.replace_vars(
+                    {"System`Definition": Expression(SymbolHoldForm, SymbolDefinition)}
+                )
+            )
+            lines.append(
+                Expression(
+                    SymbolHoldForm,
+                    Expression(
+                        up and SymbolUpSet or SymbolSet, lhs(rule.pattern.expr), r
+                    ),
+                )
+            )
+
+    def print_rules(definition: Definition):
+        """
+        Print all the rules associated
+        to a definition object
+        """
+        for rule in definition.ownvalues:
+            print_rule(rule)
+        for rule in definition.downvalues:
+            print_rule(rule)
+        for rule in definition.subvalues:
+            print_rule(rule)
+        for rule in definition.upvalues:
+            print_rule(rule, up=True)
+        for rule in definition.nvalues:
+            print_rule(rule)
+        formats = sorted(definition.formatvalues.items())
+        for format, rules in formats:
+            for rule in rules:
+
+                def lhs(expr):
+                    return Expression(SymbolFormat, expr, Symbol(format))
+
+                def rhs(expr):
+                    if expr.has_form("Infix", None):
+                        expr = Expression(
+                            Expression(SymbolHoldForm, expr.head), *expr.elements
+                        )
+                    return Expression(SymbolInputForm, expr)
+
+                print_rule(rule, lhs=lhs, rhs=rhs)
+
+    name = symbol.get_name()
+    if not name:
+        evaluation.message("Definition", "sym", symbol, 1)
+        return
+    attributes = evaluation.definitions.get_attributes(name)
+    all = evaluation.definitions.get_definition(name)
+    if attributes:
+        attributes_list = attributes_bitset_to_list(attributes)
+        lines.append(
+            Expression(
+                SymbolHoldForm,
+                Expression(
+                    SymbolSet,
+                    Expression(SymbolAttributes, symbol),
+                    to_mathics_list(*attributes_list, elements_conversion_fn=Symbol),
+                ),
+            )
+        )
+
+    if not A_READ_PROTECTED & attributes:
+        try:
+            print_rules(evaluation.definitions.get_user_definition(name, create=False))
+        except KeyError:
+            pass
+
+    for rule in all.defaultvalues:
+        print_rule(rule)
+    if all.options:
+        options = sorted(all.options.items())
+        lines.append(
+            Expression(
+                SymbolHoldForm,
+                Expression(
+                    SymbolSet,
+                    Expression(SymbolOptions, symbol),
+                    ListExpression(
+                        *(
+                            Expression(SymbolRule, Symbol(name), value)
+                            for name, value in options
+                        )
+                    ),
+                ),
+            )
+        )
+    return lines
 
 
 class Context(Builtin):
@@ -238,105 +336,10 @@ class Definition(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
     summary_text = "give values of a symbol in a form that can be stored in a package"
 
-    def format_definition(self, symbol, evaluation, grid=True):
+    def format_definition(self, symbol, evaluation: Evaluation, grid: bool = True):
         "StandardForm,TraditionalForm,OutputForm: Definition[symbol_]"
 
-        lines = []
-
-        def print_rule(rule, up=False, lhs=lambda k: k, rhs=lambda r: r):
-            evaluation.check_stopped()
-            if isinstance(rule, Rule):
-                r = rhs(
-                    rule.replace.replace_vars(
-                        {
-                            "System`Definition": Expression(
-                                SymbolHoldForm, SymbolDefinition
-                            )
-                        },
-                        evaluation,
-                    )
-                )
-                lines.append(
-                    Expression(
-                        SymbolHoldForm,
-                        Expression(
-                            SymbolUpSet if up else SymbolSet, lhs(rule.pattern.expr), r
-                        ),
-                    )
-                )
-
-        name = symbol.get_name()
-        if not name:
-            evaluation.message("Definition", "sym", symbol, 1)
-            return
-        attributes = evaluation.definitions.get_attributes(name)
-        try:
-            definition = evaluation.definitions.get_user_definition(name, create=False)
-        except KeyError:
-            # TODO: avoid to assign None to a definition variable.
-            definition = None
-
-        all = evaluation.definitions.get_definition(name)
-        if attributes:
-            attributes_list = attributes_bitset_to_list(attributes)
-            lines.append(
-                Expression(
-                    SymbolHoldForm,
-                    Expression(
-                        SymbolSet,
-                        Expression(SymbolAttributes, symbol),
-                        to_mathics_list(
-                            *attributes_list, elements_conversion_fn=Symbol
-                        ),
-                    ),
-                )
-            )
-
-        if definition is not None and not A_READ_PROTECTED & attributes:
-            for rule in definition.ownvalues:
-                print_rule(rule)
-            for rule in definition.downvalues:
-                print_rule(rule)
-            for rule in definition.subvalues:
-                print_rule(rule)
-            for rule in definition.upvalues:
-                print_rule(rule, up=True)
-            for rule in definition.nvalues:
-                print_rule(rule)
-            formats = sorted(definition.formatvalues.items())
-            for format, rules in formats:
-                for rule in rules:
-
-                    def lhs(expr):
-                        return Expression(SymbolFormat, expr, Symbol(format))
-
-                    def rhs(expr):
-                        if expr.has_form("Infix", None):
-                            expr = Expression(
-                                Expression(SymbolHoldForm, expr.head), *expr.elements
-                            )
-                        return Expression(SymbolInputForm, expr)
-
-                    print_rule(rule, lhs=lhs, rhs=rhs)
-        for rule in all.defaultvalues:
-            print_rule(rule)
-        if all.options:
-            options = sorted(all.options.items())
-            lines.append(
-                Expression(
-                    SymbolHoldForm,
-                    Expression(
-                        SymbolSet,
-                        Expression(SymbolOptions, symbol),
-                        ListExpression(
-                            *(
-                                Expression(SymbolRule, Symbol(name), value)
-                                for name, value in options
-                            )
-                        ),
-                    ),
-                )
-            )
+        lines = show_definitions(symbol, evaluation)
         if lines:
             if grid:
                 return Expression(
@@ -433,7 +436,7 @@ class Information(PrefixOperator):
     }
     summary_text = "get information about all assignments for a symbol"
 
-    def format_definition(self, symbol, evaluation, options, grid=True):
+    def format_information(self, symbol, evaluation, options, grid=True):
         "StandardForm,TraditionalForm,OutputForm: Information[symbol_, OptionsPattern[Information]]"
         ret = SymbolNull
         lines = []
@@ -450,118 +453,24 @@ class Information(PrefixOperator):
             lines.append(usagetext)
 
         if is_long_form:
-            self.show_definitions(symbol, evaluation, lines)
+            lines.extend(show_definitions(symbol, evaluation))
 
-        if grid:
-            if lines:
+        if lines:
+            if grid:
                 infoshow = Expression(
                     SymbolGrid,
                     ListExpression(*(to_mathics_list(line) for line in lines)),
                     Expression(SymbolRule, Symbol("ColumnAlignments"), SymbolLeft),
                 )
                 evaluation.print_out(infoshow)
-        else:
-            for line in lines:
-                evaluation.print_out(Expression(SymbolInputForm, line))
+            else:
+                for line in lines:
+                    evaluation.print_out(Expression(SymbolInputForm, line))
         return ret
 
-        # It would be deserable to call here the routine inside Definition, but for some reason it fails...
-        # Instead, I just copy the code from Definition
-
-    def show_definitions(self, symbol, evaluation, lines):
-        def print_rule(rule, up=False, lhs=lambda k: k, rhs=lambda r: r):
-            evaluation.check_stopped()
-            if isinstance(rule, Rule):
-                r = rhs(
-                    rule.replace.replace_vars(
-                        {
-                            "System`Definition": Expression(
-                                SymbolHoldForm, SymbolDefinition
-                            )
-                        }
-                    )
-                )
-                lines.append(
-                    Expression(
-                        SymbolHoldForm,
-                        Expression(
-                            up and SymbolUpSet or SymbolSet, lhs(rule.pattern.expr), r
-                        ),
-                    )
-                )
-
-        name = symbol.get_name()
-        if not name:
-            evaluation.message("Definition", "sym", symbol, 1)
-            return
-        attributes = evaluation.definitions.get_attributes(name)
-        definition = evaluation.definitions.get_user_definition(name, create=False)
-        all = evaluation.definitions.get_definition(name)
-        if attributes:
-            attributes_list = attributes_bitset_to_list(attributes)
-            lines.append(
-                Expression(
-                    SymbolHoldForm,
-                    Expression(
-                        SymbolSet,
-                        Expression(SymbolAttributes, symbol),
-                        ListExpression(
-                            *(Symbol(attribute) for attribute in attributes_list)
-                        ),
-                    ),
-                )
-            )
-
-        if definition is not None and not A_READ_PROTECTED & attributes:
-            for rule in definition.ownvalues:
-                print_rule(rule)
-            for rule in definition.downvalues:
-                print_rule(rule)
-            for rule in definition.subvalues:
-                print_rule(rule)
-            for rule in definition.upvalues:
-                print_rule(rule, up=True)
-            for rule in definition.nvalues:
-                print_rule(rule)
-            formats = sorted(definition.formatvalues.items())
-            for format, rules in formats:
-                for rule in rules:
-
-                    def lhs(expr):
-                        return Expression(SymbolFormat, expr, Symbol(format))
-
-                    def rhs(expr):
-                        if expr.has_form(SymbolInfix, None):
-                            expr = Expression(
-                                Expression(SymbolHoldForm, expr.head), *expr.elements
-                            )
-                        return Expression(SymbolInputForm, expr)
-
-                    print_rule(rule, lhs=lhs, rhs=rhs)
-        for rule in all.defaultvalues:
-            print_rule(rule)
-        if all.options:
-            options = sorted(all.options.items())
-            lines.append(
-                Expression(
-                    SymbolHoldForm,
-                    Expression(
-                        SymbolSet,
-                        Expression(SymbolOptions, symbol),
-                        ListExpression(
-                            *(
-                                Expression(SymbolRule, Symbol(name), value)
-                                for name, value in options
-                            )
-                        ),
-                    ),
-                )
-            )
-        return
-
-    def format_definition_input(self, symbol, evaluation: Evaluation, options: dict):
+    def format_information_input(self, symbol, evaluation: Evaluation, options: dict):
         "InputForm: Information[symbol_, OptionsPattern[Information]]"
-        self.format_definition(symbol, evaluation, options, grid=False)
+        self.format_information(symbol, evaluation, options, grid=False)
         ret = SymbolNull
         return ret
 

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -83,7 +83,7 @@ class IterationLimit(Predefined):
 
     Calculations terminated by '$IterationLimit' return '$Aborted':
 
-    > $IterationLimit
+    >> $IterationLimit
      = 1000
     """
 

--- a/mathics/builtin/list/constructing.py
+++ b/mathics/builtin/list/constructing.py
@@ -508,7 +508,7 @@ class Sow(Builtin):
 
 
 class Table(IterationFunction):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/Table.html</url>

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -238,7 +238,7 @@ class Contexts(Builtin):
       <dd>returns a list of contexts that match the string.
     </dl>
 
-    'Contexts' allows the string patterns with the follwing metacharacters:
+    'Contexts' allows the string patterns with the following metacharacters:
     <ul>
      <li> '*' zero or more characters
      <li> '@' one or more characters, excluding uppercase letters
@@ -614,7 +614,7 @@ class Unique(Predefined):
         new_name = "$%d" % (self.seq_number)
         self.seq_number += 1
         # Next symbol in case of new name is defined before
-        while evaluation.definitions.get_definition(new_name, True) is not None:
+        while evaluation.definitions.have_definition(new_name):
             new_name = "$%d" % (self.seq_number)
             self.seq_number += 1
         return Symbol(new_name)
@@ -654,7 +654,7 @@ class Unique(Predefined):
                 new_name = f"{symbol.get_string_value()}{self.seq_number}"
                 self.seq_number += 1
                 # Next symbol in case of new name is defined before
-                while evaluation.definitions.get_definition(new_name, True) is not None:
+                while evaluation.definitions.have_definition(new_name):
                     new_name = f"{symbol.get_string_value()}{self.seq_number}"
                     self.seq_number += 1
                 list.append(Symbol(new_name))

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -27,6 +27,7 @@ def get_scoping_vars(var_list, msg_symbol="", evaluation=None):
     scoping_vars = set()
     for var in vars:
         var_name = None
+        new_def = None
         if var.has_form("Set", 2):
             var_name = var.elements[0].get_name()
             new_def = var.elements[1]

--- a/mathics/core/assignment.py
+++ b/mathics/core/assignment.py
@@ -127,10 +127,10 @@ def get_symbol_values(
     return ListExpression(*elements)
 
 
-def is_protected(tag: str, defin: Definitions) -> bool:
+def is_protected(tag: str, definitions: Definitions) -> bool:
     """Check if the `Symbol` with name `tag`
-    is protected in the `Definitions` `defin`"""
-    return bool(A_PROTECTED & defin.get_attributes(tag))
+    is protected in the `definitions`"""
+    return bool(A_PROTECTED & definitions.get_attributes(tag))
 
 
 def normalize_lhs(lhs, evaluation):

--- a/mathics/core/assignment.py
+++ b/mathics/core/assignment.py
@@ -81,7 +81,7 @@ def get_symbol_values(
     symbol: BaseElement, func_name: str, position: str, evaluation: Evaluation
 ) -> Optional[ListExpression]:
     """
-    Build a ListExpression with the rules associated to `symbol` in the
+    Build a ListExpression with the rules associated with `symbol` in the
     `Definitions` object of `evaluation`.
 
     Parameters
@@ -198,23 +198,27 @@ def rejected_because_protected(
     ignore: bool = False,
 ) -> bool:
     """
+    Determine if the assignment must be rejected because
+    the symbol `tag` is protected. Show the messages
+    accordingly.
 
 
     Parameters
     ----------
     lhs : BaseElement
-        DESCRIPTION.
+        The LHS of the assignment.
     tag : str
-        DESCRIPTION.
+        The symbol to which the rule must be assigned.
     evaluation : Evaluation
-        DESCRIPTION.
+        the evaluation object.
     ignore : bool, optional
-        DESCRIPTION. The default is False.
+        If True, ignore if the tag has the attribute Protected.
+        The default is False.
 
     Returns
     -------
     bool
-        DESCRIPTION.
+       If `True`, the assignment must be rejected.
 
     """
     defs = evaluation.definitions

--- a/mathics/core/assignment.py
+++ b/mathics/core/assignment.py
@@ -1,81 +1,36 @@
 # -*- coding: utf-8 -*-
+# pylint: disable-msg=too-many-arguments
+
 """
 Support for Set and SetDelayed, and other assignment-like builtins
 """
 
-from functools import reduce
-from typing import Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
-from mathics.core.atoms import Atom, Integer, Integer1
-from mathics.core.attributes import A_LOCKED, A_PROTECTED, attribute_string_to_number
+from mathics.core.atoms import Atom
+from mathics.core.attributes import A_PROTECTED
+from mathics.core.builtin import Builtin
+from mathics.core.definitions import Definitions
 from mathics.core.element import BaseElement
-from mathics.core.evaluation import (
-    MAX_RECURSION_DEPTH,
-    Evaluation,
-    set_python_recursion_limit,
-)
-from mathics.core.expression import Expression, SymbolDefault
+from mathics.core.evaluation import Evaluation
+from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.rules import Rule
-from mathics.core.symbols import (
-    Symbol,
-    SymbolFalse,
-    SymbolList,
-    SymbolMaxPrecision,
-    SymbolMinPrecision,
-    SymbolN,
-    SymbolTrue,
-    valid_context_name,
-)
+from mathics.core.symbols import Symbol, SymbolList
 from mathics.core.systemsymbols import (
     SymbolAnd,
     SymbolBlank,
     SymbolCondition,
     SymbolHoldPattern,
-    SymbolMachinePrecision,
     SymbolOptionValue,
     SymbolPart,
     SymbolPattern,
     SymbolRuleDelayed,
 )
-from mathics.eval.list.eol import eval_Part
 
 
-class AssignmentException(Exception):
-    def __init__(self, lhs, rhs) -> None:
-        super().__init__(" %s cannot be assigned to %s" % (rhs, lhs))
-        self.lhs = lhs
-        self.rhs = rhs
-
-
-def assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset=False):
-    """
-    This is the default assignment. Stores a rule of the form lhs->rhs
-    as a value associated to each symbol listed in tags.
-    For special cases, such like conditions or patterns in the lhs,
-    lhs and rhs are rewritten in a normal form, where
-    conditions are associated to the lhs.
-    """
-    lhs, condition = unroll_conditions(lhs)
-    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
-    defs = evaluation.definitions
-    ignore_protection, tags = eval_assign_other(self, lhs, rhs, evaluation, tags, upset)
-    # In WMA, this does not happens. However, if we remove this,
-    # some combinatorica tests fail.
-    # Also, should not be at the beginning?
-    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
-    count = 0
-    rule = Rule(lhs, rhs)
-    position = "up" if upset else None
-    for tag in tags:
-        if rejected_because_protected(self, lhs, tag, evaluation, ignore_protection):
-            continue
-        count += 1
-        defs.add_rule(tag, rule, position=position)
-    return count > 0
-
-
-def build_rulopc(optval):
+def build_rulopc(optval: BaseElement) -> Rule:
+    """Build an option value rule for optval"""
     return Rule(
         Expression(
             SymbolOptionValue,
@@ -85,13 +40,34 @@ def build_rulopc(optval):
     )
 
 
-def get_symbol_list(list, error_callback):
-    if list.has_form("List", None):
-        list = list.elements
+def get_symbol_list(expr: Expression, error_callback: Callable) -> Optional[List[str]]:
+    """
+    If ``expr`` is of the form ``List[Symbol___]`` returns a list
+    with the names of the symbols as elements.
+    If `expr` is a ``Symbol``, returns a list with a
+    with the name of `expr` as its only element.
+    Otherwise, calls `error_callback` over the element,
+    and returns None.
+
+    Parameters
+    ----------
+    expr : Expression
+        The expression to be converted.
+    error_callback : Callable
+        a callback function to call if the conversion fails.
+
+    Returns
+    -------
+    values : Optional[List[str]]
+        a list with the names, or None.
+
+    """
+    if expr.has_form("List", None):
+        list_expr = expr.elements
     else:
-        list = [list]
+        list_expr = [expr]
     values = []
-    for item in list:
+    for item in list_expr:
         name = item.get_name()
         if name:
             values.append(name)
@@ -101,29 +77,60 @@ def get_symbol_list(list, error_callback):
     return values
 
 
-def get_symbol_values(symbol, func_name, position, evaluation):
+def get_symbol_values(
+    symbol: BaseElement, func_name: str, position: str, evaluation: Evaluation
+) -> Optional[ListExpression]:
+    """
+    Build a ListExpression with the rules associated to `symbol` in the
+    `Definitions` object of `evaluation`.
+
+    Parameters
+    ----------
+    symbol : BaseElement
+        The target symbol.
+    func_name : str
+        the name of the caller.
+    position : str
+        the kind of rule ('ownvalue', 'downvalue', 'upvalue', 'default', etc)
+    evaluation : Evaluation
+        The evaluation object.
+
+    Returns
+    -------
+    Optional[ListExpression]
+        A list of rules. None if `symbol` is not a Symbol.
+
+    """
     name = symbol.get_name()
     if not name:
         evaluation.message(func_name, "sym", symbol, 1)
-        return
-    if position in ("default",):
-        definition = evaluation.definitions.get_definition(name)
-    else:
-        definition = evaluation.definitions.get_user_definition(name)
+        return None
+    definitions = evaluation.definitions
+    try:
+        definition = (
+            definitions.get_definition(name, True)
+            if position in ("default",)
+            else definitions.get_user_definition(name, True)
+        )
+    except KeyError:
+        return ListExpression()
+
     elements = []
     for rule in definition.get_values_list(position):
         if isinstance(rule, Rule):
             pattern = rule.pattern
             if pattern.has_form("HoldPattern", 1):
-                pattern = pattern.expr
+                expr_pattern = pattern.expr
             else:
-                pattern = Expression(SymbolHoldPattern, pattern.expr)
-            elements.append(Expression(SymbolRuleDelayed, pattern, rule.replace))
+                expr_pattern = Expression(SymbolHoldPattern, pattern.expr)
+            elements.append(Expression(SymbolRuleDelayed, expr_pattern, rule.replace))
     return ListExpression(*elements)
 
 
-def is_protected(tag, defin):
-    return A_PROTECTED & defin.get_attributes(tag)
+def is_protected(tag: str, defin: Definitions) -> bool:
+    """Check if the `Symbol` with name `tag`
+    is protected in the `Definitions` `defin`"""
+    return bool(A_PROTECTED & defin.get_attributes(tag))
 
 
 def normalize_lhs(lhs, evaluation):
@@ -152,13 +159,18 @@ def normalize_lhs(lhs, evaluation):
     return lhs, lookup_name
 
 
-def repl_pattern_by_symbol(expr):
+def repl_pattern_by_symbol(expr: BaseElement) -> BaseElement:
+    """
+    If `expr` is a named pattern expression `Pattern[symb, pat]`,
+    return `symb`. Otherwise, return `expr`.
+    """
     elements = expr.get_elements()
     if len(elements) == 0:
         return expr
 
-    headname = expr.get_head_name()
-    if headname == "System`Pattern":
+    head = expr.get_head()
+    head_name = head.get_name()
+    if head_name == "System`Pattern":
         return elements[0]
 
     changed = False
@@ -169,9 +181,8 @@ def repl_pattern_by_symbol(expr):
             changed = True
         new_elements.append(element)
     if changed:
-        return Expression(headname, *new_elements)
-    else:
-        return expr
+        return Expression(head, *new_elements)
+    return expr
 
 
 # Here are the functions related to assign
@@ -179,7 +190,33 @@ def repl_pattern_by_symbol(expr):
 # Auxiliary routines
 
 
-def rejected_because_protected(self, lhs, tag, evaluation, ignore=False):
+def rejected_because_protected(
+    self: Builtin,
+    lhs: BaseElement,
+    tag: str,
+    evaluation: Evaluation,
+    ignore: bool = False,
+) -> bool:
+    """
+
+
+    Parameters
+    ----------
+    lhs : BaseElement
+        DESCRIPTION.
+    tag : str
+        DESCRIPTION.
+    evaluation : Evaluation
+        DESCRIPTION.
+    ignore : bool, optional
+        DESCRIPTION. The default is False.
+
+    Returns
+    -------
+    bool
+        DESCRIPTION.
+
+    """
     defs = evaluation.definitions
     if not ignore and is_protected(tag, defs):
         if lhs.get_name() == tag:
@@ -190,25 +227,39 @@ def rejected_because_protected(self, lhs, tag, evaluation, ignore=False):
     return False
 
 
-def find_tag_and_check(lhs, tags, evaluation):
-    name = lhs.get_head_name()
-    if len(lhs.elements) != 1:
-        evaluation.message_args(name, len(lhs.elements), 1)
-        raise AssignmentException(lhs, None)
-    tag = lhs.elements[0].get_name()
-    if not tag:
-        evaluation.message(name, "sym", lhs.elements[0], 1)
-        raise AssignmentException(lhs, None)
-    if tags is not None and tags != [tag]:
-        evaluation.message(name, "tag", Symbol(name), Symbol(tag))
-        raise AssignmentException(lhs, None)
-    if is_protected(tag, evaluation.definitions):
-        evaluation.message(name, "wrsym", Symbol(tag))
-        raise AssignmentException(lhs, None)
-    return tag
+def unroll_conditions(lhs: BaseElement) -> Tuple[BaseElement, Optional[Expression]]:
+    """
+    If `lhs` is a nested `Condition` expression,
+    gather all the conditions in a single one, and returns a tuple
+    with the `lhs` stripped from the conditions and the shallow condition.
+    If there is not any condition, returns the `lhs` and None
+    """
+    if isinstance(lhs, Symbol):
+        return lhs, None
+
+    name, lhs_elements = lhs.get_head_name(), lhs.get_elements()
+    conditions = []
+    # This handle the case of many successive conditions:
+    # f[x_]/; cond1 /; cond2 ... ->  f[x_]/; And[cond1, cond2, ...]
+    while name == "System`Condition" and len(lhs_elements) == 2:
+        conditions.append(lhs_elements[1])
+        lhs = lhs_elements[0]
+        if isinstance(lhs, Atom):
+            break
+        name, lhs_elements = lhs.get_head_name(), lhs.get_elements()
+    if len(conditions) == 0:
+        return lhs, None
+
+    condition: BaseElement = (
+        Expression(SymbolAnd, *conditions) if len(conditions) > 1 else conditions[0]
+    )
+    condition = Expression(SymbolCondition, lhs, condition)
+    return lhs, condition
 
 
-def unroll_patterns(lhs, rhs, evaluation) -> Tuple[BaseElement, BaseElement]:
+def unroll_patterns(
+    lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
+) -> Tuple[BaseElement, BaseElement]:
     """
     Pattern[symb, pat]=rhs -> pat = (rhs/.(symb->pat))
     HoldPattern[lhs] = rhs -> lhs = rhs
@@ -216,7 +267,7 @@ def unroll_patterns(lhs, rhs, evaluation) -> Tuple[BaseElement, BaseElement]:
     if isinstance(lhs, Atom):
         return lhs, rhs
     name = lhs.get_head_name()
-    lhs_elements = lhs.elements
+    lhs_elements = lhs.get_elements()
     if name == "System`Pattern":
         lhs = lhs_elements[1]
         rulerepl = (lhs_elements[0], repl_pattern_by_symbol(lhs))
@@ -229,623 +280,3 @@ def unroll_patterns(lhs, rhs, evaluation) -> Tuple[BaseElement, BaseElement]:
     elif name == "System`HoldPattern":
         lhs = lhs_elements[0]
     return lhs, rhs
-
-
-def unroll_conditions(lhs) -> Tuple[BaseElement, Optional[Expression]]:
-    """
-    If lhs is a nested `Condition` expression,
-    gather all the conditions in a single one, and returns a tuple
-    with the lhs stripped from the conditions and the shallow condition.
-    If there is not any condition, returns the lhs and None
-    """
-    if isinstance(lhs, Symbol):
-        return lhs, None
-    else:
-        name, lhs_elements = lhs.get_head_name(), lhs.get_elements()
-    conditions = []
-    # This handle the case of many successive conditions:
-    # f[x_]/; cond1 /; cond2 ... ->  f[x_]/; And[cond1, cond2, ...]
-    while name == "System`Condition" and len(lhs.elements) == 2:
-        conditions.append(lhs_elements[1])
-        lhs = lhs_elements[0]
-        if isinstance(lhs, Atom):
-            break
-        name, lhs_elements = lhs.get_head_name(), lhs.elements
-    if len(conditions) == 0:
-        return lhs, None
-    if len(conditions) > 1:
-        condition = Expression(SymbolAnd, *conditions)
-    else:
-        condition = conditions[0]
-    condition = Expression(SymbolCondition, lhs, condition)
-    # lhs._format_cache = None
-    return lhs, condition
-
-
-# Here starts the functions that implement `assign` for different
-# kind of expressions. Maybe they should be put in a separated module, or
-# maybe they should be member functions of _SetOperator.
-
-
-def eval_assign_attributes(self, lhs, rhs, evaluation, tags, upset):
-    """
-    Process the case where lhs is of the form
-    `Attribute[symbol]`
-    """
-    name = lhs.get_head_name()
-    if len(lhs.elements) != 1:
-        evaluation.message_args(name, len(lhs.elements), 1)
-        raise AssignmentException(lhs, rhs)
-    tag = lhs.elements[0].get_name()
-    if not tag:
-        evaluation.message(name, "sym", lhs.elements[0], 1)
-        raise AssignmentException(lhs, rhs)
-    if tags is not None and tags != [tag]:
-        evaluation.message(name, "tag", Symbol(name), Symbol(tag))
-        raise AssignmentException(lhs, rhs)
-    attributes_list = get_symbol_list(
-        rhs, lambda item: evaluation.message(name, "sym", item, 1)
-    )
-    if attributes_list is None:
-        raise AssignmentException(lhs, rhs)
-    if A_LOCKED & evaluation.definitions.get_attributes(tag):
-        evaluation.message(name, "locked", Symbol(tag))
-        raise AssignmentException(lhs, rhs)
-
-    def reduce_attributes_from_list(x: int, y: str) -> int:
-        try:
-            return x | attribute_string_to_number[y]
-        except KeyError:
-            evaluation.message("SetAttributes", "unknowattr", y)
-            return x
-
-    attributes = reduce(
-        reduce_attributes_from_list,
-        attributes_list,
-        0,
-    )
-
-    evaluation.definitions.set_attributes(tag, attributes)
-
-    return True
-
-
-def eval_assign_context(self, lhs, rhs, evaluation, tags, upset):
-    lhs_name = lhs.get_head_name()
-    new_context = rhs.get_string_value()
-    if new_context is None or not valid_context_name(
-        new_context, allow_initial_backquote=True
-    ):
-        evaluation.message(lhs_name, "cxset", rhs)
-        raise AssignmentException(lhs, None)
-
-    # With $Context in Mathematica you can do some strange
-    # things: e.g. with $Context set to Global`, something
-    # like:
-    #    $Context = "`test`"; newsym
-    # is accepted and creates Global`test`newsym.
-    # Implement this behaviour by interpreting
-    #    $Context = "`test`"
-    # as
-    #    $Context = $Context <> "test`"
-    #
-    if new_context.startswith("`"):
-        new_context = evaluation.definitions.get_current_context() + new_context.lstrip(
-            "`"
-        )
-
-    evaluation.definitions.set_current_context(new_context)
-    return True
-
-
-def eval_assign_context_path(self, lhs, rhs, evaluation, tags, upset):
-    lhs_name = lhs.get_name()
-    currContext = evaluation.definitions.get_current_context()
-    context_path = [s.get_string_value() for s in rhs.get_elements()]
-    context_path = [
-        s if (s is None or s[0] != "`") else currContext[:-1] + s for s in context_path
-    ]
-    if rhs.has_form("List", None) and all(valid_context_name(s) for s in context_path):
-        evaluation.definitions.set_context_path(context_path)
-        return True
-    else:
-        evaluation.message(lhs_name, "cxlist", rhs)
-        raise AssignmentException(lhs, None)
-
-
-def eval_assign_default(self, lhs, rhs, evaluation, tags, upset):
-    lhs, condition = unroll_conditions(lhs)
-    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
-    count = 0
-    defs = evaluation.definitions
-
-    if len(lhs.elements) not in (1, 2, 3):
-        evaluation.message_args(SymbolDefault, len(lhs.elements), 1, 2, 3)
-        raise AssignmentException(lhs, None)
-    focus = lhs.elements[0]
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, self, lhs, focus, evaluation
-    )
-    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
-    rule = Rule(lhs, rhs)
-    for tag in tags:
-        if rejected_because_protected(self, lhs, tag, evaluation):
-            continue
-        count += 1
-        defs.add_default(tag, rule)
-    return count > 0
-
-
-def eval_assign_definition_values(self, lhs, rhs, evaluation, tags, upset):
-    name = lhs.get_head_name()
-    tag = find_tag_and_check(lhs, tags, evaluation)
-    rules = rhs.get_rules_list()
-    if rules is None:
-        evaluation.message(name, "vrule", lhs, rhs)
-        raise AssignmentException(lhs, None)
-    evaluation.definitions.set_values(tag, name, rules)
-    return True
-
-
-def eval_assign_format(self, lhs, rhs, evaluation, tags, upset):
-    lhs, condition = unroll_conditions(lhs)
-    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
-    count = 0
-    defs = evaluation.definitions
-
-    if len(lhs.elements) not in (1, 2):
-        evaluation.message_args("Format", len(lhs.elements), 1, 2)
-        raise AssignmentException(lhs, None)
-    if len(lhs.elements) == 2:
-        form = lhs.elements[1]
-        form_name = form.get_name()
-        if not form_name:
-            evaluation.message("Format", "fttp", lhs.elements[1])
-            raise AssignmentException(lhs, None)
-        # If the form is not in defs.printforms / defs.outputforms
-        # add it.
-        for form_list in (defs.outputforms, defs.printforms):
-            if form not in form_list:
-                form_list.append(form)
-    else:
-        form_name = [
-            "System`StandardForm",
-            "System`TraditionalForm",
-            "System`OutputForm",
-            "System`TeXForm",
-            "System`MathMLForm",
-        ]
-    lhs = focus = lhs.elements[0]
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, self, lhs, focus, evaluation
-    )
-    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
-    rule = Rule(lhs, rhs)
-    for tag in tags:
-        if rejected_because_protected(self, lhs, tag, evaluation):
-            continue
-        count += 1
-        defs.add_format(tag, rule, form_name)
-    return count > 0
-
-
-def eval_assign_iteration_limit(lhs, rhs, evaluation):
-    """
-    Set ownvalue for the $IterationLimit symbol.
-    """
-
-    rhs_int_value = rhs.get_int_value()
-    if (
-        not rhs_int_value or rhs_int_value < 20
-    ) and not rhs.get_name() == "System`Infinity":
-        evaluation.message("$IterationLimit", "limset", rhs)
-        raise AssignmentException(lhs, None)
-    return False
-
-
-def eval_assign_line_number_and_history_length(self, lhs, rhs, evaluation, tags, upset):
-    """
-    Set ownvalue for the $Line and $HistoryLength symbols.
-    """
-
-    lhs_name = lhs.get_name()
-    rhs_int_value = rhs.get_int_value()
-    if rhs_int_value is None or rhs_int_value < 0:
-        evaluation.message(lhs_name, "intnn", rhs)
-        raise AssignmentException(lhs, None)
-    return False
-
-
-def eval_assign_list(self, lhs, rhs, evaluation, tags, upset):
-    if not (
-        rhs.get_head_name() == "System`List" and len(lhs.elements) == len(rhs.elements)
-    ):  # nopep8
-        evaluation.message(self.get_name(), "shape", lhs, rhs)
-        return False
-    result = True
-    for left, right in zip(lhs.elements, rhs.elements):
-        if not self.assign(left, right, evaluation):
-            result = False
-    return result
-
-
-def eval_assign_makeboxes(self, lhs, rhs, evaluation, tags, upset):
-    # FIXME: the below is a big hack.
-    # Currently MakeBoxes boxing is implemented as a bunch of rules.
-    # See mathics.core.builtin contribute().
-    # I think we want to change this so it works like normal SetDelayed
-    # That is:
-    #   MakeBoxes[CubeRoot, StandardForm] := RadicalBox[3, StandardForm]
-    # rather than:
-    #   MakeBoxes[CubeRoot, StandardForm] -> RadicalBox[3, StandardForm]
-
-    makeboxes_rule = Rule(lhs, rhs, system=False)
-    definitions = evaluation.definitions
-    definitions.add_rule("System`MakeBoxes", makeboxes_rule, "down")
-    #    makeboxes_defs = evaluation.definitions.builtin["System`MakeBoxes"]
-    #    makeboxes_defs.add_rule(makeboxes_rule)
-    return True
-
-
-def eval_assign_minprecision(self, lhs, rhs, evaluation, tags, upset):
-    lhs_name = lhs.get_name()
-    rhs_int_value = rhs.get_int_value()
-    # $MinPrecision = Infinity is not allowed
-    if rhs_int_value is not None and rhs_int_value >= 0:
-        max_prec = evaluation.definitions.get_config_value("$MaxPrecision")
-        if max_prec is not None and max_prec < rhs_int_value:
-            evaluation.message("$MinPrecision", "preccon", SymbolMinPrecision)
-            raise AssignmentException(lhs, None)
-        return False
-    else:
-        evaluation.message(lhs_name, "precset", lhs, rhs)
-        raise AssignmentException(lhs, None)
-
-
-def eval_assign_maxprecision(self, lhs, rhs, evaluation, tags, upset):
-    lhs_name = lhs.get_name()
-    rhs_int_value = rhs.get_int_value()
-    if rhs.has_form("DirectedInfinity", 1) and rhs.elements[0].get_int_value() == 1:
-        return False
-    elif rhs_int_value is not None and rhs_int_value > 0:
-        min_prec = evaluation.definitions.get_config_value("$MinPrecision")
-        if min_prec is not None and rhs_int_value < min_prec:
-            evaluation.message("$MaxPrecision", "preccon", SymbolMaxPrecision)
-            raise AssignmentException(lhs, None)
-        return False
-    else:
-        evaluation.message(lhs_name, "precset", lhs, rhs)
-        raise AssignmentException(lhs, None)
-
-
-def eval_assign_messagename(self, lhs, rhs, evaluation, tags, upset):
-    lhs, condition = unroll_conditions(lhs)
-    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
-    count = 0
-    defs = evaluation.definitions
-    if len(lhs.elements) != 2:
-        evaluation.message_args("MessageName", len(lhs.elements), 2)
-        raise AssignmentException(lhs, None)
-    focus = lhs.elements[0]
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, self, lhs, focus, evaluation
-    )
-    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
-    rule = Rule(lhs, rhs)
-    for tag in tags:
-        # Messages can be assigned even if the symbol is protected...
-        # if rejected_because_protected(self, lhs, tag, evaluation):
-        #    continue
-        count += 1
-        defs.add_message(tag, rule)
-    return count > 0
-
-
-def eval_assign_module_number(lhs, rhs, evaluation):
-    """
-    Set ownvalue for the $ModuleNumber symbol.
-    """
-    rhs_int_value = rhs.get_int_value()
-    if not rhs_int_value or rhs_int_value <= 0:
-        evaluation.message("$ModuleNumber", "set", rhs)
-        raise AssignmentException(lhs, None)
-    return False
-
-
-def eval_assign_options(self, lhs, rhs, evaluation, tags, upset):
-    lhs_elements = lhs.elements
-    name = lhs.get_head_name()
-    if len(lhs_elements) != 1:
-        evaluation.message_args(name, len(lhs_elements), 1)
-        raise AssignmentException(lhs, rhs)
-    tag = lhs_elements[0].get_name()
-    if not tag:
-        evaluation.message(name, "sym", lhs_elements[0], 1)
-        raise AssignmentException(lhs, rhs)
-    if tags is not None and tags != [tag]:
-        evaluation.message(name, "tag", Symbol(name), Symbol(tag))
-        raise AssignmentException(lhs, rhs)
-    if is_protected(tag, evaluation.definitions):
-        evaluation.message(name, "wrsym", Symbol(tag))
-        raise AssignmentException(lhs, None)
-    option_values = rhs.get_option_values(evaluation)
-    if option_values is None:
-        evaluation.message(name, "options", rhs)
-        raise AssignmentException(lhs, None)
-    evaluation.definitions.set_options(tag, option_values)
-    return True
-
-
-def eval_assign_numericq(self, lhs, rhs, evaluation: Evaluation, tags, upset):
-    # lhs, condition = unroll_conditions(lhs)
-    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
-    if rhs not in (SymbolTrue, SymbolFalse):
-        evaluation.message("NumericQ", "set", lhs, rhs)
-        # raise AssignmentException(lhs, rhs)
-        return True
-    elements = lhs.elements
-    if len(elements) > 1:
-        evaluation.message("NumericQ", "argx", Integer(len(elements)))
-        # raise AssignmentException(lhs, rhs)
-        return True
-    target = elements[0]
-    if isinstance(target, Symbol):
-        name = target.get_name()
-        definition = evaluation.definitions.get_definition(name)
-        if definition is not None:
-            definition.is_numeric = rhs is SymbolTrue
-        return True
-    else:
-        evaluation.message("NumericQ", "set", lhs, rhs)
-        # raise AssignmentException(lhs, rhs)
-        return True
-
-
-def eval_assign_n(self, lhs, rhs, evaluation, tags, upset):
-    lhs, condition = unroll_conditions(lhs)
-    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
-    defs = evaluation.definitions
-    # If we try to set `N=4`, (issue #210) just deal with it as with a generic expression:
-    if lhs is SymbolN:
-        return assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset)
-
-    if len(lhs.elements) not in (1, 2):
-        evaluation.message_args("N", len(lhs.elements), 1, 2)
-        raise AssignmentException(lhs, None)
-    if len(lhs.elements) == 1:
-        nprec = SymbolMachinePrecision
-    else:
-        nprec = lhs.elements[1]
-    focus = lhs.elements[0]
-    lhs = Expression(SymbolN, focus, nprec)
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, self, lhs, focus, evaluation
-    )
-    count = 0
-    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
-    rule = Rule(lhs, rhs)
-    for tag in tags:
-        if rejected_because_protected(self, lhs, tag, evaluation):
-            continue
-        count += 1
-        defs.add_nvalue(tag, rule)
-    return count > 0
-
-
-def eval_assign_other(
-    self, lhs, rhs, evaluation, tags=None, upset=False
-) -> Tuple[bool, list]:
-    """
-    Process special cases, performing certain side effects, like modifying
-    the value of internal variables that are not stored as rules.
-
-    The function returns a tuple of a bool value and a list of tags.
-    If lhs is one of the special cases, then the bool variable is
-    True, meaning that the `Protected` attribute should not be taken
-    into account.
-    Otherwise, the value is False.
-    """
-    tags, _ = process_tags_and_upset_allow_custom(
-        tags, upset, self, lhs, rhs, evaluation
-    )
-    lhs_name = lhs.get_name()
-    if lhs_name == "System`$RecursionLimit":
-        eval_assign_recursion_limit(lhs, rhs, evaluation)
-    elif lhs_name in ("System`$Line", "System`$HistoryLength"):
-        eval_assign_line_number_and_history_length(
-            self, lhs, rhs, evaluation, tags, upset
-        )
-    elif lhs_name == "System`$IterationLimit":
-        eval_assign_iteration_limit(lhs, rhs, evaluation)
-    elif lhs_name == "System`$ModuleNumber":
-        eval_assign_module_number(lhs, rhs, evaluation)
-    elif lhs_name == "System`$MinPrecision":
-        eval_assign_minprecision(self, lhs, rhs, evaluation, tags, upset)
-    elif lhs_name == "System`$MaxPrecision":
-        eval_assign_maxprecision(self, lhs, rhs, evaluation, tags, upset)
-    else:
-        return False, tags
-    return True, tags
-
-
-def eval_assign_part(self, lhs, rhs, evaluation, tags, upset):
-    """
-    Special case `A[[i,j,...]]=....`
-    """
-    defs = evaluation.definitions
-    if len(lhs.elements) < 1:
-        evaluation.message(self.get_name(), "setp", lhs)
-        return False
-    symbol = lhs.elements[0]
-    name = symbol.get_name()
-    if not name:
-        evaluation.message(self.get_name(), "setps", symbol)
-        return False
-    if is_protected(name, defs):
-        evaluation.message(self.get_name(), "wrsym", symbol)
-        return False
-    rule = defs.get_ownvalue(name)
-    if rule is None:
-        evaluation.message(self.get_name(), "noval", symbol)
-        return False
-    indices = lhs.elements[1:]
-    return eval_Part([rule.replace], indices, evaluation, rhs)
-
-
-def eval_assign_random_state(self, lhs, rhs, evaluation, tags, upset):
-    # TODO: allow setting of legal random states!
-    # (but consider pickle's insecurity!)
-    evaluation.message("$RandomState", "rndst", rhs)
-    raise AssignmentException(lhs, None)
-
-
-def eval_assign_recursion_limit(lhs, rhs, evaluation):
-    """
-    Set ownvalue for the $RecursionLimit symbol.
-    """
-    rhs_int_value = rhs.get_int_value()
-    # if (not rhs_int_value or rhs_int_value < 20) and not
-    # rhs.get_name() == 'System`Infinity':
-    if (
-        not rhs_int_value or rhs_int_value < 20 or rhs_int_value > MAX_RECURSION_DEPTH
-    ):  # nopep8
-        evaluation.message("$RecursionLimit", "limset", rhs)
-        raise AssignmentException(lhs, None)
-    try:
-        set_python_recursion_limit(rhs_int_value)
-    except OverflowError:
-        # TODO: Message
-        raise AssignmentException(lhs, None)
-    return False
-
-
-def process_rhs_conditions(lhs, rhs, condition, evaluation):
-    """
-    lhs = Condition[rhs, test] -> Condition[lhs, test]  = rhs
-    """
-    # To Handle `OptionValue` in `Condition`
-    rulopc = build_rulopc(lhs.get_head())
-    rhs_name = rhs.get_head_name()
-    while rhs_name == "System`Condition":
-        if len(rhs.elements) != 2:
-            evaluation.message_args("Condition", len(rhs.elements), 2)
-            raise AssignmentException(lhs, None)
-        lhs = Expression(
-            SymbolCondition,
-            lhs,
-            rhs.elements[1].do_apply_rules([rulopc], evaluation)[0],
-        )
-        rhs = rhs.elements[0]
-        rhs_name = rhs.get_head_name()
-
-    # Now, let's add the conditions on the LHS
-    if condition:
-        lhs = Expression(
-            SymbolCondition,
-            lhs,
-            condition.elements[1].do_apply_rules([rulopc], evaluation)[0],
-        )
-    return lhs, rhs
-
-
-def process_tags_and_upset_dont_allow_custom(
-    tags, upset, self, lhs, focus: BaseElement, evaluation: Evaluation
-):
-    if isinstance(focus, Expression):
-        focus = focus.evaluate_elements(evaluation)
-    name = lhs.get_head_name()
-    if tags is None and not upset:
-        name = focus.get_lookup_name()
-        if not name:
-            evaluation.message(self.get_name(), "setraw", focus)
-            raise AssignmentException(lhs, None)
-        tags = [name]
-    elif upset:
-        tags = [focus.get_lookup_name()]
-    else:
-        allowed_names = [focus.get_lookup_name()]
-        for name in tags:
-            if name not in allowed_names:
-                evaluation.message(self.get_name(), "tagnfd", Symbol(name))
-                raise AssignmentException(lhs, None)
-    return tags
-
-
-def process_tags_and_upset_allow_custom(
-    tags, upset, self, lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
-):
-    name = lhs.get_head_name()
-    focus = lhs
-    if isinstance(focus, Expression):
-        focus = focus.evaluate_elements(evaluation)
-    if tags is None and not upset:
-        name = focus.get_lookup_name()
-        if not name:
-            evaluation.message(self.get_name(), "setraw", focus)
-            raise AssignmentException(lhs, None)
-        tags = [name]
-    elif upset:
-        tags = []
-        if isinstance(focus, Atom):
-            symbol_name = self.get_name()
-            evaluation.message(
-                symbol_name,
-                "normal",
-                Integer1,
-                Expression(Symbol(symbol_name), lhs, rhs),
-            )
-            raise AssignmentException(lhs, None)
-        for element in focus.get_elements():
-            name = element.get_lookup_name()
-            tags.append(name)
-    else:
-        allowed_names = [focus.get_lookup_name()]
-        for element in focus.get_elements():
-            if not isinstance(element, Symbol) and element.get_head_name() in (
-                "System`HoldPattern",
-            ):
-                element = element.get_element(0)
-            if not isinstance(element, Symbol) and element.get_head_name() in (
-                "System`Pattern",
-            ):
-                element = element.get_element(1)
-            if not isinstance(element, Symbol) and element.get_head_name() in (
-                "System`Blank",
-                "System`BlankSequence",
-                "System`BlankNullSequence",
-            ):
-                if len(element.get_elements()) == 1:
-                    element = element.get_element(0)
-
-            allowed_names.append(element.get_lookup_name())
-        for name in tags:
-            if name not in allowed_names:
-                evaluation.message(self.get_name(), "tagnfd", Symbol(name))
-                raise AssignmentException(lhs, None)
-
-    return tags, focus
-
-
-# Below is a mapping from Symbol name (as a string) into an assignment eval function.
-ASSIGNMENT_FUNCTION_MAP = {
-    "System`$Context": eval_assign_context,
-    "System`$ContextPath": eval_assign_context_path,
-    "System`$RandomState": eval_assign_random_state,
-    "System`Attributes": eval_assign_attributes,
-    "System`Default": eval_assign_default,
-    "System`DefaultValues": eval_assign_definition_values,
-    "System`DownValues": eval_assign_definition_values,
-    "System`Format": eval_assign_format,
-    "System`List": eval_assign_list,
-    "System`MakeBoxes": eval_assign_makeboxes,
-    "System`MessageName": eval_assign_messagename,
-    "System`Messages": eval_assign_definition_values,
-    "System`N": eval_assign_n,
-    "System`NValues": eval_assign_definition_values,
-    "System`NumericQ": eval_assign_numericq,
-    "System`Options": eval_assign_options,
-    "System`OwnValues": eval_assign_definition_values,
-    "System`Part": eval_assign_part,
-    "System`SubValues": eval_assign_definition_values,
-    "System`UpValues": eval_assign_definition_values,
-}

--- a/mathics/core/convert/regex.py
+++ b/mathics/core/convert/regex.py
@@ -3,7 +3,7 @@ Convert expressions to Python regular expressions
 """
 import re
 from binascii import hexlify
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional
 
 from mathics.core.atoms import String
 from mathics.core.expression import Expression
@@ -158,7 +158,7 @@ def to_regex_internal(
     if expr.has_form("CharacterRange", 2):
         (start, stop) = (element.get_string_value() for element in expr.elements)
         if all(x is not None and len(x) == 1 for x in (start, stop)):
-            return "[{0}-{1}]".format(re.escape(start), re.escape(stop))
+            return f"[{re.escape(start)}-{re.escape(stop)}]"
 
     if expr.has_form("Blank", 0):
         return r"(.|\n)"
@@ -180,7 +180,7 @@ def to_regex_internal(
     if expr.has_form("Characters", 1):
         element = expr.elements[0].get_string_value()
         if element is not None:
-            return "[{0}]".format(re.escape(element))
+            return f"[{re.escape(element)}]"
     if expr.has_form("StringExpression", None):
         elements = [recurse(element) for element in expr.elements]
         if None in elements:
@@ -190,7 +190,7 @@ def to_regex_internal(
         element = recurse(expr.elements[0])
         if element is None:
             return None  # invalid regex
-        return "({0})".format(element) + q["+"]
+        return f"({element})" + q["+"]
     if expr.has_form("RepeatedNull", 1):
         element = recurse(expr.elements[0])
         if element is None:
@@ -216,7 +216,7 @@ def to_regex_internal(
                 show_message(
                     "StringExpression", "cond", expr.elements[0], expr, expr.elements[0]
                 )
-            return "(?P=%s)" % _encode_pname(name)
+            return f"(?P={_encode_pname(name)})"
         else:
             element = groups[name] = expr.elements[1]
             if element is None:
@@ -224,6 +224,6 @@ def to_regex_internal(
             result_regexp = recurse(element)
             if result_regexp is None:
                 return None
-            return "(?P<%s>%s)" % (_encode_pname(name), result_regexp)
+            return f"(?P<{_encode_pname(name)}>{result_regexp})"
 
     return None

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -546,7 +546,7 @@ class Definitions:
 
         return definition
 
-    def get_attributes(self, name: str) -> list:
+    def get_attributes(self, name: str) -> int:
         return self.get_definition(name).attributes
 
     def get_ownvalues(self, name: str) -> list:

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -474,12 +474,12 @@ class Definitions:
         builtin_instance = None
 
         if pymathics:
-            builtin_instance = pymathics
+            builtin_instance = pymathics.builtin
             candidates.append(pymathics)
         if builtin:
             candidates.append(builtin)
             if builtin_instance is None:
-                builtin_instance = builtin
+                builtin_instance = builtin.builtin
 
         definition = candidates[0] if len(candidates) == 1 else None
         if len(candidates) > 0 and not definition:

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -234,7 +234,7 @@ def insert_rule(values: list, rule: Rule) -> None:
     ----------
     values : List[Rule]
         A list of rules.
-    rule : BaseRule
+    rule : Rule
         A new rule.
 
     Returns
@@ -876,12 +876,15 @@ class Definitions:
         return result
 
     def get_nvalues(self, name: str):
+        """Return the list of nvalues"""
         return self.get_definition(name).nvalues
 
     def get_defaultvalues(self, name: str):
+        """Return the list of defaultvalues"""
         return self.get_definition(name).defaultvalues
 
     def get_value(self, name: str, pos: str, pattern, evaluation):
+        """Apply rules in `pos` until get the value of the symbol"""
         assert isinstance(name, str)
         assert "`" in name
         rules = self.get_definition(name).get_values_list(valuesname(pos))
@@ -942,10 +945,12 @@ class Definitions:
         return self.user[name]
 
     def mark_changed(self, definition: Definition) -> None:
+        """Mark a definition change"""
         self.now += 1
         definition.changed = self.now
 
     def reset_user_definition(self, name: str) -> None:
+        """Remove the user definition associated with the Symbol `name`"""
         assert not isinstance(name, Symbol)
         fullname = self.lookup_name(name)
         if fullname in self.user:
@@ -954,6 +959,7 @@ class Definitions:
         # TODO fix changed
 
     def add_user_definition(self, name: str, definition: Definition) -> None:
+        """Assign a definition to a symbol of name `name`"""
         assert not isinstance(name, Symbol)
         self.mark_changed(definition)
         fullname = self.lookup_name(name)
@@ -961,6 +967,7 @@ class Definitions:
         self.clear_cache(fullname)
 
     def set_attribute(self, name: str, attribute: int) -> None:
+        """Set an attribute to the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.attributes |= attribute
@@ -968,6 +975,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def set_attributes(self, name: str, attributes: int) -> None:
+        """Set the attribute property for the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.attributes = attributes
@@ -975,6 +983,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def clear_attribute(self, name: str, attribute: int) -> None:
+        """Clear the attributes of the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.attributes &= ~attribute
@@ -982,6 +991,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def add_rule(self, name: str, rule, position: Optional[str] = None):
+        """Add a rule for the Symbol `name` in the list `pos`."""
         definition = self.get_user_definition(self.lookup_name(name))
         if position is None:
             result = definition.add_rule(rule)
@@ -1004,6 +1014,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def add_nvalue(self, name: str, rule) -> None:
+        """Add a nvalue rule to the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.add_rule_at(rule, "n")
@@ -1011,6 +1022,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def add_default(self, name: str, rule) -> None:
+        """Add a DefaultValue to the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.add_rule_at(rule, "default")
@@ -1018,6 +1030,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def add_message(self, name: str, rule) -> None:
+        """Add a message to the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.add_rule_at(rule, "messages")
@@ -1025,6 +1038,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def set_values(self, name: str, values, rules) -> None:
+        """Set a list of rules associated with the Symbol `name`"""
         pos = valuesname(values)
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
@@ -1033,6 +1047,7 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def get_options(self, name):
+        """Get the options associated with the Symbol `name`"""
         return self.get_definition(self.lookup_name(name)).options
 
     def reset_user_definitions(self) -> None:
@@ -1067,6 +1082,7 @@ class Definitions:
         self.clear_cache(name)
 
     def set_options(self, name: str, options) -> None:
+        """Set the options dict associated with the Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.options = options
@@ -1074,6 +1090,8 @@ class Definitions:
         self.clear_definitions_cache(name)
 
     def unset(self, name: str, expr):
+        """Remove the rule corresponding to the expression `expr` in
+        the definition of Symbol `name`"""
         definition = self.get_user_definition(self.lookup_name(name))
         result = definition.remove_rule(expr)
         self.mark_changed(definition)

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Objects that represent the `Definition` associated to a `Symbol` and
+Objects that represent the `Definition` associated with a `Symbol` and
 groups of `Definitions`.
 """
 
@@ -39,7 +39,7 @@ PrintForms: Set[Symbol] = set()
 
 
 def get_file_time(file) -> float:
-    """Determine the last time that a file was accessed"""
+    """Return the last time that a file was accessed"""
     try:
         return os.stat(file).st_mtime
     except OSError:
@@ -107,14 +107,17 @@ class Definitions:
       modules.
     - user: stores the definitions created during the runtime.
     - definition_cache: keep definitions obtained by merging builtins, pymathics, and
-      user definitions associated to the same symbol.
+      user definitions associated with the same symbol.
 
     Note: we want Rules to be serializable so that we can dump and
     restore Rules in order to make startup time faster.
     """
 
     def __init__(
-        self, add_builtin=False, builtin_filename=None, extension_modules=[]
+        self,
+        add_builtin: bool = False,
+        builtin_filename: Optional[str] = None,
+        extension_modules: list = [],
     ) -> None:
         super(Definitions, self).__init__()
         self.builtin: Dict[str, Definition] = {}
@@ -177,7 +180,7 @@ class Definitions:
             autoload_files(self, ROOT_DIR, "autoload")
 
     def clear_cache(self, name: Optional[str] = None):
-        """Clear the cache of definitions. If `name` is provided,
+        """Clear the definitions cache. If `name` is provided,
         just remove the definition for `name` from the definition cache.
         """
         # The definitions cache (self.definitions_cache) caches
@@ -219,7 +222,7 @@ class Definitions:
     def clear_definitions_cache(self, name: str) -> None:
         """
         Remove from the definition cache all the entries
-        associated to name
+        associated with a `name`
         """
         definitions_cache = self.definitions_cache
         tail = strip_context(name)
@@ -287,7 +290,7 @@ class Definitions:
         return set(self.user)
 
     def get_pymathics_names(self) -> set:
-        """Return a set of the names of symbols defined in Pymathics modules"""
+        """Return a set of the names of symbols defined in Mathics3 modules"""
         return set(self.pymathics)
 
     def get_names(self) -> set:
@@ -307,7 +310,7 @@ class Definitions:
         accessible_ctxts.add(self.current_context)
         return accessible_ctxts
 
-    def get_matching_names(self, pattern) -> List[str]:
+    def get_matching_names(self, pattern: str) -> List[str]:
         """
         Return a list of the symbol names matching a string pattern.
 
@@ -361,7 +364,7 @@ class Definitions:
 
         return [name for name in self.get_names() if regex.match(name)]
 
-    def lookup_name(self, name) -> str:
+    def lookup_name(self, name: str) -> str:
         """
         Determine the full name (including context) for a symbol name.
 
@@ -410,11 +413,11 @@ class Definitions:
 
         # return sorted({name.split("`")[0] for name in self.get_names()})
 
-    def shorten_name(self, name_with_ctx) -> str:
+    def shorten_name(self, name_with_ctx: str) -> str:
         if "`" not in name_with_ctx:
             return name_with_ctx
 
-        def in_ctx(name, ctx):
+        def in_ctx(name: str, ctx: str):
             return name.startswith(ctx) and "`" not in name[len(ctx) :]
 
         current_context = self.current_context
@@ -425,16 +428,16 @@ class Definitions:
                 return name_with_ctx[len(ctx) :]
         return name_with_ctx
 
-    def have_definition(self, name) -> bool:
+    def have_definition(self, name: str) -> bool:
         try:
             self.get_definition(name, only_if_exists=True)
         except KeyError:
             return False
         return True
 
-    def get_definition(self, name: str, only_if_exists=False) -> "Definition":
+    def get_definition(self, name: str, only_if_exists: bool = False) -> Definition:
         """
-        Return the definition associated to the Symbol `name`.
+        Return the definition associated with the Symbol `name`.
         If `only_if_exists` is `True` and the symbol does not
         have an associated `Definition`, raise a `KeyError` exception.
         Otherwise, creates a temporary definition, which is not
@@ -444,7 +447,7 @@ class Definitions:
         ----------
         name : str
             The name of the Symbol.
-        only_if_exists : TYPE, optional
+        only_if_exists : bool, optional
             If True, and the symbol was not already defined, raise a KeyError
             exception. Otherwise, Creates a temporary Definition for
             the symbol, but does not store it. The default is False.
@@ -563,7 +566,7 @@ class Definitions:
 
     def get_formats(self, name: str, format_name="") -> list:
         """
-        Return a list of format rules associated to `name`.
+        Return a list of format rules associated with `name`.
         if `format_name` is given, looks to the rules associated
         to that format.
         """
@@ -588,7 +591,7 @@ class Definitions:
                 return result
         return None
 
-    def get_user_definition(self, name: str, create: bool = True) -> "Definition":
+    def get_user_definition(self, name: str, create: bool = True) -> Definition:
         """
         Return a user definition for `name`. If `create` is `False`
         and a user definition is not available, raise a KeyError exception.
@@ -638,11 +641,11 @@ class Definitions:
         self.clear_cache(name)
         return self.user[name]
 
-    def mark_changed(self, definition: "Definition") -> None:
+    def mark_changed(self, definition: Definition) -> None:
         self.now += 1
         definition.changed = self.now
 
-    def reset_user_definition(self, name) -> None:
+    def reset_user_definition(self, name: str) -> None:
         assert not isinstance(name, Symbol)
         fullname = self.lookup_name(name)
         if fullname in self.user:
@@ -650,35 +653,35 @@ class Definitions:
         self.clear_cache(fullname)
         # TODO fix changed
 
-    def add_user_definition(self, name, definition) -> None:
+    def add_user_definition(self, name: str, definition: Definition) -> None:
         assert not isinstance(name, Symbol)
         self.mark_changed(definition)
         fullname = self.lookup_name(name)
         self.user[fullname] = definition
         self.clear_cache(fullname)
 
-    def set_attribute(self, name, attribute) -> None:
+    def set_attribute(self, name: str, attribute: int) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.attributes |= attribute
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def set_attributes(self, name, attributes) -> None:
+    def set_attributes(self, name: str, attributes: int) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.attributes = attributes
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def clear_attribute(self, name, attribute) -> None:
+    def clear_attribute(self, name: str, attribute: int) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.attributes &= ~attribute
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def add_rule(self, name, rule, position=None):
+    def add_rule(self, name: str, rule, position: Optional[str] = None):
         definition = self.get_user_definition(self.lookup_name(name))
         if position is None:
             result = definition.add_rule(rule)
@@ -700,28 +703,28 @@ class Definitions:
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def add_nvalue(self, name, rule) -> None:
+    def add_nvalue(self, name: str, rule) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.add_rule_at(rule, "n")
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def add_default(self, name, rule) -> None:
+    def add_default(self, name: str, rule) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.add_rule_at(rule, "default")
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def add_message(self, name, rule) -> None:
+    def add_message(self, name: str, rule) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.add_rule_at(rule, "messages")
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def set_values(self, name, values, rules) -> None:
+    def set_values(self, name: str, values, rules) -> None:
         pos = valuesname(values)
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
@@ -759,14 +762,14 @@ class Definitions:
         self.add_rule(name, Rule(Symbol(name), value))
         self.clear_cache(name)
 
-    def set_options(self, name, options) -> None:
+    def set_options(self, name: str, options) -> None:
         definition = self.get_user_definition(self.lookup_name(name))
         if definition is not None:
             definition.options = options
             self.mark_changed(definition)
         self.clear_definitions_cache(name)
 
-    def unset(self, name, expr):
+    def unset(self, name: str, expr):
         definition = self.get_user_definition(self.lookup_name(name))
         result = definition.remove_rule(expr)
         self.mark_changed(definition)
@@ -812,7 +815,7 @@ class Definitions:
         return history_length
 
 
-def get_tag_position(pattern, name) -> Optional[str]:
+def get_tag_position(pattern, name: str) -> Optional[str]:
     """
     Determine the position of a pattern in
     the definition of the symbol ``name``
@@ -823,7 +826,7 @@ def get_tag_position(pattern, name) -> Optional[str]:
         "System`BlankNullSequence",
     )
 
-    def strip_pattern_name_and_condition(pat: BasePattern) -> BasePattern:
+    def strip_pattern_name_and_condition(pat) -> BasePattern:
         """
         In ``Pattern[name_, pattern_]`` and
         ``Condition[pattern_, cond_]``
@@ -961,7 +964,7 @@ def insert_rule(values, rule) -> None:
 
 class Definition:
     """
-    A Definition is a collection of ``Rule``s and attributes which are associated to ``Symbol``.
+    A Definition is a collection of ``Rule``s and attributes which are associated with ``Symbol``.
 
     The ``Rule``s are internally organized in terms of the context of application in
     ``ownvalues``, ``upvalues``,  ``downvalues``,  ``subvalues``, ``nvalues``,  ``format``, etc.
@@ -1023,22 +1026,22 @@ class Definition:
         self.changed = 0
         for rule in rules:
             if not self.add_rule(rule):
-                print(f"{rule.pattern.expr} could not be associated to {self.name}")
+                print(f"{rule.pattern.expr} could not be associated with {self.name}")
 
-    def get_values_list(self, pos):
+    def get_values_list(self, pos: str):
         assert pos.isalpha()
         if pos == "messages":
             return self.messages
         return getattr(self, "%svalues" % pos)
 
-    def set_values_list(self, pos, rules) -> None:
+    def set_values_list(self, pos: str, rules) -> None:
         assert pos.isalpha()
         if pos == "messages":
             self.messages = rules
         else:
             setattr(self, "%svalues" % pos, rules)
 
-    def add_rule_at(self, rule, position) -> bool:
+    def add_rule_at(self, rule, position: str) -> bool:
         values = self.get_values_list(position)
         insert_rule(values, rule)
         return True

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -598,7 +598,7 @@ class Definitions:
         accessible_ctxts.add(self.current_context)
         return accessible_ctxts
 
-    def get_matching_names(self, pattern: str) -> List[str]:
+    def get_matching_names(self, pattern) -> List[str]:
         """
         Return a list of the symbol names matching a string pattern.
 
@@ -695,6 +695,8 @@ class Definitions:
     def get_package_names(self) -> List[str]:
         """Return the list of names of the packages loaded in the system."""
         packages = self.get_ownvalue("System`$Packages")
+        if packages is None:
+            return []
         packages = packages.replace
         assert packages.has_form("System`List", None)
         packages = [c.get_string_value() for c in packages.elements]
@@ -1122,19 +1124,22 @@ class Definitions:
         self.set_ownvalue(name, Integer(new_value))
 
     def set_line_no(self, line_no: int) -> None:
-        """Set the current line number"""
+        """Set $Line, the current input line number"""
         self.set_config_value("$Line", line_no)
 
     def get_line_no(self):
-        """Get the current line number"""
+        """Get $Line, the current input line number"""
         return self.get_config_value("$Line", 0)
 
     def increment_line_no(self, increment: int = 1) -> None:
-        """Increment the line number"""
-        self.set_config_value("$Line", self.get_line_no() + increment)
+        """Increment $Line, the current input line number"""
+        line_number = self.get_line_no()
+        if line_number is not None:
+            self.set_config_value("$Line", +increment)
 
     def get_history_length(self) -> int:
-        """Return the length of the command history"""
+        """Return the length of the command history. The number will
+        never be greater than $HistoryLength"""
         history_length = self.get_config_value("$HistoryLength", 100)
         if history_length is None or history_length > 100:
             history_length = 100

--- a/mathics/core/definitions.py
+++ b/mathics/core/definitions.py
@@ -29,8 +29,6 @@ from mathics.core.systemsymbols import SymbolGet
 from mathics.core.util import canonic_filename
 from mathics.settings import ROOT_DIR
 
-type_compiled_pattern = type(re.compile("a.a"))
-
 # The contents of $OutputForms. FormMeta in mathics.base.forms adds to this.
 OutputForms: Set[Symbol] = set()
 
@@ -598,7 +596,7 @@ class Definitions:
         accessible_ctxts.add(self.current_context)
         return accessible_ctxts
 
-    def get_matching_names(self, pattern) -> List[str]:
+    def get_matching_names(self, pattern: Union[str, re.Pattern]) -> List[str]:
         """
         Return a list of the symbol names matching a string pattern.
 
@@ -613,7 +611,7 @@ class Definitions:
         which aren't uppercase letters. In the context pattern, both
         '*' and '@' match context marks.
         """
-        if isinstance(pattern, type_compiled_pattern):
+        if isinstance(pattern, re.Pattern):
             regex = pattern
         else:
             if re.match(full_names_pattern, pattern) is None:

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -202,7 +202,7 @@ class BaseRule(KeyComparable, ABC):
         return tuple((self.system, self.pattern.get_sort_key(pattern_sort)))
 
 
-# FIXME: the class name would be better called RewiteRule.
+# FIXME: the class name would be better called RewriteRule.
 class Rule(BaseRule):
     """There are two kinds of Rules.  This kind of is a rewrite rule
     and transforms an Expression into another Expression based on the

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -241,6 +241,9 @@ def parse_docstring_to_DocumentationEntry_items(
                 items.append(tests)
                 tests = None
             text = post_sub(text, post_substitutions)
+            # Remove line breaks
+            text = re.sub(r" \\\n[ ]*", r" ", text)
+            text = re.sub(r"\\\n[ ]*", r" ", text)
             items.append(text_constructor(text))
             tests = None
         if index < len(testcases) - 1:
@@ -539,8 +542,6 @@ class DocumentationEntry:
         # TODO parse XML and pretty print
         # HACK
         item = str(self.items[0])
-        item = re.sub(r" \\\n[ ]*", r" ", item)
-        item = re.sub(r"\\\n[ ]*", r" ", item)
         item = "\n".join(line.strip() for line in item.split("\n"))
         item = item.replace("<dl>", "")
         item = item.replace("</dl>", "")

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -550,6 +550,7 @@ class DocumentationEntry:
         item = item.replace("<dd>", "    ")
         item = item.replace("</dd>", "")
         item = "\n".join(line for line in item.split("\n") if not line.isspace())
+        item = re.sub(r"\$([0-9a-zA-Z]*)\$", r"\1", item)
         return item
 
     def get_tests(self) -> List["DocTest"]:

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -539,6 +539,8 @@ class DocumentationEntry:
         # TODO parse XML and pretty print
         # HACK
         item = str(self.items[0])
+        item = re.sub(r" \\\n[ ]*", r" ", item)
+        item = re.sub(r"\\\n[ ]*", r" ", item)
         item = "\n".join(line.strip() for line in item.split("\n"))
         item = item.replace("<dl>", "")
         item = item.replace("</dl>", "")

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -1,0 +1,42 @@
+"""
+Functions used in the inline (Information[]) help. 
+
+"""
+
+import re
+
+from mathics.core.evaluation import Evaluation
+from mathics.core.symbols import Symbol
+from mathics.doc.doc_entries import DocumentationEntry
+
+
+def online_doc_string(
+    symbol: Symbol, evaluation: Evaluation, is_long_form: bool
+) -> str:
+    """
+    Returns a python string with the documentation associated to a given symbol.
+    """
+    definition = evaluation.definitions.get_definition(symbol.name)
+    ruleusage = definition.get_values_list("messages")
+    usagetext = None
+
+    # First look at user definitions:
+    for rulemsg in ruleusage:
+        if rulemsg.pattern.expr.elements[1].__str__() == '"usage"':
+            usagetext = rulemsg.replace.value
+
+    if not is_long_form and usagetext:
+        return usagetext
+
+    builtins = evaluation.definitions.builtin
+    pymathics = evaluation.definitions.pymathics
+    bio = pymathics.get(definition.name) or builtins.get(definition.name)
+
+    if bio is not None:
+        docstr = bio.builtin.__class__.__doc__
+        title = bio.builtin.__class__.__name__
+        if docstr is None:
+            return usagetext
+        docstr = docstr[docstr.find("<dl>") : (docstr.find("</dl>") + 6)]
+        usagetext = DocumentationEntry(docstr, title).text()
+    return usagetext

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -1,9 +1,7 @@
 """
-Functions used in the inline (Information[]) help. 
+Functions used in the inline (Information[]) help.
 
 """
-
-import re
 
 from mathics.core.evaluation import Evaluation
 from mathics.core.symbols import Symbol

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -18,7 +18,7 @@ def online_doc_string(
     """
     definition = evaluation.definitions.get_definition(symbol.name)
     ruleusage = definition.get_values_list("messages")
-    usagetext = None
+    usagetext = ""
 
     # First look at user definitions:
     for rulemsg in ruleusage:

--- a/mathics/eval/assignments/__init__.py
+++ b/mathics/eval/assignments/__init__.py
@@ -1,0 +1,11 @@
+"""
+Evaluation routines and associated code for Built-in function found under module
+mathics.builtins.assignments.
+"""
+
+from mathics.eval.assignments.assignment import ASSIGNMENT_FUNCTION_MAP, eval_assign
+
+__all__ = [
+    "ASSIGNMENT_FUNCTION_MAP",
+    "eval_assign",
+]

--- a/mathics/eval/assignments/assignment.py
+++ b/mathics/eval/assignments/assignment.py
@@ -1,0 +1,1495 @@
+# -*- coding: utf-8 -*-
+# pylint: disable-msg=too-many-arguments
+
+"""
+evaluation routines for Set and SetDelayed, and Builtin functions
+found in module mathics.builtin.assigments.assignment
+"""
+
+from functools import reduce
+from typing import List, Optional, Tuple
+
+from mathics.core.assignment import (
+    build_rulopc,
+    get_symbol_list,
+    is_protected,
+    normalize_lhs,
+    rejected_because_protected,
+    unroll_conditions,
+    unroll_patterns,
+)
+from mathics.core.atoms import Atom, Integer, Integer1
+from mathics.core.attributes import A_LOCKED, attribute_string_to_number
+from mathics.core.builtin import Builtin
+from mathics.core.element import BaseElement
+from mathics.core.evaluation import (
+    MAX_RECURSION_DEPTH,
+    Evaluation,
+    set_python_recursion_limit,
+)
+from mathics.core.expression import Expression, SymbolDefault
+from mathics.core.rules import Rule
+from mathics.core.symbols import (
+    Symbol,
+    SymbolFalse,
+    SymbolMaxPrecision,
+    SymbolMinPrecision,
+    SymbolN,
+    SymbolTrue,
+    valid_context_name,
+)
+from mathics.core.systemsymbols import SymbolCondition, SymbolMachinePrecision
+from mathics.eval.list.eol import eval_Part
+
+
+class AssignmentException(Exception):
+    """Exception raised when Assignment fails"""
+
+    def __init__(self, lhs, rhs) -> None:
+        super().__init__(f" {rhs} cannot be assigned to {lhs}")
+        self.lhs = lhs
+        self.rhs = rhs
+
+
+def eval_assign(
+    self,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: Optional[list] = None,
+    upset: bool = False,
+) -> bool:
+    """
+    Method that implements the assignment.
+
+    Parameters
+    ----------
+    lhs : BaseElement
+        The expression to be assigned.
+    rhs : BaseElement
+        the RHS.
+    evaluation : Evaluation
+        The evaluation object.
+    tags : Optional[list], optional
+        The list of symbol names for which the rule must be associated.
+        The default is None.
+    upset : bool, optional
+        If true, the assignment is to an UpsetValue. The default is False.
+
+    Returns
+    -------
+    bool:
+        True if the assignment was successful.
+
+    """
+    lhs, lookup_name = normalize_lhs(lhs, evaluation)
+    try:
+        # Using a builtin name, find which assignment procedure to perform,
+        # and then call that function.
+        assignment_func = ASSIGNMENT_FUNCTION_MAP.get(lookup_name, None)
+        if assignment_func:
+            return assignment_func(self, lhs, rhs, evaluation, tags, upset)
+
+        return eval_assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset)
+    except AssignmentException:
+        return False
+
+
+def eval_assign_attributes(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Process the case where lhs is of the form
+    `Attribute[symbol]`
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    name = lhs.get_head_name()
+    if len(lhs.elements) != 1:
+        evaluation.message_args(name, len(lhs.elements), 1)
+        raise AssignmentException(lhs, rhs)
+    tag = lhs.elements[0].get_name()
+    if not tag:
+        evaluation.message(name, "sym", lhs.elements[0], 1)
+        raise AssignmentException(lhs, rhs)
+    if tags is not None and tags != [tag]:
+        evaluation.message(name, "tag", Symbol(name), Symbol(tag))
+        raise AssignmentException(lhs, rhs)
+    attributes_list = get_symbol_list(
+        rhs, lambda item: evaluation.message(name, "sym", item, 1)
+    )
+    if attributes_list is None:
+        raise AssignmentException(lhs, rhs)
+    if A_LOCKED & evaluation.definitions.get_attributes(tag):
+        evaluation.message(name, "locked", Symbol(tag))
+        raise AssignmentException(lhs, rhs)
+
+    def reduce_attributes_from_list(x_att: int, y_att: str) -> int:
+        try:
+            return x_att | attribute_string_to_number[y_att]
+        except KeyError:
+            evaluation.message("SetAttributes", "unknowattr", y_att)
+            return x_att
+
+    attributes = reduce(
+        reduce_attributes_from_list,
+        attributes_list,
+        0,
+    )
+
+    evaluation.definitions.set_attributes(tag, attributes)
+
+    return True
+
+
+def eval_assign_context(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: List,
+    upset: bool,
+) -> bool:
+    """
+    Process the case where lhs is ``$Context``
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs_name = lhs.get_head_name()
+    new_context = rhs.get_string_value()
+    if new_context is None or not valid_context_name(
+        new_context, allow_initial_backquote=True
+    ):
+        evaluation.message(lhs_name, "cxset", rhs)
+        raise AssignmentException(lhs, None)
+
+    # With $Context in Mathematica you can do some strange
+    # things: e.g. with $Context set to Global`, something
+    # like:
+    #    $Context = "`test`"; newsym
+    # is accepted and creates Global`test`newsym.
+    # Implement this behaviour by interpreting
+    #    $Context = "`test`"
+    # as
+    #    $Context = $Context <> "test`"
+    #
+    if new_context.startswith("`"):
+        new_context = evaluation.definitions.get_current_context() + new_context.lstrip(
+            "`"
+        )
+
+    evaluation.definitions.set_current_context(new_context)
+    return True
+
+
+def eval_assign_context_path(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Assignment to the `$ContextPath` variable.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs_name = lhs.get_name()
+    curr_context = evaluation.definitions.get_current_context()
+    context_path = [s.get_string_value() for s in rhs.get_elements()]
+    context_path = [
+        s if (s is None or s[0] != "`") else curr_context[:-1] + s for s in context_path
+    ]
+    if rhs.has_form("List", None) and all(valid_context_name(s) for s in context_path):
+        evaluation.definitions.set_context_path(context_path)
+        return True
+
+    evaluation.message(lhs_name, "cxlist", rhs)
+    raise AssignmentException(lhs, None)
+
+
+def eval_assign_default(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Process the assignment of ``DefaultValues`` of a symbol.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs, condition = unroll_conditions(lhs)
+    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
+    count = 0
+    defs = evaluation.definitions
+
+    if len(lhs.elements) not in (1, 2, 3):
+        evaluation.message_args(SymbolDefault, len(lhs.elements), 1, 2, 3)
+        raise AssignmentException(lhs, None)
+    focus = lhs.elements[0]
+    tags = process_tags_and_upset_dont_allow_custom(
+        tags, upset, self, lhs, focus, evaluation
+    )
+    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
+    rule = Rule(lhs, rhs)
+    for tag in tags:
+        if rejected_because_protected(self, lhs, tag, evaluation):
+            continue
+        count += 1
+        defs.add_default(tag, rule)
+    return count > 0
+
+
+def eval_assign_definition_values(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+
+    Implements the assignment to the Definitions attribute of a symbol.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    name = lhs.get_head_name()
+    tag = find_tag_and_check(lhs, tags, evaluation)
+    rules = rhs.get_rules_list()
+    if rules is None:
+        evaluation.message(name, "vrule", lhs, rhs)
+        raise AssignmentException(lhs, None)
+    evaluation.definitions.set_values(tag, name, rules)
+    return True
+
+
+def eval_assign_format(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+
+    Implements the assignment to Format
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs, condition = unroll_conditions(lhs)
+    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
+    count = 0
+    defs = evaluation.definitions
+
+    if len(lhs.elements) not in (1, 2):
+        evaluation.message_args("Format", len(lhs.elements), 1, 2)
+        raise AssignmentException(lhs, None)
+    if len(lhs.elements) == 2:
+        form = lhs.elements[1]
+        form_name = form.get_name()
+        if not form_name:
+            evaluation.message("Format", "fttp", lhs.elements[1])
+            raise AssignmentException(lhs, None)
+        # If the form is not in defs.printforms / defs.outputforms
+        # add it.
+        for form_list in (defs.outputforms, defs.printforms):
+            if form not in form_list:
+                form_list.append(form)
+    else:
+        form_name = [
+            "System`StandardForm",
+            "System`TraditionalForm",
+            "System`OutputForm",
+            "System`TeXForm",
+            "System`MathMLForm",
+        ]
+    lhs = focus = lhs.elements[0]
+    tags = process_tags_and_upset_dont_allow_custom(
+        tags, upset, self, lhs, focus, evaluation
+    )
+    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
+    rule = Rule(lhs, rhs)
+    for tag in tags:
+        if rejected_because_protected(self, lhs, tag, evaluation):
+            continue
+        count += 1
+        defs.add_format(tag, rule, form_name)
+    return count > 0
+
+
+def eval_assign_iteration_limit(
+    lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
+) -> bool:
+    """
+    Set ownvalue for the $IterationLimit symbol.
+    """
+
+    rhs_int_value = rhs.get_int_value()
+    if (
+        not rhs_int_value or rhs_int_value < 20
+    ) and not rhs.get_name() == "System`Infinity":
+        evaluation.message("$IterationLimit", "limset", rhs)
+        raise AssignmentException(lhs, None)
+    return True
+
+
+def eval_assign_line_number_and_history_length(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Set ownvalue for the $Line and $HistoryLength symbols.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+
+    lhs_name = lhs.get_name()
+    rhs_int_value = rhs.get_int_value()
+    if rhs_int_value is None or rhs_int_value < 0:
+        evaluation.message(lhs_name, "intnn", rhs)
+        raise AssignmentException(lhs, None)
+    return False
+
+
+def eval_assign_list(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Implement the assignment to a List expression.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    if not (
+        rhs.get_head_name() == "System`List" and len(lhs.elements) == len(rhs.elements)
+    ):  # nopep8
+        evaluation.message(self.get_name(), "shape", lhs, rhs)
+        return False
+    result = True
+    for left, right in zip(lhs.elements, rhs.elements):
+        if not eval_assign(self, left, right, evaluation):
+            result = False
+    return result
+
+
+def eval_assign_makeboxes(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Implement the assignment to a MakeBoxes expression.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    # FIXME: the below is a big hack.
+    # Currently MakeBoxes boxing is implemented as a bunch of rules.
+    # See mathics.core.builtin contribute().
+    # I think we want to change this so it works like normal SetDelayed
+    # That is:
+    #   MakeBoxes[CubeRoot, StandardForm] := RadicalBox[3, StandardForm]
+    # rather than:
+    #   MakeBoxes[CubeRoot, StandardForm] -> RadicalBox[3, StandardForm]
+    makeboxes_rule = Rule(lhs, rhs, system=False)
+    definitions = evaluation.definitions
+    definitions.add_rule("System`MakeBoxes", makeboxes_rule, "down")
+    #    makeboxes_defs = evaluation.definitions.builtin["System`MakeBoxes"]
+    #    makeboxes_defs.add_rule(makeboxes_rule)
+    return True
+
+
+def eval_assign_minprecision(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Implement the assignment to the `$MinPrecision` symbol.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs_name = lhs.get_name()
+    rhs_int_value = rhs.get_int_value()
+    # $MinPrecision = Infinity is not allowed
+    if rhs_int_value is not None and rhs_int_value >= 0:
+        max_prec = evaluation.definitions.get_config_value("$MaxPrecision")
+        if max_prec is not None and max_prec < rhs_int_value:
+            evaluation.message("$MinPrecision", "preccon", SymbolMinPrecision)
+            raise AssignmentException(lhs, None)
+        return False
+
+    evaluation.message(lhs_name, "precset", lhs, rhs)
+    raise AssignmentException(lhs, None)
+
+
+def eval_assign_maxprecision(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Implement the assignment to the `$MaxPrecision` symbol.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs_name = lhs.get_name()
+    rhs_int_value = rhs.get_int_value()
+    if rhs.has_form("DirectedInfinity", 1) and rhs.elements[0].get_int_value() == 1:
+        return False
+    if rhs_int_value is not None and rhs_int_value > 0:
+        min_prec = evaluation.definitions.get_config_value("$MinPrecision")
+        if min_prec is not None and rhs_int_value < min_prec:
+            evaluation.message("$MaxPrecision", "preccon", SymbolMaxPrecision)
+            raise AssignmentException(lhs, None)
+        return False
+
+    evaluation.message(lhs_name, "precset", lhs, rhs)
+    raise AssignmentException(lhs, None)
+
+
+def eval_assign_messagename(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+
+    Implement the assignment to `Message[...]` expressions.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs, condition = unroll_conditions(lhs)
+    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
+    count = 0
+    defs = evaluation.definitions
+    if len(lhs.elements) != 2:
+        evaluation.message_args("MessageName", len(lhs.elements), 2)
+        raise AssignmentException(lhs, None)
+    focus = lhs.elements[0]
+    tags = process_tags_and_upset_dont_allow_custom(
+        tags, upset, self, lhs, focus, evaluation
+    )
+    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
+    rule = Rule(lhs, rhs)
+    for tag in tags:
+        # Messages can be assigned even if the symbol is protected...
+        # if rejected_because_protected(self, lhs, tag, evaluation):
+        #    continue
+        count += 1
+        defs.add_message(tag, rule)
+    return count > 0
+
+
+def eval_assign_module_number(
+    lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
+) -> bool:
+    """
+    Set ownvalue for the $ModuleNumber symbol.
+    """
+    rhs_int_value = rhs.get_int_value()
+    if not rhs_int_value or rhs_int_value <= 0:
+        evaluation.message("$ModuleNumber", "set", rhs)
+        raise AssignmentException(lhs, None)
+    return False
+
+
+def eval_assign_options(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Implement the assignment to `OptionValues`.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs_elements = lhs.elements
+    name = lhs.get_head_name()
+    if len(lhs_elements) != 1:
+        evaluation.message_args(name, len(lhs_elements), 1)
+        raise AssignmentException(lhs, rhs)
+    tag = lhs_elements[0].get_name()
+    if not tag:
+        evaluation.message(name, "sym", lhs_elements[0], 1)
+        raise AssignmentException(lhs, rhs)
+    if tags is not None and tags != [tag]:
+        evaluation.message(name, "tag", Symbol(name), Symbol(tag))
+        raise AssignmentException(lhs, rhs)
+    if is_protected(tag, evaluation.definitions):
+        evaluation.message(name, "wrsym", Symbol(tag))
+        raise AssignmentException(lhs, None)
+    option_values = rhs.get_option_values(evaluation)
+    if option_values is None:
+        evaluation.message(name, "options", rhs)
+        raise AssignmentException(lhs, None)
+    evaluation.definitions.set_options(tag, option_values)
+    return True
+
+
+def eval_assign_numericq(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Assign to expressions of the form `NumericQ[expr_]`.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    # lhs, condition = unroll_conditions(lhs)
+    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
+    if rhs not in (SymbolTrue, SymbolFalse):
+        evaluation.message("NumericQ", "set", lhs, rhs)
+        # raise AssignmentException(lhs, rhs)
+        return True
+    elements = lhs.elements
+    if len(elements) > 1:
+        evaluation.message("NumericQ", "argx", Integer(len(elements)))
+        # raise AssignmentException(lhs, rhs)
+        return True
+    target = elements[0]
+    if isinstance(target, Symbol):
+        name = target.get_name()
+        try:
+            definition = evaluation.definitions.get_definition(name)
+            definition.is_numeric = rhs is SymbolTrue
+        except KeyError:
+            pass
+        return True
+
+    evaluation.message("NumericQ", "set", lhs, rhs)
+    raise AssignmentException(lhs, rhs)
+
+
+def eval_assign_n(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Assign to expressions of the form `N[expr_]`.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs, condition = unroll_conditions(lhs)
+    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
+    defs = evaluation.definitions
+    # If we try to set `N=4`, (issue #210) just deal with it as with a generic expression:
+    if lhs is SymbolN:
+        return eval_assign_store_rules_by_tag(self, lhs, rhs, evaluation, tags, upset)
+
+    if len(lhs.elements) not in (1, 2):
+        evaluation.message_args("N", len(lhs.elements), 1, 2)
+        raise AssignmentException(lhs, None)
+    if len(lhs.elements) == 1:
+        nprec = SymbolMachinePrecision
+    else:
+        nprec = lhs.elements[1]
+    focus = lhs.elements[0]
+    lhs = Expression(SymbolN, focus, nprec)
+    tags = process_tags_and_upset_dont_allow_custom(
+        tags, upset, self, lhs, focus, evaluation
+    )
+    count = 0
+    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
+    rule = Rule(lhs, rhs)
+    for tag in tags:
+        if rejected_because_protected(self, lhs, tag, evaluation):
+            continue
+        count += 1
+        defs.add_nvalue(tag, rule)
+    return count > 0
+
+
+def eval_assign_other(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: Optional[list] = None,
+    upset: bool = False,
+) -> Tuple[bool, list]:
+    """
+    Process special cases, performing certain side effects, like modifying
+    the value of internal variables that are not stored as rules.
+
+    The function returns a tuple of a bool value and a list of tags.
+    If lhs is one of the special cases, then the bool variable is
+    True, meaning that the `Protected` attribute should not be taken
+    into account.
+    Otherwise, the value is False.
+
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    tags, _ = process_tags_and_upset_allow_custom(
+        tags, upset, self, lhs, rhs, evaluation
+    )
+    lhs_name = lhs.get_name()
+    if lhs_name == "System`$RecursionLimit":
+        eval_assign_recursion_limit(lhs, rhs, evaluation)
+    elif lhs_name in ("System`$Line", "System`$HistoryLength"):
+        eval_assign_line_number_and_history_length(
+            self, lhs, rhs, evaluation, tags, upset
+        )
+    elif lhs_name == "System`$IterationLimit":
+        eval_assign_iteration_limit(lhs, rhs, evaluation)
+    elif lhs_name == "System`$ModuleNumber":
+        eval_assign_module_number(lhs, rhs, evaluation)
+    elif lhs_name == "System`$MinPrecision":
+        eval_assign_minprecision(self, lhs, rhs, evaluation, tags, upset)
+    elif lhs_name == "System`$MaxPrecision":
+        eval_assign_maxprecision(self, lhs, rhs, evaluation, tags, upset)
+    else:
+        return False, tags
+    return True, tags
+
+
+def eval_assign_part(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: Optional[List],
+    upset: bool,
+):
+    """
+    Special case `A[[i,j,...]]=....`
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    defs = evaluation.definitions
+    if len(lhs.elements) < 1:
+        evaluation.message(self.get_name(), "setp", lhs)
+        return False
+    symbol = lhs.elements[0]
+    name = symbol.get_name()
+    if not name:
+        evaluation.message(self.get_name(), "setps", symbol)
+        return False
+    if is_protected(name, defs):
+        evaluation.message(self.get_name(), "wrsym", symbol)
+        return False
+    rule = defs.get_ownvalue(name)
+    if rule is None:
+        evaluation.message(self.get_name(), "noval", symbol)
+        return False
+    indices = lhs.elements[1:]
+    return eval_Part([rule.replace], indices, evaluation, rhs)
+
+
+def eval_assign_random_state(
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+    tags: list,
+    upset: bool,
+) -> bool:
+    """
+    Assign to expressions of the form `$RandomState`.
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    # By a design decision, Mathics3 does not allow to
+    # modify this variable.
+    # To change this behaviour we should
+    #
+    # * Base `get_random_state` and `set_random_state` in a
+    #   safer serialization mechanism. The branch
+    #   origin/setteable_randomstate has a proposal for this.
+    # * Modify the behaviour of
+    #   `mathics.builtin.numbers.randomnumbers.RandomEnvBase`
+    # * Uncomment the following lines:
+    #
+    # from call here mathics.builtin.numbers.randomnumbers import (
+    # set_random_state,
+    # )
+    # set_random_state(rhs.get_int_value())
+    #
+    evaluation.message("$RandomState", "rndst", rhs)
+    return False
+
+
+def eval_assign_recursion_limit(lhs, rhs, evaluation):
+    """
+    Set ownvalue for the $RecursionLimit symbol.
+    """
+    rhs_int_value = rhs.get_int_value()
+    # if (not rhs_int_value or rhs_int_value < 20) and not
+    # rhs.get_name() == 'System`Infinity':
+    if (
+        not rhs_int_value or rhs_int_value < 20 or rhs_int_value > MAX_RECURSION_DEPTH
+    ):  # nopep8
+        evaluation.message("$RecursionLimit", "limset", rhs)
+        raise AssignmentException(lhs, None)
+    try:
+        set_python_recursion_limit(rhs_int_value)
+    except OverflowError:
+        # TODO: Show a Message
+        raise AssignmentException(lhs, None)
+    return True
+
+
+def eval_assign_store_rules_by_tag(
+    self, lhs, rhs, evaluation, tags, upset=False
+) -> bool:
+    """
+    This is the default assignment. Stores a rule of the form lhs->rhs
+    as a value associated to each symbol listed in tags.
+    For special cases, such like conditions or patterns in the lhs,
+    lhs and rhs are rewritten in a normal form, where
+    conditions are associated to the lhs.
+
+
+    Parameters
+    ----------
+    self : Builtin
+        The builtin assignment operator
+    lhs : BaseElement
+        The pattern of the rule to be assigned.
+    rhs : BaseElement
+        the expression representing the replacement.
+    evaluation : Evaluation
+        DESCRIPTION.
+    tags : list
+        the list of symbols to be associated to the rule.
+    upset : bool
+        `True` if the rule is an Up value.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    bool
+        True if the assignment was successful.
+
+    """
+    lhs, condition = unroll_conditions(lhs)
+    lhs, rhs = unroll_patterns(lhs, rhs, evaluation)
+    defs = evaluation.definitions
+    ignore_protection, tags = eval_assign_other(self, lhs, rhs, evaluation, tags, upset)
+    # In WMA, this does not happens. However, if we remove this,
+    # some combinatorica tests fail.
+    # Also, should not be at the beginning?
+    lhs, rhs = process_rhs_conditions(lhs, rhs, condition, evaluation)
+    count = 0
+    rule = Rule(lhs, rhs)
+    position = "up" if upset else None
+    for tag in tags:
+        if rejected_because_protected(self, lhs, tag, evaluation, ignore_protection):
+            continue
+        count += 1
+        defs.add_rule(tag, rule, position=position)
+    return count > 0
+
+
+def find_tag_and_check(
+    lhs: BaseElement, tags: Optional[List[str]], evaluation: Evaluation
+) -> str:
+    """
+    Deduce the `tag` from the lhs. If a list of `tags` is provided,
+    it must coincide with `[tag]`.
+
+    Parameters
+    ----------
+    lhs : BaseElement
+        The LHS of the assignment expression.
+    tags : Optional[List[str]]
+        A list of tags.
+    evaluation : Evaluation
+        The evaluation object.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    str
+        the tag associated to the expression.
+
+    """
+    name = lhs.get_head_name()
+    if len(lhs.elements) != 1:
+        evaluation.message_args(name, len(lhs.elements), 1)
+        raise AssignmentException(lhs, None)
+    tag = lhs.elements[0].get_name()
+    if not tag:
+        evaluation.message(name, "sym", lhs.elements[0], 1)
+        raise AssignmentException(lhs, None)
+    if tags is not None and tags != [tag]:
+        evaluation.message(name, "tag", Symbol(name), Symbol(tag))
+        raise AssignmentException(lhs, None)
+    if is_protected(tag, evaluation.definitions):
+        evaluation.message(name, "wrsym", Symbol(tag))
+        raise AssignmentException(lhs, None)
+    return tag
+
+
+def process_rhs_conditions(
+    lhs: BaseElement, rhs: BaseElement, condition: Expression, evaluation: Evaluation
+) -> Tuple[BaseElement, Optional[BaseElement]]:
+    """
+    lhs = Condition[rhs, test] -> Condition[lhs, test]  = rhs
+    """
+    # To Handle `OptionValue` in `Condition`
+    rulopc = build_rulopc(lhs.get_head())
+    rhs_name = rhs.get_head_name()
+    while rhs_name == "System`Condition":
+        if len(rhs.elements) != 2:
+            evaluation.message_args("Condition", len(rhs.elements), 2)
+            raise AssignmentException(lhs, None)
+        lhs = Expression(
+            SymbolCondition,
+            lhs,
+            rhs.elements[1].do_apply_rules([rulopc], evaluation)[0],
+        )
+        rhs = rhs.elements[0]
+        rhs_name = rhs.get_head_name()
+
+    # Now, let's add the conditions on the LHS
+    if condition:
+        lhs = Expression(
+            SymbolCondition,
+            lhs,
+            condition.elements[1].do_apply_rules([rulopc], evaluation)[0],
+        )
+    return lhs, rhs
+
+
+def process_tags_and_upset_dont_allow_custom(
+    tags: Optional[list],
+    upset: bool,
+    self: Builtin,
+    lhs: BaseElement,
+    focus: BaseElement,
+    evaluation: Evaluation,
+) -> list:
+    """
+    If `upset` is `True`,  collect a list of tag candidates from the elements of
+    the lhs.
+    If `upset` is `False`, and `tags` is given, check if the elements
+    in `tags` are all names of symbols in the `lhs` elements. If `tags` is
+    `None`, the list of tags contains just the `lookup_name` of the LHS.
+
+    Parameters
+    ----------
+    tags : Optional[List]
+        The list of symbols to which the rule must be associated.
+    upset : bool
+        If `True`, assign as an UpValue.
+    self : Builtin
+        The Assignment operator object that started the call.
+    lhs : BaseElement
+        The LHS of the assignment.
+    rhs : BaseElement
+        The RHS of the assignment.
+    evaluation : Evaluation
+        The evaluation object.
+
+    Raises
+    ------
+    AssignmentException
+
+    Returns
+    -------
+    tags: list
+        the list of allowed tags.
+
+    """
+    if isinstance(focus, Expression):
+        focus = focus.evaluate_elements(evaluation)
+    name = lhs.get_head_name()
+    if upset:
+        tags = [focus.get_lookup_name()]
+    elif tags is None:
+        name = focus.get_lookup_name()
+        if not name:
+            evaluation.message(self.get_name(), "setraw", focus)
+            raise AssignmentException(lhs, None)
+        tags = [name]
+    else:
+        allowed_names = [focus.get_lookup_name()]
+        for name in tags:
+            if name not in allowed_names:
+                evaluation.message(self.get_name(), "tagnfd", Symbol(name))
+                raise AssignmentException(lhs, None)
+    return tags
+
+
+def process_tags_and_upset_allow_custom(
+    tags: Optional[List],
+    upset: bool,
+    self: Builtin,
+    lhs: BaseElement,
+    rhs: BaseElement,
+    evaluation: Evaluation,
+) -> Tuple[list, BaseElement]:
+    """
+    If `upset` is `True`,  collect a list of tag candidates from the elements of
+    the lhs.
+    If `upset` is `False`, and `tags` is given, check if the elements
+    in `tags` are all names of symbols in the `lhs` elements. If `tags` is
+    `None`, the list of tags contains just the `lookup_name` of the LHS.
+
+    Parameters
+    ----------
+    tags : Optional[List]
+        The list of symbols to which the rule must be associated.
+    upset : bool
+        If `True`, assign as an UpValue.
+    self : Builtin
+        The Assignment operator object that started the call.
+    lhs : BaseElement
+        The LHS of the assignment.
+    rhs : BaseElement
+        The RHS of the assignment.
+    evaluation : Evaluation
+        The evaluation object.
+
+    Raises
+    ------
+    AssignmentException.
+
+    Returns
+    -------
+    (tags, focus,): Tuple[list, BaseElement]
+        tags: the list of symbols to which the rule must be associated.
+        focus: the lhs
+
+    """
+    name = lhs.get_head_name()
+    focus = lhs
+    if isinstance(focus, Expression):
+        focus = focus.evaluate_elements(evaluation)
+
+    if upset:
+        tags = []
+        if isinstance(focus, Atom):
+            symbol_name = self.get_name()
+            evaluation.message(
+                symbol_name,
+                "normal",
+                Integer1,
+                Expression(Symbol(symbol_name), lhs, rhs),
+            )
+            raise AssignmentException(lhs, None)
+        for element in focus.get_elements():
+            name = element.get_lookup_name()
+            tags.append(name)
+        return tags, focus
+
+    if tags is None:
+        name = focus.get_lookup_name()
+        if not name:
+            evaluation.message(self.get_name(), "setraw", focus)
+            raise AssignmentException(lhs, None)
+        tags = [name]
+    else:
+        allowed_names = [focus.get_lookup_name()]
+        for element in focus.get_elements():
+            if not isinstance(element, Symbol) and element.get_head_name() in (
+                "System`HoldPattern",
+            ):
+                element = element.get_element(0)
+            if not isinstance(element, Symbol) and element.get_head_name() in (
+                "System`Pattern",
+            ):
+                element = element.get_element(1)
+            if not isinstance(element, Symbol) and element.get_head_name() in (
+                "System`Blank",
+                "System`BlankSequence",
+                "System`BlankNullSequence",
+            ):
+                if len(element.get_elements()) == 1:
+                    element = element.get_element(0)
+
+            allowed_names.append(element.get_lookup_name())
+        for name in tags:
+            if name not in allowed_names:
+                evaluation.message(self.get_name(), "tagnfd", Symbol(name))
+                raise AssignmentException(lhs, None)
+
+    return tags, focus
+
+
+# Below is a mapping from Symbol name (as a string) into an assignment eval function.
+ASSIGNMENT_FUNCTION_MAP = {
+    "System`$Context": eval_assign_context,
+    "System`$ContextPath": eval_assign_context_path,
+    "System`$RandomState": eval_assign_random_state,
+    "System`Attributes": eval_assign_attributes,
+    "System`Default": eval_assign_default,
+    "System`DefaultValues": eval_assign_definition_values,
+    "System`DownValues": eval_assign_definition_values,
+    "System`Format": eval_assign_format,
+    "System`List": eval_assign_list,
+    "System`MakeBoxes": eval_assign_makeboxes,
+    "System`MessageName": eval_assign_messagename,
+    "System`Messages": eval_assign_definition_values,
+    "System`N": eval_assign_n,
+    "System`NValues": eval_assign_definition_values,
+    "System`NumericQ": eval_assign_numericq,
+    "System`Options": eval_assign_options,
+    "System`OwnValues": eval_assign_definition_values,
+    "System`Part": eval_assign_part,
+    "System`SubValues": eval_assign_definition_values,
+    "System`UpValues": eval_assign_definition_values,
+}

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -62,7 +62,7 @@ def show_echo(query, evaluation):
             stream = stream_manager.lookup_stream(strm.elements[1].value)
             if stream is None or stream.io is None or stream.io.closed:
                 continue
-        if stream is not None:
+        if stream is not None and stream.io is not None:
             stream.io.write(query + "\n")
 
 
@@ -257,7 +257,7 @@ class TerminalShell(MathicsLineFeeder):
 
 
 class TerminalOutput(Output):
-    def max_stored_size(self, settings):
+    def max_stored_size(self, output_settings):
         return None
 
     def __init__(self, shell):

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -479,7 +479,9 @@ Please contribute to Mathics!""",
     if args.show_statistics:
         atexit.register(show_lru_cache_statistics)
 
-    definitions = Definitions(add_builtin=True, extension_modules=extension_modules)
+    definitions = Definitions(
+        add_builtin=True, extension_modules=tuple(extension_modules)
+    )
     definitions.set_line_no(0)
 
     shell = TerminalShell(


### PR DESCRIPTION
This PR changes the way in which  `Definitions.get_definition` and `Definitions.get_user_definition` report that a `Definition` object is not available for a given symbol name, by raising an exception instead of returning `None`. This helps to avoid recasts in static type analysis.