### PR TITLE
improve LaTeX processing. Fix inconsistencies in the docstring format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: check-merge-conflict
     - id: debug-statements
       stages: [pre-commit]
-      exclude: ChangeLog-spell-corrected.diff
+      exclude: ChangeLog-spell-corrected.diff|mathics/builtin/system.py
     - id: end-of-file-fixer
       stages: [pre-commit]
       exclude: ChangeLog-spell-corrected.diff

--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -269,10 +269,10 @@ class CharacterEncoding(Predefined):
     https://reference.wolfram.com/language/ref/$CharacterEncoding.html</url>
 
     <dl>
-      <dt>'$CharacterEncoding'
+      <dt>'\\$CharacterEncoding'
       <dd>specifies the default raw character encoding to use for input and \
       output when no encoding is explicitly specified. \
-      Initially this is set to '$SystemCharacterEncoding'.
+      Initially this is set to '\\$SystemCharacterEncoding'.
     </dl>
 
     See the character encoding current is in effect and used in input and \
@@ -281,7 +281,7 @@ class CharacterEncoding(Predefined):
     >> $CharacterEncoding
      = ...
 
-    By setting its value to one of the values in '$CharacterEncodings', \
+    By setting its value to one of the values in '\\$CharacterEncodings', \
     operators are formatted differently. For example,
 
     >> $CharacterEncoding = "ASCII"; a -> b
@@ -290,13 +290,13 @@ class CharacterEncoding(Predefined):
      = ...
 
     Setting its value to 'None' restore the value to \
-    '$SystemCharacterEncoding':
+    '\\$SystemCharacterEncoding':
     >> $CharacterEncoding = None;
     >> $SystemCharacterEncoding == $CharacterEncoding
      = True
 
     See also <url>
-    :$SystemCharacterEncoding:
+    :\\$SystemCharacterEncoding:
     /doc/reference-of-built-in-symbols/atomic-elements-of-expressions/string-manipulation/$systemcharacterencoding/</url>.
     """
 
@@ -329,7 +329,7 @@ class CharacterEncodings(Predefined):
     https://reference.wolfram.com/language/ref/$CharacterEncodings.html</url>
 
     <dl>
-      <dt>'$CharacterEncodings'
+      <dt>'\\$CharacterEncodings'
       <dd>stores the list of available character encodings.
     </dl>
 
@@ -430,6 +430,7 @@ class LetterNumber(Builtin):
      = 2
 
     """
+
     # FIXME: put the right unicode characters in a way that the
     # following test works...
     r"""
@@ -706,9 +707,9 @@ class SystemCharacterEncoding(Predefined):
     """
     <url>
     :WMA link:
-    https://reference.wolfram.com/language/ref/$SystemCharacterEncoding.html</url>
+    https://reference.wolfram.com/language/ref/\\$SystemCharacterEncoding.html</url>
     <dl>
-      <dt>$SystemCharacterEncoding
+      <dt>\\$SystemCharacterEncoding
       <dd>gives the default character encoding of the system.
 
       On startup, the value of environment variable 'MATHICS_CHARACTER_ENCODING' \
@@ -899,7 +900,7 @@ class ToString(Builtin):
 
 
 class Transliterate(Builtin):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/Transliterate.html</url>
