### PR TITLE
Revise API for position tracking

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt update -qq && sudo apt install llvm-dev remake
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner[full]
         pip install -e .
 
     - name: Install Mathics with minimum dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
         cd ..
         # We can comment out after next Mathics-Scanner release
         # python -m pip install Mathics-Scanner[full]
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner[full]
         pip install -e .
         remake -x develop-full
     - name: Test Mathics3

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip install mypy==1.13 sympy==1.12
         # Adjust below for right branch
-        git clone --depth 1 https://github.com/Mathics3/mathics-scanner.git
+        git clone --depth 1 --branch position-tracking https://github.com/Mathics3/mathics-scanner
         cd mathics-scanner/
         pip install -e .
         bash ./admin-tools/make-JSON-tables.sh

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner[full]
     - name: Run Mathics3 Combinatorica tests
       run: |
         git submodule init

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -55,7 +55,7 @@ jobs:
           pip install "setuptools>=70.0.0" PyYAML click packaging pytest
 
           # We can comment out after next Mathics-Scanner release
-          python -m pip install --no-build-isolation -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner
+          python -m pip install --no-build-isolation -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner
           # pip install --no-build-isolation -e .
           # cd ..
 

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -30,7 +30,7 @@ jobs:
         pip install -e .
         cd ..
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner[full]
         pip install -e .
         cd ..
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
         cd ..
         # We can comment out after next Mathics-Scanner release
         # python -m pip install Mathics-Scanner[full]
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner[full]
         pip install -e .
         remake -x develop-full
     - name: Test Mathics

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
         pip install -e .
         cd ..
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@position-tracking#egg=Mathics-Scanner[full]
         pip install -e .
 
         # python -m pip install Mathics-Scanner[full]

--- a/examples/symbolic_logic/gries_schneider/test_gs.py
+++ b/examples/symbolic_logic/gries_schneider/test_gs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from mathics_scanner.location import ContainerKind
 
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
@@ -13,5 +14,8 @@ definitions = Definitions(add_builtin=True)
 for i in range(0, 4):
     evaluation = Evaluation(definitions=definitions, catch_interrupt=False)
 
-    expr = parse(definitions, MathicsSingleLineFeeder(f"<< GS{i}.m"))
+    expr = parse(
+        definitions,
+        MathicsSingleLineFeeder(f"<< GS{i}.m", "<test_gs>", ContainerKind.STRING),
+    )
     expr.evaluate(evaluation)

--- a/mathics/builtin/testing_expressions/string_tests.py
+++ b/mathics/builtin/testing_expressions/string_tests.py
@@ -5,6 +5,7 @@ String Tests
 import re
 
 from mathics_scanner import SingleLineFeeder, SyntaxError
+from mathics_scanner.location import ContainerKind
 
 from mathics.builtin.atomic.strings import anchor_pattern
 from mathics.core.atoms import Integer1, String
@@ -278,7 +279,7 @@ class SyntaxQ(Builtin):
             )
             return
 
-        feeder = SingleLineFeeder(string.value)
+        feeder = SingleLineFeeder(string.value, "<SyntaxQ>", ContainerKind.STRING)
         try:
             parser.parse(feeder)
         except SyntaxError:

--- a/mathics/builtin/trace.py
+++ b/mathics/builtin/trace.py
@@ -520,8 +520,8 @@ class TrackLocations(Predefined):
     summary_text = "track source-text locations in evaluation"
 
     def evaluate(self, evaluation: Evaluation) -> Symbol:
-        print(mathics_scanner.position.MATHICS3_PATHS)
-        return from_bool(mathics_scanner.position.TRACK_LOCATIONS)
+        print(mathics_scanner.location.MATHICS3_PATHS)
+        return from_bool(mathics_scanner.location.TRACK_LOCATIONS)
 
     def eval_set(self, value, evaluation):
         """Set[$TrackLocations, value_]"""

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -484,7 +484,15 @@ class Builtin:
                 definition_class = (
                     PyMathicsDefinitions() if is_pymodule else SystemDefinitions()
                 )
-                pattern = parse_builtin_rule(pattern, definition_class)
+
+                # Passing the function parameter is in a way
+                # redundant, because creating FunctionApplyRule has
+                # access to the function and sets the postion this
+                # way. But revised afte the dust has settled and
+                # we have a very good idea of what is desirable and useful.
+                pattern = parse_builtin_rule(
+                    pattern, definition_class, location=function
+                )
                 if unavailable_function:
                     function = unavailable_function
                 if attrs:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -4,6 +4,7 @@
 import math
 from bisect import bisect_left
 from itertools import chain
