### PR TITLE
small tweaks to - Isolate LHS options in Pattern Rules

### DIFF
--- a/mathics/builtin/functional/apply_fns_to_lists.py
+++ b/mathics/builtin/functional/apply_fns_to_lists.py
@@ -11,7 +11,7 @@ they are always applied to every element in a list.
 
 from typing import Iterable
 
-from mathics.core.atoms import Integer, Integer3
+from mathics.core.atoms import Integer, Integer0, Integer1, Integer3
 from mathics.core.builtin import Builtin, InfixOperator
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.evaluation import Evaluation
@@ -22,6 +22,7 @@ from mathics.core.symbols import Atom, SymbolNull, SymbolTrue
 from mathics.core.systemsymbols import SymbolMapThread
 from mathics.eval.functional.apply_fns_to_lists import eval_MapAt
 from mathics.eval.parts import python_levelspec, walk_levels
+from mathics.eval.patterns import param_and_option_from_optional_place
 
 # This tells documentation how to sort this module
 sort_order = "mathics.builtin.applying-functions-to-lists"
@@ -75,14 +76,13 @@ class Apply(InfixOperator):
         "Heads": "False",
     }
 
-    def eval_invalidlevel(self, f, expr, ls, evaluation, options={}):
-        "Apply[f_, expr_, ls_, OptionsPattern[Apply]]"
-
-        evaluation.message("Apply", "level", ls)
-
     def eval(self, f, expr, ls, evaluation, options={}):
-        """Apply[f_, expr_, Optional[Pattern[ls, _?LevelQ], {0}],
+        """Apply[f_, expr_, Optional[ls_, {0}],
         OptionsPattern[Apply]]"""
+
+        ls = param_and_option_from_optional_place(
+            ls, options, "System`Apply", evaluation
+        ) or ListExpression(Integer0)
 
         try:
             start, stop = python_levelspec(ls)
@@ -136,15 +136,13 @@ class Map(InfixOperator):
         "Heads": "False",
     }
 
-    def eval_invalidlevel(self, f, expr, ls, evaluation, options={}):
-        "Map[f_, expr_, ls_, OptionsPattern[Map]]"
-
-        evaluation.message("Map", "level", ls)
-
     def eval_level(self, f, expr, ls, evaluation, options={}):
-        """Map[f_, expr_, Optional[Pattern[ls, _?LevelQ], {1}],
+        """Map[f_, expr_, Optional[ls_, {1}],
         OptionsPattern[Map]]"""
 
+        ls = param_and_option_from_optional_place(
+            ls, options, "System`Map", evaluation
+        ) or ListExpression(Integer1)
         try:
             start, stop = python_levelspec(ls)
         except InvalidLevelspecError:
@@ -269,15 +267,12 @@ class MapIndexed(Builtin):
         "Heads": "False",
     }
 
-    def eval_invalidlevel(self, f, expr, ls, evaluation, options={}):
-        "MapIndexed[f_, expr_, ls_, OptionsPattern[MapIndexed]]"
-
-        evaluation.message("MapIndexed", "level", ls)
-
     def eval_level(self, f, expr, ls, evaluation, options={}):
-        """MapIndexed[f_, expr_, Optional[Pattern[ls, _?LevelQ], {1}],
+        """MapIndexed[f_, expr_, Optional[ls_, {1}],
         OptionsPattern[MapIndexed]]"""
-
+        ls = param_and_option_from_optional_place(
+            ls, options, "System`MapIndexed", evaluation
+        ) or ListExpression(Integer1)
         try:
             start, stop = python_levelspec(ls)
         except InvalidLevelspecError:
@@ -415,15 +410,12 @@ class Scan(Builtin):
         "Scan[f_][expr_]": "Scan[f, expr]",
     }
 
-    def eval_invalidlevel(self, f, expr, ls, evaluation, options={}):
-        "Scan[f_, expr_, ls_, OptionsPattern[Map]]"
-
-        evaluation.message("Map", "level", ls)
-
     def eval_level(self, f, expr, ls, evaluation, options={}):
-        """Scan[f_, expr_, Optional[Pattern[ls, _?LevelQ], {1}],
+        """Scan[f_, expr_, Optional[ls_, {1}],
         OptionsPattern[Map]]"""
-
+        ls = param_and_option_from_optional_place(
+            ls, options, "System`Scan", evaluation
+        ) or ListExpression(Integer0)
         try:
             start, stop = python_levelspec(ls)
         except InvalidLevelspecError:

--- a/mathics/builtin/functional/apply_fns_to_lists.py
+++ b/mathics/builtin/functional/apply_fns_to_lists.py
@@ -76,18 +76,18 @@ class Apply(InfixOperator):
         "Heads": "False",
     }
 
