### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/consistency-checks.yml
+++ b/.github/workflows/consistency-checks.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/isort-and-black-checks.yml
+++ b/.github/workflows/isort-and-black-checks.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
         os: [macOS]
         python-version: ['3.13', '3.12']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/plot-tests.yml
+++ b/.github/workflows/plot-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.13', '3.12', '3.11', '3.10']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -22,7 +22,7 @@ jobs:
       NODE_VERSION: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ubuntu-bench.yml
+++ b/.github/workflows/ubuntu-bench.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.13', '3.12', '3.11', '3.10']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ubuntu-cython.yml
+++ b/.github/workflows/ubuntu-cython.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         python-version: ['3.13', '3.12', '3.11', '3.10']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
         # trace of where things went wrong on Python before 3.11.
         python-version: ['3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Mathics3 Kernel comes with a very simple command-line program called ``mathics3`
   on CPython 3.13.5 (main, Jun 20 2025, 16:57:22) [GCC 13.3.0]
   using SymPy 1.13.3, mpmath 1.3.0, numpy 2.3.2, cython Not installed
 
-  Copyright (C) 2011-2025 The Mathics3 Team.
+  Copyright (C) 2011-2026 The Mathics3 Team.
   This program comes with ABSOLUTELY NO WARRANTY.
   This is free software, and you are welcome to redistribute it
   under certain conditions.

--- a/mathics/__init__.py
+++ b/mathics/__init__.py
@@ -64,7 +64,7 @@ for opt_package in ("cython", "scipy", "skimage"):
         version_string += f", {opt_package} {version_info[opt_package]}"
 
 license_string = """\
-Copyright (C) 2011-2025 The Mathics3 Team.
+Copyright (C) 2011-2026 The Mathics3 Team.
 This program comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions.

--- a/mathics/version.py
+++ b/mathics/version.py
@@ -5,4 +5,4 @@
 # well as importing into Python. That's why there is no
 # space around "=" below.
 # fmt: off
-__version__="9.0.1.dev0"  # noqa
+__version__="10.0.0.dev0"  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10" # bisect.insort_left with key parameter starts in 3.1
 readme = "README.rst"
 keywords = ["Mathematica", "Wolfram", "Interpreter", "Shell", "Math", "CAS"]
 maintainers = [
-    {name = "Mathics Group", email = "mathics-devel@googlegroups.com"},
+    {name = "Mathics3 Group", email = "mathics-devel@googlegroups.com"},
 ]
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
* Use v5 in workflows to squelch a nodejs complaint
* Bump version to 10.0-ish
* another Mathics->Mathics3 change.