### PR TITLE
Arg checking for `mathics.builtin.intfns.combinatorial`

### DIFF
--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -117,6 +117,9 @@ class _BooleanDissimilarity(Builtin, ABC):
             counts[(a << 1) + b] += 1
         return self._compute(len(py_u), *counts)
 
+    eval_error = Builtin.generic_argument_error
+    expected_args = 2
+
 
 class _NoBoolVector(Exception):
     pass
@@ -217,8 +220,6 @@ class DiceDissimilarity(_BooleanDissimilarity):
      = 1 / 2
     """
 
-    eval_error = Builtin.generic_argument_error
-    expected_args = 2
     summary_text = "Dice dissimilarity"
 
     def _compute(self, n, c_ff, c_ft, c_tf, c_tt) -> Expression:
@@ -325,6 +326,8 @@ class LucasL(SympyFunction):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = (1, 2)
 
     sympy_name = "lucas"
     summary_text = "get a Lucas number or polynomial"
@@ -439,6 +442,8 @@ class PolygonalNumber(Builtin):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED | A_READ_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = (1, 2)
     rules = {
         "PolygonalNumber[n_Integer]": "PolygonalNumber[3, n]",
         "PolygonalNumber[r_Integer, n_Integer]": "(1/2) n (n (r - 2) - r + 4)",
@@ -592,6 +597,8 @@ class Subsets(Builtin):
         "Subsets[list_ , Pattern[n,_List|All|DirectedInfinity[1]], spec_]": "Take[Subsets[list, n], spec]",
     }
 
+    eval_error = Builtin.generic_argument_error
+    expected_args = range(1, 4)
     summary_text = "list all the subsets"
 
     def eval_list(self, list, evaluation):

--- a/test/builtin/intfns/test_combinatorial.py
+++ b/test/builtin/intfns/test_combinatorial.py
@@ -36,6 +36,28 @@ import pytest
             ["EulerE called with 0 arguments; 1 or 2 arguments are expected."],
             "Euler argument number error",
         ),
+        (
+            "JaccardDissimilarity[]",
+            ["JaccardDissimilarity called with 0 arguments; 2 arguments are expected."],
+            "JaccardDissimilarity argument number error",
+        ),
+        (
+            "LucasL[]",
+            ["LucasL called with 0 arguments; 1 or 2 arguments are expected."],
+            "LucasL argument number error",
+        ),
+        (
+            "PolygonalNumber[]",
+            ["PolygonalNumber called with 0 arguments; 1 or 2 arguments are expected."],
+            "PolygonalNumber argument number error",
+        ),
+        (
+            "Subsets[]",
+            [
+                "Subsets called with 0 arguments; between 1 and 3 arguments are expected."
+            ],
+            "Subsets argument number error",
+        ),
     ],
 )
 def test_combinatorial_arg_errors(str_expr, msgs, fail_msg):


### PR DESCRIPTION
Finish argument checking for built-in functions in `mathics.builtin.intfns.combinatorial`.