### PR TITLE
Fix `Gamma[]` simplification rules.

### DIFF
--- a/mathics/builtin/specialfns/gamma.py
+++ b/mathics/builtin/specialfns/gamma.py
@@ -323,7 +323,7 @@ class Gamma(MPMathMultiFunction):
 
     rules = {
         "Gamma[z_, x0_, x1_]": "Gamma[z, x0] - Gamma[z, x1]",
-        "Gamma[1 + z_]": "z!",
+        "Gamma[1 + z_?IntegerQ]": "z!",
         "Gamma[Undefined]": "Undefined",
         "Gamma[x_, Undefined]": "Undefined",
         "Gamma[Undefined, y_]": "Undefined",


### PR DESCRIPTION
`Gamma[]` function has the rule:

```mathematica
Gamma[1 + z_] :> z!
```

However, this rule is only valid when `z` is an integer.

The fix changes the rule to apply only to integral `z`.
