### PR TITLE
is_multiline property

### DIFF
--- a/mathics/builtin/box/layout.py
+++ b/mathics/builtin/box/layout.py
@@ -147,6 +147,10 @@ class FormBox(BoxExpression):
         assert isinstance(expr, BoxElementMixin), f"{expr}"
         return FormBox(expr, form, **options)
 
+    @property
+    def is_multiline(self) -> bool:
+        return self.boxes.is_multiline
+
 
 class FractionBox(BoxExpression):
     """
@@ -335,6 +339,10 @@ class InterpretationBox(BoxExpression):
         """DisplayForm[boxexpr_InterpretationBox]"""
         return boxexpr.boxes
 
+    @property
+    def is_multiline(self) -> bool:
+        return self.boxes.is_multiline
+
 
 class PaneBox(BoxExpression):
     """
@@ -378,6 +386,10 @@ class PaneBox(BoxExpression):
     def eval_display(boxexpr, evaluation):
         """DisplayForm[boxexpr_PaneBox]"""
         return boxexpr.elements[0]
+
+    @property
+    def is_multiline(self) -> bool:
+        return self.boxes.is_multiline
 
 
 class RowBox(BoxExpression):
@@ -444,6 +456,10 @@ class RowBox(BoxExpression):
             return item
 
         self.items = tuple((check_item(item) for item in items))
+
+    @property
+    def is_multiline(self) -> bool:
+        return any(item.is_multiline for item in self.items)
 
 
 class ShowStringCharacters(Builtin):
@@ -586,6 +602,10 @@ class StyleBox(BoxExpression):
         assert isinstance(
             self.boxes, BoxElementMixin
         ), f"{type(self.boxes)},{self.boxes}"
+
+    @property
+    def is_multiline(self) -> bool:
+        return self.boxes.is_multiline
 
 
 class SubscriptBox(BoxExpression):
@@ -767,6 +787,10 @@ class TagBox(BoxExpression):
         expr = to_boxes(expr, evaluation, options)
         assert isinstance(expr, BoxElementMixin), f"{expr}"
         return TagBox(expr, form, **options)
+
+    @property
+    def is_multiline(self) -> bool:
+        return self.boxes.is_multiline
 
 
 class TemplateBox(BoxExpression):

--- a/mathics/core/atoms/strings.py
+++ b/mathics/core/atoms/strings.py
@@ -93,6 +93,10 @@ class String(Atom, BoxElementMixin):
         """
         return True
 
+    @property
+    def is_multiline(self) -> bool:
+        return "\n" in self.value
+
     def sameQ(self, rhs) -> bool:
         """Mathics SameQ"""
         return isinstance(rhs, String) and self.value == rhs.value

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -407,6 +407,10 @@ class BoxElementMixin(ImmutableValueMixin):
     elements
     """
 
+    @property
+    def is_multiline(self) -> bool:
+        return True
+
     def boxes_to_format(self, format: str, **options) -> str:
         from mathics.core.formatter import boxes_to_format
 

--- a/test/format/test_makeboxes.py
+++ b/test/format/test_makeboxes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from test.helper import check_evaluation
+from test.helper import check_evaluation, session
 
 import pytest
 import yaml
@@ -478,3 +478,64 @@ def test_makeboxes_custom2(str_expr, str_expected, msg):
         to_python_expected=False,
         failure_message=msg,
     )
+
+
+@pytest.mark.parametrize(
+    ["expr", "expect"],
+    (
+        (
+            '"Hola"',
+            False,
+        ),
+        (
+            '"Hola\nqué tal?"',
+            True,
+        ),
+        (
+            "a/b//MakeBoxes",
+            True,
+        ),
+        (
+            "Sqrt[a]//MakeBoxes",
+            True,
+        ),
+        (
+            "a + b * c//MakeBoxes",
+            False,
+        ),
+        (
+            "a + b / c//MakeBoxes",
+            True,
+        ),
+        (
+            "a + b * c // InputForm//MakeBoxes",
+            False,
+        ),
+        (
+            "a + b / c //InputForm//MakeBoxes",
+            False,
+        ),
+        (
+            "a + b * c // OutputForm//MakeBoxes",
+            False,
+        ),
+        (
+            "a + b / c // OutputForm//MakeBoxes",
+            False,
+        ),
+        (
+            "a + b * c // FullForm//MakeBoxes",
+            False,
+        ),
+        (
+            "a + b / c // FullForm//MakeBoxes",
+            False,
+        ),
+    ),
+)
+def test_multiline(expr, expect):
+    boxexpr = session.evaluate(expr)
+    print(expr, "->", boxexpr, (expect))
+    assert (
+        boxexpr.is_multiline == expect
+    ), f"{boxexpr} must {'not ' if not expect else ''}be multiline. Got ({boxexpr.is_multiline})"


### PR DESCRIPTION
This property can be used in #1663  instead of looking for specific characters in the LaTeX representation