+from types import MethodType
 from typing import (
     Any,
     Callable,
@@ -18,6 +19,7 @@ from typing import (
 )
 
 import sympy
+from mathics_scanner.location import SourceRange
 
 from mathics.core.atoms import Integer1, String
 from mathics.core.attributes import (
@@ -275,6 +277,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
     elements_properties: Optional[ElementsProperties]
     options: Optional[Dict[str, Any]]
     pattern_sequence: bool
+    location: Optional[Union[SourceRange, MethodType]]
 
     def __init__(
         self,
@@ -300,6 +303,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
         self._sequences = None
         self._cache = None
+        self.location = None
 
         # self.copy creates this
         self.original: Optional[Expression] = None

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 import sympy
-from mathics_scanner.location import SourceRange
+from mathics_scanner.location import SourceRange, SourceRange2
 
 from mathics.core.atoms import Integer1, String
 from mathics.core.attributes import (
@@ -277,7 +277,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
     elements_properties: Optional[ElementsProperties]
     options: Optional[Dict[str, Any]]
     pattern_sequence: bool
-    location: Optional[Union[SourceRange, MethodType]]
+    location: Optional[Union[SourceRange, SourceRange2, MethodType]]
 
     def __init__(
         self,
@@ -1254,7 +1254,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                 head, *elements, elements_properties=self.elements_properties
             )
 
-        if hasattr(self, "location"):
+        if hasattr(self, "location") and self.location is not None:
             new.location = self.location
 
         # Step 3: Now, process the attributes of head

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1254,6 +1254,9 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
                 head, *elements, elements_properties=self.elements_properties
             )
 
+        if hasattr(self, "location"):
+            new.location = self.location
+
         # Step 3: Now, process the attributes of head
         # If there are sequence, flatten them if the attributes allow it.
         if (

--- a/mathics/core/parser/ast.py
+++ b/mathics/core/parser/ast.py
@@ -23,7 +23,7 @@ class Node:
     expression's leaves and a non-leaf nodes.
     """
 
-    def __init__(self, head, *children):
+    def __init__(self, head, *children, location=None):
         if isinstance(head, Node):
             self.head = head
         else:
@@ -31,6 +31,7 @@ class Node:
         self.value = None
         self.children = list(children)
         self.parenthesised = False
+        self.location = location
 
     def get_head_name(self):
         if isinstance(self.head, Symbol):
@@ -68,11 +69,12 @@ class Atom(Node):
     their own. You can however compare Atoms for equality.
     """
 
-    def __init__(self, value):
+    def __init__(self, value, location=None):
         self.head = Symbol(self.__class__.__name__)
         self.value = value
         self.children = []
         self.parenthesised = False
+        self.location = location
 
     def __repr__(self):
         return "%s[%s]" % (self.head, self.value)
@@ -90,7 +92,13 @@ class Number(Atom):
     """
 
     def __init__(
-        self, value: str, sign: int = 1, base: int = 10, suffix=None, exp: int = 0
+        self,
+        value: str,
+        sign: int = 1,
+        base: int = 10,
+        suffix=None,
+        exp: int = 0,
+        location=None,
     ):
         assert isinstance(value, str)
         assert sign in (-1, 1)
@@ -104,6 +112,7 @@ class Number(Atom):
         self.base = base
         self.suffix = suffix
         self.exp = exp
+        self.location = location
 
     def __repr__(self):
         result = self.value
@@ -132,10 +141,11 @@ class Symbol(Atom):
     are unique as they are say in Lisp, or Python.
     """
 
-    def __init__(self, value: str, context: Optional[str] = "System"):
+    def __init__(self, value: str, context: Optional[str] = "System", location=None):
         self.context = context
         self.value = value
         self.children = []
+        self.location = location
 
     # avoids recursive definition
     @property

--- a/mathics/core/parser/convert.py
+++ b/mathics/core/parser/convert.py
@@ -194,6 +194,7 @@ class Converter(GenericConverter):
         self.definitions = definitions
         result = self.do_convert(node)
         self.definitions = None
+        self.location = None
         return result
 
     def do_convert(self, node):

--- a/mathics/core/parser/convert.py
+++ b/mathics/core/parser/convert.py
@@ -194,7 +194,6 @@ class Converter(GenericConverter):
         self.definitions = definitions
         result = self.do_convert(node)
         self.definitions = None
-        self.location = None
         return result
 
     def do_convert(self, node):

--- a/mathics/core/parser/feed.py
+++ b/mathics/core/parser/feed.py
@@ -21,7 +21,7 @@ class MathicsLineFeeder(LineFeeder):
 
 
 class MathicsSingleLineFeeder(SingleLineFeeder, MathicsLineFeeder):
-    "A feeder that feeds lines from an open ``File`` object"
+    "A feeder that feeds lines from an open location container object"
 
 
 class MathicsFileLineFeeder(FileLineFeeder, MathicsLineFeeder):
@@ -29,4 +29,4 @@ class MathicsFileLineFeeder(FileLineFeeder, MathicsLineFeeder):
 
 
 class MathicsMultiLineFeeder(MultiLineFeeder, MathicsLineFeeder):
-    "A feeder that feeds lines from an open ``File`` object"
+    "A feeder that feeds lines from an open contianer object"

--- a/mathics/core/parser/location.py
+++ b/mathics/core/parser/location.py
@@ -1,0 +1,116 @@
+"""
+Provides location tracking in parser.
+"""
+
+from typing import Callable, Optional
+
+import mathics_scanner
+from mathics_scanner.location import (
+    EVAL_METHODS,
+    ContainerKind,
+    SourceRange,
+    SourceRange2,
+)
+
+from mathics.core.parser.ast import Node
+
+
+def track_location(func: Callable) -> Callable:
+    """Python decorator for a parse method that adds location tracking
+    on non-leaf-nodes when TRACK_LOCATION is set. Otherwise, we just
+    run the parse method.
+
+    """
+
+    def wrapper(self, *args) -> Optional[Node]:
+        if not mathics_scanner.location.TRACK_LOCATIONS:
+            return func(self, *args)
+
+        # Save location information
+        # For expressions which make their way to
+        # FunctionApplyRule, saving a position here is
+        # extraneous because the FunctionApplyRule is
+        # the position.  But deal with this redundancy
+        # after the dust settles, and we have experience
+        # on what is desired.
+        start_column = self.tokeniser.pos
+        start_line = self.feeder.lineno
+        parsed_node = func(self, *args)
+
+        if parsed_node is not None and hasattr(parsed_node, "location"):
+            if self.feeder.container_kind == ContainerKind.PYTHON:
+                parsed_node.location = self.feeder.container
+                if self.feeder.container not in EVAL_METHODS:
+                    EVAL_METHODS.add(parsed_node.location)
+            else:
+                end_pos = self.tokeniser.pos
+                end_line = self.feeder.lineno
+                if start_line == end_line:
+                    parsed_node.location = SourceRange2(
+                        start_line=start_line,
+                        start_pos=start_column,
+                        end_pos=end_pos,
+                        container=self.feeder.container_index,
+                    )
+                else:
+                    parsed_node.location = SourceRange(
+                        start_line=start_line,
+                        start_pos=start_column,
+                        end_line=end_line,
+                        end_pos=end_pos,
+                        container=self.feeder.container_index,
+                    )
+
+        return parsed_node
+
+    return wrapper
+
+
+def track_token_location(func: Callable) -> Callable:
+    """Python decorator for a parse method that adds location
+    tracking to leaf-nodes, i.e. tokens. This happens though only TRACK_LOCATION is set. Otherwise, we just run the
+    normal parse method.
+
+    """
+
+    def wrapper(self, token) -> Optional[Node]:
+        if not mathics_scanner.location.TRACK_LOCATIONS:
+            return func(self, token)
+
+        # Save location information
+        # For expressions which make their way to
+        # FunctionApplyRule, saving a position here is
+        # extraneous because the FunctionApplyRule is
+        # the position.  But deal with this redundancy
+        # after the dust settles, and we have experience
+        # on what is desired.
+        start_column = token.pos
+        start_line = self.feeder.lineno
+        parsed_node = func(self, token)
+
+        if (
+            self.feeder.container_kind == ContainerKind.PYTHON
+            and self.feeder.container not in EVAL_METHODS
+        ):
+            location = self.feeder.container
+            EVAL_METHODS.add(location)
+
+        end_line = self.feeder.lineno
+        if start_line == end_line:
+            parsed_node.location = SourceRange2(
+                start_line=start_line,
+                start_pos=start_column,
+                end_pos=start_column + len(token.text) - 1,
+                container=self.feeder.container_index,
+            )
+        else:
+            parsed_node.location = SourceRange(
+                start_line=start_line,
+                start_pos=start_column,
+                end_line=self.feeder.lineno,
+                end_pos=start_column + len(token.text) - 1,
+                container=self.feeder.container_index,
+            )
+        return parsed_node
+
+    return wrapper

--- a/mathics/core/parser/parser.py
+++ b/mathics/core/parser/parser.py
@@ -16,7 +16,6 @@ from mathics_scanner.errors import (
     NamedCharacterSyntaxError,
     SyntaxError,
 )
-from mathics_scanner.location import ContainerKind, SourceRange
 from mathics_scanner.tokeniser import Token, Tokeniser, is_symbol_name
 
 from mathics.core.convert.op import builtin_constants
@@ -31,7 +30,7 @@ from mathics.core.parser.ast import (
     String,
     Symbol,
 )
-from mathics.core.parser.location import track_location
+from mathics.core.parser.location import track_location, track_token_location
 from mathics.core.parser.operators import (
     all_operators,
     binary_operators,
@@ -169,9 +168,6 @@ class Parser:
         self.current_token = None
         self.bracket_depth = 0
         self.box_depth = 0
-
-        # Advance past white space and comments to assist location tracking.
-        self.tokeniser._skip_blank()
 
         return self.parse_e()
 
@@ -564,6 +560,7 @@ class Parser:
 
     # Note: returning a list is different from how most other parse_ routines
     # work and it makes the type system more complicated.
+    @track_location
     def parse_seq(self) -> list:
         result: list = []
         while True:
@@ -725,7 +722,7 @@ class Parser:
         expr2 = self.parse_expr(q + 1)
         return Node("Alternatives", expr1, expr2).flatten()
 
-    def e_ApplyList(self, expr1, token: Token, p: int) -> Optional[Node]:
+    def e_ApplyList(self, expr1, _: Token, p: int) -> Optional[Node]:
         operator_precedence = right_binary_operators["Apply"]
         if operator_precedence < p:
             return None
@@ -734,7 +731,7 @@ class Parser:
         expr3 = Node("List", Number1)
         return Node("Apply", expr1, expr2, expr3)
 
-    def e_Derivative(self, expr1, token: Token, p: int) -> Optional[Node]:
+    def e_Derivative(self, expr1, _: Token, p: int) -> Optional[Node]:
         q = postfix_operators["Derivative"]
         if q < p:
             return None
@@ -745,7 +742,7 @@ class Parser:
         head = Node("Derivative", Number(str(n)))
         return Node(head, expr1)
 
-    def e_Divide(self, expr1, token: Token, expr1_precedence: int):
+    def e_Divide(self, expr1, _: Token, expr1_precedence: int):
         """
         Implements parsing and transformation of Divide
            expr1 /  expr2
@@ -780,7 +777,8 @@ class Parser:
         expr2 = self.parse_expr(operator_precedence + 1)
         return Node("Times", expr1, Node("Power", expr2, NumberM1)).flatten()
 
-    def e_Infix(self, expr1, token: Token, expr1_precedence) -> Optional[Node]:
+    @track_location
+    def e_Infix(self, expr1, _: Token, expr1_precedence) -> Optional[Node]:
         """
         Used to implement the rule:
            expr : expr1 '~' expr2 '~' expr3
@@ -873,7 +871,7 @@ class Parser:
         expr2 = self.parse_expr(operator_precedence)
         return Node(expr1, expr2)
 
-    def e_Postfix(self, expr1, token: Token, expr1_precedence: int) -> Optional[Node]:
+    def e_Postfix(self, expr1, _: Token, expr1_precedence: int) -> Optional[Node]:
         """
         Used to parse
            expr1 // expr2
@@ -903,7 +901,7 @@ class Parser:
         expr2 = self.parse_expr(operator_precedence + 1)
         return Node(expr2, expr1)
 
-    def e_RawColon(self, expr1, token: Token, p: int) -> Optional[Node]:
+    def e_RawColon(self, expr1, _: Token, p: int) -> Optional[Node]:
         head_name = expr1.get_head_name()
         if head_name == "Symbol":
             head = "Pattern"
@@ -924,6 +922,7 @@ class Parser:
         expr2 = self.parse_expr(q + 1)
         return Node(head, expr1, expr2)
 
+    @track_location
     def e_RawLeftBracket(self, expr, token: Token, p: int) -> Optional[Node]:
         q = all_operators["Part"]
         if q < p:
@@ -952,7 +951,8 @@ class Parser:
             result.parenthesised = True
             return result
 
-    def e_Semicolon(self, expr1, token: Token, expr1_precedence: int) -> Optional[Node]:
+    @track_location
+    def e_Semicolon(self, expr1, _: Token, expr1_precedence: int) -> Optional[Node]:
         """
         Used to parse
            expr1 ; expr2
@@ -997,6 +997,7 @@ class Parser:
             expr2 = NullSymbol
         return Node("CompoundExpression", expr1, expr2).flatten()
 
+    @track_location
     def e_Span(self, expr1, token: Token, p) -> Optional[Node]:
         q = ternary_operators["Span"]
         if q < p:
@@ -1058,7 +1059,8 @@ class Parser:
         expr3 = self.parse_expr(q + 1)
         return Node(head, expr1, expr2, expr3)
 
-    def e_Unset(self, expr1, token: Token, p: int) -> Optional[Node]:
+    @track_location
+    def e_Unset(self, expr1, _: Token, p: int) -> Optional[Node]:
         q = all_operators["Set"]
         if q < p:
             return None
@@ -1073,17 +1075,17 @@ class Parser:
     # can uniquely identified by a prefix character or string.
 
     # FIXME DRY with pre_Decrement
-    def p_Decrement(self, token: Token) -> Node:
+    def p_Decrement(self, _: Token) -> Node:
         self.consume()
         q = prefix_operators["PreDecrement"]
         return Node("PreDecrement", self.parse_expr(q))
 
-    def p_Increment(self, token: Token) -> Node:
+    def p_Increment(self, _: Token) -> Node:
         self.consume()
         q = prefix_operators["PreIncrement"]
         return Node("PreIncrement", self.parse_expr(q))
 
-    def p_Information(self, token: Token) -> Node:
+    def p_Information(self, _: Token) -> Node:
         self.consume()
         q = prefix_operators["Information"]
         child = self.parse_expr(q)
@@ -1093,7 +1095,7 @@ class Parser:
             "Information", child, Node("Rule", Symbol("LongForm"), Symbol("True"))
         )
 
-    def p_Integral(self, token: Token) -> Node:
+    def p_Integral(self, _: Token) -> Node:
         self.consume()
         inner_prec, outer_prec = all_operators["Sum"] + 1, all_operators["Power"] - 1
         expr1 = self.parse_expr(inner_prec)
@@ -1101,17 +1103,19 @@ class Parser:
         expr2 = self.parse_expr(outer_prec)
         return Node("Integrate", expr1, expr2)
 
-    def p_Factorial2(self, token: Token) -> Node:
+    def p_Factorial2(self, _: Token) -> Node:
         self.consume()
         q = prefix_operators["Not"]
         child = self.parse_expr(q)
         return Node("Not", Node("Not", child))
 
+    @track_token_location
     def p_Filename(self, token: Token) -> Filename:
         result = Filename(token.text)
         self.consume()
         return result
 
+    @track_token_location
     def p_LeftRowBox(self, token: Token) -> Union[Node, String]:
         self.consume()
         children = []
@@ -1135,7 +1139,8 @@ class Parser:
         result.parenthesised = True
         return result
 
-    def p_Minus(self, token: Token) -> Optional[Node]:
+    @track_token_location
+    def p_Minus(self, _: Token) -> Optional[Node]:
         """
         Used to parse:
            - expr1
@@ -1152,7 +1157,8 @@ class Parser:
         else:
             return Node("Times", NumberM1, expr).flatten()
 
-    def p_MinusPlus(self, token: Token) -> Node:
+    @track_token_location
+    def p_MinusPlus(self, _: Token) -> Node:
         """
         Used to parse:
            ∓ expr1
@@ -1165,7 +1171,8 @@ class Parser:
         operator_precedence = operator_precedences["UnaryMinusPlus"]
         return Node("MinusPlus", self.parse_expr(operator_precedence))
 
-    def p_Not(self, token: Token) -> Node:
+    @track_token_location
+    def p_Not(self, _: Token) -> Node:
         self.consume()
         operator_precedence = prefix_operators["Not"]
         child = self.parse_expr(operator_precedence)
@@ -1177,6 +1184,7 @@ class Parser:
     # See if we can fix this mess.
     p_Factorial = p_Not
 
+    @track_token_location
     def p_Number(self, token: Token) -> Number:
         s = token.text
 
@@ -1272,7 +1280,8 @@ class Parser:
             "Information", child, Node("Rule", Symbol("LongForm"), Symbol("False"))
         )
 
-    def p_Plus(self, token: Token):
+    @track_token_location
+    def p_Plus(self, _: Token):
         """
         Used to parse:
            + expr1

--- a/mathics/core/parser/util.py
+++ b/mathics/core/parser/util.py
@@ -3,7 +3,7 @@
 from typing import FrozenSet, Optional, Tuple
 
 from mathics_scanner.feed import LineFeeder
-from mathics_scanner.location import ContainerKind, SourceRange
+from mathics_scanner.location import ContainerKind, SourceRange2
 
 from mathics.core.definitions import Definitions
 from mathics.core.element import BaseElement
@@ -69,25 +69,15 @@ def parse_returning_code(
 
     ast = parser.parse(feeder)
 
-    # For expressions which make their way to
-    # FunctionApplyRule, saving a position here is
-    # extraneous because the FunctionApplyRule an get
-    # the position.  But deal with this redundancy
-    # after the dust settles, and we have experience
-    # on what is desired.
-    location = (
-        feeder.container
-        if feeder.container_kind == ContainerKind.PYTHON
-        else SourceRange(0, parser.tokeniser.pos, feeder.container_index)
-    )
     source_text = parser.tokeniser.source_text
 
     if ast is None:
         return None, source_text
 
     converted = convert(ast, definitions)
+
     if isinstance(converted, Expression):
-        converted.location = location
+        converted.location = ast.location
     return converted, source_text
 
 

--- a/mathics/core/parser/util.py
+++ b/mathics/core/parser/util.py
@@ -2,8 +2,9 @@
 
 from typing import FrozenSet, Optional, Tuple
 
+import mathics_scanner.location
 from mathics_scanner.feed import LineFeeder
-from mathics_scanner.location import ContainerKind, SourceRange2
+from mathics_scanner.location import ContainerKind
 
 from mathics.core.definitions import Definitions
 from mathics.core.element import BaseElement
@@ -65,18 +66,21 @@ def parse_returning_code(
     methods. See the mathics_scanner.feed module.
 
     """
-    from mathics.core.expression import Expression
-
     ast = parser.parse(feeder)
 
     source_text = parser.tokeniser.source_text
+    if (
+        mathics_scanner.location.TRACK_LOCATIONS
+        and feeder.container_kind == ContainerKind.STREAM
+    ):
+        feeder.container.append(source_text)
 
     if ast is None:
         return None, source_text
 
     converted = convert(ast, definitions)
 
-    if isinstance(converted, Expression):
+    if hasattr(converted, "location") and ast.location:
         converted.location = ast.location
     return converted, source_text
 

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -427,6 +427,7 @@ class ExpressionPattern(BasePattern):
         evaluation: Optional[Evaluation] = None,
     ):
         self.expr = expr
+        self.location = expr.location if hasattr(expr, "location") else None
         head = expr.head
         if attributes is None and evaluation:
             attributes = head.get_attributes(evaluation.definitions)

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -180,6 +180,12 @@ class BaseRule(KeyComparable, ABC):
                 expr._elements_fully_evaluated = False
                 expr._is_flat = False  # I think this is fully updated
                 expr._is_ordered = False
+            if (
+                hasattr(expression, "location")
+                and hasattr(expr, "location")
+                and expression.location is not None
+            ):
+                expr.location = expression.location
             return expr
 
         if return_list:

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -98,6 +98,7 @@ class BaseRule(KeyComparable, ABC):
         evaluation: Optional[Evaluation] = None,
         attributes: Optional[int] = None,
     ) -> None:
+        self.location = None
         self.pattern = BasePattern.create(
             pattern, attributes=attributes, evaluation=evaluation
         )
@@ -335,7 +336,7 @@ class FunctionApplyRule(BaseRule):
             pattern, system=system, attributes=attributes, evaluation=evaluation
         )
         self.name = name
