### PR TITLE
Work around Binomial args checking

### DIFF
--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -29,11 +29,29 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Set up Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: ${{ env.EMSCRIPTEN_VERSION }}
-          actions-cache-folder: emsdk-cache
+      - name: Set up Emscripten toolchain (Manually)
+        run: |
+          # Clone the emsdk repository
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+
+          # Install and activate the specified version
+          ./emsdk install ${{ env.EMSCRIPTEN_VERSION }}
+          ./emsdk activate ${{ env.EMSCRIPTEN_VERSION }}
+
+          # Add to PATH for subsequent steps
+          echo "$(pwd)" >> $GITHUB_PATH
+          echo "$(pwd)/upstream/emscripten" >> $GITHUB_PATH
+          source ./emsdk_env.sh
+
+          # Verify installation
+          emcc --version
+
+      # - name: Set up Emscripten toolchain (Cached)
+      #   uses: mymindstorm/setup-emsdk@v14
+      #   with:
+      #     version: ${{ env.EMSCRIPTEN_VERSION }}
+      #     actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
         run: |

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -156,12 +156,23 @@ class Binomial(MPMathFunction):
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
-    eval_error = Builtin.generic_argument_error
     expected_args = 2
     nargs = {2}
     sympy_name = "binomial"
     mpmath_name = "binomial"
     summary_text = "binomial coefficients"
+
+    # Something about MPMathFunction in certain cases avoids
+    # generic_argument_error from getting called.
+    # So we will define an eval function and call the internal routine
+    # explicitly.
+    def eval(self, args, evaluation: Evaluation):
+        "Binomial[args___]"
+        if len(args.elements) == 2:
+            # super().eval(invalid, evaluation) gives error message:
+            # RuntimeError: super(): no arguments
+            return super(Binomial, self).eval(args, evaluation)
+        return Builtin.generic_argument_error(self, args, evaluation)
 
 
 class CatalanNumber(SympyFunction):

--- a/mathics/builtin/intfns/combinatorial.py
+++ b/mathics/builtin/intfns/combinatorial.py
@@ -22,7 +22,7 @@ from mathics.core.attributes import (
     A_PROTECTED,
     A_READ_PROTECTED,
 )
-from mathics.core.builtin import Builtin, MPMathFunction, SympyFunction
+from mathics.core.builtin import Builtin, SympyFunction
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
@@ -124,7 +124,7 @@ class _NoBoolVector(Exception):
     pass
 
 
-class Binomial(MPMathFunction):
+class Binomial(SympyFunction):
     """
 
     <url>
@@ -151,23 +151,23 @@ class Binomial(MPMathFunction):
     >> Binomial[10, -2]
      = 0
     >> Binomial[-10.5, -3.5]
-     = 0.
+     = 0
     """
 
     attributes = A_LISTABLE | A_NUMERIC_FUNCTION | A_PROTECTED
 
     expected_args = 2
-    nargs = {2}
-    sympy_name = "binomial"
     mpmath_name = "binomial"
+    nargs = {2}
     summary_text = "binomial coefficients"
+    sympy_name = "binomial"
 
-    # Something about MPMathFunction in certain cases avoids
-    # generic_argument_error from getting called.
-    # So we will define an eval function and call the internal routine
-    # explicitly.
     def eval(self, args, evaluation: Evaluation):
         "Binomial[args___]"
+
+        # Note: sympy.stats.Binomial(name, n, p): can be used creating a random variable representing a binomial distribution
+        # for statistical modeling within SymPy. Perhaps in the future we'll have a way to determine when that should be used.
+
         if len(args.elements) == 2:
             # super().eval(invalid, evaluation) gives error message:
             # RuntimeError: super(): no arguments

--- a/test/builtin/intfns/test_combinatorial.py
+++ b/test/builtin/intfns/test_combinatorial.py
@@ -72,9 +72,35 @@ def test_combinatorial_arg_errors(str_expr, msgs, fail_msg):
 
 
 @pytest.mark.parametrize(
+    ("str_expr", "expected_messages", "str_expected", "failure_message"),
+    [
+        # ("Binomial[-10, -3.5]", None, "ComplexInfinity", None),
+        (
+            "Binomial[a, b, c]",
+            # We have had a problem where Binomial[] shows an argument error,
+            # but Binomial[a, b, c] does not! So we will check that kind of
+            # situation explicitly.
+            ["Binomial called with 3 arguments; 2 arguments are expected."],
+            "Binomial[a, b, c]",
+            "Binomial with more than two arguments",
+        ),
+    ],
+)
+def test_binomial(str_expr, expected_messages, str_expected, failure_message):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        to_string_expr=True,
+        to_string_expected=True,
+        hold_expected=True,
+        failure_message=failure_message,
+        expected_messages=expected_messages,
+    )
+
+
+@pytest.mark.parametrize(
     ("str_expr", "msgs", "str_expected", "fail_msg"),
     [
-        ("Binomial[-10, -3.5]", None, "ComplexInfinity", None),
         ("Subsets[{}]", None, "{{}}", None),
         ("Subsets[]", None, "Subsets[]", None),
         (

--- a/test/builtin/intfns/test_combinatorial.py
+++ b/test/builtin/intfns/test_combinatorial.py
@@ -74,8 +74,7 @@ def test_combinatorial_arg_errors(str_expr, msgs, fail_msg):
 @pytest.mark.parametrize(
     ("str_expr", "msgs", "str_expected", "fail_msg"),
     [
-        ## TODO should be ComplexInfinity but mpmath returns +inf
-        ("Binomial[-10, -3.5]", None, "Infinity", None),
+        ("Binomial[-10, -3.5]", None, "ComplexInfinity", None),
         ("Subsets[{}]", None, "{{}}", None),
         ("Subsets[]", None, "Subsets[]", None),
         (

--- a/test/helper.py
+++ b/test/helper.py
@@ -39,9 +39,9 @@ def evaluate(str_expr: str, form=None):
 def check_arg_counts(function_name, msg_fragment):
     """ """
     str_expr = f"{function_name}[]"
-    expected_msgs = [
-        f"{function_name} called with 0 arguments; {msg_fragment} expected."
-    ]
+    expected_msgs = (
+        f"{function_name} called with 0 arguments; {msg_fragment} expected.",
+    )
     failure_message = f"{function_name} argument number error"
     check_evaluation(
         str_expr,


### PR DESCRIPTION
Fixes #1810

Use SymPy for binomial, not mpmath!  This corrects the improper values returned for

```
     >> Binomial[-10.5, -3.5]
-     = 0.
+     = 0
```

and:

```
-        ("Binomial[-10, -3.5]", None, "Infinity", None),
+        ("Binomial[-10, -3.5]", None, "ComplexInfinity", None),
```