### PR TITLE
Find* now returns the best value found after a convergency error.

### DIFF
--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -717,9 +717,12 @@ class _BaseFinder(Builtin):
                 [String(m) for m in self.methods.keys()],
             )
             return
-        x0, success = method_caller(f, x0, x, options, evaluation)
-        if not success:
-            return
+        try:
+            x0, success = method_caller(f, x0, x, options, evaluation)
+        except ValueError:
+            # Non numerical evaluation
+            return evaluation.current_expression
+
         if isinstance(x0, tuple):
             return ListExpression(
                 x0[1],
@@ -773,9 +776,9 @@ class FindMaximum(_BaseFinder):
      = {0.5, {x -> 1.00001}}
     >> Clear[phi];
     For a not so well behaving function, the result can be less accurate:
-    >> FindMaximum[-Exp[-1/x^2]+1., {x,1.2}, MaxIterations->10]
+    >> FindMaximum[-Exp[-1/x^2]+1., {x,1.2}, MaxIterations->2]
      : The maximum number of iterations was exceeded. The result might be inaccurate.
-     = FindMaximum[-Exp[-1 / x ^ 2] + 1., {x, 1.2}, MaxIterations -> 10]
+     = ...
     """
 
     methods = {}
@@ -824,9 +827,9 @@ class FindMinimum(_BaseFinder):
      = {-0.5, {x -> 1.00001}}
     >> Clear[phi];
     For a not so well behaving function, the result can be less accurate:
-    >> FindMinimum[Exp[-1/x^2]+1., {x,1.2}, MaxIterations->10]
+    >> FindMinimum[Exp[-1/x^2]+1., {x,1.2}, MaxIterations->2]
      : The maximum number of iterations was exceeded. The result might be inaccurate.
-     =  FindMinimum[Exp[-1 / x ^ 2] + 1., {x, 1.2}, MaxIterations -> 10]
+     =  ...
     """
 
     methods = {}
@@ -897,7 +900,7 @@ class FindRoot(_BaseFinder):
     The derivative must not be 0:
     >> FindRoot[Sin[x] == x, {x, 0}]
      : Encountered a singular derivative at the point x = 0..
-     = FindRoot[Sin[x] - x, {x, 0}]
+     = ...
 
 
     >> FindRoot[x^2 - 2, {x, 1,3}, Method->"Secant"]

--- a/mathics/eval/numbers/calculus/optimizers.py
+++ b/mathics/eval/numbers/calculus/optimizers.py
@@ -58,10 +58,7 @@ def find_minimum_newton1d(f, x0, x, opts, evaluation) -> (Number, bool):
     eps = determine_epsilon(x0, opts, evaluation)
     if not isinstance(curr_val, Number):
         evaluation.message(symbol_name, "nnum", x, x0)
-        if is_find_maximum:
-            return -x0, False
-        else:
-            return x0, False
+        raise ValueError()
     d1 = dynamic_scoping(
         lambda ev: Expression(SymbolD, f, x).evaluate(ev), {x_name: None}, evaluation
     )
@@ -332,7 +329,7 @@ def find_root_newton(f, x0, x, opts, evaluation) -> (Number, bool):
         ).evaluate(evaluation)
         if not isinstance(x1, Number):
             evaluation.message("FindRoot", "nnum", x, x0)
-            return x0, False
+            raise ValueError()
 
         # Check convergency:
         new_currval = absf.replace_vars({x_name: x1}).evaluate(evaluation)


### PR DESCRIPTION
This PR improves the compatibility of `FindRoot`,`FindMinimum` and `FindMaximum`, by changing the behavior when the convergence is not achieved up to the requested tolerance. As in WMA, now the return value is the best candidate for the solution, even if the convergence fails.