### PR TITLE
Fix spurious log axes

### DIFF
--- a/mathics/builtin/box/graphics.py
+++ b/mathics/builtin/box/graphics.py
@@ -708,7 +708,9 @@ class GraphicsBox(BoxExpression):
         # "yaxis", "xtick" "labelx", "labely". Extend our language
         # here and use those in render-like routines.
 
-        use_log_for_y_axis = graphics_options.get("System`LogPlot", SymbolFalse).to_python()
+        use_log_for_y_axis = graphics_options.get(
+            "System`LogPlot", SymbolFalse
+        ).to_python()
         axes_option = graphics_options.get("System`Axes")
 
         if axes_option is SymbolTrue:


### PR DESCRIPTION
Issue #1554 

PR #1553 restricted options passed from Plot to Graphics to only include valid Graphics options in order make the tests more robust. This required adding LogPlot to the list of allowable Graphics options, with a default of False. So now all Graphics objects have a LogPlot option, most with a value of False, whereas previously only log plots generated a LogPlot option in Graphics, with a value of True. However the SVG generation code in builtin/box/graphics.py did not check the value of the LogPlot option when deciding whether to generate log axes.