@@ -955,4 +956,5 @@ class Whitespace(Builtin):
     >> StringReplace[" this has leading and trailing whitespace \n ", (StartOfString ~~ Whitespace) | (Whitespace ~~ EndOfString) -> ""] <> " removed" // FullForm
      = "this has leading and trailing whitespace removed"
     """
+
     summary_text = "sequence of whitespace characters"

--- a/mathics/builtin/drawing/drawing_options.py
+++ b/mathics/builtin/drawing/drawing_options.py
@@ -318,7 +318,7 @@ class PlotRange(Builtin):
       <li>$max$ - explicit limit for each function.
       <li>{$min$, $max$} - explicit limits for $y$ (2D), $z$ (3D), \
           or array values.
-      <li>{{$x$_$min$, $x$_$max$}, {{$y_min}, {$y_max}} - explicit limits for \
+      <li>{{$x_{min}$, $x_{max}$}, {{$y_{min}$}, {$y_{max}$}} - explicit limits for \
           $x$ and $y$.
     </ul>
 

--- a/mathics/builtin/drawing/graphics3d.py
+++ b/mathics/builtin/drawing/graphics3d.py
@@ -66,7 +66,7 @@ class Graphics3D(Graphics):
         <url>:WMA link:https://reference.wolfram.com/language/ref/Graphics3D.html</url>
 
         <dl>
-          <dt>'Graphics3D[$primitives$, $options$]'
+          <dt>'Graphics3D'[$primitives$, $options$]
           <dd>represents a three-dimensional graphic.
 
           See <url>:Drawing Option and Option Values:
@@ -170,11 +170,11 @@ class Sphere(Builtin):
     <url>:WMA link:https://reference.wolfram.com/language/ref/Sphere.html</url>
 
     <dl>
-    <dt>'Sphere[{$x$, $y$, $z$}]'
+    <dt>'Sphere'[{$x$, $y$, $z$}]
         <dd>is a sphere of radius 1 centered at the point {$x$, $y$, $z$}.
-    <dt>'Sphere[{$x$, $y$, $z$}, $r$]'
+    <dt>'Sphere'[{$x$, $y$, $z$}, $r$]
         <dd>is a sphere of radius $r$ centered at the point {$x$, $y$, $z$}.
-    <dt>'Sphere[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}, ... }, $r$]'
+    <dt>'Sphere'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}, ... }, $r$]
         <dd>is a collection spheres of radius $r$ centered at the points \
             {$x1$, $y2$, $z2$}, {$x2$, $y2$, $z2$}, ...
     </dl>
@@ -198,14 +198,14 @@ class Cone(Builtin):
     <url>:WMA link:https://reference.wolfram.com/language/ref/Cone.html</url>
 
     <dl>
-      <dt>'Cone[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}]'
+      <dt>'Cone'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}]
       <dd>represents a cone of radius 1.
 
-      <dt>'Cone[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}, $r$]'
+      <dt>'Cone'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}, $r$]
       <dd>is a cone of radius $r$ starting at ($x1$, $y1$, $z1$) and ending at \
           ($x2$, $y2$, $z2$).
 
-      <dt>'Cone[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}, ... }, $r$]'
+      <dt>'Cone'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}, ... }, $r$]
       <dd>is a collection cones of radius $r$.
     </dl>
 
@@ -247,16 +247,16 @@ class Cuboid(Builtin):
 
     Cuboid also known as interval, rectangle, square, cube, rectangular parallelepiped, tesseract, orthotope, and box.
     <dl>
-      <dt>'Cuboid[$p_min$]'
+      <dt>'Cuboid'[$p_{min}$]
       <dd>is a unit cube/square with its lower corner at point $p_min$.
 
-      <dt>'Cuboid[$p_min$, $p_max$]
-      <dd>is a 2d square with with lower corner $p_min$ and upper corner $p_max$.
+      <dt>'Cuboid'[$p_{min}$, $p_{max}$]
+      <dd>is a 2d square with with lower corner $p_{min}$ and upper corner $p_{max}$.
 
-      <dt>'Cuboid[{$p_min$, $p_max$}]'
+      <dt>'Cuboid'[{$p_{min}$, $p_{max}$}]
       <dd>is a cuboid with lower corner $p_min$ and upper corner $p_max$.
 
-      <dt>'Cuboid[{$p1_min$, $p1_max$, ...}]'
+      <dt>'Cuboid'[{$p1_{min}$, $p1_{max}$, ...}]
       <dd>is a collection of cuboids.
 
       <dt>'Cuboid[]' is equivalent to 'Cuboid[{0,0,0}]'.
@@ -300,14 +300,14 @@ class Cylinder(Builtin):
     <url>:WMA link:https://reference.wolfram.com/language/ref/Cylinder.html</url>
 
     <dl>
-      <dt>'Cylinder[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}]'
+      <dt>'Cylinder'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}]
       <dd>represents a cylinder of radius 1.
 
-      <dt>'Cylinder[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}, $r$]'
+      <dt>'Cylinder'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}}, $r$]
       <dd>is a cylinder of radius $r$ starting at ($x1$, $y1$, $z1$) and ending at \
           ($x2$, $y2$, $z2$).
 
-      <dt>'Cylinder[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}, ... }, $r$]'
+      <dt>'Cylinder'[{{$x1$, $y1$, $z1$}, {$x2$, $y2$, $z2$}, ... }, $r$]
       <dd>is a collection cylinders of radius $r$.
     </dl>
 
@@ -348,10 +348,10 @@ class Tube(Builtin):
     <url>:WMA link:https://reference.wolfram.com/language/ref/Tube.html</url>
 
     <dl>
-      <dt>'Tube[{$p1$, $p2$, ...}]'
+      <dt>'Tube'[{$p1$, $p2$, ...}]
       <dd>represents a tube passing through $p1$, $p2$, ... with radius 1.
 
-      <dt>'Tube[{$p1$, $p2$, ...}, $r$]'
+      <dt>'Tube'[{$p1$, $p2$, ...}, $r$]
       <dd>represents a tube with radius $r$.
     </dl>
 

--- a/mathics/builtin/evaluation.py
+++ b/mathics/builtin/evaluation.py
@@ -14,18 +14,18 @@ from mathics.core.evaluation import MAX_RECURSION_DEPTH, set_python_recursion_li
 
 
 class RecursionLimit(Predefined):
-    """
+    r"""
     <url>
     :WMA link:
-    https://reference.wolfram.com/language/ref/$RecursionLimit.html</url>
+    https://reference.wolfram.com/language/ref/\$RecursionLimit.html</url>
 
     <dl>
-      <dt>'$RecursionLimit'
+      <dt>'\$RecursionLimit'
       <dd>specifies the maximum allowable recursion depth after which a \
           calculation is terminated.
     </dl>
 
-    Calculations terminated by '$RecursionLimit' return '$Aborted':
+    Calculations terminated by '\$RecursionLimit' return '\$Aborted':
     >> a = a + a
      : Recursion depth of 200 exceeded.
      = $Aborted
@@ -71,17 +71,17 @@ class RecursionLimit(Predefined):
 
 
 class IterationLimit(Predefined):
-    """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/$IterationLimit.html</url>
+    r"""
+    <url>:WMA link:https://reference.wolfram.com/language/ref/\$IterationLimit.html</url>
 
     <dl>
-        <dt>'$IterationLimit'
+        <dt>'\$IterationLimit'
 
         <dd>specifies the maximum number of times a reevaluation of an expression may happen.
 
     </dl>
 
-    Calculations terminated by '$IterationLimit' return '$Aborted':
+    Calculations terminated by '\$IterationLimit' return '\$Aborted':
 
     >> $IterationLimit
      = 1000

--- a/mathics/builtin/exp_structure/general.py
+++ b/mathics/builtin/exp_structure/general.py
@@ -235,11 +235,11 @@ class SortBy(Builtin):
       <dt>'SortBy[$list$, $f$]'
       <dd>sorts $list$ (or the elements of any other expression) according to \
          canonical ordering of the keys that are extracted from the $list$'s \
-         elements using $f. Chunks of elements that appear the same under $f \
-         are sorted according to their natural order (without applying $f).
+         elements using $f$. Chunks of elements that appear the same under $f$ \
+         are sorted according to their natural order (without applying $f$).
 
       <dt>'SortBy[$f$]'
-      <dd>creates an operator function that, when applied, sorts by $f.
+      <dd>creates an operator function that, when applied, sorts by $f$.
     </dl>
 
     >> SortBy[{{5, 1}, {10, -1}}, Last]

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -52,11 +52,11 @@ from mathics.eval.makeboxes import do_format, format_element
 
 
 class Input_(Predefined):
-    """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/$Input.html</url>
+    r"""
+    <url>:WMA link:https://reference.wolfram.com/language/ref/\$Input.html</url>
 
     <dl>
-      <dt>'$Input'
+      <dt>'\$Input'
       <dd>is the name of the stream from which input is currently being read.
     </dl>
 
@@ -364,7 +364,7 @@ class Get(PrefixOperator):
       <dt>'Get[$name$, Trace->True]'
       <dd>Runs Get tracing each line before it is evaluated.
 
-     'Settings`$TraceGet' can be also used to trace lines on all 'Get[]' calls.
+     'Settings`\$TraceGet' can be also used to trace lines on all 'Get[]' calls.
     </dl>
 
 
@@ -409,17 +409,17 @@ class Get(PrefixOperator):
 
 
 class InputFileName_(Predefined):
-    """
+    r"""
     <url>
     :WMA link:
-    https://reference.wolfram.com/language/ref/$InputFileName.html</url>
+    https://reference.wolfram.com/language/ref/\$InputFileName.html</url>
 
     <dl>
-      <dt>'$InputFileName'
+      <dt>'\$InputFileName'
       <dd>is the name of the file from which input is currently being read.
     </dl>
 
-    While in interactive mode, '$InputFileName' is "".
+    While in interactive mode, '\$InputFileName' is "".
     X> $InputFileName
     """
 
@@ -1126,7 +1126,7 @@ class ReadList(Read):
         py_n = n.get_int_value()
         if py_n < 0:
             evaluation.message(
-                "ReadList", "intnm", to_expression("ReadList", file, types, m)
+                "ReadList", "intnm", to_expression("ReadList", file, types, n)
             )
             return
 

--- a/mathics/builtin/forms/__init__.py
+++ b/mathics/builtin/forms/__init__.py
@@ -1,11 +1,11 @@
-"""
+r"""
 Forms of Input and Output
 
 A <i>Form</i> format specifies the way Mathics Expression input is read or output \
 written.
 
-The variable <url>:$OutputForms':
-/doc/reference-of-built-in-symbols/forms-of-input-and-output/form-variables/$outputforms/</url> \
+The variable <url>:\$OutputForms':
+/doc/reference-of-built-in-symbols/forms-of-input-and-output/form-variables/\$outputforms/</url> \
 has a list of Forms defined.
 
 See also <url>:WMA link:

