### PR TITLE
Some remaining items from format_series revision

### DIFF
--- a/mathics/core/parser/operators.py
+++ b/mathics/core/parser/operators.py
@@ -8,19 +8,21 @@ The dictionary from these which are read in here, are used by the
 Mathics3 parser.
 """
 
-
 from collections import defaultdict
+from typing import Dict, Final
 
 from mathics_scanner.characters import OPERATOR_DATA
 
-box_operators = OPERATOR_DATA["box-operators"]
-flat_binary_operators = OPERATOR_DATA["flat-binary-operators"]
+box_operators: Final[Dict[str, str]] = OPERATOR_DATA["box-operators"]
+flat_binary_operators: Final[Dict[str, int]] = OPERATOR_DATA["flat-binary-operators"]
 left_binary_operators = OPERATOR_DATA["left-binary-operators"]
-misc_operators = OPERATOR_DATA["miscellaneous-operators"]
-nonassoc_binary_operators = OPERATOR_DATA["non-associative-binary-operators"]
-operator_precedences = OPERATOR_DATA["operator-precedences"]
-operator_to_amslatex = OPERATOR_DATA["operator-to-amslatex"]
-operator_to_string = OPERATOR_DATA.get(
+misc_operators: Final[Dict[str, int]] = OPERATOR_DATA["miscellaneous-operators"]
+nonassoc_binary_operators: Final[Dict[str, int]] = OPERATOR_DATA[
+    "non-associative-binary-operators"
+]
+operator_precedences: Final[Dict[str, int]] = OPERATOR_DATA["operator-precedences"]
+operator_to_amslatex: Final[Dict[str, str]] = OPERATOR_DATA["operator-to-amslatex"]
+operator_to_string: Final[dict] = OPERATOR_DATA.get(
     "operator-to-string", OPERATOR_DATA.get("operator-to_string", {})
 )
 postfix_operators = OPERATOR_DATA["postfix-operators"]
@@ -29,23 +31,25 @@ right_binary_operators = OPERATOR_DATA["right-binary-operators"]
 ternary_operators = OPERATOR_DATA["ternary-operators"]
 
 # FIXME: get from JSON
-inequality_operators = [
+inequality_operators: Final[tuple] = (
     "Less",
     "LessEqual",
     "Greater",
     "GreaterEqual",
     "Equal",
     "Unequal",
-]
+)
 
 # binary_operators = left_binary_operators V right_binary_operators V flat_binary_operators V nonassoc_binary_operators
-binary_operators = {}
+binary_operators: Dict[str, int] = {}
 
 # all ops - check they're disjoint
-OPERATOR_PRECEDENCE = defaultdict(lambda: 670)
+OPERATOR_PRECEDENCE = defaultdict(lambda: operator_precedences["FunctionApply"])
+BOX_OPERATOR_PRECEDENCE: Final[int] = operator_precedences["BoxGroup"]
+PLUS_PRECEDENCE: Final[int] = operator_precedences["Plus"]
 
-# Set below
-all_operator_names = []
+# Values are set below in calculate_operator_information
+all_operator_names: tuple = tuple()
 
 
 def calculate_operator_information():
@@ -77,7 +81,8 @@ def calculate_operator_information():
         for op, prec in ops.items():
             OPERATOR_PRECEDENCE[op] = prec
 
-    all_operator_names = list(OPERATOR_PRECEDENCE.keys())
+    all_operator_names = tuple(OPERATOR_PRECEDENCE.keys())
+    pass
 
 
 # Calculating operator information is also done

--- a/mathics/format/form_rule/arithfns.py
+++ b/mathics/format/form_rule/arithfns.py
@@ -3,6 +3,8 @@ Format functions for arithmetic expressions.
 
 """
 
+from mathics_scanner.characters import NAMED_CHARACTERS
+
 from mathics.builtin.arithmetic import create_infix
 from mathics.core.atoms import (
     Complex,
@@ -23,8 +25,10 @@ from mathics.core.symbols import SymbolDivide, SymbolHoldForm, SymbolPower, Symb
 from mathics.core.systemsymbols import SymbolInfix, SymbolLeft, SymbolMinus
 from mathics.format.form.util import PRECEDENCE_PLUS, PRECEDENCE_TIMES
 
+INVISIBLE_TIMES: str = NAMED_CHARACTERS["InvisibleTimes"]
 
-def format_plus(items, evaluation: Evaluation):
+
+def format_plus(items, evaluation: Evaluation) -> Expression:
     """format Times[___] using `op` as operator"""
 
     def negate(item):  # -> Expression (see FIXME below)
@@ -76,7 +80,9 @@ def format_plus(items, evaluation: Evaluation):
     )
 
 
-def format_times(items, evaluation, op="\u2062"):
+def format_times(
+    items, evaluation: Evaluation, op: str = INVISIBLE_TIMES
+) -> Expression:
     """format Times[___] using `op` as operator"""
 
     def inverse(item):

