### PR TITLE
Revise transpose

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt update -qq && sudo apt install llvm-dev remake
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
 
     - name: Install Mathics with minimum dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
         cd ..
         # We can comment out after next Mathics-Scanner release
         # python -m pip install Mathics-Scanner[full]
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
         remake -x develop-full
     - name: Test Mathics3

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip install mypy==1.13 sympy==1.12
         # Adjust below for right branch
-        git clone --depth 1 --branch BoxInputEscape https://github.com/Mathics3/mathics-scanner
+        git clone --depth 1 https://github.com/Mathics3/mathics-scanner
         cd mathics-scanner/
         pip install -e .
         bash ./admin-tools/make-JSON-tables.sh

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
     - name: Run Mathics3 Combinatorica tests
       run: |
         git submodule init

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -55,7 +55,7 @@ jobs:
           pip install "setuptools>=70.0.0" PyYAML click packaging pytest
 
           # We can comment out after next Mathics-Scanner release
-          python -m pip install --no-build-isolation -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner
+          python -m pip install --no-build-isolation -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner
           # pip install --no-build-isolation -e .
           # cd ..
 

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -30,7 +30,7 @@ jobs:
         pip install -e .
         cd ..
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
         cd ..
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -31,7 +31,7 @@ jobs:
         cd ..
         # We can comment out after next Mathics-Scanner release
         # python -m pip install Mathics-Scanner[full]
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
         remake -x develop-full
     - name: Test Mathics

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
         pip install -e .
         cd ..
         # We can comment out after next Mathics-Scanner release
-        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner@BoxInputEscape#egg=Mathics-Scanner[full]
+        python -m pip install -e git+https://github.com/Mathics3/mathics-scanner#egg=Mathics-Scanner[full]
         pip install -e .
 
         # python -m pip install Mathics-Scanner[full]

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -27,7 +27,7 @@ from mathics.eval.tensors import (
     eval_Inner,
     eval_LeviCivitaTensor,
     eval_Outer,
-    eval_Transpose2D,
+    eval_Transpose,
     get_dimensions,
 )
 
@@ -377,8 +377,21 @@ class Transpose(Builtin):
     summary_text = "transpose to rearrange indices in any way"
 
     def eval(self, m, evaluation: Evaluation):
-        "Transpose[m_?MatrixQ]"
-        return eval_Transpose2D(m)
+        """Transpose[m_List]"""
+        dimensions = get_dimensions(m)
+        if dimensions is None:
+            return
+        n = len(dimensions)
+        if not (0 <= n <= 3):
+            return
+        if n < 2:
+            return m
+        if n == 2:
+            n_0 = dimensions[0]
+            if not all(sublist == n_0 for sublist in dimensions[1:]):
+                return
+        # FIXME: check 3D dimensions
+        return eval_Transpose(m, n)
 
 
 class ConjugateTranspose(Builtin):

--- a/mathics/builtin/tensors.py
+++ b/mathics/builtin/tensors.py
@@ -347,8 +347,8 @@ class Transpose(Builtin):
     :WMA: https://reference.wolfram.com/language/ref/Transpose.html</url>)
 
     <dl>
-      <dt>'Transpose'[$m$]
-      <dd>transposes rows and columns in the matrix $m$.
+      <dt>'Transpose'[$list$]
+      <dd>transposes the first two levels in $list$. The rank of $list$ should be less than 4.
     </dl>
 
     >> square = {{1, 2, 3}, {4, 5, 6}}; Transpose[square]
@@ -366,12 +366,27 @@ class Transpose(Builtin):
      .
      . 2   4   6
 
-    Transpose is its own inverse. Transposing a matrix twice will give you back the same thing you started out with:
+    >> matrix3D = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}}; Transpose[matrix3D]
+     = {{{1, 2}, {5, 6}}, {{3, 4}, {7, 8}}}
+
+    Transpose is its own inverse. Transposing a matrix twice will give you back the same \
+    thing you started out with:
 
     >> Transpose[Transpose[matrix]] == matrix
      = True
 
