### PR TITLE
Handle encodings in docpipeline0

### DIFF
--- a/mathics/core/convert/op.py
+++ b/mathics/core/convert/op.py
@@ -62,6 +62,7 @@ AMSTEX_OPERATORS = {
 }
 
 
+@lru_cache(maxsize=1024)
 def string_to_invertible_ascii(string: str):
     """
     Replace non-ANSI characters with their names. If the character

--- a/mathics/doc/doc_entries.py
+++ b/mathics/doc/doc_entries.py
@@ -13,6 +13,7 @@ from abc import ABC
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence, Tuple
 
 from mathics.core.evaluation import Message, Print, _Out
+from mathics.eval.encoding import encode_string_value
 
 if TYPE_CHECKING:
     from mathics.doc.structure import DocSection
@@ -406,14 +407,18 @@ class DocTest:
     def __str__(self) -> str:
         return self.test
 
-    def compare(self, result: Optional[str], out: tuple = tuple()) -> bool:
+    def compare(
+        self, result: Optional[str], out: tuple = tuple(), encoding: str = "ASCII"
+    ) -> bool:
         """
         Performs a doctest comparison between ``result`` and ``wanted`` and returns
         True if the test should be considered a success.
         """
-        return self.compare_result(result) and self.compare_out(out)
+        return self.compare_result(result, encoding=encoding) and self.compare_out(
+            out, encoding=encoding
+        )
 
-    def compare_out(self, outs: tuple = tuple()) -> bool:
+    def compare_out(self, outs: tuple = tuple(), encoding: str = "ASCII") -> bool:
         """Compare messages and warnings produced during the evaluation of
         the test with the expected messages and warnings."""
         # Check out
@@ -434,12 +439,17 @@ class DocTest:
         for got, wanted in zip(outs, wanted_outs):
             if wanted.text == "...":
                 return True
-            if not tabs_to_spaces(got) == tabs_to_spaces(wanted):
+            # TODO: remove the encoding wrapper in the LHS
+            # once we finish fixing the Evaluation.format function
+            # to handle the encoding.
+            if not encode_string_value(
+                tabs_to_spaces(got), encoding=encoding
+            ) == encode_string_value(tabs_to_spaces(wanted), encoding=encoding):
                 return False
 
         return True
 
-    def compare_result(self, result: Optional[str]):
+    def compare_result(self, result: Optional[str], encoding: str = "ASCII") -> bool:
         """Compare a result with the expected result"""
         wanted = self.result
         # Check result
@@ -458,10 +468,16 @@ class DocTest:
             return False
 
         for res, want in zip(result_list, wanted_list):
-            wanted_re = re.escape(want.strip())
+            # TODO: Be more careful with special characters used in
+            # pattern matching.
+            want = encode_string_value(want.strip(), encoding=encoding)
+            # TODO: The encoding of `res` can be removed after
+            # all the documentation get updated.
+            res = encode_string_value(res.strip(), encoding=encoding)
+            wanted_re = re.escape(want)
             wanted_re = wanted_re.replace("\\.\\.\\.", ".*?")
             wanted_re = f"^{wanted_re}$"
-            if not re.match(wanted_re, res.strip()):
+            if not re.match(wanted_re, res):
                 return False
         return True
 

--- a/mathics/docpipeline.py
+++ b/mathics/docpipeline.py
@@ -21,6 +21,7 @@ from typing import Callable, Dict, Generator, List, Optional, Set, Union
 
 import mathics
 from mathics import settings, version_string
+from mathics.core.convert.op import string_to_invertible_ascii
 from mathics.core.evaluation import Output
 from mathics.core.load_builtin import _builtins, import_and_load_builtins
 from mathics.doc.doc_entries import DocTest, DocumentationEntry
@@ -44,6 +45,8 @@ STARS: str = "*" * 10
 MAX_TESTS = 100000  # A number greater than the total number of tests.
 # When 3.8 is base, the below can be a Literal type.
 INVALID_TEST_GROUP_SETUP = (None, None)
+
+CHARACTER_ENCODING = settings.SYSTEM_CHARACTER_ENCODING
 
 TestParameters = namedtuple(
     "TestParameters",
@@ -138,10 +141,6 @@ class DocTestPipeline:
         else:
             self.output_data = {}
 
-        # For consistency set the character encoding ASCII which is
-        # the lowest common denominator available on all systems.
-        settings.SYSTEM_CHARACTER_ENCODING = "ASCII"
-
         if self.session.definitions is None:
             self.print_and_log("Definitions are not initialized.")
             return INVALID_TEST_GROUP_SETUP
@@ -195,7 +194,9 @@ class TestStatus:
         """Show the current test"""
         test_str = test.test
         if not self.quiet:
-            print(f"{index:4d} ({subindex:2d}): TEST {test_str}")
+            print(
+                f"{index:4d} ({subindex:2d}): TEST {string_to_invertible_ascii(test_str)}"
+            )
 
 
 def test_case(
@@ -224,7 +225,7 @@ def test_case(
         return False
 
     time_start = datetime.now()
-    comparison_result = test.compare_result(result)
+    comparison_result = test.compare_result(result, encoding=CHARACTER_ENCODING)
 
     if test_parameters.check_partial_elapsed_time:
         test_pipeline.print_and_log(
@@ -498,10 +499,7 @@ def test_tests(
     """
     test_status: TestStatus = test_pipeline.status
     test_parameters: TestParameters = test_pipeline.parameters
