### PR TITLE
Improve get_ownvalue. Narrower type annotations.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,7 +62,7 @@ API incompatibility
 
 * ``Matcher`` now requires an additional ``evaluation`` parameter
 * ``Romberg`` removed as an ``NIntegrate[]`` method. It is depcrecated in SciPy and is to be removed by SciPy 1.15.
-
+* `Definitions.get_ownvalue` now returns a `BaseElement` instead of a `BaseRule` object.
 
 Bugs
 ----

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -516,9 +516,7 @@ class MakeBoxes(Builtin):
                 encoding_rule = evaluation.definitions.get_ownvalue(
                     "$CharacterEncoding"
                 )
-                encoding = (
-                    "UTF8" if encoding_rule is None else encoding_rule.replace.value
-                )
+                encoding = "UTF8" if encoding_rule is None else encoding_rule.value
                 op_str = (
                     operator.value
                     if isinstance(operator, String)

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -262,7 +262,7 @@ class Builtin:
                 # Otherwise it'll be created in Global` when it's
                 # used, so it won't work.
                 if option not in definitions.builtin:
-                    definitions.builtin[option] = Definition(name=name)
+                    definitions.builtin[option] = Definition(name=option)
 
         # Check if the given options are actually supported by the
         # Builtin.  If not, we might issue an "optx" error and

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -416,7 +416,7 @@ class BaseElement(KeyComparable, ABC):
     def is_inexact(self) -> bool:
         return self.get_precision() is not None
 
-    def sameQ(self, rhs: "BaseElement") -> bool:
+    def sameQ(self, rhs) -> bool:
         """Mathics SameQ"""
         return id(self) == id(rhs)
 

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -16,7 +16,17 @@ https://reference.wolfram.com/language/tutorial/PatternsAndTransformationRules.h
 
 from abc import ABC
 from itertools import chain
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 from mathics.core.atoms import Integer
 from mathics.core.attributes import A_FLAT, A_ONE_IDENTITY, A_ORDERLESS
@@ -314,11 +324,19 @@ class BasePattern(ABC):
         """Return the number of candidates that match with the pattern."""
         return len(self.get_match_candidates(elements, pattern_context))
 
+    @overload
+    def sameQ(self, other: "BasePattern") -> bool:
+        ...
+
+    @overload
     def sameQ(self, other: BaseElement) -> bool:
+        ...
+
+    def sameQ(self, other) -> bool:
         """Mathics SameQ"""
-        if not isinstance(other, BasePattern):
-            return False
-        return self.expr.sameQ(other.expr)
+        if isinstance(other, BasePattern):
+            return self.expr.sameQ(other.expr)
+        return self.expr.sameQ(other)
 
 
 class AtomPattern(BasePattern):

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -197,6 +197,9 @@ class BaseRule(KeyComparable, ABC):
     ):
         raise NotImplementedError
 
+    def get_replace_value(self) -> BaseElement:
+        raise ValueError
+
     def get_sort_key(self, pattern_sort=True) -> tuple:
         # FIXME: check if this makes sense:
         return tuple((self.system, self.pattern.get_sort_key(pattern_sort)))
@@ -268,6 +271,10 @@ class Rule(BaseRule):
             new = new.copy(reevaluate=True)
 
         return new
+
+    def get_replace_value(self) -> BaseElement:
+        """return the replace value"""
+        return self.replace
 
     def __repr__(self) -> str:
         return "<Rule: %s -> %s>" % (self.pattern, self.replace)

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -20,8 +20,8 @@ def online_doc_string(
 
     # First look at user definitions:
     for rulemsg in ruleusage:
-        if rulemsg.pattern.expr.elements[1].__str__() == '"usage"':
-            usagetext = rulemsg.replace.value
+        if rulemsg.pattern.expr.get_elements()[1].__str__() == '"usage"':
+            usagetext = rulemsg.get_replace_value().to_python()
 
     if not is_long_form and usagetext:
         return usagetext

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -24,7 +24,7 @@ def online_doc_string(
             # mypy complains about the plane conversion, but
             # to_python() returns a string wrapped in quotes.
             # So, let's get ride the quotes...
-            usagetext = rulemsg.get_replace_value().to_python()[1:-1]
+            usagetext = rulemsg.get_replace_value().to_python(use_quotes=False)
 
     if not is_long_form and usagetext:
         return usagetext

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -24,7 +24,7 @@ def online_doc_string(
             # mypy complains about the plane conversion, but
             # to_python() returns a string wrapped in quotes.
             # So, let's get ride the quotes...
-            usagetext = rulemsg.get_replace_value().to_python(use_quotes=False)
+            usagetext = rulemsg.get_replace_value().to_python(string_quotes=False)
 
     if not is_long_form and usagetext:
         return usagetext

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -21,7 +21,10 @@ def online_doc_string(
     # First look at user definitions:
     for rulemsg in ruleusage:
         if rulemsg.pattern.expr.get_elements()[1].__str__() == '"usage"':
-            usagetext = rulemsg.get_replace_value().to_python()
+            # mypy complains about the plane conversion, but
+            # to_python() returns a string wrapped in quotes.
+            # So, let's get ride the quotes...
+            usagetext = rulemsg.get_replace_value().to_python()[1:-1]
 
     if not is_long_form and usagetext:
         return usagetext

--- a/mathics/eval/assignments/assignment.py
+++ b/mathics/eval/assignments/assignment.py
@@ -1101,12 +1101,13 @@ def eval_assign_part(
     if is_protected(name, defs):
         evaluation.message(self.get_name(), "wrsym", symbol)
         return False
-    rule = defs.get_ownvalue(name)
-    if rule is None:
+    try:
+        rule = defs.get_ownvalue(name)
+    except ValueError:
         evaluation.message(self.get_name(), "noval", symbol)
         return False
     indices = lhs.elements[1:]
-    return eval_Part([rule.replace], indices, evaluation, rhs)
+    return eval_Part([rule], indices, evaluation, rhs)
 
 
 def eval_assign_random_state(

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -48,7 +48,7 @@ def get_srcdir():
 
 
 def show_echo(query, evaluation):
-    echovar = evaluation.definitions.get_ownvalue("System`$Echo").replace
+    echovar = evaluation.definitions.get_ownvalue("System`$Echo")
     if not isinstance(echovar, Expression) or not echovar.has_form("List", None):
         return
 


### PR DESCRIPTION
Investigating the causes of https://github.com/Mathics3/mathicsscript/issues/87#issue-2777113442 I discover that
we were not consistent in the use of `Definitions.get_ownvalue`. This PR tries to amend this. 