### PR TITLE
Add argument checking to `mathics.builtin.intfns.divlike`

### DIFF
--- a/mathics/builtin/forms/data.py
+++ b/mathics/builtin/forms/data.py
@@ -105,7 +105,6 @@ class _NumberForm(Builtin):
     default_NumberFormat = None
     in_outputforms = True
     messages = {
-        "argm": ("`` called with `` arguments; 1 or more " "arguments are expected."),
         "argct": "`` called with `` arguments.",
         "npad": (
             "Value for option NumberPadding -> `1` should be a string or "

--- a/mathics/builtin/intfns/divlike.py
+++ b/mathics/builtin/intfns/divlike.py
@@ -4,6 +4,7 @@
 Division-Related Functions
 """
 
+import sys
 from typing import List
 
 import sympy
@@ -54,6 +55,8 @@ class CompositeQ(Builtin):
     """
 
     attributes = A_LISTABLE | A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = 1
     summary_text = "test whether a number is composite"
 
     def eval(self, n: Integer, evaluation: Evaluation):
@@ -84,6 +87,8 @@ class Divisible(Builtin):
     """
 
     attributes = A_LISTABLE | A_PROTECTED | A_READ_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = range(2, sys.maxsize)
     rules = {
         "Divisible[n_, m_]": "Mod[n, m] == 0",
     }
@@ -145,12 +150,20 @@ class LCM(Builtin):
     """
 
     attributes = A_FLAT | A_LISTABLE | A_ONE_IDENTITY | A_ORDERLESS | A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = range(1, sys.maxsize)
+    messages = {
+        "argm": "LCM called with 0 arguments; 1 or more arguments are expected.",
+    }
     summary_text = "least common multiple"
 
     def eval(self, ns: List[Integer], evaluation: Evaluation):
         "LCM[ns___Integer]"
 
         ns = ns.get_sequence()
+        if len(ns) == 0:
+            evaluation.message("LCM", "argm")
+            return
         result = 1
         for n in ns:
             value = n.value
@@ -181,6 +194,8 @@ class Mod(SympyFunction):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = (2, 3)
     summary_text = "the remainder in an integer division"
 
     sympy_name = "Mod"
@@ -227,6 +242,8 @@ class ModularInverse(SympyFunction):
     """
 
     attributes = A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = 2
     summary_text = "returns the modular inverse $k^(-1)$ mod $n$"
     sympy_name = "mod_inverse"
 
@@ -264,6 +281,8 @@ class PowerMod(Builtin):
     """
 
     attributes = A_LISTABLE | A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = 3
 
     messages = {
         "ninv": "`1` is not invertible modulo `2`.",
@@ -303,6 +322,8 @@ class Quotient(Builtin):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = (2, 3)
 
     messages = {
         "infy": "Infinite expression `1` encountered.",
@@ -333,6 +354,8 @@ class QuotientRemainder(Builtin):
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
+    eval_error = Builtin.generic_argument_error
+    expected_args = 2
 
     messages = {
         "divz": "The argument 0 in `1` should be nonzero.",

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -64,7 +64,6 @@ class Check(Builtin):
     attributes = A_HOLD_ALL | A_PROTECTED
 
     messages = {
-        "argmu": "Check called with 1 argument; 2 or more arguments are expected.",
         "name": "Message name `1` is not of the form symbol::name or symbol::name::language.",
     }
 
@@ -175,6 +174,8 @@ class General(Builtin):
         "argct": "`1` called with `2` arguments.",
         "argctu": "`1` called with 1 argument.",
         "argr": "`1` called with 1 argument; `2` arguments are expected.",
+        "argm": "`1` called with `2` arguments; `3` or more arguments are expected.",
+        "argmu": "`1` called with 1 argument; `2` or more arguments are expected.",
         "argrx": "`1` called with `2` arguments; `3` arguments are expected.",
         "argx": "`1` called with `2` arguments; 1 argument is expected.",
         "argt": (

--- a/mathics/builtin/string/operations.py
+++ b/mathics/builtin/string/operations.py
@@ -630,8 +630,6 @@ class StringRiffle(Builtin):
 
     messages = {
         "list": "List expected at position `1` in `2`.",
-        "argmu": "StringRiffle called with 1 argument; 2 or more arguments are expected.",
-        "argm": "StringRiffle called with 0 arguments; 2 or more arguments are expected.",
         "string": "String expected at position `1` in `2`.",
         "sublist": "Sublist form in position 1 is is not implemented yet.",
         "mulsep": "Multiple separators form is not implemented yet.",

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -9,6 +9,7 @@ SympyFunction, MPMathFunction, etc.
 import importlib
 import importlib.util
 import re
+import sys
 from abc import ABC
 from functools import total_ordering
 from itertools import chain
@@ -473,14 +474,31 @@ class Builtin:
                     Integer(expected_args2),
                 )
         elif isinstance(self.expected_args, range):
-            evaluation.message(
-                name,
-                "argb",
-                Symbol(name),
-                Integer(got_arg_count),
-                Integer(self.expected_args.start),
-                Integer(self.expected_args.stop - 1),
-            )
+            if self.expected_args.stop == sys.maxsize:
+                if got_arg_count == 1:
+                    evaluation.message(
+                        name,
+                        "argmu",
+                        Symbol(name),
+                        Integer(self.expected_args.start),
+                    )
+                else:
+                    evaluation.message(
+                        name,
+                        "argm",
+                        Symbol(name),
+                        Integer(got_arg_count),
+                        Integer(self.expected_args.start),
+                    )
+            else:
+                evaluation.message(
+                    name,
+                    "argb",
+                    Symbol(name),
+                    Integer(got_arg_count),
+                    Integer(self.expected_args.start),
+                    Integer(self.expected_args.stop - 1),
+                )
         else:
             if self.expected_args == 1:
                 evaluation.message(name, "argx", Symbol(name), Integer(got_arg_count))

--- a/test/builtin/intfns/test_combinatorial.py
+++ b/test/builtin/intfns/test_combinatorial.py
@@ -76,12 +76,6 @@ def test_combinatorial_arg_errors(str_expr, msgs, fail_msg):
     [
         ## TODO should be ComplexInfinity but mpmath returns +inf
         ("Binomial[-10, -3.5]", None, "Infinity", None),
-        (
-            "Binomial[]",
-            ["Binomial called with 0 arguments; 2 arguments are expected."],
-            "Binomial[]",
-            "Binomial argument number error",
-        ),
         ("Subsets[{}]", None, "{{}}", None),
         ("Subsets[]", None, "Subsets[]", None),
         (

--- a/test/builtin/intfns/test_divlike.py
+++ b/test/builtin/intfns/test_divlike.py
@@ -46,3 +46,48 @@ def test_divlike(str_expr, msgs, str_expected, fail_msg):
         failure_message=fail_msg,
         expected_messages=msgs,
     )
+
+
+@pytest.mark.parametrize(
+    ("function_name", "msg_fragment"),
+    [
+        (
+            "CompositeQ",
+            "1 argument is",
+        ),
+        (
+            "Divisible",
+            "2 or more arguments are",
+        ),
+        (
+            "LCM",
+            "1 or more arguments are",
+        ),
+        (
+            "ModularInverse",
+            "2 arguments are",
+        ),
+        (
+            "PowerMod",
+            "3 arguments are",
+        ),
+        (
+            "Quotient",
+            "2 or 3 arguments are",
+        ),
+    ],
+)
+def test_divlike_arg_errors(function_name, msg_fragment):
+    """ """
+
+    str_expr = f"{function_name}[]"
+    expected_msgs = [
+        f"{function_name} called with 0 arguments; {msg_fragment} expected."
+    ]
+    failure_message = f"{function_name} argument number error"
+    check_evaluation(
+        str_expr,
+        str_expr,
+        failure_message=failure_message,
+        expected_messages=expected_msgs,
+    )


### PR DESCRIPTION
Adds argument checking to `mathics.builtin.intfns.divlike` module.

Remove duplicate `argm`, and `argmu` definitions.

Allow for" _start_ or more" tagging via: range(_start_, `sys.maxsize`)