### PR TITLE
Don't raise exception in `evaluate()` if parsing expr returns `None`

### DIFF
--- a/mathics/session.py
+++ b/mathics/session.py
@@ -19,6 +19,7 @@ from mathics_scanner.location import ContainerKind
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation, Result
 from mathics.core.parser import MathicsSingleLineFeeder, parse
+from mathics.core.symbols import SymbolNull
 
 
 def autoload_files(
@@ -150,7 +151,7 @@ class MathicsSession:
         )
         if form is None:
             form = self.form
-        self.last_result = expr.evaluate(self.evaluation) if expr else None
+        self.last_result = expr.evaluate(self.evaluation) if expr else SymbolNull
         return self.last_result
 
     def evaluate_as_in_cli(self, str_expression, timeout=None, form=None, src_name=""):


### PR DESCRIPTION
This can happen for example if you give it a string consisting of just a comment. I'm not sure if this behavior - returning None - is correct, but at least it's consistent with what parse does.

Also I suppose there should be a test for this, but not sure where the best place for it would be.