### PR TITLE
Bug: an association was confused with an option

### DIFF
--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -1424,7 +1424,12 @@ class Union(_SetOperation):
      = {1, 2, 2, 3, 4}
     """
 
-    attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED | A_READ_PROTECTED
+    # FIXME: WMA add the A_FLAT attribute, but that messes up function parsing.
+    # In particular:
+    #   Union[{1, -1, 2}, {-2, 3}, SameTest -> (Abs[#1] == Abs[#2] &)]
+    # is parsed/passed as
+    #   Union[{1, -1, 2}, SameTest -> (Abs[#1] == Abs[#2] &)]
+    attributes = A_ONE_IDENTITY | A_PROTECTED | A_READ_PROTECTED
     summary_text = "union distinct elements of list(s) or association(s)"
     _operation = "union"
 

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -435,7 +435,7 @@ class _SetOperation(Builtin, ABC):
         return self.eval(lists, evaluation, SymbolSameQ)
 
     def eval(self, lists, evaluation, sametest):
-        "%(name)s[lists__, SameTest->sametest_:SameQ]"
+        "%(name)s[lists__, SameTest->sametest_]"
 
         seq = lists.get_sequence()
 
@@ -1410,13 +1410,15 @@ class Union(_SetOperation):
     >> Union[{a -> b}, {c -> d}]
      = {a -> b, c -> d}
 
-    A union of one item is the item, however note that the list is sorted:
-    >> Union[{5, 1, 3, 7, 1, 8, 3}]
-     = {1, 3, 5, 7, 8}
-
+    A union of one item is the item. Note that the list is sorted:
     >> Union[{c, b, a}]
      = {a, b, c}
 
+    As usual, 'Union' removes duplicate values:
+    >> Union[{5, 1, 3, 7, 1, 8, 3}]
+     = {1, 3, 5, 7, 8}
+
+    'Union' using a custom test which compares using the last coordinate of each element list:
     >> Union[{{a, 1}, {b, 2}}, {{c, 1}, {d, 3}}, SameTest->(SameQ[Last[#1],Last[#2]]&)]
      = {{b, 2}, {c, 1}, {d, 3}}
 

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -12,7 +12,12 @@ from itertools import chain
 from typing import Callable, Optional
 
 from mathics.core.atoms import Integer, Integer0, Integer1, Number
-from mathics.core.attributes import A_FLAT, A_ONE_IDENTITY, A_PROTECTED
+from mathics.core.attributes import (
+    A_FLAT,
+    A_ONE_IDENTITY,
+    A_PROTECTED,
+    A_READ_PROTECTED,
+)
 from mathics.core.builtin import Builtin, MessageException
 from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation
@@ -1419,6 +1424,7 @@ class Union(_SetOperation):
      = {1, 2, 2, 3, 4}
     """
 
+    attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED | A_READ_PROTECTED
     summary_text = "enumerate all distinct elements in a list"
     _operation = "union"
 

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -1425,7 +1425,7 @@ class Union(_SetOperation):
     """
 
     attributes = A_FLAT | A_ONE_IDENTITY | A_PROTECTED | A_READ_PROTECTED
-    summary_text = "enumerate all distinct elements in a list"
+    summary_text = "union distinct elements of list(s) or association(s)"
     _operation = "union"
 
     def _elementwise(self, a, b, sameQ: Callable[..., bool]):

--- a/test/builtin/list/test_list.py
+++ b/test/builtin/list/test_list.py
@@ -134,13 +134,13 @@ import pytest
             "Union[{1, -1, 2}, {-2, 3}, SameTest -> (Abs[#1] == Abs[#2] &)]",
             None,
             "{-2, 1, 3}",
-            "Union",
+            "Union with SameTest option",
         ),
         (
             "Intersection[{1, -1, -2, 2, -3}, {1, -2, 2, 3}, SameTest -> (Abs[#1] == Abs[#2] &)]",
             None,
             "{-3, -2, 1}",
-            "Intersection",
+            "Intersection with SameTest option",
         ),
     ],
 )


### PR DESCRIPTION
Union, Complement and Intersection allow a SameTest option. This has to be matched not as a general options association, but instead as a SameTest association