### PR TITLE
Reinforce in get_functions that eval/format methods are indeed callable

### DIFF
--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -468,6 +468,8 @@ class Builtin:
         for name in dir(self):
             if name.startswith(prefix):
                 function = getattr(self, name)
+                if not hasattr(function, "__call__"):
+                    continue
                 pattern = function.__doc__
                 if pattern is None:  # Fixes PyPy bug
                     continue


### PR DESCRIPTION
`Builtin.get_functions` collects attributes of the subclasses with names starting with a prefix, and assumes that are methods. Until now, the way to check that are indeed methods was to check if they have a docstring. This is not completely correct (because what we want to check is if the method is callable) and since Python 3.13 it breaks the mechanism.
This PR implements the right check.