### PR TITLE
Derive `Expression` inside Builtin `eval()` methods

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -49,7 +49,7 @@ from mathics.eval.files_io.read import (
     read_name_and_stream,
 )
 from mathics.eval.makeboxes import do_format, format_element
-from mathics.eval.stack import get_eval_Expression
+from mathics.eval.stackframe import get_eval_Expression
 
 
 class Input_(Predefined):

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -695,8 +695,7 @@ class PutAppend(InfixOperator):
     def eval_default(self, exprs, filename, evaluation):
         "PutAppend[exprs___, filename_]"
         evaluation.message("PutAppend", "stream", filename)
-        expr = get_eval_Expression()
-        return expr
+        return get_eval_Expression()
 
 
 def validate_read_type(name: str, typ, evaluation: Evaluation):

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -49,6 +49,7 @@ from mathics.eval.files_io.read import (
     read_name_and_stream,
 )
 from mathics.eval.makeboxes import do_format, format_element
+from mathics.eval.stack import get_eval_Expression
 
 
 class Input_(Predefined):
@@ -693,8 +694,8 @@ class PutAppend(InfixOperator):
 
     def eval_default(self, exprs, filename, evaluation):
         "PutAppend[exprs___, filename_]"
-        expr = to_expression("PutAppend", exprs, filename)
         evaluation.message("PutAppend", "stream", filename)
+        expr = get_eval_Expression()
         return expr
 
 

--- a/mathics/eval/stackframe.py
+++ b/mathics/eval/stackframe.py
@@ -38,7 +38,7 @@ def get_eval_Expression() -> Optional[Expression]:
     not found.
 
     The method is fragile in that it relies on the Mathics3 implementation
-    having a Expression.rewrite_apply_eval_step() method.  It walks to
+    having a Expression.rewrite_apply_eval_step() method.  It walks the
     call stack to find that Expression.
 
     None is returned if we can't find this.


### PR DESCRIPTION
 Introduce `get_eval_Expression()`
    
 `get_eval_Expression()` can be used in Mathics3 Builtin evaluation methods to find the Expression that caused the evaluation to get triggered.
    
It is often needed in error messages of "eval()" methods to report what `Expression` is in error.