-        self.function = function
+        self.location = self.function = function
         self.check_options = check_options
 
     # If you update this, you must also update traced_apply_function

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -98,7 +98,7 @@ class BaseRule(KeyComparable, ABC):
         evaluation: Optional[Evaluation] = None,
         attributes: Optional[int] = None,
     ) -> None:
-        self.location = None
+        self.location: Optional[Callable] = None
         self.pattern = BasePattern.create(
             pattern, attributes=attributes, evaluation=evaluation
         )
@@ -281,44 +281,44 @@ class Rule(BaseRule):
 
 class FunctionApplyRule(BaseRule):
     """
-    A FunctionApplyRule is a rule that has a replacement term that
-    is associated a Python function rather than a Mathics Expression
-    as happens in a transformation Rule.
+        A FunctionApplyRule is a rule that has a replacement term that
+        is associated a Python function rather than a Mathics Expression
+        as happens in a transformation Rule.
 
-    Each time the Pattern part of the Rule matches an Expression, the
-    matching subexpression is replaced by the expression returned
-    by application of that function to the remaining terms.
+        Each time the Pattern part of the Rule matches an Expression, the
+        matching subexpression is replaced by the expression returned
+        by application of that function to the remaining terms.
 
-    Parameters for the function are bound to parameters matched by the pattern.
+        Parameters for the function are bound to parameters matched by the pattern.
 
-    Here is an example taken from the symbol ``System`Plus``.
-    It has has associated a FunctionApplyRule::
+        Here is an example taken from the symbol ``System`Plus``.
+        It has has associated a FunctionApplyRule::
 
-        Plus[items___] -> mathics.builtin.arithfns.basic.Plus.apply
+            Plus[items___] -> mathics.builtin.arithfns.basic.Plus.apply
 
-    The pattern ``items___`` matches a list of Expressions.
+        The pattern ``items___`` matches a list of Expressions.
 
-    When applied to the expression ``F[a+a]`` the method
-    ``mathics.builtin.arithfns.basic.Plus.apply`` is called
-    binding the parameter  ``items`` to the value ``Sequence[a,a]``.
+        When applied to the expression ``F[a+a]`` the method
+        ``mathics.builtin.arithfns.basic.Plus.apply`` is called
+        binding the parameter  ``items`` to the value ``Sequence[a,a]``.
 
-    The return value of this function is ``Times[2, a]`` (or more compactly: ``2*a``).
-    When replaced in the original expression, the result is: ``F[2*a]``.
+        The return value of this function is ``Times[2, a]`` (or more compactly: ``2*a``).
+        When replaced in the original expression, the result is: ``F[2*a]``.
 
-    In contrast to (transformation) Rules, FunctionApplyRules can
-    change the state of definitions in the the system.
+        In contrast to (transformation) Rules, FunctionApplyRules can
+        change the state of definitions in the the system.
+    p
+        For example, the rule::
 
-    For example, the rule::
+            SetAttributes[a_,b_] -> mathics.builtin.attributes.SetAttributes.apply
 
-        SetAttributes[a_,b_] -> mathics.builtin.attributes.SetAttributes.apply
+        when applied to the expression ``SetAttributes[F,  NumericFunction]``
 
-    when applied to the expression ``SetAttributes[F,  NumericFunction]``
+        sets the attribute ``NumericFunction`` in the  definition of the symbol
+        ``F`` and returns Null (``SymbolNull``).
 
-    sets the attribute ``NumericFunction`` in the  definition of the symbol
-    ``F`` and returns Null (``SymbolNull``).
-
-    This will cause `Expression.evaluate() to perform an additional
-    ``rewrite_apply_eval()`` step.
+        This will cause `Expression.evaluate() to perform an additional
+        ``rewrite_apply_eval()`` step.
 
     """
 

