### PR TITLE
Fix Alphabet documentation entry

### DIFF
--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -240,7 +240,7 @@ class Alphabet(Builtin):
      = True
 
     See also <url>
-    :$Language:
+    :\\$Language:
       /doc/reference-of-built-in-symbols/global-system-information/\\$language/
       </url>.
 


### PR DESCRIPTION
Just fix a missing escape character, which makes the LaTeX documentation compile. 