### PR TITLE
Use ".value" in expr.to_python() and more often

### DIFF
--- a/mathics/builtin/directories/directory_names.py
+++ b/mathics/builtin/directories/directory_names.py
@@ -177,14 +177,19 @@ class FileNameJoin(Builtin):
     def eval(self, pathlist, evaluation: Evaluation, options: dict):
         "FileNameJoin[pathlist_List, OptionsPattern[FileNameJoin]]"
 
+        # Convert pathlist to a Python list, and strip leading and trailing
+        # quotes if that appears.
         py_pathlist = pathlist.to_python()
-        if not all(isinstance(p, str) and p[0] == p[-1] == '"' for p in py_pathlist):
-            return
-        py_pathlist = [p[1:-1] for p in py_pathlist]
 
-        operating_system = (
-            options["System`OperatingSystem"].evaluate(evaluation).get_string_value()
-        )
+        if not all(isinstance(p, str) for p in py_pathlist):
+            return
+
+        if isinstance(py_pathlist, tuple):
+            py_pathlist = list(py_pathlist)
+        else:
+            py_pathlist = [p[1:-1] if p[0] == p[-1] == '"' else p for p in py_pathlist]
+
+        operating_system = options["System`OperatingSystem"].evaluate(evaluation).value
 
         if operating_system not in ["MacOSX", "Windows", "Unix"]:
             evaluation.message(

--- a/mathics/builtin/file_operations/file_properties.py
+++ b/mathics/builtin/file_operations/file_properties.py
@@ -4,21 +4,18 @@ File Properties
 
 import os
 import os.path as osp
-import time
+from datetime import datetime
 
 from mathics.builtin.exp_structure.size_and_sig import Hash
 from mathics.builtin.files_io.files import MathicsOpen
-from mathics.core.atoms import Real, String
+from mathics.core.atoms import String
 from mathics.core.attributes import A_PROTECTED, A_READ_PROTECTED
 from mathics.core.builtin import Builtin, MessageException
 from mathics.core.convert.expression import to_expression
-from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Evaluation
-from mathics.core.expression import Expression
 from mathics.core.streams import path_search
 from mathics.core.symbols import Symbol, SymbolNull
-from mathics.core.systemsymbols import SymbolAbsoluteTime, SymbolFailed, SymbolNone
-from mathics.eval.nevaluator import eval_N
+from mathics.core.systemsymbols import SymbolFailed, SymbolNone
 
 sort_order = "mathics.builtin.file-operations.file_properties"
 
@@ -103,17 +100,17 @@ class FileDate(Builtin):
             evaluation.message("FileDate", "datetype")
             return
 
-        # Offset for system epoch
-        epochtime_expr = Expression(
-            SymbolAbsoluteTime, String(time.strftime("%Y-%m-%d %H:%M", time.gmtime(0)))
+        dt_object = datetime.fromtimestamp(result)
+        # Extract the year, month, day, hour, and minute into a tuple
+        datetime_tuple = (
+            dt_object.year,
+            dt_object.month,
+            dt_object.day,
+            dt_object.hour,
+            dt_object.minute,
+            dt_object.second,
         )
-        epochtime_N = eval_N(epochtime_expr, evaluation)
-        if epochtime_N is None:
-            return None
-        epochtime = epochtime_N.to_python()
-        result += epochtime
-
-        return to_expression("DateList", Real(result))
+        return to_expression("DateList", datetime_tuple)
 
     def eval_default(self, path, evaluation):
         "FileDate[path_]"
@@ -299,7 +296,7 @@ class SetFileDate(Builtin):
 
         # Check datelist
         if not (
-            isinstance(py_datelist, list)
+            isinstance(py_datelist, (list, tuple))
             and len(py_datelist) == 6
             and all(isinstance(d, int) for d in py_datelist[:-1])
             and isinstance(py_datelist[-1], float)
@@ -311,25 +308,13 @@ class SetFileDate(Builtin):
             evaluation.message("SetFileDate", "datetype")
             return
 
-        epochtime = (
-            to_expression(
-                "AbsoluteTime", time.strftime("%Y-%m-%d %H:%M", time.gmtime(0))
-            )
-            .evaluate(evaluation)
-            .to_python()
-        )
-
-        stattime = to_expression("AbsoluteTime", from_python(py_datelist))
-        stattime_N = eval_N(stattime, evaluation)
-        if stattime_N is None:
-            return
-
-        stattime = stattime_N.to_python() - epochtime
+        file_timestamp = datetime(*py_datelist[:4]).timestamp()
 
         try:
             os.stat(py_filename)
             if py_attr == '"Access"':
-                os.utime(py_filename, (stattime, osp.getatime(py_filename)))
+                os.utime(py_filename, (file_timestamp, osp.getatime(py_filename)))
+                return SymbolNull
             if py_attr == '"Creation"':
                 if os.name == "posix":
                     evaluation.message("SetFileDate", "nocreationunix")
@@ -338,9 +323,9 @@ class SetFileDate(Builtin):
                     # TODO: Note: This is windows only
                     return SymbolFailed
             if py_attr == '"Modification"':
-                os.utime(py_filename, (osp.getatime(py_filename), stattime))
-            if py_attr == "All":
-                os.utime(py_filename, (stattime, stattime))
+                os.utime(py_filename, (osp.getatime(py_filename), file_timestamp))
+            elif py_attr == "All":
+                os.utime(py_filename, (file_timestamp, file_timestamp))
         except OSError:
             # evaluation.message(...)
             return SymbolFailed

--- a/mathics/builtin/files_io/filesystem.py
+++ b/mathics/builtin/files_io/filesystem.py
@@ -66,10 +66,12 @@ class AbsoluteFileName(Builtin):
 
         py_name = name.to_python()
 
-        if not (isinstance(py_name, str) and py_name[0] == py_name[-1] == '"'):
+        if not isinstance(py_name, str):
             evaluation.message("AbsoluteFileName", "fstr", name)
             return
-        py_name = py_name[1:-1]
+
+        if py_name[0] == py_name[-1] == '"':
+            py_name = py_name[1:-1]
 
         result, _ = path_search(py_name)
 
@@ -164,15 +166,18 @@ class CopyFile(Builtin):
         py_dest = dest.to_python()
 
         # Check filenames
-        if not (isinstance(py_source, str) and py_source[0] == py_source[-1] == '"'):
+        if not (isinstance(py_source, str)):
             evaluation.message("CopyFile", "fstr", source)
             return
-        if not (isinstance(py_dest, str) and py_dest[0] == py_dest[-1] == '"'):
+        if not (isinstance(py_dest, str)):
             evaluation.message("CopyFile", "fstr", dest)
             return
 
-        py_source = py_source[1:-1]
-        py_dest = py_dest[1:-1]
+        if py_source[0] == py_source[-1] == '"':
+            py_source = py_source[1:-1]
+
+        if py_dest[0] == py_dest[-1] == '"':
+            py_dest = py_dest[1:-1]
 
         py_source, _ = path_search(py_source)
 
@@ -290,13 +295,13 @@ class DeleteFile(Builtin):
         "DeleteFile[filename_]"
 
         py_path = filename.to_python()
-        if not isinstance(py_path, list):
+        if not isinstance(py_path, (list, tuple)):
             py_path = [py_path]
 
         py_paths = []
         for path in py_path:
             # Check filenames
-            if not (isinstance(path, str) and path[0] == path[-1] == '"'):
+            if not isinstance(path, str):
                 evaluation.message(
                     "DeleteFile",
                     "strs",
@@ -305,7 +310,8 @@ class DeleteFile(Builtin):
                 )
                 return
 
-            path = path[1:-1]
+            if path[0] == path[-1] == '"':
+                path = path[1:-1]
             path, _ = path_search(path)
 
             if path is None:

--- a/mathics/builtin/forms/output.py
+++ b/mathics/builtin/forms/output.py
@@ -508,7 +508,7 @@ class PythonForm(FormBaseClass):
     >> E // PythonForm
     = sympy.E
     >> {1, 2, 3} // PythonForm
-    = [1, 2, 3]
+    = (1, 2, 3)
     """
 
     in_outputforms = True

--- a/mathics/builtin/list/rearrange.py
+++ b/mathics/builtin/list/rearrange.py
@@ -682,19 +682,21 @@ class Flatten(Builtin):
         # prepare levels
         # find max depth which matches `h`
         expr, max_depth = walk_levels(expr)
-        max_depth = {"max_depth": max_depth}  # hack to modify max_depth from callback
+        max_depth_dict = {
+            "max_depth": max_depth
+        }  # hack to modify max_depth from callback
 
         def callback(expr, pos):
-            if len(pos) < max_depth["max_depth"] and (
+            if len(pos) < max_depth_dict["max_depth"] and (
                 isinstance(expr, Atom) or expr.head != h
             ):
-                max_depth["max_depth"] = len(pos)
+                max_depth_dict["max_depth"] = len(pos)
             return expr
 
-        expr, depth = walk_levels(expr, callback=callback, include_pos=True, start=0)
-        max_depth = max_depth["max_depth"]
+        expr, _ = walk_levels(expr, callback=callback, include_pos=True, start=0)
+        max_depth = max_depth_dict["max_depth"]
 
-        levels = n.to_python()
+        levels = list(n.to_python())
 
         # mappings
         if isinstance(levels, list) and all(isinstance(level, int) for level in levels):
@@ -706,7 +708,7 @@ class Flatten(Builtin):
             return
         seen_levels = []
         for level in levels:
-            if not (isinstance(level, list) and len(level) > 0):
+            if not (isinstance(level, (list, tuple)) and len(level) > 0):
                 evaluation.message("Flatten", "flpi", n)
                 return
             for r in level:

--- a/mathics/builtin/numbers/numbertheory.py
+++ b/mathics/builtin/numbers/numbertheory.py
@@ -1062,7 +1062,7 @@ class RandomPrime(Builtin):
         py_n = n.to_python()
 
         py_int = interval.to_python()
-        if not (isinstance(py_int, list) and len(py_int) == 2):
+        if not (isinstance(py_int, (list, tuple)) and len(py_int) == 2):
             evaluation.message("RandomPrime", "prmrng", interval)
 
         imin, imax = min(py_int), max(py_int)

--- a/mathics/builtin/numbers/randomnumbers.py
+++ b/mathics/builtin/numbers/randomnumbers.py
@@ -424,7 +424,7 @@ class RandomComplex(Builtin):
             return
 
         py_ns = ns.to_python()
-        if not isinstance(py_ns, list):
+        if not isinstance(py_ns, (list, tuple)):
             py_ns = [py_ns]
 
         if not all(isinstance(i, int) and i >= 0 for i in py_ns):

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -63,8 +63,20 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         """
         return (self._value,)
 
+    def __eq__(self, other):
+        if isinstance(other, Number):
+            return self.get_sort_key() == other.get_sort_key()
+        else:
+            return False
+
     def __str__(self) -> str:
         return str(self.value)
+
+    def default_format(self, evaluation, form) -> str:
+        return str(self.value)
+
+    def do_copy(self) -> "Number":
+        raise NotImplementedError
 
     # FIXME: can we refactor or subclass objects to remove pattern_sort?
     def get_sort_key(self, pattern_sort=False) -> tuple:
@@ -109,21 +121,15 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
                 return mpmath.mpf(self.value)
         return mpmath.mpf(self.value)
 
-    @property
-    def value(self) -> T:
+    def to_python(self, *_, **kwargs):
+        """Returns a native builtin Python object
+        something in (int, float, complex, str, tuple, list or dict.).
+        (See discussions in
+        https://github.com/Mathics3/mathics-core/discussions/550
+        and
+        https://github.com/Mathics3/mathics-core/pull/551
         """
-        Returns this number's value.
-        """
-        return self._value
-
-    def __eq__(self, other):
-        if isinstance(other, Number):
-            return self.get_sort_key() == other.get_sort_key()
-        else:
-            return False
-
-    def default_format(self, evaluation, form) -> str:
-        return str(self.value)
+        return self.value
 
     def round(self, d: Optional[int] = None) -> "Number":
         """
@@ -131,8 +137,12 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         """
         return self
 
-    def do_copy(self) -> "Number":
-        raise NotImplementedError
+    @property
+    def value(self) -> T:
+        """
+        Equivalent value in Python's native datatype.
+        """
+        return self._value
 
 
 def _ExponentFunction(value):
@@ -256,11 +266,23 @@ class Integer(Number[int]):
             else super().__ne__(other)
         )
 
+    def __neg__(self) -> "Integer":
+        return Integer(-self._value)
+
     def abs(self) -> "Integer":
         return -self if self < Integer0 else self
 
     def atom_to_boxes(self, f, evaluation):
         return self.make_boxes(f.get_name())
+
+    def get_int_value(self) -> int:
+        return self._value
+
+    @property
+    def is_zero(self) -> bool:
+        # Note: 0 is self._value or the other way around is a syntax
+        # error.
+        return self._value == 0
 
     def make_boxes(self, form) -> "String":
         from mathics.eval.makeboxes import _boxed_string
@@ -281,12 +303,6 @@ class Integer(Number[int]):
 
             return int_to_string_shorter_repr(self._value, form)
 
-    def to_sympy(self, **kwargs):
-        return sympy.Integer(self._value)
-
-    def to_python(self, *args, **kwargs):
-        return self.value
-
     def round(self, d: Optional[int] = None) -> Union["MachineReal", "PrecisionReal"]:
         """
         Produce a Real approximation of ``self`` with decimal precision ``d``.
@@ -302,8 +318,8 @@ class Integer(Number[int]):
                 d = MACHINE_PRECISION_VALUE
         return PrecisionReal(sympy.Float(self.value, d))
 
-    def get_int_value(self) -> int:
-        return self._value
+    def to_sympy(self, **_):
+        return sympy.Integer(self._value)
 
     def sameQ(self, other) -> bool:
         """Mathics SameQ"""
@@ -314,15 +330,6 @@ class Integer(Number[int]):
 
     def user_hash(self, update):
         update(b"System`Integer>" + str(self._value).encode("utf8"))
-
-    def __neg__(self) -> "Integer":
-        return Integer(-self._value)
-
-    @property
-    def is_zero(self) -> bool:
-        # Note: 0 is self._value or the other way around is a syntax
-        # error.
-        return self._value == 0
 
 
 Integer0 = Integer(0)

--- a/mathics/core/convert/expression.py
+++ b/mathics/core/convert/expression.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Any, Callable, Type, Union
+from typing import Any, Callable, Union
 
 from mathics.core.convert.python import from_python
 from mathics.core.element import BaseElement
@@ -52,7 +52,7 @@ def to_expression(
 def to_expression_with_specialization(
     head: BaseElement,
     *elements: Any,
-    elements_conversion_fn: Callable = from_python,
+    _: Callable = from_python,
 ) -> Union[ListExpression, Expression]:
     """
     This expression constructor will figure out what the right kind of
@@ -77,11 +77,13 @@ def to_mathics_list(
         to_mathics_list(1, 2, 3)
         to_mathics_list(1, 2, 3, elements_conversion_fn=Integer)
     """
-    elements_tuple, elements_properties, _ = convert_expression_elements(
+    elements_tuple, elements_properties, literal_values = convert_expression_elements(
         elements, elements_conversion_fn
     )
     list_expression = ListExpression(
-        *elements_tuple, elements_properties=elements_properties
+        *elements_tuple,
+        elements_properties=elements_properties,
+        literal_values=literal_values,
     )
     return list_expression
 
@@ -102,5 +104,5 @@ def to_numeric_args(mathics_args: BaseElement, evaluation) -> tuple:
 
 
 expression_constructor_map = {
-    SymbolList: lambda head, *args, **kwargs: ListExpression(*args, **kwargs)
+    SymbolList: lambda _, *args, **kwargs: ListExpression(*args, **kwargs)
 }

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -431,13 +431,13 @@ class BaseElement(KeyComparable, ABC):
         raise NotImplementedError
 
     def to_python(self, *args, **kwargs):
-        # Returns a native builtin Python object
-        # something in (int, float, complex, str, tuple, list or dict.).
-        # (See discussions in
-        #  https://github.com/Mathics3/mathics-core/discussions/550
-        # and
-        # https://github.com/Mathics3/mathics-core/pull/551
-        #
+        """Returns a native builtin Python object
+        something in (int, float, complex, str, tuple, list or dict.).
+        (See discussions in
+        https://github.com/Mathics3/mathics-core/discussions/550
+        and
+        https://github.com/Mathics3/mathics-core/pull/551
+        """
         raise NotImplementedError
 
     def to_mpmath(self):

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -353,9 +353,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         values = []
         for element in self._elements:
             # Test for the literalness, and the three properties mentioned above
-            if element.is_literal:
-                values.append(element.value)
-            else:
+            if not element.is_literal:
                 self.elements_properties.elements_fully_evaluated = False
 
             if isinstance(element, Expression):
@@ -1547,7 +1545,7 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
     def to_mpmath(self):
         return None
 
-    def to_python(self, *args, **kwargs):
+    def to_python(self, *args, **kwargs) -> Any:
         """
         Convert the Expression to a Python object:
         List[...]  -> Python list
@@ -1562,6 +1560,13 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         If kwarg n_evaluation is given, apply N first to the expression.
         """
         from mathics.core.builtin import mathics_to_python
+
+        # When self.value of is None, it might mean either it is
+        # not set or it is legitamately the None value.
+        # If self.value is legitimately None, we'll
+        # catch further down.
+        if hasattr(self, "value") and self.value is not None:
+            return self.value
 
         n_evaluation = kwargs.get("n_evaluation", None)
         assert n_evaluation is None

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -25,7 +25,7 @@ class ListExpression(Expression):
     Keyword Arguments:
 
     - ``elements_properties`` -- properties of the collection of elements
-    - ``literal_values`` -- if this is not ``None``, then it is a tuple of Python values
+    - ``literal_values`` -- if this is not ``None``, then it is a tuple of Python values and the expression is a literal.
     """
 
     _is_literal: bool
@@ -49,16 +49,16 @@ class ListExpression(Expression):
         #     call_frame = inspect.getouterframes(curframe, 2)
         #     print("caller name:", call_frame[1][3])
 
-        # from mathics.core.element import BaseElement
-        # for element in elements:
-        #     if not isinstance(element, BaseElement):
-        #          from trepan.api import debug; debug()
-
         self._elements = elements
-        self.value = literal_values
+
+        # When self.value is not None it a Python tuple (not Python
+        # list) sort that is the Python equivalent value for the Mathics3 list.
 
         # Check for literalness if it is not known
-        if literal_values is None:
+        if literal_values is not None:
+            self._is_literal = True
+            self.value = literal_values
+        else:
             self._is_literal = True
             values = []
             for element in elements:

--- a/mathics/core/streams.py
+++ b/mathics/core/streams.py
@@ -85,7 +85,7 @@ def path_search(filename: str) -> Tuple[Optional[str], bool]:
             result = urlsave_tmp(filename)
             is_temporary_file = True
         else:
-            for p in PATH_VAR + [""]:
+            for p in list(PATH_VAR) + [""]:
                 path = canonic_filename(osp.join(p, filename))
                 if osp.exists(path):
                     result = path

--- a/mathics/eval/drawing/plot.py
+++ b/mathics/eval/drawing/plot.py
@@ -131,7 +131,7 @@ def get_plot_range_option(
             "System`Automatic",
             "System`All",
         )
-        or isinstance(pr, list)
+        or isinstance(pr, (list, tuple))
         for pr in plotrange
     )
     return plotrange

--- a/mathics/eval/drawing/plot3d.py
+++ b/mathics/eval/drawing/plot3d.py
@@ -49,441 +49,435 @@ def eval_plot3d(
 ):
     """%(name)s[functions_, {x_Symbol, xstart_, xstop_},
     {y_Symbol, ystart_, ystop_}, OptionsPattern[%(name)s]]"""
-    if True:
-        xexpr_limits = ListExpression(x, xstart, xstop)
-        yexpr_limits = ListExpression(y, ystart, ystop)
-        expr = Expression(
-            Symbol(self.get_name()),
-            functions,
-            xexpr_limits,
-            yexpr_limits,
-            *options_to_rules(options),
-        )
 
-        functions = self.get_functions_param(functions)
-        plot_name = self.get_name()
+    xexpr_limits = ListExpression(x, xstart, xstop)
+    yexpr_limits = ListExpression(y, ystart, ystop)
+    expr = Expression(
+        Symbol(self.get_name()),
+        functions,
+        xexpr_limits,
+        yexpr_limits,
+        *options_to_rules(options),
+    )
 
-        def convert_limit(value, limits):
-            result = value.round_to_float(evaluation)
-            if result is None:
-                evaluation.message(plot_name, "plln", value, limits)
-            return result
+    functions = self.get_functions_param(functions)
+    plot_name = self.get_name()
 
-        xstart = convert_limit(xstart, xexpr_limits)
-        xstop = convert_limit(xstop, xexpr_limits)
-        ystart = convert_limit(ystart, yexpr_limits)
-        ystop = convert_limit(ystop, yexpr_limits)
-        if None in (xstart, xstop, ystart, ystop):
-            return
+    def convert_limit(value, limits):
+        result = value.round_to_float(evaluation)
+        if result is None:
+            evaluation.message(plot_name, "plln", value, limits)
+        return result
 
-        if ystart >= ystop:
-            evaluation.message(plot_name, "plln", ystop, expr)
-            return
+    xstart = convert_limit(xstart, xexpr_limits)
+    xstop = convert_limit(xstop, xexpr_limits)
+    ystart = convert_limit(ystart, yexpr_limits)
+    ystop = convert_limit(ystop, yexpr_limits)
+    if None in (xstart, xstop, ystart, ystop):
+        return
 
-        if xstart >= xstop:
-            evaluation.message(plot_name, "plln", xstop, expr)
-            return
+    if ystart >= ystop:
+        evaluation.message(plot_name, "plln", ystop, expr)
+        return
 
-        # Mesh Option
-        mesh_option = self.get_option(options, "Mesh", evaluation)
-        mesh = mesh_option.to_python()
-        if mesh not in ["System`None", "System`Full", "System`All"]:
-            evaluation.message("Mesh", "ilevels", mesh_option)
-            mesh = "System`Full"
+    if xstart >= xstop:
+        evaluation.message(plot_name, "plln", xstop, expr)
+        return
 
-        # PlotPoints Option
-        plotpoints_option = self.get_option(options, "PlotPoints", evaluation)
-        plotpoints = plotpoints_option.to_python()
+    # Mesh Option
+    mesh_option = self.get_option(options, "Mesh", evaluation)
+    mesh = mesh_option.to_python()
+    if mesh not in ["System`None", "System`Full", "System`All"]:
+        evaluation.message("Mesh", "ilevels", mesh_option)
+        mesh = "System`Full"
 
-        def check_plotpoints(steps):
-            if isinstance(steps, int) and steps > 0:
-                return True
-            return False
+    # PlotPoints Option
+    plotpoints_option = self.get_option(options, "PlotPoints", evaluation)
+    plotpoints = plotpoints_option.to_python()
 
-        if plotpoints == "System`None":
-            plotpoints = [7, 7]
-        elif check_plotpoints(plotpoints):
-            plotpoints = [plotpoints, plotpoints]
+    def check_plotpoints(steps):
+        if isinstance(steps, int) and steps > 0:
+            return True
+        return False
 
-        if not (
-            isinstance(plotpoints, list)
-            and len(plotpoints) == 2
-            and check_plotpoints(plotpoints[0])
-            and check_plotpoints(plotpoints[1])
-        ):
-            evaluation.message(self.get_name(), "invpltpts", plotpoints)
-            plotpoints = [7, 7]
+    if plotpoints == "System`None":
+        plotpoints = (7, 7)
+    elif check_plotpoints(plotpoints):
+        plotpoints = (plotpoints, plotpoints)
 
-        # MaxRecursion Option
-        maxrec_option = self.get_option(options, "MaxRecursion", evaluation)
-        max_depth = maxrec_option.to_python()
-        if isinstance(max_depth, int):
-            if max_depth < 0:
-                max_depth = 0
-                evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
-            elif max_depth > 15:
-                max_depth = 15
-                evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
-            else:
-                pass  # valid
-        elif max_depth == float("inf"):
+    if not (
+        isinstance(plotpoints, (list, tuple))
+        and len(plotpoints) == 2
+        and check_plotpoints(plotpoints[0])
+        and check_plotpoints(plotpoints[1])
+    ):
+        evaluation.message(self.get_name(), "invpltpts", plotpoints)
+        plotpoints = (7, 7)
+
+    # MaxRecursion Option
+    maxrec_option = self.get_option(options, "MaxRecursion", evaluation)
+    max_depth = maxrec_option.to_python()
+    if isinstance(max_depth, int):
+        if max_depth < 0:
+            max_depth = 0
+            evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
+        elif max_depth > 15:
             max_depth = 15
             evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
         else:
-            max_depth = 0
-            evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
+            pass  # valid
+    elif max_depth == float("inf"):
+        max_depth = 15
+        evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
+    else:
+        max_depth = 0
+        evaluation.message(self.get_name(), "invmaxrec", max_depth, 15)
 
-        # Plot the functions
-        graphics = []
-        for indx, f in enumerate(functions):
-            stored = {}
+    # Plot the functions
+    graphics = []
+    for _, f in enumerate(functions):
+        stored = {}
 
-            compiled_fn = compile_quiet_function(
-                f, [x.get_name(), y.get_name()], evaluation, False
+        compiled_fn = compile_quiet_function(
+            f, [x.get_name(), y.get_name()], evaluation, False
+        )
+
+        def apply_fn(compiled_fn: Callable, x_value, y_value):
+            try:
+                # Try to used cached value first
+                return stored[(x_value, y_value)]
+            except KeyError:
+                value = compiled_fn(x_value, y_value)
+                if value is not None:
+                    value = float(value)
+                stored[(x_value, y_value)] = value
+                return value
+
+        triangles = []
+
+        split_edges = set()  # subdivided edges
+
+        def triangle(x1, y1, x2, y2, x3, y3, depth=0):
+            v1, v2, v3 = (
+                apply_fn(compiled_fn, x1, y1),
+                apply_fn(compiled_fn, x2, y2),
+                apply_fn(compiled_fn, x3, y3),
             )
 
-            def apply_fn(compiled_fn: Callable, x_value, y_value):
-                try:
-                    # Try to used cached value first
-                    return stored[(x_value, y_value)]
-                except KeyError:
-                    value = compiled_fn(x_value, y_value)
-                    if value is not None:
-                        value = float(value)
-                    stored[(x_value, y_value)] = value
-                    return value
+            if (v1 is v2 is v3 is None) and (depth > max_depth // 2):
+                # fast finish because the entire region is undefined but
+                # recurse 'a little' to avoid missing well defined regions
+                return
+            elif v1 is None or v2 is None or v3 is None:
+                # 'triforce' pattern recursion to find the edge of defined region
+                #         1
+                #         /\
+                #      4 /__\ 6
+                #       /\  /\
+                #      /__\/__\
+                #     2   5    3
+                if depth < max_depth:
+                    x4, y4 = 0.5 * (x1 + x2), 0.5 * (y1 + y2)
+                    x5, y5 = 0.5 * (x2 + x3), 0.5 * (y2 + y3)
+                    x6, y6 = 0.5 * (x1 + x3), 0.5 * (y1 + y3)
+                    split_edges.add(
+                        ((x1, y1), (x2, y2))
+                        if (x2, y2) > (x1, y1)
+                        else ((x2, y2), (x1, y1))
+                    )
+                    split_edges.add(
+                        ((x2, y2), (x3, y3))
+                        if (x3, y3) > (x2, y2)
+                        else ((x3, y3), (x2, y2))
+                    )
+                    split_edges.add(
+                        ((x1, y1), (x3, y3))
+                        if (x3, y3) > (x1, y1)
+                        else ((x3, y3), (x1, y1))
+                    )
+                    triangle(x1, y1, x4, y4, x6, y6, depth + 1)
+                    triangle(x4, y4, x2, y2, x5, y5, depth + 1)
+                    triangle(x6, y6, x5, y5, x3, y3, depth + 1)
+                    triangle(x4, y4, x5, y5, x6, y6, depth + 1)
+                return
+            triangles.append(sorted(((x1, y1, v1), (x2, y2, v2), (x3, y3, v3))))
 
-            triangles = []
-
-            split_edges = set()  # subdivided edges
-
-            def triangle(x1, y1, x2, y2, x3, y3, depth=0):
-                v1, v2, v3 = (
-                    apply_fn(compiled_fn, x1, y1),
-                    apply_fn(compiled_fn, x2, y2),
-                    apply_fn(compiled_fn, x3, y3),
+        # linear (grid) sampling
+        numx = plotpoints[0] * 1.0
+        numy = plotpoints[1] * 1.0
+        for xi in range(plotpoints[0]):
+            for yi in range(plotpoints[1]):
+                # Decide which way to break the square grid into triangles
+                # by looking at diagonal lengths.
+                #
+                # 3___4        3___4
+                # |\  |        |  /|
+                # | \ | versus | / |
+                # |__\|        |/__|
+                # 1   2        1   2
+                #
+                # Approaching the boundary of the well defined region is
+                # important too. Use first strategy if 1 or 4 are undefined
+                # and strategy 2 if either 2 or 3 are undefined.
+                #
+                x1, x2, x3, x4 = (
+                    xstart + value * (xstop - xstart)
+                    for value in (
+                        xi / numx,
+                        (xi + 1) / numx,
+                        xi / numx,
+                        (xi + 1) / numx,
+                    )
+                )
+                y1, y2, y3, y4 = (
+                    ystart + value * (ystop - ystart)
+                    for value in (
+                        yi / numy,
+                        yi / numy,
+                        (yi + 1) / numy,
+                        (yi + 1) / numy,
+                    )
                 )
 
-                if (v1 is v2 is v3 is None) and (depth > max_depth // 2):
-                    # fast finish because the entire region is undefined but
-                    # recurse 'a little' to avoid missing well defined regions
-                    return
-                elif v1 is None or v2 is None or v3 is None:
-                    # 'triforce' pattern recursion to find the edge of defined region
-                    #         1
-                    #         /\
-                    #      4 /__\ 6
-                    #       /\  /\
-                    #      /__\/__\
-                    #     2   5    3
-                    if depth < max_depth:
-                        x4, y4 = 0.5 * (x1 + x2), 0.5 * (y1 + y2)
-                        x5, y5 = 0.5 * (x2 + x3), 0.5 * (y2 + y3)
-                        x6, y6 = 0.5 * (x1 + x3), 0.5 * (y1 + y3)
-                        split_edges.add(
-                            ((x1, y1), (x2, y2))
-                            if (x2, y2) > (x1, y1)
-                            else ((x2, y2), (x1, y1))
-                        )
-                        split_edges.add(
-                            ((x2, y2), (x3, y3))
-                            if (x3, y3) > (x2, y2)
-                            else ((x3, y3), (x2, y2))
-                        )
-                        split_edges.add(
-                            ((x1, y1), (x3, y3))
-                            if (x3, y3) > (x1, y1)
-                            else ((x3, y3), (x1, y1))
-                        )
-                        triangle(x1, y1, x4, y4, x6, y6, depth + 1)
-                        triangle(x4, y4, x2, y2, x5, y5, depth + 1)
-                        triangle(x6, y6, x5, y5, x3, y3, depth + 1)
-                        triangle(x4, y4, x5, y5, x6, y6, depth + 1)
-                    return
-                triangles.append(sorted(((x1, y1, v1), (x2, y2, v2), (x3, y3, v3))))
+                v1 = apply_fn(compiled_fn, x1, y1)
+                v2 = apply_fn(compiled_fn, x2, y2)
+                v3 = apply_fn(compiled_fn, x3, y3)
+                v4 = apply_fn(compiled_fn, x4, y4)
 
-            # linear (grid) sampling
-            numx = plotpoints[0] * 1.0
-            numy = plotpoints[1] * 1.0
-            for xi in range(plotpoints[0]):
-                for yi in range(plotpoints[1]):
-                    # Decide which way to break the square grid into triangles
-                    # by looking at diagonal lengths.
-                    #
-                    # 3___4        3___4
-                    # |\  |        |  /|
-                    # | \ | versus | / |
-                    # |__\|        |/__|
-                    # 1   2        1   2
-                    #
-                    # Approaching the boundary of the well defined region is
-                    # important too. Use first strategy if 1 or 4 are undefined
-                    # and strategy 2 if either 2 or 3 are undefined.
-                    #
-                    x1, x2, x3, x4 = (
-                        xstart + value * (xstop - xstart)
-                        for value in (
-                            xi / numx,
-                            (xi + 1) / numx,
-                            xi / numx,
-                            (xi + 1) / numx,
-                        )
-                    )
-                    y1, y2, y3, y4 = (
-                        ystart + value * (ystop - ystart)
-                        for value in (
-                            yi / numy,
-                            yi / numy,
-                            (yi + 1) / numy,
-                            (yi + 1) / numy,
-                        )
-                    )
-
-                    v1 = apply_fn(compiled_fn, x1, y1)
-                    v2 = apply_fn(compiled_fn, x2, y2)
-                    v3 = apply_fn(compiled_fn, x3, y3)
-                    v4 = apply_fn(compiled_fn, x4, y4)
-
-                    if v1 is None or v4 is None:
-                        triangle(x1, y1, x2, y2, x3, y3)
-                        triangle(x4, y4, x3, y3, x2, y2)
-                    elif v2 is None or v3 is None:
+                if v1 is None or v4 is None:
+                    triangle(x1, y1, x2, y2, x3, y3)
+                    triangle(x4, y4, x3, y3, x2, y2)
+                elif v2 is None or v3 is None:
+                    triangle(x2, y2, x1, y1, x4, y4)
+                    triangle(x3, y3, x4, y4, x1, y1)
+                else:
+                    if abs(v3 - v2) > abs(v4 - v1):
                         triangle(x2, y2, x1, y1, x4, y4)
                         triangle(x3, y3, x4, y4, x1, y1)
                     else:
-                        if abs(v3 - v2) > abs(v4 - v1):
-                            triangle(x2, y2, x1, y1, x4, y4)
-                            triangle(x3, y3, x4, y4, x1, y1)
-                        else:
-                            triangle(x1, y1, x2, y2, x3, y3)
-                            triangle(x4, y4, x3, y3, x2, y2)
+                        triangle(x1, y1, x2, y2, x3, y3)
+                        triangle(x4, y4, x3, y3, x2, y2)
 
-            # adaptive resampling
-            # TODO: optimise this
-            # Cos of the maximum angle between successive line segments
-            ang_thresh = cos(20 * pi / 180)
-            for depth in range(1, max_depth):
-                needs_removal = set()
-                lent = len(triangles)  # number of initial triangles
-                for i1 in range(lent):
-                    for i2 in range(lent):
-                        # find all edge pairings
-                        if i1 == i2:
-                            continue
-                        t1 = triangles[i1]
-                        t2 = triangles[i2]
-
-                        edge_pairing = (
-                            (t1[0], t1[1]) == (t2[0], t2[1])
-                            or (t1[0], t1[1]) == (t2[1], t2[2])
-                            or (t1[0], t1[1]) == (t2[0], t2[2])
-                            or (t1[1], t1[2]) == (t2[0], t2[1])
-                            or (t1[1], t1[2]) == (t2[1], t2[2])
-                            or (t1[1], t1[2]) == (t2[0], t2[2])
-                            or (t1[0], t1[2]) == (t2[0], t2[1])
-                            or (t1[0], t1[2]) == (t2[1], t2[2])
-                            or (t1[0], t1[2]) == (t2[0], t2[2])
-                        )
-                        if not edge_pairing:
-                            continue
-                        v1 = [t1[1][i] - t1[0][i] for i in range(3)]
-                        w1 = [t1[2][i] - t1[0][i] for i in range(3)]
-                        v2 = [t2[1][i] - t2[0][i] for i in range(3)]
-                        w2 = [t2[2][i] - t2[0][i] for i in range(3)]
-                        n1 = (  # surface normal for t1
-                            (v1[1] * w1[2]) - (v1[2] * w1[1]),
-                            (v1[2] * w1[0]) - (v1[0] * w1[2]),
-                            (v1[0] * w1[1]) - (v1[1] * w1[0]),
-                        )
-                        n2 = (  # surface normal for t2
-                            (v2[1] * w2[2]) - (v2[2] * w2[1]),
-                            (v2[2] * w2[0]) - (v2[0] * w2[2]),
-                            (v2[0] * w2[1]) - (v2[1] * w2[0]),
-                        )
-                        try:
-                            angle = (
-                                n1[0] * n2[0] + n1[1] * n2[1] + n1[2] * n2[2]
-                            ) / sqrt(
-                                (n1[0] ** 2 + n1[1] ** 2 + n1[2] ** 2)
-                                * (n2[0] ** 2 + n2[1] ** 2 + n2[2] ** 2)
-                            )
-                        except ZeroDivisionError:
-                            angle = 0.0
-                        if abs(angle) < ang_thresh:
-                            for i, t in ((i1, t1), (i2, t2)):
-                                # subdivide
-                                x1, y1 = t[0][0], t[0][1]
-                                x2, y2 = t[1][0], t[1][1]
-                                x3, y3 = t[2][0], t[2][1]
-                                x4, y4 = 0.5 * (x1 + x2), 0.5 * (y1 + y2)
-                                x5, y5 = 0.5 * (x2 + x3), 0.5 * (y2 + y3)
-                                x6, y6 = 0.5 * (x1 + x3), 0.5 * (y1 + y3)
-                                needs_removal.add(i)
-                                split_edges.add(
-                                    ((x1, y1), (x2, y2))
-                                    if (x2, y2) > (x1, y1)
-                                    else ((x2, y2), (x1, y1))
-                                )
-                                split_edges.add(
-                                    ((x2, y2), (x3, y3))
-                                    if (x3, y3) > (x2, y2)
-                                    else ((x3, y3), (x2, y2))
-                                )
-                                split_edges.add(
-                                    ((x1, y1), (x3, y3))
-                                    if (x3, y3) > (x1, y1)
-                                    else ((x3, y3), (x1, y1))
-                                )
-                                triangle(x1, y1, x4, y4, x6, y6, depth=depth)
-                                triangle(x2, y2, x4, y4, x5, y5, depth=depth)
-                                triangle(x3, y3, x5, y5, x6, y6, depth=depth)
-                                triangle(x4, y4, x5, y5, x6, y6, depth=depth)
-                # remove subdivided triangles which have been divided
-                triangles = [
-                    t for i, t in enumerate(triangles) if i not in needs_removal
-                ]
-
-            # fix up subdivided edges
-            #
-            # look at every triangle and see if its edges need updating.
-            # depending on how many edges require subdivision we proceede with
-            # one of two subdivision strategies
-            #
-            # TODO possible optimisation: don't look at every triangle again
-            made_changes = True
-            while made_changes:
-                made_changes = False
-                new_triangles = []
-                for i, t in enumerate(triangles):
-                    new_points = []
-                    if ((t[0][0], t[0][1]), (t[1][0], t[1][1])) in split_edges:
-                        new_points.append([0, 1])
-                    if ((t[1][0], t[1][1]), (t[2][0], t[2][1])) in split_edges:
-                        new_points.append([1, 2])
-                    if ((t[0][0], t[0][1]), (t[2][0], t[2][1])) in split_edges:
-                        new_points.append([0, 2])
-
-                    if len(new_points) == 0:
+        # adaptive resampling
+        # TODO: optimise this
+        # Cos of the maximum angle between successive line segments
+        ang_thresh = cos(20 * pi / 180)
+        for depth in range(1, max_depth):
+            needs_removal = set()
+            lent = len(triangles)  # number of initial triangles
+            for i1 in range(lent):
+                for i2 in range(lent):
+                    # find all edge pairings
+                    if i1 == i2:
                         continue
-                    made_changes = True
-                    # 'triforce' subdivision
-                    #         1
-                    #         /\
-                    #      4 /__\ 6
-                    #       /\  /\
-                    #      /__\/__\
-                    #     2   5    3
-                    # if less than three edges require subdivision bisect them
-                    # anyway but fake their values by averaging
-                    x4 = 0.5 * (t[0][0] + t[1][0])
-                    y4 = 0.5 * (t[0][1] + t[1][1])
-                    v4 = stored.get((x4, y4), 0.5 * (t[0][2] + t[1][2]))
+                    t1 = triangles[i1]
+                    t2 = triangles[i2]
 
-                    x5 = 0.5 * (t[1][0] + t[2][0])
-                    y5 = 0.5 * (t[1][1] + t[2][1])
-                    v5 = stored.get((x5, y5), 0.5 * (t[1][2] + t[2][2]))
-
-                    x6 = 0.5 * (t[0][0] + t[2][0])
-                    y6 = 0.5 * (t[0][1] + t[2][1])
-                    v6 = stored.get((x6, y6), 0.5 * (t[0][2] + t[2][2]))
-
-                    if not (v4 is None or v6 is None):
-                        new_triangles.append(sorted((t[0], (x4, y4, v4), (x6, y6, v6))))
-                    if not (v4 is None or v5 is None):
-                        new_triangles.append(sorted((t[1], (x4, y4, v4), (x5, y5, v5))))
-                    if not (v5 is None or v6 is None):
-                        new_triangles.append(sorted((t[2], (x5, y5, v5), (x6, y6, v6))))
-                    if not (v4 is None or v5 is None or v6 is None):
-                        new_triangles.append(
-                            sorted(((x4, y4, v4), (x5, y5, v5), (x6, y6, v6)))
+                    edge_pairing = (
+                        (t1[0], t1[1]) == (t2[0], t2[1])
+                        or (t1[0], t1[1]) == (t2[1], t2[2])
+                        or (t1[0], t1[1]) == (t2[0], t2[2])
+                        or (t1[1], t1[2]) == (t2[0], t2[1])
+                        or (t1[1], t1[2]) == (t2[1], t2[2])
+                        or (t1[1], t1[2]) == (t2[0], t2[2])
+                        or (t1[0], t1[2]) == (t2[0], t2[1])
+                        or (t1[0], t1[2]) == (t2[1], t2[2])
+                        or (t1[0], t1[2]) == (t2[0], t2[2])
+                    )
+                    if not edge_pairing:
+                        continue
+                    v1 = [t1[1][i] - t1[0][i] for i in range(3)]
+                    w1 = [t1[2][i] - t1[0][i] for i in range(3)]
+                    v2 = [t2[1][i] - t2[0][i] for i in range(3)]
+                    w2 = [t2[2][i] - t2[0][i] for i in range(3)]
+                    n1 = (  # surface normal for t1
+                        (v1[1] * w1[2]) - (v1[2] * w1[1]),
+                        (v1[2] * w1[0]) - (v1[0] * w1[2]),
+                        (v1[0] * w1[1]) - (v1[1] * w1[0]),
+                    )
+                    n2 = (  # surface normal for t2
+                        (v2[1] * w2[2]) - (v2[2] * w2[1]),
+                        (v2[2] * w2[0]) - (v2[0] * w2[2]),
+                        (v2[0] * w2[1]) - (v2[1] * w2[0]),
+                    )
+                    try:
+                        angle = (n1[0] * n2[0] + n1[1] * n2[1] + n1[2] * n2[2]) / sqrt(
+                            (n1[0] ** 2 + n1[1] ** 2 + n1[2] ** 2)
+                            * (n2[0] ** 2 + n2[1] ** 2 + n2[2] ** 2)
                         )
-                    triangles[i] = None
-
-                triangles.extend(new_triangles)
-                triangles = [t for t in triangles if t is not None]
-
-            # add the mesh
-            mesh_points = []
-            if mesh == "System`Full":
-                for xi in range(plotpoints[0] + 1):
-                    xval = xstart + xi / numx * (xstop - xstart)
-                    mesh_row = []
-                    for yi in range(plotpoints[1] + 1):
-                        yval = ystart + yi / numy * (ystop - ystart)
-                        z = stored[(xval, yval)]
-                        mesh_row.append((xval, yval, z))
-                    mesh_points.append(mesh_row)
-
-                for yi in range(plotpoints[1] + 1):
-                    yval = ystart + yi / numy * (ystop - ystart)
-                    mesh_col = []
-                    for xi in range(plotpoints[0] + 1):
-                        xval = xstart + xi / numx * (xstop - xstart)
-                        z = stored[(xval, yval)]
-                        mesh_col.append((xval, yval, z))
-                    mesh_points.append(mesh_col)
-
-                # handle edge subdivisions
-                made_changes = True
-                while made_changes:
-                    made_changes = False
-                    for mesh_line in mesh_points:
-                        i = 0
-                        while i < len(mesh_line) - 1:
-                            x1, y1, v1 = mesh_line[i]
-                            x2, y2, v2 = mesh_line[i + 1]
-                            key = (
+                    except ZeroDivisionError:
+                        angle = 0.0
+                    if abs(angle) < ang_thresh:
+                        for i, t in ((i1, t1), (i2, t2)):
+                            # subdivide
+                            x1, y1 = t[0][0], t[0][1]
+                            x2, y2 = t[1][0], t[1][1]
+                            x3, y3 = t[2][0], t[2][1]
+                            x4, y4 = 0.5 * (x1 + x2), 0.5 * (y1 + y2)
+                            x5, y5 = 0.5 * (x2 + x3), 0.5 * (y2 + y3)
+                            x6, y6 = 0.5 * (x1 + x3), 0.5 * (y1 + y3)
+                            needs_removal.add(i)
+                            split_edges.add(
                                 ((x1, y1), (x2, y2))
                                 if (x2, y2) > (x1, y1)
                                 else ((x2, y2), (x1, y1))
                             )
-                            if key in split_edges:
-                                x3 = 0.5 * (x1 + x2)
-                                y3 = 0.5 * (y1 + y2)
-                                v3 = stored[(x3, y3)]
-                                mesh_line.insert(i + 1, (x3, y3, v3))
-                                made_changes = True
-                                i += 1
-                            i += 1
-
-                # handle missing regions
-                old_meshpoints, mesh_points = mesh_points, []
-                for mesh_line in old_meshpoints:
-                    mesh_points.extend(
-                        [
-                            sorted(g)
-                            for k, g in itertools.groupby(
-                                mesh_line, lambda x: x[2] is None
+                            split_edges.add(
+                                ((x2, y2), (x3, y3))
+                                if (x3, y3) > (x2, y2)
+                                else ((x3, y3), (x2, y2))
                             )
-                        ]
-                    )
-                mesh_points = [
-                    mesh_line
-                    for mesh_line in mesh_points
-                    if not any(x[2] is None for x in mesh_line)
-                ]
-            elif mesh == "System`All":
-                mesh_points = set()
-                for t in triangles:
-                    mesh_points.add((t[0], t[1]) if t[1] > t[0] else (t[1], t[0]))
-                    mesh_points.add((t[1], t[2]) if t[2] > t[1] else (t[2], t[1]))
-                    mesh_points.add((t[0], t[2]) if t[2] > t[0] else (t[2], t[0]))
-                mesh_points = list(mesh_points)
+                            split_edges.add(
+                                ((x1, y1), (x3, y3))
+                                if (x3, y3) > (x1, y1)
+                                else ((x3, y3), (x1, y1))
+                            )
+                            triangle(x1, y1, x4, y4, x6, y6, depth=depth)
+                            triangle(x2, y2, x4, y4, x5, y5, depth=depth)
+                            triangle(x3, y3, x5, y5, x6, y6, depth=depth)
+                            triangle(x4, y4, x5, y5, x6, y6, depth=depth)
+            # remove subdivided triangles which have been divided
+            triangles = [t for i, t in enumerate(triangles) if i not in needs_removal]
 
-            # find the max and min height
-            v_min = v_max = None
-            for t in triangles:
-                for tx, ty, v in t:
-                    if v_min is None or v < v_min:
-                        v_min = v
-                    if v_max is None or v > v_max:
-                        v_max = v
-            graphics.extend(
-                self.construct_graphics(
-                    triangles, mesh_points, v_min, v_max, options, evaluation
+        # fix up subdivided edges
+        #
+        # look at every triangle and see if its edges need updating.
+        # depending on how many edges require subdivision we proceede with
+        # one of two subdivision strategies
+        #
+        # TODO possible optimisation: don't look at every triangle again
+        made_changes = True
+        while made_changes:
+            made_changes = False
+            new_triangles = []
+            for i, t in enumerate(triangles):
+                new_points = []
+                if ((t[0][0], t[0][1]), (t[1][0], t[1][1])) in split_edges:
+                    new_points.append([0, 1])
+                if ((t[1][0], t[1][1]), (t[2][0], t[2][1])) in split_edges:
+                    new_points.append([1, 2])
+                if ((t[0][0], t[0][1]), (t[2][0], t[2][1])) in split_edges:
+                    new_points.append([0, 2])
+
+                if len(new_points) == 0:
+                    continue
+                made_changes = True
+                # 'triforce' subdivision
+                #         1
+                #         /\
+                #      4 /__\ 6
+                #       /\  /\
+                #      /__\/__\
+                #     2   5    3
+                # if less than three edges require subdivision bisect them
+                # anyway but fake their values by averaging
+                x4 = 0.5 * (t[0][0] + t[1][0])
+                y4 = 0.5 * (t[0][1] + t[1][1])
+                v4 = stored.get((x4, y4), 0.5 * (t[0][2] + t[1][2]))
+
+                x5 = 0.5 * (t[1][0] + t[2][0])
+                y5 = 0.5 * (t[1][1] + t[2][1])
+                v5 = stored.get((x5, y5), 0.5 * (t[1][2] + t[2][2]))
+
+                x6 = 0.5 * (t[0][0] + t[2][0])
+                y6 = 0.5 * (t[0][1] + t[2][1])
+                v6 = stored.get((x6, y6), 0.5 * (t[0][2] + t[2][2]))
+
+                if not (v4 is None or v6 is None):
+                    new_triangles.append(sorted((t[0], (x4, y4, v4), (x6, y6, v6))))
+                if not (v4 is None or v5 is None):
+                    new_triangles.append(sorted((t[1], (x4, y4, v4), (x5, y5, v5))))
+                if not (v5 is None or v6 is None):
+                    new_triangles.append(sorted((t[2], (x5, y5, v5), (x6, y6, v6))))
+                if not (v4 is None or v5 is None or v6 is None):
+                    new_triangles.append(
+                        sorted(((x4, y4, v4), (x5, y5, v5), (x6, y6, v6)))
+                    )
+                triangles[i] = None
+
+            triangles.extend(new_triangles)
+            triangles = [t for t in triangles if t is not None]
+
+        # add the mesh
+        mesh_points = []
+        if mesh == "System`Full":
+            for xi in range(plotpoints[0] + 1):
+                xval = xstart + xi / numx * (xstop - xstart)
+                mesh_row = []
+                for yi in range(plotpoints[1] + 1):
+                    yval = ystart + yi / numy * (ystop - ystart)
+                    z = stored[(xval, yval)]
+                    mesh_row.append((xval, yval, z))
+                mesh_points.append(mesh_row)
+
+            for yi in range(plotpoints[1] + 1):
+                yval = ystart + yi / numy * (ystop - ystart)
+                mesh_col = []
+                for xi in range(plotpoints[0] + 1):
+                    xval = xstart + xi / numx * (xstop - xstart)
+                    z = stored[(xval, yval)]
+                    mesh_col.append((xval, yval, z))
+                mesh_points.append(mesh_col)
+
+            # handle edge subdivisions
+            made_changes = True
+            while made_changes:
+                made_changes = False
+                for mesh_line in mesh_points:
+                    i = 0
+                    while i < len(mesh_line) - 1:
+                        x1, y1, v1 = mesh_line[i]
+                        x2, y2, v2 = mesh_line[i + 1]
+                        key = (
+                            ((x1, y1), (x2, y2))
+                            if (x2, y2) > (x1, y1)
+                            else ((x2, y2), (x1, y1))
+                        )
+                        if key in split_edges:
+                            x3 = 0.5 * (x1 + x2)
+                            y3 = 0.5 * (y1 + y2)
+                            v3 = stored[(x3, y3)]
+                            mesh_line.insert(i + 1, (x3, y3, v3))
+                            made_changes = True
+                            i += 1
+                        i += 1
+
+            # handle missing regions
+            old_meshpoints, mesh_points = mesh_points, []
+            for mesh_line in old_meshpoints:
+                mesh_points.extend(
+                    [
+                        sorted(g)
+                        for k, g in itertools.groupby(mesh_line, lambda x: x[2] is None)
+                    ]
                 )
+            mesh_points = [
+                mesh_line
+                for mesh_line in mesh_points
+                if not any(x[2] is None for x in mesh_line)
+            ]
+        elif mesh == "System`All":
+            mesh_points = set()
+            for t in triangles:
+                mesh_points.add((t[0], t[1]) if t[1] > t[0] else (t[1], t[0]))
+                mesh_points.add((t[1], t[2]) if t[2] > t[1] else (t[2], t[1]))
+                mesh_points.add((t[0], t[2]) if t[2] > t[0] else (t[2], t[0]))
+            mesh_points = list(mesh_points)
+
+        # find the max and min height
+        v_min = v_max = None
+        for t in triangles:
+            for tx, ty, v in t:
+                if v_min is None or v < v_min:
+                    v_min = v
+                if v_max is None or v > v_max:
+                    v_max = v
+        graphics.extend(
+            self.construct_graphics(
+                triangles, mesh_points, v_min, v_max, options, evaluation
             )
-        return self.final_graphics(graphics, options)
+        )
+    return self.final_graphics(graphics, options)
 
 
 def construct_density_plot(

--- a/mathics/eval/files_io/read.py
+++ b/mathics/eval/files_io/read.py
@@ -168,7 +168,7 @@ def parse_read_options(options) -> dict:
         record_separators = options["System`RecordSeparators"].to_python(
             string_quotes=False
         )
-        assert isinstance(record_separators, list)
+        assert isinstance(record_separators, (list, tuple))
         # assert all(
         #     isinstance(s, str) and s[0] == s[-1] == '"' for s in record_separators
         # )
@@ -180,7 +180,7 @@ def parse_read_options(options) -> dict:
         word_separators = options["System`WordSeparators"].to_python(
             string_quotes=False
         )
-        assert isinstance(word_separators, list)
+        assert isinstance(word_separators, (list, tuple))
         result["WordSeparators"] = word_separators
 
     # NullRecords
@@ -308,7 +308,7 @@ def read_check_options(options: dict, evaluation: Evaluation) -> Optional[dict]:
         record_separators = options["System`RecordSeparators"].to_python(
             string_quotes=False
         )
-        assert isinstance(record_separators, list)
+        assert isinstance(record_separators, (list, tuple))
         result["RecordSeparators"] = record_separators
 
     # WordSeparators
@@ -316,7 +316,7 @@ def read_check_options(options: dict, evaluation: Evaluation) -> Optional[dict]:
         word_separators = options["System`WordSeparators"].to_python(
             string_quotes=False
         )
-        assert isinstance(word_separators, list)
+        assert isinstance(word_separators, (list, tuple))
         result["WordSeparators"] = word_separators
 
     # NullRecords
@@ -334,7 +334,9 @@ def read_check_options(options: dict, evaluation: Evaluation) -> Optional[dict]:
     # TokenWords
     if "System`TokenWords" in keys:
         token_words = options["System`TokenWords"].to_python(string_quotes=False)
-        if not (isinstance(token_words, list) or isinstance(token_words, String)):
+        if not (
+            isinstance(token_words, (list, tuple)) or isinstance(token_words, String)
+        ):
             evaluation.message("ReadList", "opstl", token_words)
             return None
         result["TokenWords"] = token_words
@@ -344,7 +346,7 @@ def read_check_options(options: dict, evaluation: Evaluation) -> Optional[dict]:
 
 def read_get_separators(
     options, evaluation: Evaluation
-) -> Optional[Tuple[dict, dict, dict]]:
+) -> Optional[Tuple[list, list, list]]:
     """Get record and word separators from apply "options"."""
     # Options
     # TODO Implement extra options
@@ -357,7 +359,7 @@ def read_get_separators(
     token_words = py_options.get("TokenWords", {})
     word_separators = py_options["WordSeparators"]
 
-    return record_separators, token_words, word_separators
+    return list(record_separators), list(token_words), list(word_separators)
 
 
 def read_from_stream(

--- a/test/builtin/files_io/test_files.py
+++ b/test/builtin/files_io/test_files.py
@@ -111,7 +111,7 @@ def test_close():
         ('Close["abc"]', ("abc is not open.",), "Close[abc]", ""),
         (
             "exp = Sin[1]; FilePrint[exp]",
-            ("File specification Sin[1] is not a string of one or more characters.",),
+            ("The specified argument, Sin[1], should be a valid string.",),
             "FilePrint[Sin[1]]",
             "",
         ),
@@ -123,7 +123,7 @@ def test_close():
         ),
         (
             'FilePrint[""]',
-            ("File specification  is not a string of one or more characters.",),
+            ("The file name cannot be an empty string.",),
             "FilePrint[]",
             "",
         ),
@@ -344,7 +344,12 @@ def test_close():
             "Null",
             "",
         ),
-        ('FileDate[tmpfilename, "Access"]', None, "{2002, 1, 1, 0, 0, 0.}", ""),
+        (
+            'FileDate[tmpfilename, "Access"]',
+            None,
+            "{2002, 1, 1, 0, 0, 0.}",
+            "",
+        ),
         ("DeleteFile[tmpfilename]", None, "Null", ""),
     ],
 )
@@ -524,18 +529,6 @@ def test_write_string():
 # I do not know what this is it supposed to test with this...
 # def test_Inputget_and_put():
 #    stream = Expression('Plus', Symbol('x'), Integer(2))
-
-# TODO: add these Unix-specific test. Be sure not to test
-# sys.platform for not Windows and to test for applicability
-# ## writing to dir
-# S> x >> /var/
-#  : Cannot open /var/.
-#  = x >> /var/
-
-# ## writing to read only file
-# S> x >> /proc/uptime
-#  : Cannot open /proc/uptime.
-#  = x >> /proc/uptime
 
 # ## writing to full file
 # S> x >> /dev/full

--- a/test/core/test_sympy_python_convert.py
+++ b/test/core/test_sympy_python_convert.py
@@ -225,7 +225,7 @@ class PythonConvert(unittest.TestCase):
         self.compare(Complex(Integer1, Integer0), 1)
 
     def testList(self):
-        self.compare(ListExpression(Integer1), [1])
+        self.compare(ListExpression(Integer1), (1,))
 
 
 if __name__ == "__main__":

--- a/test/test_to_python.py
+++ b/test/test_to_python.py
@@ -11,7 +11,7 @@ def test_to_infinity():
         ),
         (
             "PythonForm[{1, 2, 3, 4}]",
-            '"[1, 2, 3, 4]"',
+            '"(1, 2, 3, 4)"',
             "Simple List of integers",
         ),
         (


### PR DESCRIPTION
Make use of the  ".value" field in BaseElement objects, especially  Expression.to_python(). 

Recall, the parser creates Python equivalents for certain literal values. In particular, a list of strings. For this, a Python tuple of `str` appears. And this kind of thing happens a lot.  And note that in contrast to Mathics3 strings, a Python string can be duplicated. So by using `.value` of strings found in parsing, we are not only saving time in creation by not copying, but also memory. And we save time in `to_python()` access as well. In some cases, like datetime objects, we can just skip `to_python()`  and use `.value` instead.

This motivation for this came from a desire to do a similar thing for SymPy and NumPy expressions, but that will have to wait. 

In the parser, list element literals are `tuple` types, whereas `to_python ()` returns `lists`.  In the places where a  Python list for a literal was expected, we have a Python tuple for the literal. In these cases, the code has been adjusted to allow both tuple and list types. Where certain list-only operations like mutation were needed, tuples are converted to lists in a new variable.

Methods in module `mathics.core.atoms` have been put in alphabetical order. A bug in `convert_expression_elements`  in setting `.value` was fixed. I suspect it wasn't noticed before because we were not making use of `.value`.

Some of the `FilePrint` error messages have been aligned better for WMA's (and this makes the errors clearer, too.) 

