### PR TITLE
Miscellaneous small evaluation improvements..

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -631,14 +631,23 @@ class I_(Predefined, SympyObject):
     summary_text = "imaginary unit number Sqrt[-1]"
     python_equivalent = 1j
 
-    def is_constant(self) -> bool:
-        return True
-
-    def to_sympy(self, symb, **kwargs):
-        return self.sympy_obj
-
     def evaluate(self, evaluation: Evaluation):
         return Complex(Integer0, Integer1)
+
+    def is_constant(self) -> bool:
+        """The value and evaluation of this object can never change."""
+        return True
+
+    @property
+    def is_literal(self):
+        return True
+
+    @property
+    def value(self) -> complex:
+        return complex(0, 1)
+
+    def to_sympy(self, expr, **kwargs):
+        return self.sympy_obj
 
 
 class Im(SympyFunction):

--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -81,6 +81,7 @@ class _Constant_Common(Predefined):
         return self.get_constant(precision, evaluation)
 
     def is_constant(self) -> bool:
+        """The value and evaluation of this object can never change."""
         return True
 
     def get_constant(

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -18,7 +18,6 @@ Mathics3 represents tensors of vectors and matrices as lists; tensors \
 of any rank can be handled.
 """
 
-
 from mathics.core.atoms import Integer
 from mathics.core.attributes import A_FLAT, A_ONE_IDENTITY, A_PROTECTED
 from mathics.core.builtin import Builtin, InfixOperator
@@ -28,6 +27,7 @@ from mathics.eval.tensors import (
     eval_Inner,
     eval_LeviCivitaTensor,
     eval_Outer,
+    eval_Transpose2D,
     get_dimensions,
 )
 
@@ -378,15 +378,7 @@ class Transpose(Builtin):
 
     def eval(self, m, evaluation: Evaluation):
         "Transpose[m_?MatrixQ]"
-
-        result = []
-        for row_index, row in enumerate(m.elements):
-            for col_index, item in enumerate(row.elements):
-                if row_index == 0:
-                    result.append([item])
-                else:
-                    result[col_index].append(item)
-        return ListExpression(*[ListExpression(*row) for row in result])
+        return eval_Transpose2D(m)
 
 
 class ConjugateTranspose(Builtin):

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -739,6 +739,10 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
                 f"Argument 'image' must be an Integer, Real, or Rational type; is {imag}."
             )
 
+        # Note: for the below test, imag.value == 0 catches more
+        # reals.  In particular, MachineReals that have an imaginary
+        # value of floating point 0.0. But MachineReal 0.0 is "approximate 0",
+        # not exactly 0. So "Complex[0., 0.]" is "0. + 0." and not "0."
         if imag.sameQ(Integer0):
             return real
 

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -573,18 +573,21 @@ class SympyObject(Builtin):
             self.sympy_name = strip_context(self.get_name()).lower()
         self.mathics_to_sympy[self.__class__.__name__] = self.sympy_name
 
-    def is_constant(self) -> bool:
-        return False
-
     def get_sympy_names(self) -> List[str]:
         if self.sympy_name:
             return [self.sympy_name]
         return []
 
-    def to_sympy(self, expr=None, **kwargs):
-        raise NotImplementedError
+    def is_constant(self) -> bool:
+        """Returns true if the value of evaluation of this object can
+        never change.
+        """
+        return False
 
     def from_sympy(self, elements: Tuple[BaseElement, ...]) -> Expression:
+        raise NotImplementedError
+
+    def to_sympy(self, expr=None, **kwargs):
         raise NotImplementedError
 
 

--- a/mathics/eval/tensors.py
+++ b/mathics/eval/tensors.py
@@ -322,3 +322,31 @@ def eval_LeviCivitaTensor(d, type):
             for p in perms
         ]
         return Expression(SymbolSparseArray, from_python(rules), from_python([d] * d))
+
+
+def eval_Transpose2D(m) -> Expression:
+    "Transpose of a 2D matrix"
+
+    # Below is some skeletal code that might get used in the future.
+    # NumPy handles complex numbers differently.
+    # There is a bigger problem in handling literals and
+    # value.
+
+    # if m.is_literal:
+    #     m.numpy = np.array(m.value)
+    #     transposed = np.transpose(m.numpy)
+    #     transposed_list_of_lists = transposed.tolist()
+    #     mathics_transposed = ListExpression(
+    #         *[to_mathics_list(*row) for row in transposed_list_of_lists]
+    #     )
+    #     mathics_transposed.numpy = transposed
+    #     return mathics_transposed
+
+    transposed_list_of_lists = []
+    for row_index, row in enumerate(m.elements):
+        for col_index, item in enumerate(row.elements):
+            if row_index == 0:
+                transposed_list_of_lists.append([item])
+            else:
+                transposed_list_of_lists[col_index].append(item)
+    return ListExpression(*[ListExpression(*row) for row in transposed_list_of_lists])


### PR DESCRIPTION
mathics.builtin.arithmetic:
  Mark "I" constant and add a "value" property

tensors: move evaluation code for Transpose to mathics.eval.tensors.
  Suggest what might possibly happen by adding NumPy code.

Order more methods in alphabetical order.
Improve or add some comments.

eval_tensors.py: convert from DOS format to Unix (CR's removed)