### PR TITLE
Add mathics.pdf to wheel and tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include Makefile
 include requirements-cython.txt
 include requirements-dev.txt
 include requirements-full.txt
+include mathics/doc/latex/mathics.pdf
 recursive-include mathics *.py
 recursive-include mathics/autoload *
 recursive-include mathics/data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,9 @@ include = ["mathics*"]
     "data/*.yaml",
     "data/*.yml",
     "data/ExampleData/*",
-    "doc/tex/data",
-    "doc/xml/data",
+    # Documentation stuff that will be removed in 9.0.0 or before
+    "doc/latex/mathics.pdf",
+    # End doc stuff
     "test/data/*",
 ]
 "mathics.doc" = [


### PR DESCRIPTION
Adding all of the files and build system is a lot more involved. But we can at least add the pdf.