### PR TITLE
Simplfy invalid-argumnent-count pytest testing

### DIFF
--- a/test/builtin/arithmetic/test_basic.py
+++ b/test/builtin/arithmetic/test_basic.py
@@ -2,7 +2,7 @@
 """
 Unit tests for mathics.builtins.arithmetic.basic
 """
-from test.helper import check_evaluation
+from test.helper import check_evaluation, check_wrong_number_of_arguments
 
 import pytest
 
@@ -493,9 +493,8 @@ def test_private_doctests_arithmetic(str_expr, msgs, str_expected, fail_msg):
     )
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
-    [
+def test_wrong_number_of_arguments():
+    tests = [
         (
             "CubeRoot[a, b]",
             ["CubeRoot called with 2 arguments; 1 argument is expected."],
@@ -536,16 +535,5 @@ def test_private_doctests_arithmetic(str_expr, msgs, str_expected, fail_msg):
             ["Subtract called with 1 argument; 2 arguments are expected."],
             "Subtract argrx error call with 1 argument",
         ),
-    ],
-)
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
-    """ """
-    check_evaluation(
-        str_expr,
-        str_expr,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=assert_fail_msg,
-        expected_messages=msgs,
-    )
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/builtin/atomic/test_strings.py
+++ b/test/builtin/atomic/test_strings.py
@@ -4,7 +4,7 @@ Unit tests from mathics.builtin.atomic.strings.
 
 In particular, Alphabet
 """
-from test.helper import check_evaluation
+from test.helper import check_evaluation, check_wrong_number_of_arguments
 
 import pytest
 
@@ -120,26 +120,14 @@ def test_string(str_expr, warnings, str_expected):
     )
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
-    [
+def test_wrong_number_of_arguments():
+    tests = [
         (
             "ToExpression[]",
-            (
-                "ToExpression called with 0 arguments; between 1 and 3 arguments are expected.",
-            ),
+            [
+                "ToExpression called with 0 arguments; between 1 and 3 arguments are expected."
+            ],
             "ToExpression argument error call",
-        ),
-    ],
-)
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
-    """ """
-    check_evaluation(
-        str_expr,
-        str_expr,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=assert_fail_msg,
-        expected_messages=msgs,
-    )
+        )
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/builtin/specialfns/test_elliptic.py
+++ b/test/builtin/specialfns/test_elliptic.py
@@ -2,14 +2,11 @@
 """
 Unit tests for mathics.builtins.specialfns.elliptic
 """
-from test.helper import check_evaluation
-
-import pytest
+from test.helper import check_wrong_number_of_arguments
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
-    [
+def test_wrong_number_of_arguments():
+    tests = [
         (
             "EllipticE[]",
             ["EllipticE called with 0 arguments; 1 or 2 arguments are expected."],
@@ -45,16 +42,5 @@ import pytest
             ["EllipticPi called with 0 arguments; 2 or 3 arguments are expected."],
             "EllipticPi error call with too many arguments; 'argt' tag",
         ),
-    ],
-)
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
-    """ """
-    check_evaluation(
-        str_expr,
-        str_expr,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=assert_fail_msg,
-        expected_messages=msgs,
-    )
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/builtin/test_numeric.py
+++ b/test/builtin/test_numeric.py
@@ -4,7 +4,7 @@ Unit tests for mathics.builtins.numeric
 
 In particular, Rationalize and RealValuNumberQ
 """
-from test.helper import check_evaluation
+from test.helper import check_evaluation, check_wrong_number_of_arguments
 
 import pytest
 
@@ -121,7 +121,7 @@ def test_realvalued():
         ('Sign["20"]', None, "Sign[20]", None),
     ],
 )
-def test_private_doctests_numeric(str_expr, msgs, str_expected, fail_msg):
+def test_numeric(str_expr, msgs, str_expected, fail_msg):
     """ """
     check_evaluation(
         str_expr,
@@ -135,36 +135,23 @@ def test_private_doctests_numeric(str_expr, msgs, str_expected, fail_msg):
 
 
 @pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
+    ("str_expr", "assert_fail_msg"),
     [
         (
             "Round[a, b]",
-            None,
             "Round with one symbolic argument should not give an error message",
         ),
         (
             "Round[a, b]",
-            None,
             "Round with two symbolic arguments should not give an error message",
         ),
         (
-            "Round[a, b, c]",
-            ("Round called with 3 arguments; 1 or 2 arguments are expected.",),
-            "Round wrong number of arguments",
-        ),
-        (
             "Sign[x]",
-            None,
             "Sign with one symbolic argument should not give an error message",
-        ),
-        (
-            "Sign[4, 5, 6]",
-            ("Sign called with 3 arguments; 1 argument is expected.",),
-            "Sign wrong number of arguments",
         ),
     ],
 )
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
+def test_right_number_of_arguments(str_expr, assert_fail_msg):
     """ """
     check_evaluation(
         str_expr,
@@ -173,5 +160,21 @@ def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
         to_string_expected=True,
         hold_expected=True,
         failure_message=assert_fail_msg,
-        expected_messages=msgs,
+        expected_messages=None,
     )