--- a/mathics/eval/files_io/files.py
+++ b/mathics/eval/files_io/files.py
@@ -11,6 +11,7 @@ from mathics_scanner.errors import (
     InvalidSyntaxError,
     SyntaxError,
 )
+from mathics_scanner.location import ContainerKind
 
 import mathics
 import mathics.core.parser
@@ -271,7 +272,9 @@ def eval_Read(
                 assert isinstance(tmp, str)
                 while True:
                     try:
-                        feeder = MathicsMultiLineFeeder(tmp)
+                        feeder = MathicsMultiLineFeeder(
+                            tmp, "<Read[]>", ContainerKind.STREAM
+                        )
                         expr = parse_incrementally_by_line(
                             evaluation.definitions, feeder
                         )

--- a/mathics/main.py
+++ b/mathics/main.py
@@ -19,6 +19,9 @@ import subprocess
 import sys
 from typing import List
 
+import mathics_scanner.location
+from mathics_scanner.location import ContainerKind
+
 import mathics.core as mathics_core
 from mathics import __version__, license_string, settings, version_string
 from mathics.builtin.trace import TraceBuiltins, traced_apply_function
@@ -79,7 +82,7 @@ class TerminalShell(MathicsLineFeeder):
         in_prefix: str = "In",
         out_prefix: str = "Out",
     ):
