### PR TITLE
More on Builtin.contribute and Builtin.get_functions.

### DIFF
--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -515,7 +515,12 @@ class Builtin:
         requires = getattr(self, "requires", [])
         return None if check_requires_list(requires) else UnavailableFunction(self)
 
-    def get_option_string(self, *params):
+    def get_option_string(self, *params) -> Tuple[str, BaseElement]:
+        """
+        Return a tuple of a `str` representing the option name,
+        and the proper Mathics value of the option.
+        If the value does not have a name, the name is None.
+        """
         s = self.get_option(*params)
         if isinstance(s, String):
             return s.get_string_value(), s
@@ -801,7 +806,9 @@ def check_requires_list(requires: list) -> bool:
     return True
 
 
-def get_option(options: dict, name, evaluation, pop=False, evaluate=True):
+def get_option(
+    options: dict, name, evaluation, pop=False, evaluate=True
+) -> Optional[BaseElement]:
     # we do not care whether an option X is given as System`X,
     # Global`X, or with any prefix from $ContextPath for that
     # matter. Also, the quoted string form "X" is ok. all these

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -503,7 +503,7 @@ class Builtin:
                     yield (pattern, function)
 
     @staticmethod
-    def get_option(options, name, evaluation, pop=False):
+    def get_option(options, name, evaluation, pop=False) -> Optional[BaseElement]:
         return get_option(options, name, evaluation, pop)
 
     def _get_unavailable_function(self) -> Optional[Callable]:
@@ -515,7 +515,7 @@ class Builtin:
         requires = getattr(self, "requires", [])
         return None if check_requires_list(requires) else UnavailableFunction(self)
 
-    def get_option_string(self, *params):
+    def get_option_string(self, *params) -> Tuple[Optional[str], Optional[BaseElement]]:
         """
         Return a tuple of a `str` representing the option name,
         and the proper Mathics value of the option.

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -515,7 +515,7 @@ class Builtin:
         requires = getattr(self, "requires", [])
         return None if check_requires_list(requires) else UnavailableFunction(self)
 
-    def get_option_string(self, *params) -> Tuple[str, BaseElement]:
+    def get_option_string(self, *params):
         """
         Return a tuple of a `str` representing the option name,
         and the proper Mathics value of the option.

--- a/test/core/test_builtin.py
+++ b/test/core/test_builtin.py
@@ -1,0 +1,63 @@
+"""
+Test how builtins are loaded
+"""
+
+from mathics.builtin.makeboxes import MakeBoxes
+from mathics.core.builtin import Builtin
+from mathics.core.definitions import Definitions
+
+
+def test_contribute_builtin():
+    """Test for Builtin.contribute."""
+
+    definitions = Definitions()
+    MakeBoxes.context = "System`"
+    MakeBoxes(expression=False).contribute(definitions)
+
+    class TestBuiltin(Builtin):
+        """
+        <dl>
+          <dt>'TestBuiltin'[$x$]
+          <dd>nothing
+        </dl>
+        """
+
+        messages = {
+            "nomsg": "Test message `1`.",
+        }
+
+        def eval_downvalue(self, expr, evaluation):
+            """expr: TestBuiltin[_:Symbol]"""
+            return
+
+        def eval_upvalue(self, expr, x, evaluation):
+            """expr: G[TestBuiltin[x_:Symbol]]"""
+            return
+
+        def format_parm1(self, expr, x, evaluation):
+            """(CustomForm,): expr: F[x_:Symbol]"""
+            return
+
+        def format_parm2(self, expr, x, y, evaluation):
+            """(MakeBoxes, ):expr: G[x_:Symbol,
+            y_]
+            """
+            return
+
+        def format_parmb(self, expr, x, y, evaluation):
+            """(OutputForm,): expr: G[x_:Symbol,
+            y:P|Q]
+            """
+            return
+
+    TestBuiltin(expression=False).contribute(definitions)
+    assert "System`TestBuiltin" in definitions.builtin.keys()
+    definition = definitions.get_definition("System`TestBuiltin")
+    # Check that the formats are loaded into the right places.
+    assert "System`MakeBoxes" in definition.formatvalues
+    assert "System`CustomForm" in definition.formatvalues
+    assert "System`OutputForm" in definition.formatvalues
+    # Test if the rules are loaded into the right place.
+    assert definition.upvalues
+    assert definition.downvalues
+    assert definition.messages

