### PR TITLE
Sort methods in DocElement classes. Add a base class.

### DIFF
--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -14,7 +14,11 @@ from mathics.doc.doc_entries import (
     HYPERTEXT_RE,
     IMG_PNG_RE,
     IMG_RE,
+    LATEX_DISPLAY_EQUATION_RE,
+    LATEX_HREF_RE,
+    LATEX_INLINE_EQUATION_RE,
     LATEX_RE,
+    LATEX_URL_RE,
     LIST_ITEM_RE,
     LIST_RE,
     MATHICS_RE,
@@ -57,11 +61,6 @@ LATEX_ARRAY_RE = re.compile(
 LATEX_CHAR_RE = re.compile(r"(?<!\\)(\^)")
 LATEX_CONSOLE_RE = re.compile(r"\\console\{(.*?)\}")
 LATEX_INLINE_END_RE = re.compile(r"(?s)(?P<all>\\lstinline'[^']*?'\}?[.,;:])")
-
-LATEX_DISPLAY_EQUATION_RE = re.compile(r"(?m)(?<!\\)\$\$([\s\S]+?)(?<!\\)\$\$")
-LATEX_INLINE_EQUATION_RE = re.compile(r"(?m)(?<!\\)\$([\s\S]+?)(?<!\\)\$")
-LATEX_HREF_RE = re.compile(r"(?s)\\href\{(?P<content>.*?)\}\{(?P<text>.*?)\}")
-LATEX_URL_RE = re.compile(r"(?s)\\url\{(?P<content>.*?)\}")
 
 
 LATEX_TEXT_RE = re.compile(
@@ -132,7 +131,7 @@ def escape_latex(text):
 
     * First the verbatim Python code is extracted.
     * Then,  URLs are and references are collected.
-    * After that, anything sorrounded by '$' or '$$'
+    * After that, anything surrounded by '$' or '$$'
       is processed.
     * Then, some LaTeX special characters, like brackets,
       are escaped.

--- a/mathics/doc/structure.py
+++ b/mathics/doc/structure.py
@@ -17,7 +17,13 @@ from mathics.core.load_builtin import (
     builtins_by_module as global_builtins_by_module,
     mathics3_builtins_modules,
 )
-from mathics.doc.doc_entries import DocTest, DocumentationEntry, Tests, filter_comments
+from mathics.doc.doc_entries import (
+    BaseDocElement,
+    DocTest,
+    DocumentationEntry,
+    Tests,
+    filter_comments,
+)
 from mathics.doc.utils import slugify
 from mathics.eval.pymathics import pymathics_builtins_by_module, pymathics_modules
 
@@ -42,7 +48,7 @@ MATHICS3_MODULES_TITLE = "Mathics3 Modules"
 
 
 # DocSection has to appear before DocGuideSection which uses it.
-class DocSection:
+class DocSection(BaseDocElement):
     """An object for a Documented Section.
     A Section is part of a Chapter. It can contain subsections.
     """
@@ -97,6 +103,16 @@ class DocSection:
     def __str__(self) -> str:
         return f"    == {self.title} ==\n{self.doc}"
 
+    def get_children(self) -> list:
+        """Get children"""
+        return list(self.subsections)
+
+    def get_tests(self):
+        """yield tests"""
+        if self.installed:
+            for test in self.doc.get_tests():
+                yield test
+
     @property
     def parent(self):
         "the container where the section is"
@@ -107,15 +123,9 @@ class DocSection:
         "the container where the section is"
         raise TypeError("parent is a read-only property")
 
-    def get_tests(self):
-        """yield tests"""
-        if self.installed:
-            for test in self.doc.get_tests():
-                yield test
-
 
 # DocChapter has to appear before DocGuideSection which uses it.
-class DocChapter:
+class DocChapter(BaseDocElement):
     """An object for a Documented Chapter.
     A Chapter is part of a Part[dChapter. It can contain (Guide or plain) Sections.
     """
@@ -163,6 +173,10 @@ class DocChapter:
         "guides and normal sections"
         return sorted(self.guide_sections) + sorted(self.sections)
 
+    def get_children(self) -> list:
+        """Get children"""
+        return self.all_sections
+
     @property
     def parent(self):
         "the container where the chapter is"
@@ -196,7 +210,7 @@ class DocGuideSection(DocSection):
             print("    DEBUG Creating Guide Section", title)
 
 
-class DocPart:
+class DocPart(BaseDocElement):
     """
     Represents one of the main parts of the document. Parts
     can be loaded from a mdoc file, generated automatically from
@@ -222,8 +236,22 @@ class DocPart:
             str(chapter) for chapter in sorted_chapters(self.chapters)
         )
 
+    def get_children(self) -> list:
+        """Get children"""
+        return self.chapters
 
-class Documentation:
+    @property
+    def parent(self):
+        "the container where the element is"
+        return self.documentation
+
+    @parent.setter
+    def parent(self, value):
+        "the container where the section is"
+        raise TypeError("parent is a read-only property")
+
+
+class Documentation(BaseDocElement):
     """
     `Documentation` describes an object containing the whole documentation system.
     Documentation
@@ -381,9 +409,8 @@ class Documentation:
         builtin_part = self.part_class(self, title, is_reference=start)
         self.parts.append(builtin_part)
 
-    def get_part(self, part_slug):
-        """return a section from part key"""
-        return self.parts_by_slug.get(part_slug)
+    def get_children(self):
+        return self.parts
 
     def get_chapter(self, part_slug, chapter_slug):
         """return a section from part and chapter keys"""
@@ -391,6 +418,10 @@ class Documentation:
         if part:
             return part.chapters_by_slug.get(chapter_slug)
         return None
+
+    def get_part(self, part_slug):
+        """return a section from part key"""
+        return self.parts_by_slug.get(part_slug)
 
     def get_section(self, part_slug, chapter_slug, section_slug):
         """return a section from part, chapter and section keys"""
@@ -547,8 +578,18 @@ class Documentation:
             self.parts.append(part)
         return chapter_order
 
+    @property
+    def parent(self):
+        "the container where the element is"
+        return None
 
-class DocSubsection:
+    @parent.setter
+    def parent(self, value):
+        "the container where the section is"
+        raise TypeError("parent is a read-only property")
+
+
+class DocSubsection(BaseDocElement):
     """An object for a Documented Subsection.
     A Subsection is part of a Section.
     """
@@ -626,6 +667,16 @@ class DocSubsection:
     def __str__(self) -> str:
         return f"=== {self.title} ===\n{self.doc}"
 
+    def get_children(self) -> list:
+        """Get children"""
+        return list(self.subsections)
+
+    def get_tests(self):
+        """yield tests"""
+        if self.installed:
+            for test in self.doc.get_tests():
+                yield test
+
     @property
     def parent(self):
         """the chapter where the section is"""
@@ -633,13 +684,8 @@ class DocSubsection:
 
     @parent.setter
     def parent(self, value):
+        "the container where the section is"
         raise TypeError("parent is a read-only property")
-
-    def get_tests(self):
-        """yield tests"""
-        if self.installed:
-            for test in self.doc.get_tests():
-                yield test
 
 
 class MathicsMainDocumentation(Documentation):
@@ -698,9 +744,9 @@ def sorted_chapters(chapters: List[DocChapter]) -> List[DocChapter]:
     """Return chapters sorted by title"""
     return sorted(
         chapters,
-        key=lambda chapter: str(chapter.sort_order)
-        if chapter.sort_order is not None
-        else chapter.title,
+        key=lambda chapter: (
+            str(chapter.sort_order) if chapter.sort_order is not None else chapter.title
+        ),
     )
 
 
@@ -709,7 +755,7 @@ def sorted_modules(modules) -> list:
     exists, or the module's name if not."""
     return sorted(
         modules,
-        key=lambda module: module.sort_order
-        if hasattr(module, "sort_order")
-        else module.__name__,
+        key=lambda module: (
+            module.sort_order if hasattr(module, "sort_order") else module.__name__
+        ),
     )

--- a/test/doc/test_doctests.py
+++ b/test/doc/test_doctests.py
@@ -95,4 +95,7 @@ def test_create_doctest():
     for index, test_case in enumerate(test_cases):
         doctest = DocTest(1, test_case["test"], key)
         for property_key, value in test_case["properties"].items():
-            assert getattr(doctest, property_key) == value
+            if property_key == "result" and value is None:
+                assert getattr(doctest, property_key) == ""
+            else:
+                assert getattr(doctest, property_key) == value


### PR DESCRIPTION
This is the part of #1341 that I would like to include in the release. Apart from a small tidy-up of the order of the methods and where are stored some pattern constants, the proposed change allows to process the documentation in a more similar fashion as Sphinx does, without limit of "levels".  
The rest of the code in #1341 can be moved to another repo to be worked out independently.