-        super(TerminalShell, self).__init__("<stdin>")
+        super(TerminalShell, self).__init__([], ContainerKind.STREAM)
         self.input_encoding = locale.getpreferredencoding()
         self.lineno = 0
         self.in_prefix = in_prefix
@@ -250,6 +253,8 @@ class TerminalShell(MathicsLineFeeder):
 
     def feed(self):
         result = self.read_line(self.get_in_prompt()) + "\n"
+        if mathics_scanner.location.TRACK_LOCATIONS:
+            self.container.append(self.source_text)
         if result == "\n":
             return ""  # end of input
         self.lineno += 1

--- a/mathics/session.py
+++ b/mathics/session.py
@@ -14,6 +14,8 @@ import os.path as osp
 from os.path import join as osp_join
 from typing import Optional
 
+from mathics_scanner.location import ContainerKind
+
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Result
 from mathics.core.parser import MathicsSingleLineFeeder, parse
@@ -140,7 +142,10 @@ class MathicsSession:
     def evaluate(self, str_expression, timeout=None, form=None):
         """Parse str_expression and evaluate using the `evaluate` method of the Expression"""
         self.evaluation.out.clear()
-        expr = parse(self.definitions, MathicsSingleLineFeeder(str_expression))
+        expr = parse(
+            self.definitions,
+            MathicsSingleLineFeeder(str_expression, ContainerKind.STREAM),
+        )
         if form is None:
             form = self.form
         self.last_result = expr.evaluate(self.evaluation)

