### PR TITLE
Ensure date formats have a year in them.

### DIFF
--- a/mathics/builtin/datentime.py
+++ b/mathics/builtin/datentime.py
@@ -295,24 +295,33 @@ class _DateFormat(Builtin):
                 etime[1] = [str(s).strip('"') for s in etime[1]]
 
                 if sum(is_spec) == len(is_spec):
-                    forms = []
+                    time_formats = []
                     fields = [DATE_STRING_FORMATS[s] for s in etime[1]]
                     for sep in ["", " ", "/", "-", ".", ",", ":"]:
-                        forms.append(sep.join(fields))
+                        time_formats.append(sep.join(fields))
                 else:
-                    forms = [""]
+                    time_formats = [""]
                     for i, s in enumerate(etime[1]):
                         if is_spec[i]:
-                            forms[0] += DATE_STRING_FORMATS[s]
+                            time_formats[0] += DATE_STRING_FORMATS[s]
                         else:
                             # TODO: Escape % signs?
-                            forms[0] += s
+                            time_formats[0] += s
 
                 date = _Date()
                 date.date = None
-                for form in forms:
+                for time_format in time_formats:
+                    date_str = str(etime[0]).strip('"')
                     try:
-                        date.date = datetime.strptime(str(etime[0]).strip('"'), form)
+                        # Python 3.15 requires an unambiguous year; dates cannot be yearless.
+                        # Therefore, if a year is not provided via "%y" or "%Y", we will
+                        # add year 2000 along with the specifier %Y.
+                        if "%Y" not in time_format and "%y" not in time_format:
+                            date.date = datetime.strptime(
+                                f"2000 {date_str}", f"%Y {time_format}"
+                            )
+                        else:
+                            date.date = datetime.strptime(date_str, time_format)
                         break
                     except ValueError:
                         pass


### PR DESCRIPTION
In Python 3.14 we get warning when a date specification without a year is used. In 3.15 it will be mandatory.

Therefore, if a year is not provided via "%y" or "%Y", we will add year 2000 along with the specifier %Y.