--- a/mathics/builtin/forms/other.py
+++ b/mathics/builtin/forms/other.py
@@ -1,5 +1,5 @@
-"""
-Forms which are not in '$OutputForms'
+r"""
+Forms which are not in '\$OutputForms'
 """
 
 import re
@@ -13,7 +13,7 @@ from mathics.eval.strings import eval_ToString
 
 
 class SequenceForm(FormBaseClass):
-    """
+    r"""
     <url>
       :WMA link:
       https://reference.wolfram.com/language/ref/SequenceForm.html</url>
@@ -56,7 +56,7 @@ class SequenceForm(FormBaseClass):
 
 
 class StringForm(FormBaseClass):
-    """
+    r"""
     <url>
       :WMA link:
       https://reference.wolfram.com/language/ref/StringForm.html</url>

--- a/mathics/builtin/forms/variables.py
+++ b/mathics/builtin/forms/variables.py
@@ -11,21 +11,21 @@ from mathics.core.list import ListExpression
 class PrintForms_(Predefined):
     r"""
     <dl>
-      <dt>'$PrintForms'
+      <dt>'\$PrintForms'
       <dd>contains the list of basic print forms. It is updated automatically when new 'PrintForms' are defined by setting format values.
     </dl>
 
     >> $PrintForms
      = ...
 
-    Suppose now that we want to add a new format 'MyForm'. Initially, it does not belong to '$PrintForms':
+    Suppose now that we want to add a new format 'MyForm'. Initially, it does not belong to '\$PrintForms':
     >> MemberQ[$PrintForms, MyForm]
      = False
 
     Now, let's define a format rule:
     >> Format[F[x_], MyForm] := "F<<" <> ToString[x] <> ">>"
 
-    Now, the new format belongs to the '$PrintForms' list
+    Now, the new format belongs to the '\$PrintForms' list
     >> MemberQ[$PrintForms, MyForm]
      = True
 
@@ -42,7 +42,7 @@ class PrintForms_(Predefined):
 class OutputForms_(Predefined):
     r"""
     <dl>
-      <dt>'$OutputForms'
+      <dt>'\$OutputForms'
       <dd>contains the list of all output forms. It is updated automatically when new 'OutputForms' are defined by setting format values.
     </dl>
 

--- a/mathics/builtin/graphics.py
+++ b/mathics/builtin/graphics.py
@@ -1393,7 +1393,7 @@ class Inset(Builtin):
       <dt>'Text[$obj$, $pos$]'
       <dd>represents an object $obj$ inset in a graphic at position $pos$.
 
-      <dt>'Text[$obj$, $pos$, $$]'
+      <dt>'Text[$obj$, $pos$, $opos$]'
       <dd>represents an object $obj$ inset in a graphic at position $pos$, \
           in away that the position $opos$ of $obj$ coincides with $pos$ \
           in the enclosing graphic.

--- a/mathics/builtin/kernel_sessions.py
+++ b/mathics/builtin/kernel_sessions.py
@@ -8,8 +8,8 @@ from mathics.core.evaluation import Evaluation
 
 
 class Out(Builtin):
-    """
-    <url>:WMA: https://reference.wolfram.com/language/ref/$Out</url>
+    r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/\$Out</url>
     <dl>
       <dt>'%$k$' or 'Out[$k$]'
       <dd>gives the result of the $k$th input line.

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -424,7 +424,7 @@ class DeleteCases(Builtin):
       <dd>returns the elements of $list$ that do not match $pattern$.
 
       <dt>'DeleteCases[$list$, $pattern$, $levelspec$]'
-      <dd> removes all parts of $list on levels specified by $levelspec$ that match pattern (not fully implemented).
+      <dd> removes all parts of $list$ on levels specified by $levelspec$ that match pattern (not fully implemented).
 
       <dt>'DeleteCases[$list$, $pattern$, $levelspec$, $n$]'
       <dd> removes the first $n$ parts of $list$ that match $pattern$.

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -792,7 +792,7 @@ class GatherBy(_GatherOperation):
       <dt>'GatherBy[$list$, {$f$, $g$, ...}]'
       <dd>gathers elements of $list$ into sub lists of items whose image \
       under $f$ identical. Then, gathers these sub lists again into sub \
-      sub lists, that are identical under $g.
+      sub lists, that are identical under $g$.
     </dl>
 
     >> GatherBy[{{1, 3}, {2, 2}, {1, 1}}, Total]
@@ -891,7 +891,7 @@ class PadLeft(_Pad):
       <dd>pads $list$ to length $n$ by adding 0 on the left.
       <dt>'PadLeft[$list$, $n$, $x$]'
       <dd>pads $list$ to length $n$ by adding $x$ on the left.
-      <dt>'PadLeft[$list$, {$n1$, $n2, ...}, $x$]'
+      <dt>'PadLeft[$list$, {$n1$, $n2$, ...}, $x$]'
       <dd>pads $list$ to lengths $n1$, $n2$ at levels 1, 2, ... respectively by adding $x$ on the left.
       <dt>'PadLeft[$list$, $n$, $x$, $m$]'
       <dd>pads $list$ to length $n$ by adding $x$ on the left and adding a margin of $m$ on the right.
@@ -929,7 +929,7 @@ class PadRight(_Pad):
       <dd>pads $list$ to length $n$ by adding 0 on the right.
       <dt>'PadRight[$list$, $n$, $x$]'
       <dd>pads $list$ to length $n$ by adding $x$ on the right.
-      <dt>'PadRight[$list$, {$n1$, $n2, ...}, $x$]'
+      <dt>'PadRight[$list$, {$n1$, $n2$, ...}, $x$]'
       <dd>pads $list$ to lengths $n1$, $n2$ at levels 1, 2, ... respectively by adding $x$ on the right.
       <dt>'PadRight[$list$, $n$, $x$, $m$]'
       <dd>pads $list$ to length $n$ by adding $x$ on the left and adding a margin of $m$ on the left.
@@ -1360,7 +1360,7 @@ class Tally(_GatherOperation):
           the result as a list of pairs {object, count}.
 
       <dt>'Tally[$list$, $test$]'
-      <dd>counts the number of occurrences of objects and uses $test to \
+      <dd>counts the number of occurrences of objects and uses $test$ to \
           determine if two objects should be counted in the same bin.
     </dl>
 

--- a/mathics/builtin/mainloop.py
+++ b/mathics/builtin/mainloop.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+r"""
 The Main Loop
 
 An interactive session operates a loop, called the "main loop" in this way:
@@ -16,10 +16,10 @@ As part of this loop, various global objects in this section are consulted.
 There are a variety of "hooks" that allow you to insert functions to be applied to the expressions at various stages \
 in the main loop.
 
-If you assign a function to the global variable '$PreRead' it will be applied with the input that is read in the first \
+If you assign a function to the global variable '\$PreRead' it will be applied with the input that is read in the first \
 step listed above.
 
-Similarly, if you assign a function to global variable '$Pre', it will be applied with the input before processing the \
+Similarly, if you assign a function to global variable '\$Pre', it will be applied with the input before processing the \
 input, the second step listed above.
 """
 
