### PR TITLE
improve Information

### DIFF
--- a/test/builtin/atomic/test_symbols.py
+++ b/test/builtin/atomic/test_symbols.py
@@ -40,14 +40,14 @@ def test_downvalues():
         ## awkward parser cases
         ("FullForm[a`b_]", None, "Pattern[a`b, Blank[]]", None),
         ("a = 2;", None, "Null", None),
-        ("Information[a]", ("a = 2\n",), "Null", None),
+        ("Information[a]", tuple(), "Global`a\n\na = 2\n", None),
         ("f[x_] := x ^ 2;", None, "Null", None),
         ("g[f] ^:= 2;", None, "Null", None),
         ('f::usage = "f[x] returns the square of x";', None, "Null", None),
         (
             "Information[f]",
-            (("f[x] returns the square of x\n\n" "f[x_] = x ^ 2\n\n" "g[f] ^= 2\n"),),
-            "Null",
+            tuple(),
+            "f[x] returns the square of x\n\nf[x_] = x ^ 2\n\ng[f] ^= 2\n",
             None,
         ),
         ('Length[Names["System`*"]] > 350', None, "True", None),

--- a/test/test_help.py
+++ b/test/test_help.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from mathics.core.builtin import Builtin
 
-from .helper import check_evaluation
+from .helper import check_evaluation, session
+
+# TODO: These builtins should be loaded in Definitions
+# to have any effect...
 
 
 class Builtin1(Builtin):
@@ -9,12 +12,31 @@ class Builtin1(Builtin):
 
 
 class Builtin2(Builtin):
-    "long description"
+    """
+    <url>fake:http://fake</url>
+    long description
+
+    <dl>
+      <dt>'Builtin2'
+      <dd>a description of what this symbol does.
+    </dl>
+
+    """
 
 
 def test_short_description():
-    check_evaluation("?Builtin1", "Null", "short description")
+    check_evaluation(
+        "?Builtin1", "Global`Builtin1\n", "short description", hold_expected=True
+    )
+    check_evaluation(
+        "?Builtin2", "Global`Builtin2\n", "short description", hold_expected=True
+    )
 
 
 def test_long_description():
-    check_evaluation("??Builtin2", "Null", "long description")
+    check_evaluation(
+        "??Builtin1", "Global`Builtin1\n", "long description", hold_expected=True
+    )
+    check_evaluation(
+        "??Builtin2", "Global`Builtin2\n", "long description", hold_expected=True
+    )


### PR DESCRIPTION
This PR is one step towards improving the compatibility of the symbol `Information` between Mathics and Mathematica >=12.0.

Since the first implementation of the Builtin associated with this symbol (I guess, my first contribution to the project, circa 2013) and now, the way in which WMA implements this symbol has changed a lot.

Until WMA 11., `Information[symb_, LongForm->longform_]`  does not have an evaluation rule, just a format rule. The format rule printed some information about  `symb`, and return `Null` (like `Print`). The `LongForm` option controled if user defined rules where shown or not.

Since WMA 12., `Information[symb_, LongForm->longform_]` now is evaluated to an `InformationData[..]`, expression, which at the time, has format rules producing the output that we can see when we evaluate `?symb` or `?? symb`.

Since to have full compatibility with the current version requires many changes, I opted by starting with just provide a closer output to the new version, using the old "style". Then,  `InformationData` and related functions can be included.