-    # For consistency set the character encoding ASCII which is
-    # the lowest common denominator available on all systems.
 
-    settings.SYSTEM_CHARACTER_ENCODING = "ASCII"
     test_pipeline.reset_user_definitions()
 
     output_data, names = test_pipeline.validate_group_setup(

--- a/mathics/eval/encoding.py
+++ b/mathics/eval/encoding.py
@@ -1,0 +1,76 @@
+"""
+Functions to format strings in a given encoding.
+"""
+
+from typing import Dict
+
+from mathics_scanner.characters import UNICODE_CHARACTER_TO_ASCII
+
+from mathics.core.convert.op import operator_to_ascii, operator_to_unicode
+
+# Map WMA encoding names to Python encoding names
+ENCODING_WMA_TO_PYTHON = {
+    "WindowsEastEurope": "cp1250",
+    "WindowsCyrillic": "cp1251",
+    "WindowsANSI": "cp1252",
+    "WindowsGreek": "cp1252",
+    "WindowsTurkish": "cp1254",
+}
+
+
+# These characters are used in encoding
+# in WMA, and differs from what we have
+# in Mathics3-scanner tables:
+UNICODE_CHARACTER_TO_ASCII.update(
+    {
+        operator_to_unicode["Times"]: r" x ",
+        "": r"\[DifferentialD]",
+    }
+)
+# Some printable ASCII characters appears in the name
+# table. We should remove them:
+for raw_char_code in range(32, 127):
+    char = chr(raw_char_code)
+    if char in UNICODE_CHARACTER_TO_ASCII:
+        del UNICODE_CHARACTER_TO_ASCII[char]
+
+
+class EncodingNameError(Exception):
+    pass
+
+
+def get_encoding_table(encoding: str) -> Dict[str, str]:
+    """
+    Return a dictionary with a map from
+    character codes in the internal (Unicode)
+    representation to the request encoding.
+    """
+    if encoding == "Unicode":
+        return {}
+
+    # In the final implementation, this should load the corresponding
+    # json table or an encoding file as  in WMA
+    # SystemFiles/CharacterEncodings/*.m
+    # If the encoding is not available, raise an EncodingError
+    try:
+        return {
+            "ASCII": UNICODE_CHARACTER_TO_ASCII,
+            "UTF-8": {},
+        }[encoding]
+    except KeyError:
+        raise EncodingNameError
+
+
+def encode_string_value(value: str, encoding: str) -> str:
+    """Convert an Unicode string `value` to the required `encoding`"""
+
+    # In WMA, encodings are readed from SystemFiles/CharacterEncodings/*.m
+    # on the fly. We should load them from Mathics3-Scanner tables.
+    encoding_table = get_encoding_table(encoding)
+    if not encoding_table:
+        return value
+    result = ""
+    for ch in value:
+        ch = encoding_table.get(ch, ch)
+        result += ch
+    return result

--- a/test/format/test_format.py
+++ b/test/format/test_format.py
@@ -40,7 +40,7 @@ MATHML_STRICT = (
 
 PATH = os.path.dirname(__file__) + os.path.sep
 
-with open(PATH + "format_tests.yaml", "r") as src:
+with open(PATH + "format_tests.yaml", "r", encoding="utf-8") as src:
     all_test = yaml.safe_load(src)
 
 


### PR DESCRIPTION
This is the part of #1766 that does not imply changes in docstrings. `docpipeline.py` still requires setting the `MATHICS_CHARACTER_ENCODING="ASCII" ` encoding in tests.
Also, this adds a missing image file in the documentation, and comment out a font choice that produced errors in the compilation of  latex documentation.