### PR TITLE
Revise (slightly) Complex number implementation

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -677,7 +677,8 @@ class Times(InfixOperator, SympyFunction):
                 negative.append(item.denominator())
             else:
                 positive.append(item)
-        if positive and positive[0].get_int_value() == -1:
+
+        if positive and hasattr(positive[0], "value") and positive[0].value == -1:
             del positive[0]
             minus = True
         else:

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -190,13 +190,17 @@ class BaseElement(KeyComparable, ABC):
         """
         raise NotImplementedError
 
-    # FIXME: this behavior of defining a specific default implementation
-    # that is basically saying it isn't implemented is wrong.
-    # However fixing this means not only removing but fixing up code
-    # in the callers.
-    def get_float_value(self, permit_complex=False):
+    # FIXME: this behavior -- defining a specific default implementation
+    # that is basically saying: "it isn't implemented" -- is wrong.
+    # To remove this method, we need to fix up calls that expect this behavior,
+    # that I am not certain how to do right now. - rocky
+    def get_float_value(self, permit_complex=False) -> Optional[complex]:
         return None
 
+    # FIXME: this behavior -- defining a specific default implementation
+    # that is basically saying: "it isn't implemented" -- is wrong.
+    # To remove this method, we need to fix up calls that expect this behavior,
+    # that I am not certain how to do right now. - rocky
     def get_int_value(self) -> Optional[int]:
         return None
 

--- a/mathics/eval/makeboxes/numberform.py
+++ b/mathics/eval/makeboxes/numberform.py
@@ -113,7 +113,7 @@ def NumberForm_to_String(
     value: Union[Real, Integer],
     digits: Optional[int],
     digits_after_decimal_point: Optional[int],
-    evaluation: Evaluation,
+    evaluation: Optional[Evaluation],
     options: dict,
 ) -> String:
     """


### PR DESCRIPTION
Save precision, which is a computed part of Complex numbers. Distinguish exact value (the 2 parts of a complex number plus a derived "precision" value) from the often-used and possibly approximate "value"; "value" is generally the more useful and more wanted quantity. In most computations, "value" is as good as, or indistinguishable from, the "exact_value".

Go over and correct some types.