--- a/test/builtin/test_trace.py
+++ b/test/builtin/test_trace.py
@@ -33,7 +33,7 @@ def test_TraceEvaluation():
         """
         global trace_evaluation_calls
         trace_evaluation_calls += 1
-        assert status in ("Evaluating", "Returning")
+        assert status in ("Evaluating", "Returning", "Rewriting")
         if "cython" not in version_info:
             assert isfunction(fn), "Expecting 4th argument to be a function"
         return None
@@ -119,9 +119,9 @@ def test_skip_trivial_evaluation():
         assert [
             "  Evaluating: System`Plus[System`Times[2, 3], 4]",
             "    Evaluating: System`Times[2, 3]",
-            "      Returning: System`Times[2, 3] = (<Integer: 6>, False)",
+            "      Evaluating/Replacing: System`Times[2, 3] = 6",
             "    Returning: System`Times[2, 3] = 6",
-            "    Returning: System`Plus[System`Times[2, 3], 4] = (<Integer: 10>, False)",
+            "    Evaluating/Replacing: System`Plus[System`Times[2, 3], 4] = 10",
             "  Returning: System`Plus[System`Times[2, 3], 4] = 10",
         ] == event_queue
         # print()

--- a/test/core/parser/test_box_parser.py
+++ b/test/core/parser/test_box_parser.py
@@ -7,6 +7,7 @@ import time
 from typing import Optional
 
 from mathics_scanner import SingleLineFeeder
+from mathics_scanner.location import ContainerKind
 
 from mathics.core.parser.parser import Parser
 
@@ -14,12 +15,14 @@ from mathics.core.parser.parser import Parser
 # Note we don't import mathics.session here since we
 # are testing just the parse layer, not the evaluation layer.
 # Simpler is better.
-parser = Parser()
+core_parser = Parser()
 
 
 def check_evaluation(str_expr: str, str_expected: str, assert_message: Optional[str]):
-    def parse(s: str):
-        return parser.parse(SingleLineFeeder(s))
+    def parse(source_text: str):
+        return core_parser.parse(
+            SingleLineFeeder(source_text, "<test_box_parser>", ContainerKind.STRING)
+        )
 
     result = parse(str_expr)
     expected = parse(str_expected)

--- a/test/core/parser/test_convert.py
+++ b/test/core/parser/test_convert.py
@@ -8,20 +8,26 @@ from mathics_scanner.errors import (
     InvalidSyntaxError,
     SyntaxError,
 )
+from mathics_scanner.location import ContainerKind
 
 from mathics.core.atoms import Integer, Integer0, Integer1, Rational, Real, String
 from mathics.core.definitions import Definitions
 from mathics.core.expression import Expression
-from mathics.core.parser import parse
+from mathics.core.load_builtin import import_and_load_builtins
+from mathics.core.parser import parse as core_parse
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolDerivative
 
+import_and_load_builtins()
 definitions = Definitions(add_builtin=True)
 
 
 class ConvertTests(unittest.TestCase):
-    def parse(self, code):
-        return parse(definitions, SingleLineFeeder(code))
+    def parse(self, source_text):
+        return core_parse(
+            definitions,
+            SingleLineFeeder(source_text, "<test_convert>", ContainerKind.STRING),
+        )
 
     def check(self, expr1, expr2):
         if isinstance(expr1, str):

--- a/test/core/parser/test_parser.py
+++ b/test/core/parser/test_parser.py
@@ -12,6 +12,7 @@ from mathics_scanner.errors import (
     NamedCharacterSyntaxError,
     SyntaxError,
 )
+from mathics_scanner.location import ContainerKind
 
 from mathics.core.parser.ast import Filename, Node, Number, String, Symbol
 from mathics.core.parser.parser import Parser
@@ -22,7 +23,9 @@ class ParserTests(unittest.TestCase):
         self.parser = Parser()
 
     def parse(self, s: str):
-        return self.parser.parse(SingleLineFeeder(s))
+        return self.parser.parse(
+            SingleLineFeeder(s, "<ParserTests>", ContainerKind.STRING)
+        )
 
     def check(self, expr1, expr2):
         if isinstance(expr1, str):

--- a/test/core/test_elements_properties.py
+++ b/test/core/test_elements_properties.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from mathics_scanner.location import ContainerKind
+
 from mathics.core.parser import MathicsSingleLineFeeder
 from mathics.core.parser.convert import convert
 from mathics.core.parser.parser import Parser
@@ -40,7 +42,9 @@ def test_elements_properties():
     ]:
         # fmt: on
         session.evaluation.out.clear()
-        feeder = MathicsSingleLineFeeder(str_expression)
+        feeder = MathicsSingleLineFeeder(
+            str_expression, "<test_elements_properties>", ContainerKind.STRING
+        )
         ast = parser.parse(feeder)
 
         # convert() creates the initial Expression. In that various properties should

--- a/test/core/test_is_literal.py
+++ b/test/core/test_is_literal.py
@@ -3,6 +3,8 @@
 Test mathics.core property on BaseElement is_literal.
 """
 
