### PR TITLE
use `session.evaluate` instead of `session.parse(...).evaluate`

### DIFF
--- a/test/builtin/drawing/test_plot_detail.py
+++ b/test/builtin/drawing/test_plot_detail.py
@@ -139,8 +139,7 @@ def one_test(name, str_expr, vec, opt, act_dir="/tmp"):
 
     try:
         # evaluate the expression to be tested
-        expr = session.parse(str_expr)
-        act_expr = expr.evaluate(session.evaluation)
+        act_expr = session.evaluate(str_expr)
         if len(session.evaluation.out):
             print("=== messages:")
             for message in session.evaluation.out:


### PR DESCRIPTION
Just a small fix to the `test/builtin/drawing/test_plot_detail.py`: using `session.evaluate` ensures that trailing messages from previous tests are cleaned before the new evaluation.
This was the reason for the last failure in CI for #1538