--- a/mathics/format/form_rule/arithfns.py
+++ b/mathics/format/form_rule/arithfns.py
@@ -3,6 +3,8 @@ Format functions for arithmetic expressions.
 
 """
 
+from typing import Optional
+
 from mathics_scanner.characters import NAMED_CHARACTERS
 
 from mathics.builtin.arithmetic import create_infix
@@ -82,7 +84,7 @@ def format_plus(items, evaluation: Evaluation) -> Expression:
 
 def format_times(
     items, evaluation: Evaluation, op: str = INVISIBLE_TIMES
-) -> Expression:
+) -> Optional[Expression]:
     """format Times[___] using `op` as operator"""
 
     def inverse(item):
@@ -99,44 +101,46 @@ def format_times(
 
     items = items.get_sequence()
     if len(items) < 2:
-        return
-    positive = []
-    negative = []
+        return None
+    positive_formatted = []
+    negative_formatted = []
     for item in items:
         if (
             item.has_form("Power", 2)
             and isinstance(item.elements[1], (Integer, Rational, Real))
             and item.elements[1].to_sympy() < 0
         ):  # nopep8
-            negative.append(inverse(item))
+            negative_formatted.append(inverse(item))
         elif isinstance(item, Rational):
             numerator = item.numerator()
             if not numerator.sameQ(Integer1):
-                positive.append(numerator)
-            negative.append(item.denominator())
+                positive_formatted.append(numerator)
+            negative_formatted.append(item.denominator())
         else:
-            positive.append(item)
+            positive_formatted.append(item)
 
-    if positive and hasattr(positive[0], "value") and positive[0].value == -1:
-        del positive[0]
+    if (
+        positive_formatted
+        and hasattr(positive_formatted[0], "value")
+        and positive_formatted[0].value == -1
+    ):
+        del positive_formatted[0]
         minus = True
     else:
         minus = False
-    positive = [Expression(SymbolHoldForm, item) for item in positive]
-    negative = [Expression(SymbolHoldForm, item) for item in negative]
-    if positive:
-        positive = create_infix(positive, op, PRECEDENCE_TIMES, "Left")
+    if positive_formatted:
+        positive_result = create_infix(positive_formatted, op, PRECEDENCE_TIMES, "Left")
     else:
-        positive = Integer1
-    if negative:
-        negative = create_infix(negative, op, PRECEDENCE_TIMES, "Left")
+        positive_result = Integer1
+    if negative_formatted:
+        negative_result = create_infix(negative_formatted, op, PRECEDENCE_TIMES, "Left")
         result = Expression(
             SymbolDivide,
-            Expression(SymbolHoldForm, positive),
-            Expression(SymbolHoldForm, negative),
+            Expression(SymbolHoldForm, positive_result),
+            Expression(SymbolHoldForm, negative_result),
         )
     else:
-        result = positive
+        result = positive_result
     if minus:
         result = Expression(
             SymbolMinus, result

--- a/mathics/format/form_rule/calculus.py
+++ b/mathics/format/form_rule/calculus.py
@@ -1,14 +1,11 @@
-from mathics.core.atoms import (
-    Integer,
-    Integer0,
-    Integer1,
-    Integer310,
-    IntegerM1,
-    Rational,
-    String,
-)
+from typing import Final
+
+from mathics.core.atoms import Integer, Integer0, Integer1, IntegerM1, Rational, String
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
+from mathics.core.parser.operators import PLUS_PRECEDENCE
+from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import (
     SymbolDivide,
     SymbolHoldForm,
@@ -18,8 +15,19 @@ from mathics.core.systemsymbols import (
     SymbolPlus,
 )
 
+PLUS_PRECEDENCE_INTEGER: Final[int] = Integer(PLUS_PRECEDENCE)
+STRING_PLUS: Final[String] = String("+")
 
-def format_series(x, x0, data, nmin, nmax, den, evaluation):
+
+def format_series(
+    x: Symbol,
+    x0: Integer,
+    data: ListExpression,
+    nmin: Integer,
+    nmax: Integer,
+    den: Integer,
+    evaluation: Evaluation,
+) -> Expression:
     if den.value != 1:
         powers = [Rational(i, den) for i in range(nmin.value, nmax.value + 1)]
     else:
@@ -71,7 +79,7 @@ def format_series(x, x0, data, nmin, nmax, den, evaluation):
     return Expression(
         SymbolInfix,
         ListExpression(regular, last),
-        String("+"),
-        Integer310,
+        STRING_PLUS,
+        PLUS_PRECEDENCE_INTEGER,
         SymbolLeft,
     )

--- a/mathics/format/form_rule/calculus.py
+++ b/mathics/format/form_rule/calculus.py
@@ -1,11 +1,10 @@
-from typing import Final
+from typing import Final, List, Union
 
 from mathics.core.atoms import Integer, Integer0, Integer1, IntegerM1, Rational, String
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.parser.operators import PLUS_PRECEDENCE
-from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import (
     SymbolDivide,
     SymbolHoldForm,
@@ -15,19 +14,12 @@ from mathics.core.systemsymbols import (
     SymbolPlus,
 )
 
-PLUS_PRECEDENCE_INTEGER: Final[int] = Integer(PLUS_PRECEDENCE)
+PLUS_PRECEDENCE_INTEGER: Final[Integer] = Integer(PLUS_PRECEDENCE)
 STRING_PLUS: Final[String] = String("+")
 
 
-def format_series(
-    x: Symbol,
-    x0: Integer,
-    data: ListExpression,
-    nmin: Integer,
-    nmax: Integer,
-    den: Integer,
-    evaluation: Evaluation,
-) -> Expression:
+def format_series(x, x0, data, nmin, nmax, den, evaluation: Evaluation) -> Expression:
+    powers: List[Union[Rational, Integer]]
     if den.value != 1:
         powers = [Rational(i, den) for i in range(nmin.value, nmax.value + 1)]
     else:


### PR DESCRIPTION
Finishes out and fixes #1629 

<dl>
  <dt>mathics.parers.operators</dt>
  <dl>Add more type annotations to data read in from JSON<dl>
  <dt>format.form_rule.arithfns</dt>
  <dl>Replace magic unicode character and magc precedence number with values from JSON, and split up dual-use dual-typed variables (which mypy complains about)</dl>
</dt>