+from mathics_scanner.location import ContainerKind
+
 from mathics.core.parser import MathicsSingleLineFeeder
 from mathics.core.parser.convert import convert
 from mathics.core.parser.parser import Parser
@@ -33,7 +35,9 @@ def test_is_literal():
     ]:
         # fmt: on
         session.evaluation.out.clear()
-        feeder = MathicsSingleLineFeeder(str_expression)
+        feeder = MathicsSingleLineFeeder(
+            str_expression, "<test_is_literal>", ContainerKind.STRING
+        )
         ast = parser.parse(feeder)
         # print("XXX", ast)
 

--- a/test/eval/test_patterns.py
+++ b/test/eval/test_patterns.py
@@ -6,6 +6,7 @@ Unit tests for mathics.eval.patterns
 from test.helper import session
 
 import pytest
+from mathics_scanner.location import ContainerKind
 
 from mathics.core.definitions import Definitions
 from mathics.core.parser import MathicsSingleLineFeeder, parse
@@ -17,8 +18,18 @@ defintions = Definitions(True)
 
 
 def check_pattern(str_expr, str_pattern):
-    expr = parse(defintions, MathicsSingleLineFeeder(str_expr))
-    pattern = ExpressionPattern(parse(defintions, MathicsSingleLineFeeder(str_pattern)))
+    expr = parse(
+        defintions,
+        MathicsSingleLineFeeder(str_expr, "<test_patterns_expr>", ContainerKind.STRING),
+    )
+    pattern = ExpressionPattern(
+        parse(
+            defintions,
+            MathicsSingleLineFeeder(
+                str_pattern, "<check_pattern>", ContainerKind.STRING
+            ),
+        )
+    )
     ret = Matcher(pattern, session.evaluation).match(expr, session.evaluation)
     assert ret is True
 


### PR DESCRIPTION
Start tracking locations in specific expressions to aid error reporting and debugging.

We need some care to make sure we don't bloat memory with positions. Right now, we start locations are tagged for FunctionApplyRule, an ExpressionPattern -> Python method. Here, the location is the Python method, or rather can be extracted from that. So we can reuse the location information that Python is storing anyway.

For Expressions and ExpressionPatterns that are read in from Files, things are more complicated..

This needs to be coordinated with a changes in mathics-scanner of the same branch name.