-    def eval(self, f, expr, ls, evaluation, options={}):
-        """Apply[f_, expr_, Optional[ls_, {0}],
+    def eval(self, f, expr, lhs, evaluation: Evaluation, options={}):
+        """Apply[f_, expr_, Optional[lhs_, {0}],
         OptionsPattern[Apply]]"""
 
-        ls = param_and_option_from_optional_place(
-            ls, options, "System`Apply", evaluation
+        lhs = param_and_option_from_optional_place(
+            lhs, options, "System`Apply", evaluation
         ) or ListExpression(Integer0)
 
         try:
-            start, stop = python_levelspec(ls)
+            start, stop = python_levelspec(lhs)
         except InvalidLevelspecError:
-            evaluation.message("Apply", "level", ls)
+            evaluation.message("Apply", "level", lhs)
             return
 
         def callback(level):
@@ -136,17 +136,17 @@ class Map(InfixOperator):
         "Heads": "False",
     }
 
-    def eval_level(self, f, expr, ls, evaluation, options={}):
-        """Map[f_, expr_, Optional[ls_, {1}],
+    def eval_level(self, f, expr, lhs, evaluation: Evaluation, options={}):
+        """Map[f_, expr_, Optional[lhs_, {1}],
         OptionsPattern[Map]]"""
 
-        ls = param_and_option_from_optional_place(
-            ls, options, "System`Map", evaluation
+        lhs = param_and_option_from_optional_place(
+            lhs, options, "System`Map", evaluation
         ) or ListExpression(Integer1)
         try:
-            start, stop = python_levelspec(ls)
+            start, stop = python_levelspec(lhs)
         except InvalidLevelspecError:
-            evaluation.message("Map", "level", ls)
+            evaluation.message("Map", "level", lhs)
             return
 
         def callback(level):
@@ -267,16 +267,16 @@ class MapIndexed(Builtin):
         "Heads": "False",
     }
 
-    def eval_level(self, f, expr, ls, evaluation, options={}):
-        """MapIndexed[f_, expr_, Optional[ls_, {1}],
+    def eval_level(self, f, expr, lhs, evaluation: Evaluation, options={}):
+        """MapIndexed[f_, expr_, Optional[lhs_, {1}],
         OptionsPattern[MapIndexed]]"""
-        ls = param_and_option_from_optional_place(
-            ls, options, "System`MapIndexed", evaluation
+        lhs = param_and_option_from_optional_place(
+            lhs, options, "System`MapIndexed", evaluation
         ) or ListExpression(Integer1)
         try:
-            start, stop = python_levelspec(ls)
+            start, stop = python_levelspec(lhs)
         except InvalidLevelspecError:
-            evaluation.message("MapIndexed", "level", ls)
+            evaluation.message("MapIndexed", "level", lhs)
             return
 
         def callback(level, pos: Iterable):
@@ -410,16 +410,16 @@ class Scan(Builtin):
         "Scan[f_][expr_]": "Scan[f, expr]",
     }
 
-    def eval_level(self, f, expr, ls, evaluation, options={}):
-        """Scan[f_, expr_, Optional[ls_, {1}],
+    def eval_level(self, f, expr, lhs, evaluation: Evaluation, options={}):
+        """Scan[f_, expr_, Optional[lhs_, {1}],
         OptionsPattern[Map]]"""
-        ls = param_and_option_from_optional_place(
-            ls, options, "System`Scan", evaluation
+        lhs = param_and_option_from_optional_place(
+            lhs, options, "System`Scan", evaluation
         ) or ListExpression(Integer0)
         try:
-            start, stop = python_levelspec(ls)
+            start, stop = python_levelspec(lhs)
         except InvalidLevelspecError:
-            evaluation.message("Map", "level", ls)
+            evaluation.message("Map", "level", lhs)
             return
 
         def callback(level):
@@ -427,7 +427,7 @@ class Scan(Builtin):
             return level
 
         heads = self.get_option(options, "Heads", evaluation) is SymbolTrue
-        result, depth = walk_levels(expr, start, stop, heads=heads, callback=callback)
+        walk_levels(expr, start, stop, heads=heads, callback=callback)
 
         return SymbolNull
 

--- a/mathics/eval/patterns.py
+++ b/mathics/eval/patterns.py
@@ -68,3 +68,30 @@ def get_default_value(
 
 def match(expr, form, evaluation: Evaluation):
     return Matcher(form, evaluation).match(expr, evaluation)
+
+
+def param_and_option_from_optional_place(opt_param, options, head, evaluation):
+    """
+    If ls is a `Rule` or `RuleDelayed` expression, and it is not
+    expected in an Optional parameter, store the option in the
+    `options` dictionary, and return the default value for the
+    parameter.
+
+    Used for rules of the form
+     ```Head[elem1,... ,Optional[...],OptionValues[]]```
+    """
+
+    if not opt_param.has_form(
+        (
+            "Rule",
+            "RuleDelayed",
+        ),
+        2,
+    ):
+        return opt_param
+
+    options_ = opt_param.get_option_values(evaluation, True)
+    for key in options_:
+        del options[key]
+    options.update(options_)
+    return get_default_value(head, evaluation)


### PR DESCRIPTION
variable `ls` renamed to `lhs` and lint the program a little. 