### PR TITLE
Improve get functions for patterns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,8 +52,14 @@ Compatibility
 Internals
 ---------
 
-Operator information has been gone over and is picked up from JSON
+* Operator information has been gone over and is picked up from JSON
 tables produced from the Mathics Scanner project.
+* Patterns in ``eval_`` and ``format_`` methods of builtin classes
+  parses patterns in docstrings of the form
+  ``Symbol: Expr`` as `Pattern[Symbol, Expr]`.
+  To specify associated format in ``format_`` methods the
+  docstring, the list of format must be wrapped in parenthesis, like
+  ``(InputForm,): Definitions[...]`` instead of just ``InputForm: Definitions[...]``.
 
 
 Performance

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -676,15 +676,15 @@ class Times(InfixOperator, SympyFunction):
         return result
 
     def format_inputform(self, items, evaluation):
-        "InputForm: Times[items__]"
+        "(InputForm,): Times[items__]"
         return self.format_times(items, evaluation, op="*")
 
     def format_standardform(self, items, evaluation):
-        "StandardForm: Times[items__]"
+        "(StandardForm,): Times[items__]"
         return self.format_times(items, evaluation, op=" ")
 
     def format_outputform(self, items, evaluation):
-        "OutputForm: Times[items__]"
+        "(OutputForm,): Times[items__]"
         return self.format_times(items, evaluation, op=" ")
 
     def eval(self, items, evaluation):

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -677,16 +677,16 @@ class StringRepeat(Builtin):
 
     summary_text = "build a string by concatenating repetitions"
 
-    def eval(self, s, n, expression, evaluation):
-        "StringRepeat[s_String, n_]"
+    def eval(self, expression, s, n, evaluation):
+        "expression: StringRepeat[s_String, n_]"
         py_n = n.value if isinstance(n, Integer) else 0
         if py_n < 1:
             evaluation.message("StringRepeat", "intp", 2, expression)
         else:
             return String(s.value * py_n)
 
-    def eval_truncated(self, s, n, m, expression, evaluation):
-        "StringRepeat[s_String, n_Integer, m_Integer]"
+    def eval_truncated(self, expression, s, n, m, evaluation):
+        "expression: StringRepeat[s_String, n_Integer, m_Integer]"
         # The above rule insures that n and m are boht Integer type
         py_n = n.value
         py_m = m.value

--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -322,7 +322,7 @@ class Definition(Builtin):
     def format_definition(
         self, symbol: Symbol, evaluation: Evaluation, grid: bool = True
     ) -> Symbol:
-        "StandardForm,TraditionalForm,OutputForm: Definition[symbol_]"
+        "(StandardForm,TraditionalForm,OutputForm,): Definition[symbol_]"
 
         lines = gather_and_format_definition_rules(symbol, evaluation)
         if lines:
@@ -339,7 +339,7 @@ class Definition(Builtin):
         return SymbolNull
 
     def format_definition_input(self, symbol: Symbol, evaluation: Evaluation) -> Symbol:
-        "InputForm: Definition[symbol_]"
+        "(InputForm,): Definition[symbol_]"
         return self.format_definition(symbol, evaluation, grid=False)
 
 
@@ -424,7 +424,7 @@ class Information(PrefixOperator):
     def format_information(
         self, symbol: Symbol, evaluation: Evaluation, options: dict, grid: bool = True
     ) -> Symbol:
-        "StandardForm,TraditionalForm,OutputForm: Information[symbol_, OptionsPattern[Information]]"
+        "(StandardForm,TraditionalForm,OutputForm,): Information[symbol_, OptionsPattern[Information]]"
         ret = SymbolNull
         lines = []
         if isinstance(symbol, String):
@@ -458,7 +458,7 @@ class Information(PrefixOperator):
     def format_information_input(
         self, symbol: Symbol, evaluation: Evaluation, options: dict
     ) -> Symbol:
-        "InputForm: Information[symbol_, OptionsPattern[Information]]"
+        "(InputForm,): Information[symbol_, OptionsPattern[Information]]"
         self.format_information(symbol, evaluation, options, grid=False)
         ret = SymbolNull
         return ret

--- a/mathics/builtin/distance/clusters.py
+++ b/mathics/builtin/distance/clusters.py
@@ -423,9 +423,9 @@ class Nearest(Builtin):
     summary_text = "the nearest element from a list"
 
     def eval(
-        self, items, pivot, limit, expression, evaluation: Evaluation, options: dict
+        self, expression, items, pivot, limit, evaluation: Evaluation, options: dict
     ):
-        "Nearest[items_, pivot_, limit_, OptionsPattern[%(name)s]]"
+        "expression: Nearest[items_, pivot_, limit_, OptionsPattern[%(name)s]]"
 
         method = self.get_option(options, "Method", evaluation)
         if not isinstance(method, String) or method.get_string_value() != "Scan":

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -674,7 +674,7 @@ class First(Builtin):
 
     # FIXME: the code and the code for Last are similar and can be DRY'd
     def eval(self, expr, evaluation: Evaluation, expression: Expression):
