### PR TITLE
Document `ImageSize -> {h, w}`

### DIFF
--- a/mathics/builtin/drawing/drawing_options.py
+++ b/mathics/builtin/drawing/drawing_options.py
@@ -197,10 +197,15 @@ class ImageSize(Builtin):
       <dd>determined by location or other dimension (default)
       <dt>Tiny, Small, Medium, Large
       <dd>pre defined absolute sizes
+      <dt>{$w, h$}
+      <dd>explicit width and height
     </dl>
 
 
     >> Plot[Sin[x], {x, 0, 10}, ImageSize -> Small]
+     = -Graphics-
+
+    >> Plot[Sin[x], {x, 0, 10}, ImageSize -> {300, 300}]
      = -Graphics-
     """
 

--- a/mathics/format/asy.py
+++ b/mathics/format/asy.py
@@ -241,7 +241,7 @@ def bezier_curve_box(self: BezierCurveBox, **options) -> str:
             asy += """pair[] P%d_%d={%s};\n""" % (i, j, triple)
             asy += """pair G%d_%d(real t){return Bezier(P%d_%d,t);}\n""" % (i, j, i, j)
             asy += """draw(shift(0, -2)*graph(G%d_%d,0,1,350), %s);\n""" % (i, j, pen)
-    # print("BezierCurveBox: " asy)
+    # print("BezierCurveBox: ", asy)
     return asy
 
 
@@ -409,6 +409,7 @@ def graphics_elements(self, **options) -> str:
         else:
             result.append(format_fn(element))
 
+    # print("### elements", result)
     return "\n".join(result)
 
 


### PR DESCRIPTION
With the recent introduction of PaneBox, it looks like `ImageSize -> {h, w}` is now supported.

Also, tweak some commented-out debug statements in asy and svg formatters