### PR TITLE
Missing from a String should not produce a Symbol definition.

### DIFF
--- a/mathics/builtin/atomic/symbols.py
+++ b/mathics/builtin/atomic/symbols.py
@@ -507,14 +507,17 @@ class Information(PrefixOperator):
         "(StandardForm,TraditionalForm,InputForm,OutputForm,): Information[strpat_String, OptionsPattern[Information]]"
         definitions = evaluation.definitions
         string_str = strpat.value
-
         if any(char in string_str for char in NAMES_WILDCARDS):
             return self.build_list_of_matching_symbols(
                 string_str, evaluation, options, grid
             )
-        return self.format_information_symbol(
-            Symbol(definitions.lookup_name(string_str)), evaluation, options
-        )
+        try:
+            symbol_name = definitions.get_definition(
+                string_str, only_if_exists=True
+            ).name
+        except KeyError:
+            return self.build_missing(strpat)
+        return self.format_information_symbol(Symbol(symbol_name), evaluation, options)
 
     def format_information_symbol(
         self, symbol: Symbol, evaluation: Evaluation, options: dict, grid: bool = True

--- a/test/builtin/atomic/test_symbols.py
+++ b/test/builtin/atomic/test_symbols.py
@@ -41,6 +41,18 @@ def test_downvalues():
         ("FullForm[a`b_]", None, "Pattern[a`b, Blank[]]", None),
         ("a = 2;", None, "Null", None),
         ("Information[a]", tuple(), "Global`a\n\na = 2\n", None),
+        (
+            "{?? q, ?? q}",
+            tuple(),
+            "{Missing[UnknownSymbol, q], Missing[UnknownSymbol, q]}",
+            "q does not exist, and Information does not create it.",
+        ),
+        (
+            '{Information[s], Information["s"]}',
+            tuple(),
+            "{Global`s\n, Global`s\n}",
+            "When s is passed as a symbol, it creates the definition.",
+        ),
         ("f[x_] := x ^ 2;", None, "Null", None),
         ("g[f] ^:= 2;", None, "Null", None),
         ('f::usage = "f[x] returns the square of x";', None, "Null", None),


### PR DESCRIPTION
This PR completes what was missing to fix the wrong behavior of `Information` reported in #1655, and refined in #1713. 
What was still wrong in the current master branch is that when a String is passed to `Information`, and the string is not a name pattern, the standard routine for `Symbol` is used, creating the definition. As a result, in the example shown in https://github.com/Mathics3/mathics-core/issues/1655#issuecomment-4024136105 , the first line creates the definition that hides the effect of the `Begin/End` block.

