### PR TITLE
Remove `boxes_to` deprecation and duplicate TeX mapping tables.

### DIFF
--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -417,13 +417,10 @@ class BoxElementMixin(ImmutableValueMixin):
         return box_to_format(self, format, **options)
 
     def boxes_to_mathml(self, **options) -> str:
-        """For compatibility deprecated"""
         return self.box_to_format("mathml", **options)
 
     def boxes_to_tex(self, **options) -> str:
-        """For compatibility deprecated"""
         return self.box_to_format("latex", **options)
 
     def boxes_to_text(self, **options) -> str:
-        """For compatibility deprecated"""
         return self.box_to_format("text", **options)

--- a/mathics/format/render/latex.py
+++ b/mathics/format/render/latex.py
@@ -576,11 +576,28 @@ def pane_box(box: PaneBox, **options):
 add_conversion_fn(PaneBox, pane_box)
 
 
+def rowbox_parenthesized(items, **options):
+    if len(items) < 2:
+        return None
+    key = (
+        items[0],
+        items[-1],
+    )
+    items = items[1:-1]
+    try:
+        bracket_data = BRACKET_INFO[key]
+    except KeyError:
+        return None
+
+    contain = rowbox_sequence(items, **options) if len(items) > 0 else ""
+
+    if any(item.is_multiline for item in items):
+        return f'{bracket_data["latex_open_large"]}{contain}{bracket_data["latex_closing_large"]}'
+    return f'{bracket_data["latex_open"]}{contain}{bracket_data["latex_closing"]}'
+
+
 def rowbox_sequence(items, **options):
-    parts_str = [
-        lookup_conversion_method(element, "latex")(element, **options)
-        for element in items
-    ]
+    parts_str = [convert_box_to_format(element, **options) for element in items]
     if len(parts_str) == 0:
         return ""
     if len(parts_str) == 1:
@@ -602,26 +619,6 @@ def rowbox_sequence(items, **options):
 
         result += elem
     return result
-
-
-def rowbox_parenthesized(items, **options):
-    if len(items) < 2:
-        return None
-    key = (
-        items[0],
-        items[-1],
-    )
-    items = items[1:-1]
-    try:
-        bracket_data = BRACKET_INFO[key]
-    except KeyError:
-        return None
-
-    contain = rowbox_sequence(items, **options) if len(items) > 0 else ""
-
-    if any(item.is_multiline for item in items):
-        return f'{bracket_data["latex_open_large"]}{contain}{bracket_data["latex_closing_large"]}'
-    return f'{bracket_data["latex_open"]}{contain}{bracket_data["latex_closing"]}'
 
 
 def rowbox(box: RowBox, **options) -> str:

--- a/mathics/format/render/mathml.py
+++ b/mathics/format/render/mathml.py
@@ -35,7 +35,6 @@ from mathics.core.formatter import (
     add_conversion_fn,
     convert_box_to_format,
     convert_inner_box_field,
-    lookup_method as lookup_conversion_method,
 )
 from mathics.core.load_builtin import display_operators_set as operators
 from mathics.core.symbols import SymbolFalse, SymbolTrue
@@ -317,11 +316,9 @@ add_conversion_fn(String, string)
 
 
 def subscriptbox(box: SubscriptBox, **options):
-    # Note: values set in `options` take precedence over `box_options`
-    child_options = {**options, **box.box_options}
     return "<msub>%s %s</msub>" % (
-        lookup_conversion_method(box.base, "mathml")(box.base, **child_options),
-        lookup_conversion_method(box.subindex, "mathml")(box.subindex, **child_options),
+        convert_inner_box_field(box, "base", **options),
+        convert_inner_box_field(box, "subindex", **options),
     )
 
 
@@ -330,14 +327,11 @@ add_conversion_fn(SubscriptBox, subscriptbox)
 
 def subsuperscriptbox(box: SubsuperscriptBox, **options):
     # Note: values set in `options` take precedence over `box_options`
-    child_options = {**box.box_options, **options}
     box.base.inside_row = box.subindex.inside_row = box.superindex.inside_row = True
     return "<msubsup>%s %s %s</msubsup>" % (
-        lookup_conversion_method(box.base, "mathml")(box.base, **child_options),
-        lookup_conversion_method(box.subindex, "mathml")(box.subindex, **child_options),
-        lookup_conversion_method(box.superindex, "mathml")(
-            box.superindex, **child_options
-        ),
+        convert_inner_box_field(box, "base", **options),
+        convert_inner_box_field(box, "subindex", **options),
+        convert_inner_box_field(box, "superindex", **options),
     )
 
 
@@ -346,12 +340,9 @@ add_conversion_fn(SubsuperscriptBox, subsuperscriptbox)
 
 def superscriptbox(box: SuperscriptBox, **options):
     # Note: values set in `options` take precedence over `box_options`
-    child_options = {**options, **box.box_options}
     return "<msup>%s %s</msup>" % (
-        lookup_conversion_method(box.base, "mathml")(box.base, **child_options),
-        lookup_conversion_method(box.superindex, "mathml")(
-            box.superindex, **child_options
-        ),
+        convert_inner_box_field(box, "base", **options),
+        convert_inner_box_field(box, "superindex", **options),
     )
 
 


### PR DESCRIPTION
* DRY a little more. 
* Remove deprecation message since this doesn't seem to be deprecated. 
* Remove unused TeX-format code that has been moved to the TeX renderer.