-    #> Clear[matrix, square]
+    >> Transpose[Transpose[matrix3D]] == matrix3D
+     = True
+
+    If the rank of the list is 0 or 1, you get the list back
+
+    >> Transpose[{}]
+     = {}
+
+    >> Transpose[{a, b, c}]
+     = {a, b, c}
+
+    #> Clear[matrix, matrix3D, square]
     """
 
     summary_text = "transpose to rearrange indices in any way"
@@ -385,8 +400,9 @@ class Transpose(Builtin):
         if not (0 <= n <= 3):
             return
         if n < 2:
+            # Transpose of a 0 or 1-dimensional tensor is itself.
             return m
-        if n == 2:
+        if n == 3:
             n_0 = dimensions[0]
             if not all(sublist == n_0 for sublist in dimensions[1:]):
                 return

--- a/mathics/core/convert/matrix.py
+++ b/mathics/core/convert/matrix.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"""low-level Functions involving matrices"""
+"""low-level Functions involving Matrices and Arrays"""
 
 from typing import Optional
 
-from sympy import Matrix
+from sympy import Array, Matrix
 
 
 def matrix_data(m):
@@ -20,10 +20,35 @@ def matrix_data(m):
             return result
 
 
-def to_sympy_matrix(m) -> Optional[Matrix]:
+def to_sympy_array(m) -> Optional[Array]:
+    """Converts a Mathics3 List of nested lists into a SymPy Array.
+    If there is an problem in conversion return None.
+    """
     if not m.has_form("List", None):
         return None
     if all(element.has_form("List", None) for element in m.elements):
+        if m.is_literal and m.value is not None:
+            return Array(m.value)
+        result = [[item.to_sympy() for item in row.elements] for row in m.elements]
+        if not any(None in row for row in result):
+            return Array(result)
+    elif not any(element.has_form("List", None) for element in m.elements):
+        result = [item.to_sympy() for item in m.elements]
+        if None not in result:
+            return Array(result)
+
+
+def to_sympy_matrix(m) -> Optional[Matrix]:
+    """
+    Converts a 2D Mathics3 List of Lists into a SymPy Matrix.
+    (Matrices in SymPy are always 2D.)
+    If there is an problem in conversion return None.
+    """
+    if not m.has_form("List", None):
+        return None
+    if all(element.has_form("List", None) for element in m.elements):
+        if m.is_literal and m.value is not None:
+            return Matrix(m.value)
         result = [[item.to_sympy() for item in row.elements] for row in m.elements]
         if not any(None in row for row in result):
             return Matrix(result)

--- a/mathics/core/convert/matrix.py
+++ b/mathics/core/convert/matrix.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"low-level Functions involving matrices"
+"""low-level Functions involving matrices"""
+
+from typing import Optional
+
+from sympy import Matrix
 
 
 def matrix_data(m):
@@ -14,3 +18,16 @@ def matrix_data(m):
         result = [item.to_sympy() for item in m.elements]
         if None not in result:
             return result
+
+
+def to_sympy_matrix(m) -> Optional[Matrix]:
+    if not m.has_form("List", None):
+        return None
+    if all(element.has_form("List", None) for element in m.elements):
+        result = [[item.to_sympy() for item in row.elements] for row in m.elements]
+        if not any(None in row for row in result):
+            return Matrix(result)
+    elif not any(element.has_form("List", None) for element in m.elements):
+        result = [item.to_sympy() for item in m.elements]
+        if None not in result:
+            return Matrix(result)

--- a/mathics/core/convert/matrix.py
+++ b/mathics/core/convert/matrix.py
@@ -18,6 +18,7 @@ def matrix_data(m):
         result = [item.to_sympy() for item in m.elements]
         if None not in result:
             return result
+    return None
 
 
 def to_sympy_array(m) -> Optional[Array]:
@@ -36,6 +37,7 @@ def to_sympy_array(m) -> Optional[Array]:
         result = [item.to_sympy() for item in m.elements]
         if None not in result:
             return Array(result)
+    return None
 
 
 def to_sympy_matrix(m) -> Optional[Matrix]:
@@ -47,8 +49,6 @@ def to_sympy_matrix(m) -> Optional[Matrix]:
     if not m.has_form("List", None):
         return None
     if all(element.has_form("List", None) for element in m.elements):
-        if m.is_literal and m.value is not None:
-            return Matrix(m.value)
         result = [[item.to_sympy() for item in row.elements] for row in m.elements]
         if not any(None in row for row in result):
             return Matrix(result)
@@ -56,3 +56,4 @@ def to_sympy_matrix(m) -> Optional[Matrix]:
         result = [item.to_sympy() for item in m.elements]
         if None not in result:
             return Matrix(result)
+    return None

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -294,7 +294,7 @@ def to_numeric_sympy_args(mathics_args: BaseElement, evaluation) -> list:
 
 
 def from_sympy_matrix(
-    expr: Union[sympy.Matrix, sympy.ImmutableMatrix]
+    expr: Union[sympy.Matrix, sympy.ImmutableMatrix, sympy.Array]
 ) -> ListExpression:
     """
     Convert `expr` of the type sympy.Matrix or sympy.ImmutableMatrix to

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -287,44 +287,44 @@ class Rule(BaseRule):
 
 class FunctionApplyRule(BaseRule):
     """
-        A FunctionApplyRule is a rule that has a replacement term that
-        is associated a Python function rather than a Mathics Expression
-        as happens in a transformation Rule.
+    A FunctionApplyRule is a rule that has a replacement term that
+    is associated a Python function rather than a Mathics Expression
+    as happens in a transformation Rule.
 
-        Each time the Pattern part of the Rule matches an Expression, the
-        matching subexpression is replaced by the expression returned
-        by application of that function to the remaining terms.
+    Each time the Pattern part of the Rule matches an Expression, the
+    matching subexpression is replaced by the expression returned
+    by application of that function to the remaining terms.
 
-        Parameters for the function are bound to parameters matched by the pattern.
+    Parameters for the function are bound to parameters matched by the pattern.
 
-        Here is an example taken from the symbol ``System`Plus``.
-        It has has associated a FunctionApplyRule::
+    Here is an example taken from the symbol ``System`Plus``.
+    It has has associated a FunctionApplyRule::
 
-            Plus[items___] -> mathics.builtin.arithfns.basic.Plus.apply
+        Plus[items___] -> mathics.builtin.arithfns.basic.Plus.apply
 
-        The pattern ``items___`` matches a list of Expressions.
+    The pattern ``items___`` matches a list of Expressions.
 
-        When applied to the expression ``F[a+a]`` the method
-        ``mathics.builtin.arithfns.basic.Plus.apply`` is called
-        binding the parameter  ``items`` to the value ``Sequence[a,a]``.
+    When applied to the expression ``F[a+a]`` the method
+    ``mathics.builtin.arithfns.basic.Plus.apply`` is called
+    binding the parameter  ``items`` to the value ``Sequence[a,a]``.
 
-        The return value of this function is ``Times[2, a]`` (or more compactly: ``2*a``).
-        When replaced in the original expression, the result is: ``F[2*a]``.
+    The return value of this function is ``Times[2, a]`` (or more compactly: ``2*a``).
+    When replaced in the original expression, the result is: ``F[2*a]``.
 
-        In contrast to (transformation) Rules, FunctionApplyRules can
-        change the state of definitions in the the system.
-    p
-        For example, the rule::
+    In contrast to (transformation) Rules, FunctionApplyRules can
+    change the state of definitions in the the system.
 
-            SetAttributes[a_,b_] -> mathics.builtin.attributes.SetAttributes.apply
+    For example, the rule::
 
-        when applied to the expression ``SetAttributes[F,  NumericFunction]``
+        SetAttributes[a_,b_] -> mathics.builtin.attributes.SetAttributes.apply
 
-        sets the attribute ``NumericFunction`` in the  definition of the symbol
-        ``F`` and returns Null (``SymbolNull``).
+    when applied to the expression ``SetAttributes[F,  NumericFunction]``
 
-        This will cause `Expression.evaluate() to perform an additional
-        ``rewrite_apply_eval()`` step.
+    sets the attribute ``NumericFunction`` in the  definition of the symbol
+    ``F`` and returns Null (``SymbolNull``).
+
+    This will cause `Expression.evaluate() to perform an additional
+    ``rewrite_apply_eval()`` step.
 
     """
 

