### PR TITLE
Shorten TraceEvaluation

### DIFF
--- a/mathics/eval/tracing.py
+++ b/mathics/eval/tracing.py
@@ -122,7 +122,10 @@ def print_evaluate(expr, evaluation, status: str, fn: Callable, orig_expr=None):
                 expr = expr[0]
             elif not evaluation.definitions.trace_evaluation:
                 return
-            evaluation.print_out(f"{indents}{status}: {orig_expr} = " + str(expr))
+            expr_str = str(expr)
+            if status == "Replacing" and orig_expr == expr_str:
+                return
+            evaluation.print_out(f"{indents}{status}: {orig_expr} = {expr_str}")
 
     elif not is_performing_rewrite(fn):
         if not evaluation.definitions.trace_evaluation:


### PR DESCRIPTION
Lines of the form:

Replacing: x -> x

don't add much, so remove them.

In the future, maybe we can have a "verbosity level" to include something like this. The only purpose I can see is to indicate that a rewrite rule was considered and did nothing. However, TraceEvaluations are typically very long and, in my experience, don't add clarity, just clutter.