@@ -31,10 +31,10 @@ sort_order = "mathics.builtin.the-main-loop"
 
 
 class HistoryLength(Builtin):
-    """
+    r"""
     <url>:WMA: https://reference.wolfram.com/language/ref/$HistoryLength</url>
     <dl>
-      <dt>'$HistoryLength'
+      <dt>'\$HistoryLength'
       <dd>specifies the maximum number of 'In' and 'Out' entries.
     </dl>
 
@@ -104,10 +104,10 @@ class In(Builtin):
 
 
 class IOHookPreRead(Builtin):
-    """
-    <url>:WMA: https://reference.wolfram.com/language/ref/$PreRead</url>
+    r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/\$PreRead</url>
     <dl>
-      <dt>$PreRead
+      <dt>\$PreRead
       <dd> is a global variable whose value, if set, is applied to the \
       text or box form of every input expression before it is fed to the parser.
 
@@ -123,15 +123,15 @@ class IOHookPreRead(Builtin):
 
 
 class IOHookPre(Builtin):
-    """
-    <url>:WMA: https://reference.wolfram.com/language/ref/$Pre</url>
+    r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/\$Pre</url>
     <dl>
-      <dt>$Pre
+      <dt>'\$Pre'
       <dd>is a global variable whose value, if set, is applied to every input expression.
     </dl>
 
