### PR TITLE
fix ToString rule

### DIFF
--- a/mathics/builtin/atomic/strings.py
+++ b/mathics/builtin/atomic/strings.py
@@ -897,7 +897,7 @@ class ToString(Builtin):
         return self.eval_form(value, SymbolOutputForm, evaluation, options)
 
     def eval_form(self, expr, form, evaluation: Evaluation, options: dict):
-        "ToString[expr_, form_, OptionsPattern[ToString]]"
+        "ToString[expr_, form_Symbol, OptionsPattern[ToString]]"
         encoding = options["System`CharacterEncoding"]
         return eval_ToString(expr, form, encoding.value, evaluation)
 


### PR DESCRIPTION
This PR fixes the rule for `ToString`, to avoid that options like `CharacterEncoding` be taken as the `Form` parameter.