### PR TITLE
Track LLVM changes

### DIFF
--- a/mathics/compile/compile.py
+++ b/mathics/compile/compile.py
@@ -6,7 +6,6 @@ from mathics.compile.ir import IRGenerator
 from mathics.compile.utils import llvm_to_ctype
 
 # setup llvm for code generation
-llvm.initialize()
 llvm.initialize_native_target()
 llvm.initialize_native_asmprinter()  # yes, even this one
 

--- a/test/builtin/test_compilation.py
+++ b/test/builtin/test_compilation.py
@@ -3,9 +3,7 @@
 Unit tests from mathics.builtin.compilation.
 """
 
-import sys
-import time
-from test.helper import check_evaluation, evaluate
+from test.helper import check_evaluation
 
 import pytest
 


### PR DESCRIPTION
LLVM disallows explicit initialization.

test_compilation.py: remove unused imports