### PR TITLE
Improve traceprint

### DIFF
--- a/mathics/doc/latex/mathics.tex
+++ b/mathics/doc/latex/mathics.tex
@@ -232,7 +232,7 @@
 }
 % Test case print output
 \newenvironment{testprint}{\item
-  \vspace{-0.5em}
+  \vspace{0.0em}
   \begin{minipage}{\codewidth}
     \begin{ttfamily}%
       \vspace{0.1em}%


### PR DESCRIPTION
This PR changes `TracePrint` to show the result through the  `Print[]` interface. This allows us to show the result in the browser/CLI/docpipeline instead of the (raw) terminal.  

This is how it looks in the PDF documentation:
<img width="743" height="677" alt="imagen" src="https://github.com/user-attachments/assets/c6dd2ebd-513a-4f77-a109-23a00739c355" />

and this is how it looks in Mathics-Django help
<img width="787" height="683" alt="imagen" src="https://github.com/user-attachments/assets/9ffe7427-71bc-4693-9acc-9d2d24e9a951" />
