### PR TITLE
not show Out[]=Null as in wolframscript

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 CHANGES
 =======
 
+
+8.0.1
+-----
+
+
+Compatibility
+-------------
+
+* When the result of an evaluation is ``Symbol`Null``, Mathics CLI
+  now does not show an ``Out[...]=`` line, following the behavior of
+  the WMA CLI.
+
+
 8.0.0
 -----
 

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -185,8 +185,9 @@ class TerminalShell(MathicsLineFeeder):
         return input(prompt)
 
     def print_result(self, result, no_out_prompt=False, strict_wl_output=False):
-        if result is None:
-            # FIXME decide what to do here
+        if result is None or result.last_eval is SymbolNull:
+            # Following WMA CLI, if the result is `SymbolNull`, just print an empty line.
+            print("")
             return
 
         form = result.form


### PR DESCRIPTION
In the WMA CLI, when an expression evaluates to ```System`Null```, there is no `Out[]=...` line. This PR reproduces this behavior.