### PR TITLE
mathics/settings.py: create USER_PACKAGE_DIR with its parents

### DIFF
--- a/mathics/settings.py
+++ b/mathics/settings.py
@@ -110,7 +110,7 @@ def ensure_directory(directory: str):
     """
     dir_path = Path(directory)
     if not dir_path.is_dir():
-        os.mkdir(directory)
+        os.makedirs(directory)
 
 
 def get_doctest_latex_data_path(should_be_readable=False, create_parent=False) -> str:


### PR DESCRIPTION
On my workstation $HOME/.local/var did not exist, and mathics failed with this error:

FileNotFoundError: [Errno 2] No such file or directory: '/home/thierry/.local/var/Mathics3/'

This simple one-liner create USER_PACKAGE_DIR if necessary.