### PR TITLE
Add get_eval_Expression()

### DIFF
--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -49,6 +49,7 @@ from mathics.eval.files_io.read import (
     read_name_and_stream,
 )
 from mathics.eval.makeboxes import do_format, format_element
+from mathics.eval.stackframe import get_eval_Expression
 
 
 class Input_(Predefined):
@@ -567,7 +568,7 @@ class Put(InfixOperator):
 
     summary_text = "write an expression to a file"
 
-    def eval(self, exprs, filename, evaluation):
+    def eval(self, exprs, filename, evaluation: Evaluation):
         "Put[exprs___, filename_String]"
         instream = to_expression("OpenWrite", filename).evaluate(evaluation)
         if len(instream.elements) == 2:
@@ -581,7 +582,7 @@ class Put(InfixOperator):
         close_stream(py_instream, instream_number)
         return result
 
-    def eval_input(self, exprs, name, n, evaluation):
+    def eval_input(self, exprs, name, n, evaluation: Evaluation):
         "Put[exprs___, OutputStream[name_, n_]]"
         stream = stream_manager.lookup_stream(n.get_int_value())
 
@@ -608,11 +609,10 @@ class Put(InfixOperator):
 
         return SymbolNull
 
-    def eval_default(self, exprs, filename, evaluation):
+    def eval_default(self, exprs, filename, evaluation: Evaluation):
         "Put[exprs___, filename_]"
-        expr = to_expression("Put", exprs, filename)
         evaluation.message("Put", "stream", filename)
-        return expr
+        return to_expression("Put", exprs, filename)
 
 
 class PutAppend(InfixOperator):
@@ -661,7 +661,7 @@ class PutAppend(InfixOperator):
 
     summary_text = "append an expression to a file"
 
-    def eval(self, exprs, filename, evaluation):
+    def eval(self, exprs, filename: String, evaluation):
         "PutAppend[exprs___, filename_String]"
         instream = to_expression("OpenAppend", filename).evaluate(evaluation)
         if len(instream.elements) == 2:
@@ -672,12 +672,12 @@ class PutAppend(InfixOperator):
         to_expression("Close", instream).evaluate(evaluation)
         return result
 
-    def eval_input(self, exprs, name, n, evaluation):
+    def eval_input(self, exprs, name, n, evaluation: Evaluation):
         "PutAppend[exprs___, OutputStream[name_, n_]]"
         stream = stream_manager.lookup_stream(n.get_int_value())
 
         if stream is None or stream.io.closed:
-            evaluation.message("Put", "openx", to_expression("OutputSteam", name, n))
+            evaluation.message("Put", "openx", get_eval_Expression())
             return
 
         text = [
@@ -691,11 +691,10 @@ class PutAppend(InfixOperator):
 
         return SymbolNull
 
-    def eval_default(self, exprs, filename, evaluation):
+    def eval_default(self, exprs, filename, evaluation: Evaluation):
         "PutAppend[exprs___, filename_]"
-        expr = to_expression("PutAppend", exprs, filename)
         evaluation.message("PutAppend", "stream", filename)
-        return expr
+        return get_eval_Expression()
 
 
 def validate_read_type(name: str, typ, evaluation: Evaluation):
@@ -1100,11 +1099,9 @@ class ReadList(Read):
         # token_words = py_options['TokenWords']
         # word_separators = py_options['WordSeparators']
 
-        py_n = n.get_int_value()
+        py_n = n.value
         if py_n < 0:
-            evaluation.message(
-                "ReadList", "intnm", to_expression("ReadList", file, types, n)
-            )
+            evaluation.message("ReadList", "intnm", get_eval_Expression())
             return
 
         result = []
@@ -1215,9 +1212,7 @@ class SetStreamPosition(Builtin):
 
         seekpos = m.to_python()
         if not (isinstance(seekpos, int) or seekpos == float("inf")):
-            evaluation.message(
-                "SetStreamPosition", "stmrng", to_expression("InputStream", name, n), m
-            )
+            evaluation.message("SetStreamPosition", "stmrng", get_eval_Expression(), m)
             return
 
         try:
@@ -1312,7 +1307,7 @@ class Skip(Read):
             evaluation.message(
                 "Skip",
                 "intm",
-                to_expression("Skip", to_expression("InputStream", name, n), typ, m),
+                to_expression("Skip", stream, typ, m),
             )
             return
         for i in range(py_m):
@@ -1478,7 +1473,7 @@ class Streams(Builtin):
         "Streams[]"
         return self.eval_name(None, evaluation)
 
-    def eval_name(self, name, evaluation):
+    def eval_name(self, name: String, evaluation):
         "Streams[name_String]"
         result = []
         for stream in stream_manager.STREAMS.values():

--- a/mathics/eval/stackframe.py
+++ b/mathics/eval/stackframe.py
@@ -1,0 +1,82 @@
+"""
+Mathics3 Introspection routines to get Mathics3-oriented Python frames.
+"""
+
+import inspect
+from types import FrameType
+from typing import Optional
+
+from mathics.core.builtin import Builtin
+from mathics.core.expression import Expression
+
+
+def find_Mathics3_evaluation_method(frame: Optional[FrameType]) -> Optional[FrameType]:
+    """
+    Returns the most recent Mathics3 evaluation frame given "frame".
+    """
+    if not inspect.isframe(frame):
+        return None
+
+    while frame is not None:
+        if is_Mathics3_eval_method(frame):
+            return frame
+        frame = frame.f_back
+    return None
+
+
+def get_self(frame: FrameType) -> Optional[FrameType]:
+    """Returns the `self` object in a Python frame if it exists, or None if
+    it does not exist.
+    """
+    return frame.f_locals.get("self", None)
+
+
+def get_eval_Expression() -> Optional[Expression]:
+    """Returns the Expression used in a Mathics3 evaluation() or
+    eval() Builtin method. This is often needed in an error message to
+    report what Expression was getting evaluated. None is returned if
+    not found.
+
+    The method is fragile in that it relies on the Mathics3 implementation
+    having a Expression.rewrite_apply_eval_step() method.  It walks to
+    call stack to find that Expression.
+
+    None is returned if we can't find this.
+    """
+    frame = inspect.currentframe()
+    if frame is None:
+        return None
+
+    frame = frame.f_back
+    while True:
+        if frame is None:
+            return None
+        method_code = frame.f_code
+        if method_code.co_name == "rewrite_apply_eval_step":
+            if (self_obj := get_self(frame)) is not None and isinstance(
+                self_obj, Expression
+            ):
+                return self_obj
+
+        frame = frame.f_back
+
+
+def is_Mathics3_eval_method(frame) -> bool:
+    """
+    Returns True if frame is Python frame object for a Mathics3 Builtin, and
+    returns False otherwise.
+    """
+    if not inspect.isframe(frame):
+        return False
+
+    method_code = frame.f_code
+    if not method_code.co_name.startswith("eval"):
+        return False
+    if frame.f_locals.get("evaluation", None) is None:
+        return False
+
+    if (self_obj := get_self(frame)) is None or frame.f_locals.get(
+        "evaluation", None
+    ) is None:
+        return False
+    return isinstance(self_obj, Builtin)


### PR DESCRIPTION
Introduce `get_eval_Expression()`

`get_eval_Expression()` can be used in Mathics3 Builtin evaluation methods to find the Expression that caused the evaluation to get triggered.

mathics.file_io.files module converted to use this function to test worthiness.