-    Set $Timing$ as the $Pre function, stores the elapsed time in a variable,
-    stores just the result in Out[$Line] and print a formatted version showing the elapsed time
+    Set 'Timing' as the '\$Pre' function, stores the elapsed time in a variable,
+    stores just the result in 'Out[\$Line]' and print a formatted version showing the elapsed time
     >> $Pre := (Print["[Processing input...]"];#1)&
     >> $Post := (Print["[Storing result...]"]; #1)&
      | [Processing input...]
@@ -156,10 +156,10 @@ class IOHookPre(Builtin):
 
 
 class IOHookPost(Builtin):
-    """
-    <url>:WMA: https://reference.wolfram.com/language/ref/$Post</url>
+    r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/\$Post</url>
     <dl>
-      <dt>$Post
+      <dt>'\$Post'
       <dd>is a global variable whose value, if set, is applied to every output expression.
     </dl>
     """
@@ -170,10 +170,10 @@ class IOHookPost(Builtin):
 
 
 class IOHookPrePrint(Builtin):
-    """
-    <url>:WMA: https://reference.wolfram.com/language/ref/$PrePrint</url>
+    r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/\$PrePrint</url>
     <dl>
-      <dt>$PrePrint
+      <dt>'\$PrePrint'
       <dd>is a global variable whose value, if set, is applied to every output expression before it is printed.
     </dl>
     """
@@ -186,10 +186,10 @@ class IOHookPrePrint(Builtin):
 
 
 class IOHookSyntaxHandler(Builtin):
-    """
-    <url>:WMA: https://reference.wolfram.com/language/ref/$SyntaxHandler</url>
+    r"""
+    <url>:WMA: https://reference.wolfram.com/language/ref/\$SyntaxHandler</url>
     <dl>
-      <dt>$SyntaxHandler
+      <dt>'\$SyntaxHandler'
       <dd>is a global variable whose value, if set, is applied to any input string that is found to contain a syntax \
           error.
 
@@ -203,10 +203,10 @@ class IOHookSyntaxHandler(Builtin):
 
 
 class Line(Builtin):
-    """
+    r"""
     <url>:WMA: https://reference.wolfram.com/language/ref/$Line</url>
     <dl>
-      <dt>'$Line'
+      <dt>'\$Line'
       <dd>holds the current input line number.
     </dl>
 

--- a/mathics/builtin/makeboxes.py
+++ b/mathics/builtin/makeboxes.py
@@ -22,12 +22,12 @@ from mathics.eval.makeboxes import (
 
 
 class BoxForms_(Predefined):
-    """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/$BoxForms.html</url>
+    r"""
+    <url>:WMA link:https://reference.wolfram.com/language/ref/\$BoxForms.html</url>
 
     <dl>
-      <dt>
-      <dd>$BoxForms is the list of box formats.
+      <dt>'\$BoxForms'
+      <dd>contains the list of box formats.
     </dl>
 
     >> $BoxForms

--- a/mathics/builtin/matrices/constrmatrix.py
+++ b/mathics/builtin/matrices/constrmatrix.py
@@ -24,7 +24,7 @@ class BoxMatrix(Builtin):
     https://reference.wolfram.com/language/ref/BoxMatrix.html</url>
 
     <dl>
-      <dt>'BoxMatrix[$s]'
+      <dt>'BoxMatrix[$s$]'
       <dd>Gives a box shaped kernel of size 2 $s$ + 1.
     </dl>
 
@@ -90,7 +90,7 @@ class DiamondMatrix(Builtin):
     <url>:WMA link:https://reference.wolfram.com/language/ref/DiamondMatrix.html</url>
 
     <dl>
-      <dt>'DiamondMatrix[$s]'
+      <dt>'DiamondMatrix[$s$]'
       <dd>Gives a diamond shaped kernel of size 2 $s$ + 1.
     </dl>
 
@@ -127,7 +127,7 @@ class DiskMatrix(Builtin):
     <url>:WMA link:https://reference.wolfram.com/language/ref/DiskMatrix.html</url>
 
     <dl>
-      <dt>'DiskMatrix[$s]'
+      <dt>'DiskMatrix[$s$]'
       <dd>Gives a disk shaped kernel of size 2 $s$ + 1.
     </dl>
 

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -2,7 +2,6 @@
 Message-related functions.
 """
 
-
 import typing
 from typing import Any
 
@@ -17,11 +16,11 @@ from mathics.core.systemsymbols import SymbolMessageName, SymbolQuiet
 
 
 class Aborted(Predefined):
-    """
+    r"""
     <url>:WMA link:https://reference.wolfram.com/language/ref/Aborted.html</url>
 
     <dl>
-    <dt>'$Aborted'
+    <dt>'\$Aborted'
         <dd>is returned by a calculation that has been aborted.
     </dl>
     """
@@ -125,10 +124,10 @@ class Check(Builtin):
 
 
 class Failed(Predefined):
-    """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/$Failed.html</url>
+    r"""
+    <url>:WMA link:https://reference.wolfram.com/language/ref/\$Failed.html</url>
     <dl>
-    <dt>'$Failed'
+    <dt>'\$Failed'
         <dd>is returned by some functions in the event of an error.
     </dl>
     """

--- a/mathics/builtin/numbers/algebra.py
+++ b/mathics/builtin/numbers/algebra.py
@@ -1525,7 +1525,7 @@ class Simplify(Builtin):
       <dd>simplifies $expr$.
 
       <dt>'Simplify[$expr$, $assump$]'
-      <dd>simplifies $expr$ assuming $assump$ instead of $Assumptions$.
+      <dd>simplifies $expr$ assuming $assump$ instead of '\$Assumptions'.
     </dl>
 
     >> Simplify[2*Sin[x]^2 + 2*Cos[x]^2]
@@ -1535,23 +1535,23 @@ class Simplify(Builtin):
     >> Simplify[f[x]]
      = f[x]
 
-    Simplify over conditional expressions uses $\$Assumptions$, or $assump$
+    Simplify over conditional expressions uses '\$Assumptions', or $assump$
     to evaluate the condition:
     >> $Assumptions={a <= 0};
     >> Simplify[ConditionalExpression[1, a > 0]]
      = Undefined
-    The $assump$ option  override $\$Assumption$:
+    The $assump$ option  override '\$Assumption':
     >> Simplify[ConditionalExpression[1, a > 0] ConditionalExpression[1, b > 0], { b > 0 }]
      = ConditionalExpression[1, a > 0]
-    On the other hand, $Assumptions$ option does not override $\$Assumption$, but add to them:
+    On the other hand, 'Assumptions' option does not override '\$Assumptions', but add to them:
     >> Simplify[ConditionalExpression[1, a > 0] ConditionalExpression[1, b > 0], Assumptions -> { b > 0 }]
      = ConditionalExpression[1, a > 0]
-    Passing both options overwrites $Assumptions with the union of $assump$ the option
+    Passing both options overwrites '\$Assumptions' with the union of $assump$ the option
     >> Simplify[ConditionalExpression[1, a > 0] ConditionalExpression[1, b > 0], {a>0},Assumptions -> { b > 0 }]
      = 1
     >> $Assumptions={};
 
-    The option $ComplexityFunction$ allows to control the way in which the \
+    The option 'ComplexityFunction' allows to control the way in which the \
     evaluator decides if one expression is simpler than another. For example, \
     by default, 'Simplify' tries to avoid expressions involving numbers with many digits:
     >> Simplify[20 Log[2]]

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -595,19 +595,19 @@ class Overflow(Builtin):
 
 
 class MaxMachineNumber(Predefined):
-    """
+    r"""
     Largest normalizable machine number (<url>
     :WMA:
-    https://reference.wolfram.com/language/ref/$MaxMachineNumber.html
+    https://reference.wolfram.com/language/ref/\$MaxMachineNumber.html
     </url>)
 
     <dl>
-      <dt>'$MaxMachineNumber'
+      <dt>'\$MaxMachineNumber'
       <dd>Represents the largest positive number that can be represented \
           as a normalized machine number in the system.
     </dl>
 
-    The product of '$MaxMachineNumber' and  '$MinMachineNumber' is a constant:
+    The product of '\$MaxMachineNumber' and  '\$MinMachineNumber' is a constant:
     >> $MaxMachineNumber * $MinMachineNumber
      = 4.
 
@@ -621,14 +621,14 @@ class MaxMachineNumber(Predefined):
 
 
 class MinMachineNumber(Predefined):
-    """
+    r"""
     Smallest normalizable machine number (<url>
     :WMA:
-    https://reference.wolfram.com/language/ref/$MinMachineNumber.html
+    https://reference.wolfram.com/language/ref/\$MinMachineNumber.html
     </url>)
 
     <dl>
-      <dt>'$MinMachineNumber'
+      <dt>'\$MinMachineNumber'
       <dd>Represents the smallest positive number that can be represented \
           as a normalized machine number in the system.
     </dl>

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -88,7 +88,7 @@ class DivisorSigma(SympyFunction):
 
     <dl>
       <dt>'DivisorSigma[$k$, $n$]'
-      <dd>returns $\sigma_k$($n$)
+      <dd>returns $\sigma_k(n)$
     </dl>
 
     For reference, let us first get the integer divisors of 20:
@@ -1001,7 +1001,7 @@ class RandomPrime(Builtin):
     <url>:Prime numbers:https://reference.wolfram.com/language/ref/RandomPrime.html</url>
 
     <dl>
-      <dt>'RandomPrime[{$imin$, $imax}]'
+      <dt>'RandomPrime[{$imin$, $imax$}]'
       <dd>gives a random prime between $imin$ and $imax$.
 
       <dt>'RandomPrime[$imax$]'

--- a/mathics/builtin/procedural.py
+++ b/mathics/builtin/procedural.py
@@ -41,13 +41,13 @@ SymbolWhich = Symbol("Which")
 
 
 class Abort(Builtin):
-    """
+    r"""
     <url>:WMA link:
     https://reference.wolfram.com/language/ref/Abort.html</url>
 
     <dl>
       <dt>'Abort[]'
-      <dd>aborts an evaluation completely and returns '$Aborted'.
+      <dd>aborts an evaluation completely and returns '\$Aborted'.
     </dl>
 
     >> Print["a"]; Abort[]; Print["b"]
@@ -416,12 +416,12 @@ class If(Builtin):
 
 
 class Interrupt(Builtin):
-    """
+    r"""
     <url>:WMA link:https://reference.wolfram.com/language/ref/Interrupt.html</url>
 
     <dl>
       <dt>'Interrupt[]'
-      <dd>Interrupt an evaluation and returns '$Aborted'.
+      <dd>Interrupt an evaluation and returns '\$Aborted'.
     </dl>
 
     >> Print["a"]; Interrupt[]; Print["b"]

--- a/mathics/builtin/quantum_mechanics/angular.py
+++ b/mathics/builtin/quantum_mechanics/angular.py
@@ -40,8 +40,8 @@ class ClebschGordan(SympyFunction):
 
     <dl>
       <dt>'ClebschGordan[{$j1$, $m1$}, {$j2$, $m2$}, {$j$ $m$}]'
-      <dd>returns the Clebsch-Gordan coefficient for the decomposition of |$j$,$m$> \
-      in terms of |$j1$, $m$>, |$j2$, $m2$>.
+      <dd>returns the Clebsch-Gordan coefficient for the decomposition of $|j, m\rangle$ \
+      in terms of $|j1, m\rangle$, $|j2, m2\rangle$.
     </dl>
 
     >> ClebschGordan[{3 / 2, 3 / 2}, {1 / 2, -1 / 2}, {1, 1}]
@@ -143,7 +143,7 @@ class SixJSymbol(SympyFunction):
     https://reference.wolfram.com/language/ref/SixJSymbol.html</url>)
 
     <dl>
-      <dt>'SixJSymbol[{$j1, $j2$, $j3$}, {$j4$, $j5$, $j6$}]'
+      <dt>'SixJSymbol[{$j1$, $j2$, $j3$}, {$j4$, $j5$, $j6$}]'
       <dd>returns the values of the Wigner 6-$j$ symbol.
     </dl>
 

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -112,7 +112,7 @@ class Begin(Builtin):
 
 
 class BeginPackage(Builtin):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/BeginPackage.html</url>
@@ -123,7 +123,7 @@ class BeginPackage(Builtin):
     </dl>
 
     The $context$ argument must be a valid context name. 'BeginPackage' changes \
-    the values of '$Context' and '$ContextPath', setting the current context to $context$.
+    the values of '\$Context' and '\$ContextPath', setting the current context to $context$.
 
     ## >> BeginPackage["test`"]
     ##  = test`
@@ -269,12 +269,12 @@ class Contexts(Builtin):
 
 
 class ContextPath_(Predefined):
-    """
+    r"""
     <url>
     :WMA link
-    :https://reference.wolfram.com/language/ref/$ContextPath.html</url>
+    :https://reference.wolfram.com/language/ref/\$ContextPath.html</url>
     <dl>
-      <dt>'$ContextPath'
+      <dt>'\$ContextPath'
       <dd>is the search path for contexts.
     </dl>
 
@@ -299,14 +299,14 @@ class ContextPath_(Predefined):
 
 
 class ContextPathStack(Builtin):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/ContextPathStack.html</url>
 
     <dl>
-      <dt>'System`Private`$ContextPathStack'
-      <dd>is an internal variable tracking the values of '$ContextPath' \
+      <dt>'System`Private`\$ContextPathStack'
+      <dd>is an internal variable tracking the values of '\$ContextPath' \
           saved by 'Begin' and 'BeginPackage'.
     </dl>
     """
@@ -321,13 +321,13 @@ class ContextPathStack(Builtin):
 
 
 class ContextStack(Builtin):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/ContextStack.html</url>
     <dl>
-        <dt>'System`Private`$ContextStack'
-        <dd>is an internal variable tracking the values of '$Context'
+        <dt>'System`Private`\$ContextStack'
+        <dd>is an internal variable tracking the values of '\$Context'
         saved by 'Begin' and 'BeginPackage'.
     </dl>
     """
@@ -372,7 +372,7 @@ class End(Builtin):
 
 
 class EndPackage(Builtin):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/EndPackage.html</url>
@@ -382,8 +382,8 @@ class EndPackage(Builtin):
       <dd>marks the end of a package, undoing a previous 'BeginPackage'.
     </dl>
 
-    After 'EndPackage', the values of '$Context' and '$ContextPath' at the \
-    time of the 'BeginPackage' call are restored, with the new package\'s context prepended to $ContextPath.
+    After 'EndPackage', the values of '\$Context' and '\$ContextPath' at the \
+    time of the 'BeginPackage' call are restored, with the new package\'s context prepended to '\$ContextPath'.
     """
 
     messages = {
@@ -408,7 +408,7 @@ class EndPackage(Builtin):
 
 
 class Module(Builtin):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/Module.html</url>
@@ -416,8 +416,8 @@ class Module(Builtin):
     <dl>
       <dt>'Module[{$vars$}, $expr$]'
       <dd>localizes variables by giving them a temporary name of the form \
-          'name$number', where number is the current value of '$ModuleNumber'. \
-          Each time a module is evaluated, '$ModuleNumber' is incremented.
+          'name\$number', where number is the current value of '\$ModuleNumber'. \
+          Each time a module is evaluated, '\$ModuleNumber' is incremented.
     </dl>
 
     ## FIXME: fix and go over
@@ -483,30 +483,30 @@ class Module(Builtin):
 
 
 class ModuleNumber_(Predefined):
-    """
+    r"""
     <url>
     :WMA link:
-    https://reference.wolfram.com/language/ref/$ModuleNumber.html</url>
+    https://reference.wolfram.com/language/ref/\$ModuleNumber.html</url>
     <dl>
-      <dt>'$ModuleNumber'
+      <dt>'\$ModuleNumber'
       <dd>is the current "serial number" to be used for local module variables.
     </dl>
 
 
     <ul>
-      <li>'$ModuleNumber' is incremented every time 'Module' or 'Unique' is called.
-      <li> a Mathics session starts with '$ModuleNumber' set to 1.
-      <li> You can reset $ModuleNumber to a positive machine integer, but if \
+      <li>'\$ModuleNumber' is incremented every time 'Module' or 'Unique' is called.
+      <li> a Mathics session starts with '\$ModuleNumber' set to 1.
+      <li> You can reset '\$ModuleNumber' to a positive machine integer, but if \
       you do so, naming conflicts may lead to inefficiencies.
     </li>
 
     ## Fixme: go over and adjuset
-    ## Each use of 'Module' increments '$ModuleNumber':
+    ## Each use of 'Module' increments '\$ModuleNumber':
     ## >> {$ModuleNumber, Module[{y}, y], $ModuleNumber}
     ##  = {..., ...}
 
     ## FIXME and go over
-    ## You can reset $ModuleNumber:
+    ## You can reset '\$ModuleNumber':
     ## >> $ModuleNumber = 17; {Module[{x}, x], $ModuleNumber}
     ##  = {x$17, 18}
     ##
@@ -529,17 +529,17 @@ class ModuleNumber_(Predefined):
 
 
 class Unique(Predefined):
-    """
+    r"""
     <url>
     :WMA link:
     https://reference.wolfram.com/language/ref/Unique.html</url>
 
     <dl>
       <dt>'Unique[]'
-      <dd>generates a new symbol and gives a name of the form '$number'.
+      <dd>generates a new symbol and gives a name of the form '\$number'.
 
       <dt>'Unique[x]'
-      <dd>generates a new symbol and gives a name of the form 'x$number'.
+      <dd>generates a new symbol and gives a name of the form 'x\$number'.
 
       <dt>'Unique[{x, y, ...}]'
       <dd>generates a list of new symbols.
@@ -557,7 +557,7 @@ class Unique(Predefined):
     = x...
 
     ## FIXME: include the rest of these in test/builtin/test-unique.py
-    ## Each use of Unique[symbol] increments $ModuleNumber:
+    ## Each use of Unique[symbol] increments '\$ModuleNumber':
     ## >> {$ModuleNumber, Unique[x], $ModuleNumber}
     ##  = ...
 

--- a/mathics/builtin/string/regexp.py
+++ b/mathics/builtin/string/regexp.py
@@ -15,7 +15,7 @@ class RegularExpression(Builtin):
 
     <dl>
     <dt>'RegularExpression["regex"]'
-      <dd>represents the regex specified by the string $"regex"$.
+      <dd>represents the regex specified by the string "$regex$".
     </dl>
 
     >> StringSplit["1.23, 4.56  7.89", RegularExpression["(\\s|,)+"]]

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -76,15 +76,17 @@ class Breakpoint(Builtin):
 
     def eval(self, evaluation: Evaluation):
         "Breakpoint[]"
-
-        breakpoint()
+        # I have to comment out this to pass the
+        # "precommit". @rocky, any idea about how to
+        # remove the comment?
+        # breakpoint()
 
 
 class CommandLine(Predefined):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/$CommandLine.html</url>
+    <url>:WMA link:https://reference.wolfram.com/language/ref/\\$CommandLine.html</url>
     <dl>
-    <dt>'$CommandLine'
+    <dt>'\\$CommandLine'
       <dd>is a list of strings passed on the command line to launch the Mathics3 session.
     </dl>
 
@@ -217,10 +219,10 @@ class GetEnvironment(Builtin):
 
 class Machine(Predefined):
     """
-    <url>:WMA link:https://reference.wolfram.com/language/ref/$Machine.html</url>
+    <url>:WMA link:https://reference.wolfram.com/language/ref/\\$Machine.html</url>
 
     <dl>
-    <dt>'$Machine'
+    <dt>'\\$Machine'
         <dd>returns a string describing the type of computer system on which the \
             Mathics3 is being run.
     </dl>
@@ -241,7 +243,7 @@ class MachineName(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/MachineName.html</url>
 
     <dl>
-      <dt>'$MachineName'
+      <dt>'\\$MachineName'
       <dd>is a string that gives the assigned name of the computer on which Mathics3 \
           is being run, if such a name is defined.
     </dl>
@@ -287,7 +289,7 @@ class MaxLengthIntStringConversion(Predefined):
           string value is too large, then the middle of the integer contains \
           an indication of the number of digits elided inside << >>.
 
-          If '$MaxLengthIntStringConversion' is set to 0, there is no \
+          If '\\$MaxLengthIntStringConversion' is set to 0, there is no \
           bound. Aside from 0, 640 is the smallest value allowed.
 
           The initial value can be set via environment variable \
@@ -303,7 +305,7 @@ class MaxLengthIntStringConversion(Predefined):
     the number of digits allows when converting a large integer into \
     a string.
 
-    Show the default value of '$MaxLengthIntStringConversion':
+    Show the default value of '\\$MaxLengthIntStringConversion':
     >> $MaxLengthIntStringConversion
      = ...
 
@@ -311,14 +313,14 @@ class MaxLengthIntStringConversion(Predefined):
     >> 500! //ToString//StringLength
      = ...
 
-    We first set '$MaxLengthIntStringConversion' to the smallest value allowed, \
+    We first set '\\$MaxLengthIntStringConversion' to the smallest value allowed, \
     so that we can see the truncation of digits in the middle:
     >> $MaxLengthIntStringConversion = 640
     ## Pyston 2.3.5 returns 0 while CPython returns 640
     ## Therefore output testing below is generic.
      = ...
 
-    Note that setting '$MaxLengthIntStringConversion' has an effect only on Python 3.11 and later;
+    Note that setting '\\$MaxLengthIntStringConversion' has an effect only on Python 3.11 and later;
     Pyston 2.x however ignores this.
 
     Now when we print the string value of 500! and Pyston 2.x is not used, \
@@ -397,7 +399,7 @@ class Packages(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/Packages.html</url>
 
     <dl>
-      <dt>'$Packages'
+      <dt>'\\$Packages'
       <dd>returns a list of the contexts corresponding to all packages which have \
           been loaded into Mathics.
     </dl>
@@ -418,7 +420,7 @@ class ParentProcessID(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/$ParentProcessID.html</url>
 
     <dl>
-      <dt>'$ParentProcesID'
+      <dt>'\$ParentProcesID'
       <dd>gives the ID assigned to the process which invokes Mathics3 by the operating \
           system under which it is run.
     </dl>
@@ -440,7 +442,7 @@ class ProcessID(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/ProcessID.html</url>
 
     <dl>
-      <dt>'$ProcessID'
+      <dt>'\$ProcessID'
       <dd>gives the ID assigned to the Mathics3 process by the operating system under \
           which it is run.
     </dl>
@@ -463,7 +465,7 @@ class ProcessorType(Predefined):
     https://reference.wolfram.com/language/ref/ProcessorType.html</url>
 
     <dl>
-      <dt>'$ProcessorType'
+      <dt>'\\$ProcessorType'
       <dd>gives a string giving the architecture of the processor on which \
           Mathics3 is being run.
     </dl>
@@ -487,7 +489,7 @@ class PythonImplementation(Predefined):
     ## <url>:PythonImplementation native symbol:</url>
 
     <dl>
-    <dt>'$PythonImplementation'
+    <dt>'\$PythonImplementation'
         <dd>gives a string indication the Python implementation used to run Mathics3.
     </dl>
 
@@ -532,7 +534,7 @@ class ScriptCommandLine(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/ScriptCommandLine.html</url>
 
     <dl>
-      <dt>'$ScriptCommandLine'
+      <dt>'\\$ScriptCommandLine'
       <dd>is a list of string arguments when running the kernel is script mode.
     </dl>
 
@@ -559,10 +561,10 @@ class SetEnvironment(Builtin):
      <url>:WMA link:https://reference.wolfram.com/language/ref/SetEnvironment.html</url>
 
      <dl>
-       <dt>'SetEnvironment["$var$" -> $value"]'
+       <dt>'SetEnvironment["$var$" -> "$value$"]'
        <dd>sets the value of an operating system environment variable.
 
-       <dt>'SetEnvironment[{"$var$" -> $value", ...}]'
+       <dt>'SetEnvironment[{"$var$" -> "$value$", ...}]'
        <dd>sets more than one environment variable.
      </dl>
 
@@ -682,7 +684,7 @@ class SystemID(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/SystemID.html</url>
 
     <dl>
-       <dt>'$SystemID'
+       <dt>'\$SystemID'
        <dd>is a short string that identifies the type of computer system on which the \Mathics is being run.
     </dl>
 
@@ -702,7 +704,7 @@ class SystemWordLength(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/SystemWordLength.html</url>
 
     <dl>
-      <dt>'$SystemWordLength'
+      <dt>'\$SystemWordLength'
       <dd>gives the effective number of bits in raw machine words on the computer \
           system where Mathics3 is running.
     </dl>
@@ -729,7 +731,7 @@ class UserName(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/UserName.html</url>
 
     <dl>
-      <dt>$UserName
+      <dt>\$UserName
       <dd>returns the login name, according to the operative system, of the user that started the current
       \Mathics session.
     </dl>
@@ -776,7 +778,7 @@ class VersionNumber(Predefined):
     <url>:WMA link:https://reference.wolfram.com/language/ref/VersionNumber.html</url>
 
     <dl>
-      <dt>'$VersionNumber'
+      <dt>'\$VersionNumber'
       <dd>is a real number which gives the current Wolfram Language version that \Mathics tries to be compatible with.
     </dl>
 
@@ -801,7 +803,7 @@ if have_psutil:
         <url>:WMA link:https://reference.wolfram.com/language/ref/SystemMemory.html</url>
 
         <dl>
-          <dt>'$SystemMemory'
+          <dt>'\\$SystemMemory'
           <dd>Returns the total amount of physical memory.
         </dl>
 
@@ -828,7 +830,7 @@ if have_psutil:
         >> MemoryAvailable[]
          = ...
 
-        The relationship between $SystemMemory, MemoryAvailable, and MemoryInUse:
+        The relationship between \\$SystemMemory, MemoryAvailable, and MemoryInUse:
         >> $SystemMemory > MemoryAvailable[] > MemoryInUse[]
          = True
         """

--- a/mathics/builtin/system.py
+++ b/mathics/builtin/system.py
@@ -76,10 +76,7 @@ class Breakpoint(Builtin):
 
     def eval(self, evaluation: Evaluation):
         "Breakpoint[]"
-        # I have to comment out this to pass the
-        # "precommit". @rocky, any idea about how to
-        # remove the comment?
-        # breakpoint()
+        breakpoint()
 
 
 class CommandLine(Predefined):

--- a/mathics/builtin/testing_expressions/equality_inequality.py
+++ b/mathics/builtin/testing_expressions/equality_inequality.py
@@ -766,7 +766,7 @@ class Min(_MinMax):
 
 
 class SameQ(_ComparisonOperator):
-    """
+    r"""
     <url>:WMA link:https://reference.wolfram.com/language/ref/SameQ.html</url>
 
     <dl>
@@ -809,7 +809,7 @@ class SameQ(_ComparisonOperator):
     $0.222`3$ is not equivalent to $0.2222`3$:
     >> .2222222`6 === .222`3
      = False
-    15.9546 is the value of '$MaxPrecision'
+    15.9546 is the value of '\$MaxPrecision'
     """
 
     grouping = "None"  # Indeterminate grouping: Neither left nor right

--- a/mathics/builtin/trace.py
+++ b/mathics/builtin/trace.py
@@ -101,7 +101,7 @@ class ClearTrace(Builtin):
 
 
 class PrintTrace(_TraceBase):
-    """
+    r"""
     ## <url>:trace native symbol:</url>
 
     <dl>
@@ -120,7 +120,7 @@ class PrintTrace(_TraceBase):
     Note that in a browser the information only appears in a console.
 
 
-    Note: before '$TraceBuiltins' is set to 'True', 'PrintTrace[]' will print an empty
+    Note: before '\$TraceBuiltins' is set to 'True', 'PrintTrace[]' will print an empty
     list.
     >> PrintTrace[] (* See console log *)
 
@@ -277,11 +277,11 @@ class TraceBuiltins(_TraceBase):
 # The convention is to use the name of the variable without the "$" as
 # the class name, but it is already taken by the builtin `TraceBuiltins`
 class TraceBuiltinsVariable(Builtin):
-    """
+    r"""
     ## <url>:trace native symbol:</url>
 
     <dl>
-      <dt>'$TraceBuiltins'
+      <dt>'\$TraceBuiltins'
       <dd>A Boolean Built-in variable when True collects function evaluation statistics.
     </dl>
 
@@ -310,7 +310,7 @@ class TraceBuiltinsVariable(Builtin):
     To  clear statistics collected use 'ClearTrace[]':
     X> ClearTrace[]
 
-    '$TraceBuiltins'  cannot be set to a non-boolean value.
+    '\$TraceBuiltins'  cannot be set to a non-boolean value.
     >> $TraceBuiltins = x
      : x should be True or False.
      = x
@@ -404,11 +404,11 @@ class TraceEvaluation(Builtin):
 
 
 class TraceEvaluationVariable(Builtin):
-    """
+    r"""
     ## <url>:trace native symbol:</url>
 
     <dl>
-      <dt>'$TraceEvaluation'
+      <dt>'\$TraceEvaluation'
       <dd>A Boolean variable which when set True traces Expression evaluation calls and returns.
     </dl>
 
@@ -429,7 +429,7 @@ class TraceEvaluationVariable(Builtin):
 
     >> a + a
      = 2 a
-    '$TraceEvaluation' cannot be set to a non-boolean value.
+    '\$TraceEvaluation' cannot be set to a non-boolean value.
     >> $TraceEvaluation = x
      : x should be True or False.
      = x

--- a/mathics/builtin/vectors/math_ops.py
+++ b/mathics/builtin/vectors/math_ops.py
@@ -94,7 +94,7 @@ class Curl(SympyFunction):
       <dt>'Curl[{$f1$, $f2$}, {$x1$, $x2$}]'
       <dd>returns the curl $df2$/$dx1$ - $df1$/$dx2$
 
-      <dt>'Curl[{$f1$, $f2$, $f3} {$x1$, $x2$, $x3}]'
+      <dt>'Curl[{$f1$, $f2$, $f3$} {$x1$, $x2$, $x3$}]'
       <dd>returns the curl ($df3$/$dx2$ - $df2$/$dx3$, $dx3$/$df$3 - $df3$/$dx1$, $df2$/$df1$ - $df1$/$dx2$)
     </dl>
 

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -10,7 +10,7 @@ system, and the functions used to parse docstrings into these objects.
 import logging
 import re
 from os import getenv
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple
 
 from mathics.core.evaluation import Message, Print, _Out
 
@@ -160,9 +160,11 @@ def filter_comments(doc: str) -> str:
 POST_SUBSTITUTION_TAG = "_POST_SUBSTITUTION%d_"
 
 
-def pre_sub(regexp, text: str, repl_func: Callable):
+def pre_sub(
+    regexp, text: str, repl_func: Callable, prev_subst: Tuple = tuple()
+) -> Tuple[str, Tuple]:
     """apply substitutions previous to parse the text"""
-    post_substitutions: List[str] = []
+    post_substitutions: List[str] = list(prev_subst)
 
     def repl_pre(match):
         repl = repl_func(match)
@@ -172,10 +174,10 @@ def pre_sub(regexp, text: str, repl_func: Callable):
 
     text = regexp.sub(repl_pre, text)
 
-    return text, post_substitutions
+    return text, tuple(post_substitutions)
 
 
-def post_sub(text: str, post_substitutions) -> str:
+def post_sub(text: str, post_substitutions: Tuple) -> str:
     """apply substitutions after parsing the doctests."""
     for index, sub in enumerate(post_substitutions):
         text = text.replace(POST_SUBSTITUTION_TAG % index, sub)

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -746,8 +746,8 @@ However, sometimes "local" variables are needed in order not to disturb the glob
 <dl>
   <dt>'Module[{$vars$}, $expr$]'
   <dd>localizes variables by giving them a temporary name of the form
-      'name$number', where number is the current value of '$ModuleNumber'. Each time a module
-      is evaluated, '$ModuleNumber' is incremented.
+      'name\$number', where number is the current value of '\$ModuleNumber'. Each time a module
+      is evaluated, '\$ModuleNumber' is incremented.
 
   <dt>'Block[{$vars$}, $expr$]'
   <dd>temporarily stores the definitions of certain variables, evaluates

--- a/test/doc/test_latex.py
+++ b/test/doc/test_latex.py
@@ -87,8 +87,8 @@ def test_load_latex_documentation():
         r"\begin{testresult}o\end{testresult}\end{testcase}"
     )
     assert (
-        doc_in_section.latex(doc_data)[:39]
-    ).strip() == "Let's sketch the function\n\\begin{tests}"
+        doc_in_section.latex(doc_data)[:40]
+    ).strip() == "Let\\'s sketch the function\n\\begin{tests}"
     assert (
         first_section.latex(doc_data)[:30]
     ).strip() == "\\section{Curve Sketching}{}"


### PR DESCRIPTION
This is another pass through the documentation system. The PR includes
* Fix inconsistencies in the docstrings (missing '$', escape characters, etc)
* Remove the hardcoded code that handles special characters from the `DocumentEntry.latex()`. Almost all special characters are now handled by the mathicsscanner tables.
* Increase a little bit the consistency in using the `$` character in docstrings. Now it must be explicitly escaped.
* The docstring of `escape_latex` function was improved.
* Expressions of the form `'Head'[$var_1$,$var_2$]`   now are formatted as expected (`'Head'` as a code variable, and `$var_1$` as a LaTeX expressions).
