### PR TITLE
Add Close["path"]

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -177,7 +177,7 @@ class Character(Builtin):
     summary_text = "single character, returned as a one‐character string"
 
 
-# Note: WMA specify that Close["name"] should be unique, but it appears it
+# Note: WMA documentation specifies that Close["name"] should be unique, but it appears it
 # as of 13.2.0 name does not have to be unique. We'll follow what WMA
 # does as opposed to what the documentation says.
 class Close(Builtin):
@@ -186,7 +186,9 @@ class Close(Builtin):
 
     <dl>
       <dt>'Close[$obj$]'
-      <dd>Closes a stream or socket. $obj$ can be an 'InputStream', or an 'OutputStream' object, or a 'String'. \
+      <dd>Closes a stream or socket.
+
+      $obj$ can be an 'InputStream', or an 'OutputStream' object, or a 'String'. \
       When $obj$ is a string file path, one of the channels associated with it is closed.
     </dl>
 

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -202,6 +202,36 @@ class Close(Builtin):
     >> DeleteFile[file];
 
     #> Clear[file]
+
+    If two streams are open with the same file, then \
+    a 'Close' by file path closes only one of the streams:
+
+    >> stream1 = OpenRead["ExampleData/numbers.txt"]
+     = InputStream[ExampleData/numbers.txt, ...]
+
+    >> stream2 = OpenRead["ExampleData/numbers.txt"]
+     = InputStream[ExampleData/numbers.txt, ...]
+
+    >> Close["ExampleData/numbers.txt"]
+     = ExampleData/numbers.txt
+
+    Usually, the most-recent stream is closed, while the earlier-opened \
+    stream still persists:
+    >> Read[stream1]
+     = 8205.79
+
+
+    However, one of the streams <i>is</i> closed:
+    >> Read[stream2]
+     : ...
+     = $Failed
+
+    >> Close["ExampleData/numbers.txt"]
+     = ExampleData/numbers.txt
+
+    >> Read[stream1]
+     : ...
+     = $Failed
     """
 
     summary_text = "close a stream"

--- a/mathics/core/streams.py
+++ b/mathics/core/streams.py
@@ -242,6 +242,21 @@ class StreamsManager:
                 return self.STREAMS[i]
         return None
 
+    # Note: WMA specify that lookup by "name" should be unique, but it appears it
+    # as of 13.2.0 name does not have to be unique. We'll follow what WMA
+    # does as opposed to what the documentation says.
+    def get_stream_and_channel_by_name(self, name: str) -> Tuple[Optional[Stream], int]:
+        """
+        Find a stream given its stream name. If there is only one channel associated with that
+        name, then return a tuple of the the name and channel.
+        """
+        # When there are duplicates, WMA seems to find largest, the most-recent? stream
+        # first. We will mimic this behavior using reversed().
+        for i in reversed(self.STREAMS):
+            if self.STREAMS[i].name == name:
+                return self.STREAMS[i], i
+        return None, -1
+
     def lookup_stream(self, n: int) -> Optional[Stream]:
         """
         Find and return a stream given is stream number `n`.

--- a/mathics/core/streams.py
+++ b/mathics/core/streams.py
@@ -242,7 +242,7 @@ class StreamsManager:
                 return self.STREAMS[i]
         return None
 
-    # Note: WMA specify that lookup by "name" should be unique, but it appears it
+    # Note: WMA documentationspecifies that lookup by "name" should be unique, but it appears it
     # as of 13.2.0 name does not have to be unique. We'll follow what WMA
     # does as opposed to what the documentation says.
     def get_stream_and_channel_by_name(self, name: str) -> Tuple[Optional[Stream], int]:


### PR DESCRIPTION
Also, move code to class to eval_Close under `mathics.eval`

We mimic WMA behavior which is slightly different from what the docs say it should do when closing duplicate open streams by name.