### PR TITLE
Remove double loading of rules, from times of apply_ methods

### DIFF
--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -305,18 +305,6 @@ class Builtin:
                     system=True,
                 )
             )
-        for pattern, function in self.get_functions(is_pymodule=is_pymodule):
-            pat_attr = attributes if pattern.get_head_name() == name else None
-            rules.append(
-                FunctionApplyRule(
-                    name,
-                    pattern,
-                    function,
-                    check_options,
-                    attributes=pat_attr,
-                    system=True,
-                )
-            )
         for pattern_str, replace_str in self.rules.items():
             pattern_str = pattern_str % {"name": name}
             pattern = parse_builtin_rule(pattern_str, definition_class)


### PR DESCRIPTION
This PR removes a block of code that we keep from the transition from `apply_` to `eval_` methods, which makes that FunctionRules be loaded twice.