### PR TITLE
Small lint-like changes to BinaryRead and Import

### DIFF
--- a/mathics/autoload/formats/Asy/Export.m
+++ b/mathics/autoload/formats/Asy/Export.m
@@ -1,4 +1,4 @@
-(* Text Exporter *)
+(* Asymptote Exporter *)
 
 Begin["System`Convert`Asy`"]
 

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -1536,7 +1536,7 @@ class Import(Builtin):
                 evaluation.predetermined_out = current_predetermined_out
                 return result
         else:
-            assert len(elements) == 1
+            assert len(elements) >= 1
             el = elements[0]
             if el == "Elements":
                 defaults = get_results(default_function, findfile)

--- a/test/builtin/test_binary.py
+++ b/test/builtin/test_binary.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from test.helper import check_evaluation, session
+from test.helper import check_evaluation
 
 import pytest
 


### PR DESCRIPTION
These items were noticed in looking at what is needed to support some version of PacletManager.  After this there set of changes, there will be more changes to put more Import code, BinaryRead, into `mathics.eval` and to handle `BinaryReadList` which is needed to be able to support Importing gzip files. 