--- a/mathics/eval/tensors.py
+++ b/mathics/eval/tensors.py
@@ -5,7 +5,7 @@ from sympy.tensor.array.expressions import PermuteDims
 from sympy.utilities.iterables import permutations
 
 from mathics.core.atoms import Integer, Integer0, Integer1, String
-from mathics.core.convert.matrix import to_sympy_matrix
+from mathics.core.convert.matrix import to_sympy_array, to_sympy_matrix
 from mathics.core.convert.python import from_python
 from mathics.core.convert.sympy import from_sympy_matrix
 from mathics.core.evaluation import Evaluation
@@ -328,14 +328,15 @@ def eval_LeviCivitaTensor(d, type):
 
 
 def eval_Transpose(m, dimensions: int) -> Optional[Expression]:
-    """Transpose a two-dimensional matrix"""
+    """Transpose a two- or three-dimensional matrix"""
 
+    if dimensions == 3:
+        sympy_m = to_sympy_array(m)
+        # The below seems to be the default permuatation WMA uses
+        # for 3D matrices.
+        p = PermuteDims(sympy_m, (1, 0, 2))
+        return from_sympy_matrix(p.as_explicit())
+
+    assert dimensions == 2
     sympy_m = to_sympy_matrix(m)
-    if sympy_m is None:
-        return None
-
-    if dimensions == 2:
-        return from_sympy_matrix(sympy_m.T)
-    elif dimensions == 3:
-        # Swap the last two dimensions
-        return from_sympy_matrix(PermuteDims(sympy_m, (0, 2, 1)))
+    return None if sympy_m is None else from_sympy_matrix(sympy_m.T)


### PR DESCRIPTION
Expand `Transpose[]` and add  SymPy  conversion to SymPy `Array`
    
 Transpose can now handle 3-dimensional (and 0-dimensional and 1-dimensional) tensors.

 Make use of  `.value` on list literals when converting to SymPy.

Fixes #1412
