### PR TITLE
ByteArray access without item expansion in `Part[]`

### DIFF
--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -1188,7 +1188,6 @@ class Part(Builtin):
         indices = i.get_sequence()
         # How to deal with ByteArrays
         if list.get_head() is SymbolByteArray:
-            list = list.evaluate(evaluation)
             if len(indices) > 1:
                 print(
                     "Part::partd1: Depth of object ByteArray[<3>] "
@@ -1200,7 +1199,7 @@ class Part(Builtin):
                 idx = idx.value
                 if idx == 0:
                     return SymbolByteArray
-                n = len(list.items)
+                n = len(list.value)
                 if idx < 0:
                     idx = n - idx
                     if idx < 0:
@@ -1211,7 +1210,7 @@ class Part(Builtin):
                     if idx > n:
                         evaluation.message("Part", "partw", i, list)
                         return
-                return list.items[idx]
+                return Integer(list[idx])
             if idx is Symbol("System`All"):
                 return list
             # TODO: handling ranges and lists...

--- a/mathics/core/atoms.py
+++ b/mathics/core/atoms.py
@@ -675,6 +675,12 @@ class ByteArray(Atom, ImmutableValueMixin):
         self.hash = hash(("ByteArray", str(self.value)))
         return self
 
+    def __getitem__(self, index: int) -> int:
+        """
+        Support List index lookup without having to expand the entire bytearray into a Mathics3 list.
+        """
+        return self.value[index]
+
     def __getnewargs__(self):
         return (self.value,)
 
@@ -701,9 +707,9 @@ class ByteArray(Atom, ImmutableValueMixin):
         return '"' + value.__str__() + '"'
 
     @property
-    def items(self) -> Tuple[int, ...]:
+    def items(self) -> Tuple[Integer, ...]:
         """
-        Return a tuple value of Mathics3 Inteters for each element of the ByteArray.
+        Return a tuple value of Mathics3 Integers for each element of the ByteArray.
         """
         if self._items is None:
             self._items = tuple([Integer(i) for i in self.value])


### PR DESCRIPTION
Add `__getitem(self, value)` to `ByteArray` so we can access a Python `bytearray` element without expanding the full Python `bytearray` value into a Mathics3 ListExpression. 

There might be other places in the Mathics3 where we might benefit from this. But this is a start.