--- a/test/core/test_builtin.py
+++ b/test/core/test_builtin.py
@@ -5,54 +5,98 @@ Test how builtins are loaded
 from mathics.builtin.makeboxes import MakeBoxes
 from mathics.core.builtin import Builtin
 from mathics.core.definitions import Definitions
+from mathics.core.element import BaseElement
+from mathics.core.evaluation import Evaluation
+from mathics.core.load_builtin import import_and_load_builtins
+from mathics.core.symbols import SymbolTrue
+
+
+class TrialBuiltin(Builtin):
+    """
+    <dl>
+      <dt>'TrialBuiltin'[$x$]
+      <dd>nothing
+    </dl>
+    """
+
+    options = {
+        "FakeOption": "True",
+    }
+    messages = {
+        "nomsg": "Test message `1`.",
+    }
+
+    def eval_downvalue(self, expr, evaluation):
+        """expr: TrialBuiltin[_:Symbol]"""
+        return
+
+    def eval_upvalue(self, expr, x, evaluation):
+        """expr: G[TrialBuiltin[x_:Symbol]]"""
+        return
+
+    def format_parm1(self, expr, x, evaluation):
+        """(CustomForm,): expr: TrialBuiltin[x_:Symbol]"""
+        return
+
+    def format_parm2(self, expr, x, y, evaluation):
+        """(MakeBoxes, ):expr: TrialBuiltin[x_:Symbol,
+        y_]
+        """
+        return
+
+    def format_parmb(self, expr, x, y, evaluation):
+        """(OutputForm,): expr: TrialBuiltin[x_:Symbol,
+        y:P|Q]
+        """
+        return
+
+
+# This happens before any call to import_and_load_builtins
+DEFINITIONS = Definitions()
+EVALUATION = Evaluation(DEFINITIONS)
+MakeBoxes(expression=False).contribute(DEFINITIONS)
+TrialBuiltin(expression=False).contribute(DEFINITIONS)
+
+
+def test_other_attributes_builtin():
+    import_and_load_builtins()
+    definitions = Definitions(add_builtin=True)
+    definition = definitions.builtin["System`Plus"]
+
+    builtin = definition.builtin
+    assert builtin.context == "System`"
+    assert builtin.get_name() == "System`Plus"
+    assert builtin.get_name(short=True) == "Plus"
+
+
+def test_builtin_get_functions():
+    definitions = DEFINITIONS
+    MakeBoxes.context = "System`"
+    MakeBoxes(expression=False).contribute(definitions)
+    builtin = definitions.builtin["System`TrialBuiltin"].builtin
+    evalrules = list(builtin.get_functions("eval"))
+    for r in evalrules:
+        assert isinstance(r, tuple) and len(r) == 2
+        assert isinstance(r[0], BaseElement)
+
+    evalrules = list(builtin.get_functions("format_"))
+    for r in evalrules:
+        assert isinstance(r, tuple) and len(r) == 2
+        assert isinstance(r[0], tuple)
+        assert isinstance(r[0][0], list)
+        assert isinstance(r[0][1], BaseElement)
 
 
 def test_contribute_builtin():
     """Test for Builtin.contribute."""
 
     definitions = Definitions()
-    MakeBoxes.context = "System`"
+    evaluation = Evaluation(definitions)
     MakeBoxes(expression=False).contribute(definitions)
 