+
+
+def test_wrong_number_of_arguments():
+    tests = [
+        (
+            "Round[a, b, c]",
+            ["Round called with 3 arguments; 1 or 2 arguments are expected."],
+            "Round wrong number of arguments",
+        ),
+        (
+            "Sign[4, 5, 6]",
+            ["Sign called with 3 arguments; 1 argument is expected."],
+            "Sign wrong number of arguments",
+        ),
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/builtin/test_procedural.py
+++ b/test/builtin/test_procedural.py
@@ -3,7 +3,12 @@
 Unit tests from mathics.builtin.procedural.
 """
 
-from test.helper import check_evaluation, check_evaluation_as_in_cli, session
+from test.helper import (
+    check_evaluation,
+    check_evaluation_as_in_cli,
+    check_wrong_number_of_arguments,
+    session,
+)
 
 import pytest
 
@@ -152,9 +157,8 @@ def test_history_compound_expression():
     session.evaluation.stopped = False
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
-    [
+def test_wrong_number_of_arguments():
+    tests = [
         # (
         #     "Abort[a, b]",
         #     ["Abort called with 2 arguments; 0 arguments are expected."],
@@ -186,16 +190,5 @@ def test_history_compound_expression():
             ["While called with 3 arguments; 1 or 2 arguments are expected."],
             "While argument error call",
         ),
-    ],
-)
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
-    """ """
-    check_evaluation(
-        str_expr,
-        str_expr,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=assert_fail_msg,
-        expected_messages=msgs,
-    )
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/builtin/test_quantities.py
+++ b/test/builtin/test_quantities.py
@@ -5,7 +5,7 @@ Unit tests for mathics.builtins.quantities
 In particular, Rationalize and RealValuNumberQ
 """
 
-from test.helper import check_evaluation
+from test.helper import check_evaluation, check_wrong_number_of_arguments
 
 import pytest
 
@@ -180,9 +180,8 @@ def test_quantity_operations(str_expr, str_expected):
     )
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
-    [
+def test_wrong_number_of_arguments():
+    tests = [
         (
             "QuantityQ[a, b]",
             ["QuantityQ called with 2 arguments; 1 argument is expected."],
@@ -193,16 +192,5 @@ def test_quantity_operations(str_expr, str_expected):
             ["Quantity called with 0 arguments; 1 argument is expected."],
             "Quantity called with wrong number of arguments",
         ),
-    ],
-)
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
-    """ """
-    check_evaluation(
-        str_expr,
-        str_expr,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=assert_fail_msg,
-        expected_messages=msgs,
-    )
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/builtin/vectors/test_mathops.py
+++ b/test/builtin/vectors/test_mathops.py
@@ -5,7 +5,7 @@ Unit tests for mathics.builtin.vectors.math_ops
 In particular, Curl[] and Norm[].
 """
 
-from test.helper import check_evaluation
+from test.helper import check_evaluation, check_wrong_number_of_arguments
 
 import pytest
 
@@ -52,9 +52,8 @@ def test_norm():
         check_evaluation(str_expr=str_expr, str_expected=str_expected)
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "msgs", "assert_fail_msg"),
-    [
+def test_wrong_number_of_arguments():
+    tests = [
         (
             "Curl[a]",
             ["Curl called with 1 argument; 2 or 3 arguments are expected."],
@@ -65,16 +64,5 @@ def test_norm():
             ["Curl called with 4 arguments; 2 or 3 arguments are expected."],
             "Curl with more than three arguments",
         ),
-    ],
-)
-def test_wrong_number_of_arguments(str_expr, msgs, assert_fail_msg):
-    """ """
-    check_evaluation(
-        str_expr,
-        str_expr,
-        to_string_expr=True,
-        to_string_expected=True,
-        hold_expected=True,
-        failure_message=assert_fail_msg,
-        expected_messages=msgs,
-    )
+    ]
+    check_wrong_number_of_arguments(tests)

--- a/test/helper.py
+++ b/test/helper.py
@@ -2,7 +2,7 @@
 import os.path as osp
 import re
 import time
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from mathics.core.load_builtin import import_and_load_builtins
 from mathics.session import MathicsSession
@@ -126,10 +126,10 @@ def check_evaluation(
 
     print(time.asctime())
     if failure_message:
-        print((result, expected))
+        print(f"got: {result}, expect: {expected} -- {failure_message}")
         assert result == expected, failure_message
     else:
-        print((result, expected))
+        print(f"got: {result}, expect: {expected}")
         if isinstance(expected, re.Pattern):
             assert expected.match(result)
         else:
@@ -176,3 +176,21 @@ def check_evaluation_as_in_cli(
     if failure_message:
         assert res.result == str_expected, failure_message
     assert res.result == str_expected
+
+
+# List below could be a Tuple, but List looks better in the tests
+def check_wrong_number_of_arguments(tests: List[Tuple[str, List[str], str]]):
+    """
+    Boilerplate code to check that for giving an error message when the wrong
+    number of arguments is provided.
+    """
+    for str_expr, msgs, assert_fail_msg in tests:
+        check_evaluation(
+            str_expr,
+            str_expr,
+            to_string_expr=True,
+            to_string_expected=True,
+            hold_expected=True,
+            failure_message=assert_fail_msg,
+            expected_messages=msgs,
+        )


### PR DESCRIPTION
There was way too much verbiage and clutter around running pytests to look check that we are giving a message calling Builtin Function with the wrong number of arguments.

Also, in pytest -s output, show the failure reason. This makes it easier to find an error in the pytest file.