### PR TITLE
removing <CON>...</CON> in favor of <CONSOLE>...</CONSOLE> and single quote codemarks

### DIFF
--- a/mathics/builtin/drawing/uniform_polyhedra.py
+++ b/mathics/builtin/drawing/uniform_polyhedra.py
@@ -115,9 +115,9 @@ class UniformPolyhedron(Builtin):
     https://reference.wolfram.com/language/ref/UniformPolyhedron.html</url>
 
     <dl>
-      <dt>'UniformPolyhedron["name"]'
+      <dt>'UniformPolyhedron'["$name$"]
       <dd>return a uniform polyhedron with the given name.
-      <dd>Names are "tetrahedron", "octahedron", "dodecahedron", or "icosahedron".
+      <dd>Names are "$tetrahedron$", "$octahedron$", "$dodecahedron$", or "$icosahedron$".
     </dl>
 
     >> Graphics3D[UniformPolyhedron["octahedron"]]

--- a/mathics/builtin/quantum_mechanics/angular.py
+++ b/mathics/builtin/quantum_mechanics/angular.py
@@ -227,7 +227,7 @@ class ThreeJSymbol(SympyFunction):
     https://reference.wolfram.com/language/ref/ThreeJSymbol.html</url>)
 
     <dl>
-      <dt>'ThreeJSymbol'[{$j1, $m_1$}, {$j_2$, $m_2$}, {$j_3$, $m_3$}]
+      <dt>'ThreeJSymbol'[{$j_1$, $m_1$}, {$j_2$, $m_2$}, {$j_3$, $m_3$}]
       <dd>returns the values of the Wigner 3-$j$ symbol.
     </dl>
 

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -33,7 +33,6 @@ ALLOWED_TAGS = (
     "i",
     "ol",
     "li",
-    "con",
     "console",
     "img",
     "imgpng",
@@ -52,7 +51,9 @@ END_LINE_SENTINAL = "#<--#"
 # The regular expressions below (strings ending with _RE
 # pull out information from docstring or text in a file. Ghetto parsing.
 
-CONSOLE_RE = re.compile(r"(?s)<(?P<tag>con|console)>(?P<content>.*?)</(?P=tag)>")
+# <(?<tag>console)> in the following rule is just keep for compatibility
+# with Mathics-Django documentation.
+CONSOLE_RE = re.compile(r"(?s)<(?P<tag>console)>(?P<content>.*?)</console>")
 DL_ITEM_RE = re.compile(
     r"(?s)<(?P<tag>d[td])>(?P<content>.*?)(?:</(?P=tag)>|)\s*(?:(?=<d[td]>)|$)"
 )

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -69,12 +69,12 @@ A <url>:docker image of the v.9 release: https://hub.docker.com/r/arkadi/mathics
 Around 2017, the project was largely abandoned in its largely Python 2.7 state, with some support for Python 3.2-3.5 via six.
 
 Subsequently, around mid 2020, it was picked up by the current developers. A list of authors and contributors can be found in the <url>
-:<con>AUTHORS.txt</con>:
+:<console>AUTHORS.txt</console>:
 https://github.com/Mathics3/mathics-core/blob/master/AUTHORS.txt</url> file.
 </section>
 
 <section title="What is missing?">
-There are lots of ways in which \Mathics could still be improved. <url>:<con>FUTURE.rst</con>: https://github.com/Mathics3/mathics-core/blob/master/FUTURE.rst</url> has the current roadmap.
+There are lots of ways in which \Mathics could still be improved. <url>:<console>FUTURE.rst</console>: https://github.com/Mathics3/mathics-core/blob/master/FUTURE.rst</url> has the current roadmap.
 
 We always could use help in Python programming and improving the documentation. But there are other ways to help. For example:
 
@@ -1346,19 +1346,19 @@ When you use the Django-based Web interface of \Mathics, a browser session is cr
 
 This implies that you should not store sensitive, private information in \Mathics variables when using the online Web interface. In addition to their values being stored in a database on the server, your queries might be saved for debugging purposes. However, the fact that they are transmitted over plain HTTP should make you aware that you should not transmit any sensitive information. When you want to do calculations with that kind of stuff, simply install \Mathics locally!
 
-If you are using a public terminal, to erase all your definitions and close the browser window. When you use \Mathics in a browser, use the command <con>Quit[]</con> or its alias, <con>Exit[]</con>.
+If you are using a public terminal, to erase all your definitions and close the browser window. When you use \Mathics in a browser, use the command 'Quit[]' or its alias, 'Exit[]'.
 
-When you reload the current page in a browser using the default URL, e.g., <con>http:localhost:8000</con>, all of the previous input and output disappears.
+When you reload the current page in a browser using the default URL, e.g., <console>http:localhost:8000</con>, all of the previous input and output disappears.
 
-On the other hand, Definitions as described above do not, unless <con>Quit[]</con> or <con>Exit[]</con> is entered as described above.
+On the other hand, Definitions as described above do not, unless 'Quit[]' or 'Exit[]' is entered as described above.
 
 If you want a URL that records the input entered, the <em>Generate Input Hash</em> button does this. The button looks like this:
 
 <imgpng src="generate-hash-button.png" title="Mathics Generate Input Hash Button" label="generate-input-hash-button">
 
-For example, assuming you have a \Mathics server running at port 8000 on <con>localhost</con>, and you enter the URL <con>http://localhost:8000/#cXVlcmllcz14</con>, you should see a single line of input containing <con>x</con> entered.
+For example, assuming you have a \Mathics server running at port 8000 on <console>localhost</console>, and you enter the URL <console>http://localhost:8000/#cXVlcmllcz14</console>, you should see a single line of input containing 'x' entered.
 
-Of course, what the value of this is when evaluated depends on whether <con>x</con> has been previously defined.
+Of course, what the value of this is when evaluated depends on whether 'x' has been previously defined.
 
 </section>
 

--- a/mathics/doc/documentation/1-Manual.mdoc
+++ b/mathics/doc/documentation/1-Manual.mdoc
@@ -1348,7 +1348,7 @@ This implies that you should not store sensitive, private information in \Mathic
 
 If you are using a public terminal, to erase all your definitions and close the browser window. When you use \Mathics in a browser, use the command 'Quit[]' or its alias, 'Exit[]'.
 
-When you reload the current page in a browser using the default URL, e.g., <console>http:localhost:8000</con>, all of the previous input and output disappears.
+When you reload the current page in a browser using the default URL, e.g., <console>http:localhost:8000</console>, all of the previous input and output disappears.
 
 On the other hand, Definitions as described above do not, unless 'Quit[]' or 'Exit[]' is entered as described above.
 

--- a/mathics/doc/latex/1-Manual.mdoc
+++ b/mathics/doc/latex/1-Manual.mdoc
@@ -1,1 +1,0 @@
-../documentation/1-Manual.mdoc

--- a/mathics/doc/latex/Makefile
+++ b/mathics/doc/latex/Makefile
@@ -43,7 +43,7 @@ logo-heptatom.pdf logo-text-nodrop.pdf:
 	(cd .. && $(BASH) ./images.sh)
 
 #: The build of the documentation which is derived from docstrings in the Python code and doctest data
-documentation.tex: $(DOCTEST_LATEX_DATA_PCL) 1-Manual.mdoc
+documentation.tex: $(DOCTEST_LATEX_DATA_PCL) ../documentation/1-Manual.mdoc
 	$(PYTHON) ./doc2latex.py $(MATHICS3_MODULE_OPTION) && $(BASH) ./sed-hack.sh
 
 #: Same as mathics.pdf

--- a/mathics/doc/latex_doc.py
+++ b/mathics/doc/latex_doc.py
@@ -324,12 +324,9 @@ def escape_latex(text):
     text = REF_RE.sub(repl_ref, text)
 
     def repl_console(match):
-        tag = match.group("tag")
         content = match.group("content")
         content = content.strip()
         content = content.replace(r"\$", "$")
-        if tag == "con":
-            return "\\console{%s}" % content
         return "\\begin{lstlisting}\n%s\n\\end{lstlisting}" % content
 
     text = CONSOLE_RE.sub(repl_console, text)


### PR DESCRIPTION
Among other hacks, the homebrew documentation system introduces some *custom* tags, that make the parsing process unnecessarily complex. A couple of them are `<CONSOLE>content</CONSOLE>` and `<CON>content</CON>`. Both means more or less the same as using `'content'`.
This PR removes the second form, with the idea of removing the first form too, in favor of using '``' or  
```'.. code-block:: console```, following markdown or ReStructuredText conventions.

Also, `mathics/doc/latex/1-Manual.mdoc` was removed, which is just a copy of `mathics/doc/documentation/1-Manual.mdoc`