### PR TITLE
Add a script entrypoint named `mathics3`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ cython = [
 
 [project.scripts]
 mathics = "mathics.__main__:main"
+mathics3 = "mathics.__main__:main"
 
 [tool.setuptools]
 include-package-data = false


### PR DESCRIPTION
I'm always frustrated when starting mathics by uvx. I have to run `uvx --from mathics3 mathics` to start mathics.

This commit make user able to execute mathics with uvx directly like `uvx mathics3`.