### PR TITLE
Limit-inspired changes

### DIFF
--- a/mathics/autoload/rules/Limit.m
+++ b/mathics/autoload/rules/Limit.m
@@ -1,3 +1,4 @@
+(* -*- wolfram -*- *)
 (* Additions to mathics.builtin.numbers.trig that are either wrong
    or not covered by SymPy.
 
@@ -7,8 +8,16 @@
 
 Begin["System`Limit`private`"]
 Unprotect[Limit];
+
+(* We have the following Indeterminate rules on Limit to prevent them
+   from coming out Infinity. Other cases like:
+     Limit[Tan[x], x->Infinity] or
+     Limit[Cot[x], x->Infinity]
+   SymPy matches WMA.
+ *)
 Limit[Tan[x_], x_Symbol->Pi/2] = Indeterminate;
 Limit[Cot[x_], x_Symbol->0] = Indeterminate;
+
 Limit[x_ Sqrt[2 Pi]^(x_^-1) (Sin[x_]/(x_!))^(x_^-1), x_Symbol->Infinity] = E;
 Protect[Limit];
 End[]

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -220,6 +220,7 @@ class General(Builtin):
         "matsq": "Argument `1` is not a non-empty square matrix.",
         "newpkg": "In WL, there is a new package for this.",
         "nffil": "File not found during `1`.",
+        "nonopt": "Options expected (instead of `1`) beyond position `2` in `3`. An option must be a rule or a list of rules.",
         "noopen": "Cannot open `1`.",
         "nord": "Invalid comparison with `1` attempted.",
         "normal": "Nonatomic expression expected at position `1` in `2`.",

--- a/mathics/builtin/numbers/calculus.py
+++ b/mathics/builtin/numbers/calculus.py
@@ -1240,7 +1240,9 @@ class Integrate(SympyFunction):
 class Limit(Builtin):
     """
 
-    <url>:WMA link:https://reference.wolfram.com/language/ref/Limit.html</url>
+    <url>:Limit:
+    https://en.wikipedia.org/wiki/Limit_(mathematics)</url> (<url>
+    :WMA link:https://reference.wolfram.com/language/ref/Limit.html</url>)
 
     <dl>
       <dt>'Limit'[$expr$, $x$->$x_0$]
@@ -1255,15 +1257,36 @@ class Limit(Builtin):
 
     >> Limit[x, x->2]
      = 2
+
     >> Limit[Sin[x] / x, x->0]
      = 1
+
+    The limit value can change depending on which direction the \
+    limit is approached from.
+
+    Consider this inverse $x$ function:
+
+    >> Plot[1/x, {x, -10, +10}]
+     = -Graphics-
+
+    When coming to zero from positive values:
     >> Limit[1/x, x->0, Direction->-1]
      = Infinity
+
+    But when coming to zero from negative values:
     >> Limit[1/x, x->0, Direction->1]
      = -Infinity
+
+    A limit can be <url>:Indeterminate:
+    /doc/reference-of-built-in-symbols/integer-and-number-theoretical-functions/mathematical-constants/indeterminate/</url>:
+    >> Limit[Tan[x], x->Infinity]
+     = Indeterminate
     """
 
     attributes = A_LISTABLE | A_PROTECTED
+
+    eval_error = Builtin.generic_argument_error
+    expected_args = (2, 3)
 
     messages = {
         "ldir": "Value of Direction -> `1` should be -1 or 1.",

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -86,7 +86,10 @@ from mathics.core.symbols import (
     strip_context,
 )
 from mathics.core.systemsymbols import (
+    SymbolComplexInfinity,
     SymbolDefault,
+    SymbolDirectedInfinity,
+    SymbolInfinity,
     SymbolLessEqual,
     SymbolMessageName,
     SymbolRule,
@@ -455,7 +458,11 @@ class Builtin:
         "%(name)s[invalid___]"
 
         name = self.get_name(short=True)
-        if isinstance(invalid, Atom):
+        if isinstance(invalid, Atom) or invalid.head in (
+            SymbolComplexInfinity,
+            SymbolDirectedInfinity,
+            SymbolInfinity,
+        ):
             got_arg_count = 1
         else:
             got_arg_count = len(invalid.elements)
@@ -464,15 +471,27 @@ class Builtin:
             if got_arg_count in self.expected_args:
                 return None
 
+        # invalid.elements is not in bounds.
+        # Figure out the right message to report
         if isinstance(self.expected_args, tuple):
-            expected_args1, expected_args2 = self.expected_args
+            expected_args_start, expected_args_end = self.expected_args
+            if hasattr(self, "options") and self.options:
+                if got_arg_count > expected_args_end:
+                    evaluation.message(
+                        name,
+                        "nonopt",
+                        invalid.elements[expected_args_end],
+                        Integer(expected_args_end),
+                        evaluation.current_expression,
+                    )
+                    return
             if got_arg_count == 1:
                 evaluation.message(
                     name,
                     "argtu",
                     Symbol(name),
-                    Integer(expected_args1),
-                    Integer(expected_args2),
+                    Integer(expected_args_start),
+                    Integer(expected_args_end),
                 )
             else:
                 evaluation.message(
@@ -480,8 +499,8 @@ class Builtin:
                     "argt",
                     Symbol(name),
                     Integer(got_arg_count),
-                    Integer(expected_args1),
-                    Integer(expected_args2),
+                    Integer(expected_args_start),
+                    Integer(expected_args_end),
                 )
         elif isinstance(self.expected_args, range):
             if self.expected_args.stop == sys.maxsize:

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -13,6 +13,7 @@ from sympy import (
     false as SympyFalse,
     true as SympyTrue,
 )
+from sympy.calculus.accumulationbounds import AccumulationBounds
 from sympy.core.singleton import S
 
 from mathics.core.atoms import (
@@ -597,6 +598,9 @@ def old_from_sympy(expr) -> BaseElement:
             return Expression(SymbolPower, o_expr, power)
         else:
             return Expression(SymbolO, from_sympy(expr.args[0]))
+
+    if isinstance(expr, AccumulationBounds):
+        return SymbolIndeterminate
 
     raise ValueError(
         "Unknown SymPy expression: {} (instance of {})".format(

--- a/test/builtin/calculus/test_limit.py
+++ b/test/builtin/calculus/test_limit.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests for mathics.builtins.arithmetic.Element
+Unit tests for mathics.builtins.numbers.calculus.Limit
 """
-from test.helper import check_evaluation
+from test.helper import check_arg_counts, check_evaluation
 
 import pytest
 
@@ -12,6 +12,8 @@ import pytest
     [
         ("Limit[Tan[x], x->Pi/2]", "Indeterminate", None),
         ("Limit[Cot[x], x->0]", "Indeterminate", None),
+        ("Limit[Cot[x], x->Infinity]", "Indeterminate", None),
+        ("Limit[Cot[x], x->-Infinity]", "Indeterminate", None),
         ("Limit[x*Sqrt[2*Pi]^(x^-1)*(Sin[x]/(x!))^(x^-1), x->Infinity]", "E", None),
         (
             "Limit[x, x -> x0, Direction -> x]",
@@ -22,3 +24,17 @@ import pytest
 )
 def test_limit(str_expr, str_expected, msg):
     check_evaluation(str_expr, str_expected, failure_message=msg)
+
+
+@pytest.mark.parametrize(
+    ("function_name", "msg_fragment"),
+    [
+        (
+            "Limit",
+            "2 or 3 arguments are",
+        ),
+    ],
+)
+def test_limit_arg_errors(function_name, msg_fragment):
+    """ """
+    check_arg_counts(function_name, msg_fragment)


### PR DESCRIPTION
Improve argument checking in builtins with options to emit "nonopt" tags when appropriate

Improve from_sympy so it understands SymPy reporting Indeterminate

Go over Limit docs, and autoload rules

Expand limit tests