### PR TITLE
Add Module test to lambdify_compile

### DIFF
--- a/test/core/convert/test_lambdify_compile.py
+++ b/test/core/convert/test_lambdify_compile.py
@@ -454,7 +454,7 @@ def one(name, args, scipy=False, expected=None, fail=False):
     elif fail:
         raise Exception(f"unexpected success: result {result}, expected {expected}")
     else:
-        #print(f"{name} succeeds: expected {expected}, got {result}")
+        # print(f"{name} succeeds: expected {expected}, got {result}")
         pass
 
 


### PR DESCRIPTION
Following on to the [recent discussion](https://github.com/Mathics3/mathics-core/pull/1539#issuecomment-3656847717), I thought it would be worthwhile to add a `Module` test to `lambdify_compile`.