### PR TITLE
Add argument mismatch checks and error messages

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -83,6 +83,10 @@ class CubeRoot(Builtin):
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
 
+    # Set checking that the number of arguments required is one.
+    eval_error = Builtin.generic_argument_error
+    expected_args = 1
+
     messages = {
         "preal": "The parameter `1` should be real valued.",
     }
@@ -97,7 +101,7 @@ class CubeRoot(Builtin):
 
     summary_text = "compute cube root of a number"
 
-    def eval(self, n, evaluation):
+    def eval(self, n, evaluation: Evaluation):
         "CubeRoot[n_Complex]"
 
         evaluation.message("CubeRoot", "preal", n)
@@ -152,6 +156,10 @@ class Divide(InfixOperator):
 
     default_formats = False
 
+    # Set checking that the number of arguments required is two.
+    eval_error = Builtin.generic_argument_error
+    expected_args = 2
+
     formats = {
         (("InputForm", "OutputForm"), "Divide[x_, y_]"): (
             'Infix[{HoldForm[x], HoldForm[y]}, "/", 400, Left]'
@@ -196,6 +204,10 @@ class Minus(PrefixOperator):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
+
+    # Set checking that the number of arguments required is two.
+    eval_error = Builtin.generic_argument_error
+    expected_args = 1
 
     formats = {
         "Minus[x_]": 'Prefix[{HoldForm[x]}, "-", 480]',
@@ -284,6 +296,11 @@ class Plus(InfixOperator, SympyFunction):
     # Remember to up sympy doc link when this is corrected
     sympy_name = "Add"
 
+    def eval(self, elements, evaluation: Evaluation):
+        "Plus[elements___]"
+        elements_tuple = numerify(elements, evaluation).get_sequence()
+        return eval_Plus(*elements_tuple)
+
     def format_plus(self, items, evaluation: Evaluation):
         "Plus[items__]"
 
@@ -334,11 +351,6 @@ class Plus(InfixOperator, SympyFunction):
             Integer310,
             SymbolLeft,
         )
-
-    def eval(self, items, evaluation: Evaluation):
-        "Plus[items___]"
-        items_tuple = numerify(items, evaluation).get_sequence()
-        return eval_Plus(*items_tuple)
 
 
 class Power(InfixOperator, MPMathFunction):
@@ -509,6 +521,10 @@ class Sqrt(SympyFunction):
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
+    # Set checking that the number of arguments required is one.
+    eval_error = Builtin.generic_argument_error
+    expected_args = 1
+
     rules = {
         "Sqrt[x_]": "x ^ (1/2)",
         "MakeBoxes[Sqrt[x_], f:StandardForm|TraditionalForm]": (
@@ -543,6 +559,11 @@ class Subtract(InfixOperator):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
+
+    # Set checking that the number of arguments required is two.
+    eval_error = Builtin.generic_argument_error
+    expected_args = 2
+
     grouping = "Left"
 
     rules = {
@@ -615,9 +636,14 @@ class Times(InfixOperator, SympyFunction):
     # Remember to up sympy doc link when this is corrected
     sympy_name = "Mul"
 
-    summary_text = "multiply a number"
+    summary_text = "multiply numbers"
 
-    def format_times(self, items, evaluation, op="\u2062"):
+    def eval(self, elements, evaluation: Evaluation):
+        "Times[elements___]"
+        numeric_elements = numerify(elements, evaluation).get_sequence()
+        return eval_Times(*numeric_elements)
+
+    def format_times(self, items, evaluation: Evaluation, op="\u2062"):
         "Times[items__]"
 
         def inverse(item):
@@ -689,8 +715,3 @@ class Times(InfixOperator, SympyFunction):
     def format_outputform(self, items, evaluation):
         "(OutputForm,): Times[items__]"
         return self.format_times(items, evaluation, op=" ")
-
-    def eval(self, items, evaluation):
-        "Times[items___]"
-        items = numerify(items, evaluation).get_sequence()
-        return eval_Times(*items)

--- a/test/builtin/arithmetic/test_basic.py
+++ b/test/builtin/arithmetic/test_basic.py
@@ -491,3 +491,69 @@ def test_private_doctests_arithmetic(str_expr, msgs, str_expected, fail_msg):
         failure_message=fail_msg,
         expected_messages=msgs,
     )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "msgs", "str_expected", "assert_fail_msg"),
+    [
+        (
+            "CubeRoot[a, b]",
+            ["CubeRoot called with 2 arguments; 1 argument is expected."],
+            "CubeRoot[a, b]",
+            "CubeRoot error call",
+        ),
+        (
+            "CubeRoot[a, b, c]",
+            ["CubeRoot called with 3 arguments; 1 argument is expected."],
+            "CubeRoot[a, b, c]",
+            "CubeRoot error call with 3 arguments",
+        ),
+        (
+            "Divide[a]",
+            ["Divide called with 1 argument; 2 arguments are expected."],
+            "Divide[a]",
+            "Divide error call with 1 argument",
+        ),
+        (
+            "Minus[]",
+            ["Minus called with 0 arguments; 1 argument is expected."],
+            "Minus[]",
+            "Minus error call with 0 arguments",
+        ),
+        (
+            "Sqrt[a, b, c, d]",
+            ["Sqrt called with 4 arguments; 1 argument is expected."],
+            "Sqrt[a, b, c, d]",
+            "Sqrt error call with 4 arguments",
+        ),
+        (
+            "Sqrt[]",
+            ["Sqrt called with 0 arguments; 1 argument is expected."],
+            "Sqrt[]",
+            "Sqrt error call with 0 arguments",
+        ),
+        (
+            "Subtract[]",
+            ["Subtract called with 0 arguments; 2 arguments are expected."],
+            "Subtract[]",
+            "argrx error call with 0 arguments",
+        ),
+        (
+            "Subtract[a]",
+            ["Subtract called with 1 argument; 2 arguments are expected."],
+            "Subtract[a]",
+            "Subtract argrx error call with 1 argument",
+        ),
+    ],
+)
+def test_wrong_number_of_arguments(str_expr, msgs, str_expected, assert_fail_msg):
+    """ """
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=assert_fail_msg,
+        expected_messages=msgs,
+    )


### PR DESCRIPTION
Specifically to CubeRoot, Divide, Minus, Sqrt, and Subtract