### PR TITLE
remove some error checking-only eval methods and two small tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ MATHICS3_MODULE_OPTION ?= --load-module pymathics.graph,pymathics.natlang
    gstest \
    latexdoc \
    pytest \
+   pytest-x \
    rmChangeLog \
    test \
    texdoc
@@ -122,6 +123,9 @@ clean: clean-cython clean-cache
 pytest:
 	MATHICS_CHARACTER_ENCODING="ASCII" $(PYTHON) -m pytest $(PYTEST_OPTIONS) $(PYTEST_WORKERS) test
 
+#: Run pytest tests stopping at first failure.
+pytest-x :
+	PYTEST_OPTIONS="-x" $(MAKE) pytest
 
 #: Run a more extensive pattern-matching test
 gstest:

--- a/mathics/builtin/atomic/numbers.py
+++ b/mathics/builtin/atomic/numbers.py
@@ -20,6 +20,7 @@ However, things like 'N[Pi, 100]' should work as expected.
 import mpmath
 
 from mathics.core.atoms import (
+    Complex,
     Integer,
     Integer0,
     Integer3,
@@ -393,10 +394,6 @@ class RealDigits(Builtin):
 
     summary_text = "get digits of a real number"
 
-    def eval_complex(self, n, var, evaluation):
-        "%(name)s[n_Complex, var___]"
-        evaluation.message("RealDigits", "realx", n)
-
     def eval_rational_with_base(self, n, b, evaluation):
         "%(name)s[n_Rational, b_Integer]"
         # expr = Expression(SymbolRealDigits, n)
@@ -436,6 +433,10 @@ class RealDigits(Builtin):
     def eval_with_base(self, n, b, evaluation, nr_elements=None, pos=None):
         """%(name)s[n_?NumericQ, b_Integer]"""
 
+        if isinstance(n, Complex):
+            evaluation.message("RealDigits", "realx", n)
+            return
+
         expr = Expression(SymbolRealDigits, n)
         rational_no = (
             True if isinstance(n, Rational) else False
@@ -456,6 +457,7 @@ class RealDigits(Builtin):
                 else:
                     evaluation.message("RealDigits", "ndig", expr)
                     return
+
         py_n = abs(n.value)
 
         if not py_b > 1:

--- a/mathics/builtin/files_io/files.py
+++ b/mathics/builtin/files_io/files.py
@@ -661,8 +661,13 @@ class PutAppend(InfixOperator):
 
     summary_text = "append an expression to a file"
 
-    def eval(self, exprs, filename: String, evaluation):
-        "PutAppend[exprs___, filename_String]"
+    def eval(self, exprs, filename, evaluation):
+        "PutAppend[exprs___, filename_]"
+
+        if not isinstance(filename, String):
+            evaluation.message("PutAppend", "stream", filename)
+            return
+
         instream = to_expression("OpenAppend", filename).evaluate(evaluation)
         if len(instream.elements) == 2:
             name, n = instream.elements
@@ -690,11 +695,6 @@ class PutAppend(InfixOperator):
         stream.io.write(text)
 
         return SymbolNull
-
-    def eval_default(self, exprs, filename, evaluation: Evaluation):
-        "PutAppend[exprs___, filename_]"
-        evaluation.message("PutAppend", "stream", filename)
-        return get_eval_Expression()
 
 
 def validate_read_type(name: str, typ, evaluation: Evaluation):

--- a/test/builtin/patterns/test_rules.py
+++ b/test/builtin/patterns/test_rules.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for mathics.builtins.patterns.rules
+"""
+from test.helper import check_evaluation
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "expected_messages", "str_expected", "assert_message"),
+    [
+        (
+            "ReplaceList[expr, {}, -1]",
+            (
+                "Non-negative integer or Infinity expected at position 3 in ReplaceList[expr, {}, -1]",
+            ),
+            "ReplaceList[expr, {}, -1]",
+            None,
+        ),
+    ],
+)
+def test_associations_private_doctests(
+    str_expr, expected_messages, str_expected, assert_message
+):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        failure_message=assert_message,
+        expected_messages=expected_messages,
+    )


### PR DESCRIPTION
Remove two builtin eval-methods that existed only to issue some errors.

Instead, the tests which are parameter type checks, have been folded into the broader evaluation method for that builtin.

Also, add Makefile target `pytest-x` option to stop on first pytest failure. 
Add a ReduceList pytest.