-        "First[expr__]"
+        "expression: First[expr__]"
 
         if isinstance(expr, Atom):
             evaluation.message("First", "normal", Integer1, expression)
@@ -947,8 +947,8 @@ class Last(Builtin):
     summary_text = "last element of a list or expression"
 
     # FIXME: the code and the code for First are similar and can be DRY'd
-    def eval(self, expr, evaluation: Evaluation, expression: Expression):
-        "Last[expr__]"
+    def eval(self, expression: Expression, expr, evaluation: Evaluation):
+        "expression: Last[expr__]"
 
         if isinstance(expr, Atom):
             evaluation.message("Last", "normal", Integer1, expression)
@@ -1030,8 +1030,8 @@ class Most(Builtin):
 
     summary_text = "remove the last element"
 
-    def eval(self, expr, evaluation: Evaluation, expression: Expression):
-        "Most[expr_]"
+    def eval(self, expression: Expression, expr, evaluation: Evaluation):
+        "expression: Most[expr_]"
 
         if isinstance(expr, Atom):
             evaluation.message("Most", "normal", Integer1, expression)
@@ -1526,7 +1526,7 @@ class Rest(Builtin):
     summary_text = "remove the first element"
 
     def eval(self, expr, evaluation: Evaluation, expression: Expression):
-        "Rest[expr_]"
+        "expression: Rest[expr_]"
 
         if isinstance(expr, Atom):
             evaluation.message("Rest", "normal", Integer1, expression)

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -930,8 +930,8 @@ class StringTrim(Builtin):
         "StringTrim[s_String]"
         return String(s.get_string_value().strip(" \t\n"))
 
-    def eval_pattern(self, s, patt, expression, evaluation):
-        "StringTrim[s_String, patt_]"
+    def eval_pattern(self, expression, s, patt, evaluation):
+        "expression: StringTrim[s_String, patt_]"
         text = s.get_string_value()
         if not text:
             return s

--- a/mathics/builtin/trace.py
+++ b/mathics/builtin/trace.py
@@ -42,8 +42,6 @@ def traced_apply_function(
         if not self.check_options(options, evaluation):
             return None
     vars_noctx = dict(((strip_context(s), vars[s]) for s in vars))
-    if self.pass_expression:
-        vars_noctx["expression"] = expression
     builtin_name = self.function.__qualname__.split(".")[0]
     stat = TraceBuiltins.function_stats[builtin_name]
     t_start = time()

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -468,7 +468,7 @@ class Builtin:
                 if pattern is None:  # Fixes PyPy bug
                     continue
                 else:
-                    m = re.match(r"([\w,]+)\:\s*(.*)", pattern)
+                    m = re.match(r"[(]([\w,]+),[)]\:\s*(.*)", pattern)
                 if m is not None:
                     attrs = m.group(1).split(",")
                     pattern = m.group(2)

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -339,7 +339,6 @@ class FunctionApplyRule(BaseRule):
         self.name = name
         self.function = function
         self.check_options = check_options
-        self.pass_expression = "expression" in function_arguments(function)
 
     # If you update this, you must also update traced_apply_function
     # (that's in the same file TraceBuiltins is)
@@ -353,8 +352,6 @@ class FunctionApplyRule(BaseRule):
         # argument names corresponding to the symbol names without
         # context marks.
         vars_noctx = dict(((strip_context(s), vars[s]) for s in vars))
-        if self.pass_expression:
-            vars_noctx["expression"] = expression
         if options:
             return self.function(evaluation=evaluation, options=options, **vars_noctx)
         else:


### PR DESCRIPTION
This is one tiny change I wanted to implement for a while. Im WMA, if you want to implement a rule that returns the same expression if certain test fails, the way to do it is
```
expression: Half[expr]:=If[NumberQ[expr], expr/2, expression]
```
i.e. use a `Pattern[patname, pat]` expression to pass the whole original unevaluated expression (`Half[a]` in the example) to the replace expression. However, we could not do this in the patterns especified in docstrings, because we "overloaded" the meaning of `patname: pattern` in the function that loads `eval_*` and `format_*` methods: we use them to indicate in the case of `format_` methods to which `Format` corresponds the rule. 
As in some methods we need the full original expression, then we added a "hack" to interpret a parameter `expression` in an `eval_` function to contain the whole expression.

This PR removes the need of all this hackiness by changing the convention in `format_` methods docstrings: if you want to especify an specific Format, you can do it with a docstring of the form `(form1, form2,...,): exprpattern` which is not a valid WL expression.


We can also use this form to avoid the use of `Optional` in the `eval_` methods, so each `eval_` method could return always a `BaseExpression`. But this will come later.
  