-    class TestBuiltin(Builtin):
-        """
-        <dl>
-          <dt>'TestBuiltin'[$x$]
-          <dd>nothing
-        </dl>
-        """
-
-        messages = {
-            "nomsg": "Test message `1`.",
-        }
-
-        def eval_downvalue(self, expr, evaluation):
-            """expr: TestBuiltin[_:Symbol]"""
-            return
-
-        def eval_upvalue(self, expr, x, evaluation):
-            """expr: G[TestBuiltin[x_:Symbol]]"""
-            return
-
-        def format_parm1(self, expr, x, evaluation):
-            """(CustomForm,): expr: F[x_:Symbol]"""
-            return
-
-        def format_parm2(self, expr, x, y, evaluation):
-            """(MakeBoxes, ):expr: G[x_:Symbol,
-            y_]
-            """
-            return
-
-        def format_parmb(self, expr, x, y, evaluation):
-            """(OutputForm,): expr: G[x_:Symbol,
-            y:P|Q]
-            """
-            return
-
-    TestBuiltin(expression=False).contribute(definitions)
-    assert "System`TestBuiltin" in definitions.builtin.keys()
-    definition = definitions.get_definition("System`TestBuiltin")
+    TrialBuiltin(expression=False).contribute(definitions)
+    assert "System`TrialBuiltin" in definitions.builtin.keys()
+    definition = definitions.get_definition("System`TrialBuiltin")
     # Check that the formats are loaded into the right places.
     assert "System`MakeBoxes" in definition.formatvalues
     assert "System`CustomForm" in definition.formatvalues
@@ -61,3 +105,9 @@ def test_contribute_builtin():
     assert definition.upvalues
     assert definition.downvalues
     assert definition.messages
+    assert definition.options
+    builtin = definition.builtin
+    assert builtin.get_option_string(definition.options, "FakeOption", evaluation) == (
+        "True",
+        SymbolTrue,
+    )

--- a/test/core/test_builtin.py
+++ b/test/core/test_builtin.py
@@ -26,26 +26,39 @@ class TrialBuiltin(Builtin):
         "nomsg": "Test message `1`.",
     }
 
+    # A Downvalue
     def eval_downvalue(self, expr, evaluation):
         """expr: TrialBuiltin[_:Symbol]"""
         return
 
+    # An Upvalue
     def eval_upvalue(self, expr, x, evaluation):
         """expr: G[TrialBuiltin[x_:Symbol]]"""
         return
 
+    # A format rule for a custom format
     def format_parm1(self, expr, x, evaluation):
         """(CustomForm,): expr: TrialBuiltin[x_:Symbol]"""
         return
 
+    # A MakeBoxes rule, using a name pattern,
+    # with a line break.
     def format_parm2(self, expr, x, y, evaluation):
         """(MakeBoxes, ):expr: TrialBuiltin[x_:Symbol,
         y_]
         """
         return
 
+    # A format rule for OutputForm
     def format_parmb(self, expr, x, y, evaluation):
         """(OutputForm,): expr: TrialBuiltin[x_:Symbol,
+        y:P|Q]
+        """
+        return
+
+    # A general format rule.
+    def format_parm_general(self, expr, x, y, evaluation):
+        """expr: TrialBuiltin[x_:Symbol,
         y:P|Q]
         """
         return
@@ -82,9 +95,14 @@ def test_builtin_get_functions():
     evalrules = list(builtin.get_functions("format_"))
     for r in evalrules:
         assert isinstance(r, tuple) and len(r) == 2
-        assert isinstance(r[0], tuple)
-        assert isinstance(r[0][0], list)
-        assert isinstance(r[0][1], BaseElement)
+        # For formatvalues, the pattern can be both a BaseElement
+        # or a tuple of a string with a format name and a BaseElement.
+        if isinstance(r[0], tuple):
+            assert len(r[0]) == 2
+            assert isinstance(r[0][0], list)
+            assert isinstance(r[0][1], BaseElement)
+        else:
+            assert isinstance(r[0], BaseElement)
 
 
 def test_contribute_builtin():


### PR DESCRIPTION
Some missing details that I discovered regarding these methods, and a pytest to test the right behaviour:

* Fix the regular expression used in get_function to support multiline docstrings.
* Fix how the full name of builtins are built in `contribute`  when the class does not have a `context` attribute.
* Add tests for Builtin.contribute

More tests can be added later.