### PR TITLE
Cache sympy values

### DIFF
--- a/mathics/builtin/numbers/constants.py
+++ b/mathics/builtin/numbers/constants.py
@@ -673,7 +673,7 @@ class Pi(_MPMathConstant, _NumpyConstant, _SympyConstant):
     >> N[Pi, 20]
      = 3.1415926535897932385
 
-    Note that the above is not the same thing as the number of digits <i>after</i> the decimal point. This may differ from similar concepts from other mathematical libraries, including those which Mathics uses!
+    Note that the above is not the same thing as the number of digits <i>after</i> the decimal point. This may differ from similar concepts from other mathematical libraries, including those which Mathics3 uses!
 
     Use numpy to compute Pi to 20 digits:
     >> N[Pi, 20, Method->"numpy"]

--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 import mpmath
 import sympy
+from sympy import Float as sympy_Float
 from sympy.core import numbers as sympy_numbers
 
 from mathics.core.atoms.strings import String
@@ -335,7 +336,7 @@ class Integer(Number[int]):
             else:
                 d = 16  # MACHINE_PRECISION_VALUE rounded up
 
-        return PrecisionReal(sympy.Float(self.value, d))
+        return PrecisionReal(sympy_Float(self.value, d))
 
     @property
     def sympy(self) -> sympy_numbers.Integer:
@@ -387,7 +388,7 @@ class Real(Number[T]):
                     )
                 else:
                     p = prec(len(digits.zfill(dps(FP_MANTISA_BINARY_DIGITS))))
-        elif isinstance(value, sympy.Float):
+        elif isinstance(value, sympy_Float):
             if p is None:
                 p = value._prec + 1
         elif isinstance(value, (Integer, sympy.Number, mpmath.mpf, float, int)):
@@ -487,6 +488,9 @@ class MachineReal(Real[float]):
             # event that different objects have the same Python value
             self.hash = hash((cls, n))
 
+            # We will set sympy lazialy
+            self._sympy = None
+
         return self
 
     # __hash__ is defined so that we can store Number-derived objects
@@ -567,18 +571,24 @@ class MachineReal(Real[float]):
         else:
             return False
 
-    def to_python(self, *args, **kwargs) -> float:
+    @property
+    def sympy(self):
+        if self._sympy is None:
+            self._sympy = sympy_Float(self.value)
+        return self._sympy
+
+    def to_python(self, *_, **__) -> float:
         return self.value
 
-    def to_sympy(self, *args, **kwargs):
-        return sympy.Float(self.value)
+    def to_sympy(self, *_, **__):
+        return self.sympy
 
 
 MachineReal0 = MachineReal(0)
 MachineReal1 = MachineReal(1)
 
 
-class PrecisionReal(Real[sympy.Float]):
+class PrecisionReal(Real[sympy_Float]):
     """
     Arbitrary precision real number.
 
@@ -592,7 +602,6 @@ class PrecisionReal(Real[sympy.Float]):
     # The key is the PrecisionReal's sympy.Float, and the
     # dictionary's value is the corresponding Mathics3 PrecisionReal object.
     _precision_reals: Dict[Any, "PrecisionReal"] = {}
-    _sympy: sympy.Float
 
     # Note: We have no _value attribute or value property .
     # value attribute comes from Number.value
@@ -602,7 +611,7 @@ class PrecisionReal(Real[sympy.Float]):
         self = cls._precision_reals.get(n)
         if self is None:
             self = Number.__new__(cls)
-            self._sympy = self._value = n
+            self._value = n
 
             # Cache object so we don't allocate again.
             self._precision_reals[n] = self
@@ -663,7 +672,7 @@ class PrecisionReal(Real[sympy.Float]):
         if d is None:
             return MachineReal(float(self.value))
         _prec = min(prec(d), self.value._prec)
-        return PrecisionReal(sympy.Float(self.value, precision=_prec))
+        return PrecisionReal(sympy_Float(self.value, precision=_prec))
 
     def sameQ(self, rhs) -> bool:
         """Mathics3 SameQ for PrecisionReal"""
@@ -684,11 +693,19 @@ class PrecisionReal(Real[sympy.Float]):
         diff = abs(value - other_value)
         return diff < 0.5**prec
 
-    def to_python(self, *args, **kwargs) -> float:
-        return float(self.value)
+    @property
+    def sympy(self):
+        return self._value
 
-    def to_sympy(self, *args, **kwargs) -> sympy.Float:
-        return self.value
+    def to_python(self, *_, **__) -> float:
+        return float(self._value)
+
+    def to_sympy(self, *_, **__) -> sympy_Float:
+        return self._value
+
+    @property
+    def value(self) -> sympy_Float:
+        return self._value
 
 
 class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
@@ -768,6 +785,7 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
             self.precision = precision
 
             self._exact_value = exact_value
+            self._sympy = None  # lazy evaluation for sympy
             self._value = complex(real.value, imag.value)
 
             # Cache object so we don't allocate again.
@@ -810,7 +828,7 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
             if hasattr(self.imag, "is_approx_zero")
             else self.imag.is_zero
         )
-        return real_zero and imag_zero
+        return bool(real_zero) and bool(imag_zero)
 
     @property
     def is_zero(self) -> bool:
@@ -897,6 +915,10 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
             isinstance(rhs, Complex) and self.real == rhs.real and self.imag == rhs.imag
         )
 
+    @property
+    def sympy(self):
+        return self.to_sympy()
+
     def user_hash(self, update) -> None:
         update(b"System`Complex>")
         update(self.real)
@@ -912,8 +934,10 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
             self.real.to_mpmath(precision), self.imag.to_mpmath(precision)
         )
 
-    def to_sympy(self, **kwargs):
-        return self.real.to_sympy() + sympy.I * self.imag.to_sympy()
+    def to_sympy(self, **_):
+        if self._sympy is None:
+            self._sympy = self.real.to_sympy() + sympy.I * self.imag.to_sympy()
+        return self._sympy
 
 
 class Rational(Number[sympy.Rational]):
@@ -980,10 +1004,10 @@ class Rational(Number[sympy.Rational]):
             self.numerator().is_zero
         )  # (implicit) and not (self.denominator().is_zero)
 
-    def to_sympy(self, **kwargs):
+    def to_sympy(self, **__):
         return self.value
 
-    def to_python(self, *args, **kwargs) -> float:
+    def to_python(self, *_, **__kwargs) -> float:
         return float(self.value)
 
     def round(self, d=None) -> Union["MachineReal", "PrecisionReal"]:

--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -328,7 +328,7 @@ class Integer(Number[int]):
         if d is None:
             d = self.value.bit_length()
             # Many WMA implementations seem to change behavior of the integer
-            # represetation that have more than 1024 digits. In theory this is
+            # representation that have more than 1024 digits. In theory this is
             # number can vary depending on hardware characteristics.
             # In practice, a reasonable
             if d <= 1024:
@@ -485,10 +485,10 @@ class MachineReal(Real[float]):
             # it is used this is fast. Note that in contrast to the
             # cached object key, the hash key needs to be unique across all
             # Python objects, so we include the class in the
-            # event that different objects have the same Python value
+            # event that different objects have the same Python value.
             self.hash = hash((cls, n))
 
-            # We will set sympy lazialy
+            # We will set the sympy value lazily.
             self._sympy = None
 
         return self

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -355,36 +355,38 @@ sympy_conversion_by_type = {
 #    return sympy_conversion_by_type.get(type(expr), old_from_sympy)(expr)
 
 
-def old_from_sympy(expr) -> BaseElement:
+def from_sympy(sympy_expr) -> BaseElement:
     """
     converts a SymPy object to a Mathics3 element.
     """
-    if isinstance(expr, (tuple, list)):
-        return to_mathics_list(*expr, elements_conversion_fn=from_sympy)
-    if isinstance(expr, int):
-        return Integer(expr)
-    if isinstance(expr, float):
-        return Real(expr)
-    if isinstance(expr, complex):
-        return Complex(Real(expr.real), Real(expr.imag))
-    if isinstance(expr, str):
-        return String(expr)
-    if expr is None:
+    if isinstance(sympy_expr, (tuple, list)):
+        return to_mathics_list(*sympy_expr, elements_conversion_fn=from_sympy)
+    if isinstance(sympy_expr, int):
+        return Integer(sympy_expr)
+    if isinstance(sympy_expr, float):
+        return Real(sympy_expr)
+    if isinstance(sympy_expr, complex):
+        return Complex(Real(sympy_expr.real), Real(sympy_expr.imag))
+    if isinstance(sympy_expr, str):
+        return String(sympy_expr)
+    if sympy_expr is None:
         return SymbolNull
-    if isinstance(expr, sympy.Matrix) or isinstance(expr, sympy.ImmutableMatrix):
-        return from_sympy_matrix(expr)
-    if isinstance(expr, sympy.MatPow):
+    if isinstance(sympy_expr, sympy.Matrix) or isinstance(
+        sympy_expr, sympy.ImmutableMatrix
+    ):
+        return from_sympy_matrix(sympy_expr)
+    if isinstance(sympy_expr, sympy.MatPow):
         return Expression(
-            SymbolMatrixPower, from_sympy(expr.base), from_sympy(expr.exp)
+            SymbolMatrixPower, from_sympy(sympy_expr.base), from_sympy(sympy_expr.exp)
         )
-    if expr.is_Atom:
+    if sympy_expr.is_Atom:
         name = None
-        if expr.is_Symbol:
-            name = str(expr)
-            if isinstance(expr, sympy.Dummy):
+        if sympy_expr.is_Symbol:
+            name = str(sympy_expr)
+            if isinstance(sympy_expr, sympy.Dummy):
                 name = name[1:]
                 if "_" not in name:
-                    name = f"sympy`dummy`Dummy${expr.dummy_index}"  # type: ignore[attr-defined]
+                    name = f"sympy`dummy`Dummy${sympy_expr.dummy_index}"  # type: ignore[attr-defined]
                 else:
                     name = sympy_decode_mathics_symbol_name(name)
                 # Probably, this should be the value attribute
@@ -395,25 +397,25 @@ def old_from_sympy(expr) -> BaseElement:
             if name.startswith(SYMPY_SLOT_PREFIX):
                 index = int(name[len(SYMPY_SLOT_PREFIX) :])
                 return Expression(SymbolSlot, Integer(index))
-        elif expr.is_NumberSymbol:
-            name = str(expr)
+        elif sympy_expr.is_NumberSymbol:
+            name = str(sympy_expr)
         if name is not None:
             builtin = sympy_to_mathics.get(name)
             if builtin is not None:
                 name = builtin.get_name()
             return Symbol(name)
-        if isinstance(expr, sympy.core.numbers.Infinity):
+        if isinstance(sympy_expr, sympy.core.numbers.Infinity):
             return MATHICS3_INFINITY
-        if isinstance(expr, sympy.core.numbers.ComplexInfinity):
+        if isinstance(sympy_expr, sympy.core.numbers.ComplexInfinity):
             return MATHICS3_COMPLEX_INFINITY
-        if isinstance(expr, sympy.core.numbers.NegativeInfinity):
+        if isinstance(sympy_expr, sympy.core.numbers.NegativeInfinity):
             return MATHICS3_NEG_INFINITY
-        if isinstance(expr, sympy.core.numbers.ImaginaryUnit):
+        if isinstance(sympy_expr, sympy.core.numbers.ImaginaryUnit):
             return MATHICS3_COMPLEX_I
-        if isinstance(expr, sympy.Integer):
-            return Integer(int(expr))
-        if isinstance(expr, sympy.Rational):
-            numerator, denominator = map(int, expr.as_numer_denom())
+        if isinstance(sympy_expr, sympy.Integer):
+            return Integer(int(sympy_expr))
+        if isinstance(sympy_expr, sympy.Rational):
+            numerator, denominator = map(int, sympy_expr.as_numer_denom())
             if denominator == 0:
                 if numerator > 0:
                     return MATHICS3_INFINITY
@@ -423,63 +425,63 @@ def old_from_sympy(expr) -> BaseElement:
                     assert numerator == 0
                     return SymbolIndeterminate
             return Rational(numerator, denominator)
-        if isinstance(expr, sympy.Float):
-            if expr._prec == FP_MANTISA_BINARY_DIGITS:
-                return MachineReal(float(expr))
-            return Real(expr)
-        if isinstance(expr, sympy.core.numbers.NaN):
+        if isinstance(sympy_expr, sympy.Float):
+            if sympy_expr._prec == FP_MANTISA_BINARY_DIGITS:
+                return MachineReal(float(sympy_expr))
+            return Real(sympy_expr)
+        if isinstance(sympy_expr, sympy.core.numbers.NaN):
             return SymbolIndeterminate
-        if isinstance(expr, sympy.core.function.FunctionClass):
-            name = str(expr).replace("_", "`")
+        if isinstance(sympy_expr, sympy.core.function.FunctionClass):
+            name = str(sympy_expr).replace("_", "`")
             return Symbol(name)
-        if expr is sympy.true:
+        if sympy_expr is sympy.true:
             return SymbolTrue
-        if expr is sympy.false:
+        if sympy_expr is sympy.false:
             return SymbolFalse
 
-    if expr.is_number and all(x.is_Number for x in expr.as_real_imag()):
+    if sympy_expr.is_number and all(x.is_Number for x in sympy_expr.as_real_imag()):
         # Hack to convert <Integer> * I to Complex[0, <Integer>]
         try:
-            return Complex(*[from_sympy(arg) for arg in expr.as_real_imag()])
+            return Complex(*[from_sympy(arg) for arg in sympy_expr.as_real_imag()])
         except ValueError:
             # The exception happens if one of the components is infinity
             pass
-    if expr.is_Add:
+    if sympy_expr.is_Add:
         return to_expression(
-            SymbolPlus, *sorted([from_sympy(arg) for arg in expr.args])
+            SymbolPlus, *sorted([from_sympy(arg) for arg in sympy_expr.args])
         )
-    if expr.is_Mul:
+    if sympy_expr.is_Mul:
         return to_expression(
-            SymbolTimes, *sorted([from_sympy(arg) for arg in expr.args])
+            SymbolTimes, *sorted([from_sympy(arg) for arg in sympy_expr.args])
         )
-    if expr.is_Pow:
-        return to_expression(SymbolPower, *[from_sympy(arg) for arg in expr.args])
-    if expr.is_Equality:
-        return to_expression(SymbolEqual, *[from_sympy(arg) for arg in expr.args])
+    if sympy_expr.is_Pow:
+        return to_expression(SymbolPower, *[from_sympy(arg) for arg in sympy_expr.args])
+    if sympy_expr.is_Equality:
+        return to_expression(SymbolEqual, *[from_sympy(arg) for arg in sympy_expr.args])
 
-    if isinstance(expr, SympyExpression):
-        return expr.expr
+    if isinstance(sympy_expr, SympyExpression):
+        return sympy_expr.expr
 
-    if isinstance(expr, sympy.Piecewise):
+    if isinstance(sympy_expr, sympy.Piecewise):
         return Expression(
             SymbolPiecewise,
             ListExpression(
                 *[
                     to_mathics_list(from_sympy(case), from_sympy(cond))
                     for case, cond in cast(
-                        Sequence[Tuple[sympy.Basic, sympy.Basic]], expr.args
+                        Sequence[Tuple[sympy.Basic, sympy.Basic]], sympy_expr.args
                     )
                 ]
             ),
         )
 
-    if isinstance(expr, SympyPrime):
-        return Expression(SymbolPrime, from_sympy(expr.args[0]))
-    if isinstance(expr, sympy.RootSum):
-        return Expression(SymbolRootSum, from_sympy(expr.poly), from_sympy(expr.fun))  # type: ignore[attr-defined]
-    if isinstance(expr, sympy.PurePoly):
-        coeffs = expr.coeffs()
-        monoms = expr.monoms()
+    if isinstance(sympy_expr, SympyPrime):
+        return Expression(SymbolPrime, from_sympy(sympy_expr.args[0]))
+    if isinstance(sympy_expr, sympy.RootSum):
+        return Expression(SymbolRootSum, from_sympy(sympy_expr.poly), from_sympy(sympy_expr.fun))  # type: ignore[attr-defined]
+    if isinstance(sympy_expr, sympy.PurePoly):
+        coeffs = sympy_expr.coeffs()
+        monoms = sympy_expr.monoms()
         result: List[BaseElement] = []
         for coeff, monom in zip(coeffs, monoms):
             factors = []
@@ -500,9 +502,9 @@ def old_from_sympy(expr) -> BaseElement:
             else:
                 result.append(Integer1)
         return Expression(SymbolFunction, Expression(SymbolPlus, *sorted(result)))
-    if isinstance(expr, sympy.CRootOf):
+    if isinstance(sympy_expr, sympy.CRootOf):
         try:
-            e_root, indx = expr.args
+            e_root, indx = sympy_expr.args
         except ValueError:
             return SymbolNull
 
@@ -512,15 +514,15 @@ def old_from_sympy(expr) -> BaseElement:
             pass
 
         return Expression(SymbolRoot, from_sympy(e_root), Integer(indx + 1))
-    if isinstance(expr, sympy.Lambda):
+    if isinstance(sympy_expr, sympy.Lambda):
         variables = [
             sympy.Symbol(f"{SYMPY_SLOT_PREFIX}{index + 1}")
-            for index in range(len(expr.variables))
+            for index in range(len(sympy_expr.variables))
         ]
-        return Expression(SymbolFunction, from_sympy(expr(*variables)))
+        return Expression(SymbolFunction, from_sympy(sympy_expr(*variables)))
 
-    if expr.is_Function or isinstance(
-        expr,
+    if sympy_expr.is_Function or isinstance(
+        sympy_expr,
         (
             sympy.Derivative,
             sympy.Integral,
@@ -528,12 +530,12 @@ def old_from_sympy(expr) -> BaseElement:
             sympy.Sum,
         ),
     ):
-        if isinstance(expr, sympy.Integral):
+        if isinstance(sympy_expr, sympy.Integral):
             name = "Integral"
-        elif isinstance(expr, sympy.Derivative):
+        elif isinstance(sympy_expr, sympy.Derivative):
             name = "Derivative"
             margs = []
-            for arg in expr.args:
+            for arg in sympy_expr.args:
                 # parse (x, 1) ==> just x for test_conversion
                 # IMHO this should be removed in future versions
                 if isinstance(arg, sympy.Tuple):
@@ -547,69 +549,70 @@ def old_from_sympy(expr) -> BaseElement:
             assert builtin is not None
             return builtin.from_sympy(tuple(margs))
 
-        elif isinstance(expr, sympy.sign):
+        elif isinstance(sympy_expr, sympy.sign):
             name = "Sign"
         else:
-            name = expr.func.__name__
+            name = sympy_expr.func.__name__
             assert name is not None
             if is_Cn_expr(name):
                 return Expression(
                     Expression(Symbol("C"), Integer(int(name[1:]))),
-                    *[from_sympy(arg) for arg in expr.args],
+                    *[from_sympy(arg) for arg in sympy_expr.args],
                 )
             name = sympy_decode_mathics_symbol_name(name)
-        args = [from_sympy(arg) for arg in expr.args]
+        args = [from_sympy(arg) for arg in sympy_expr.args]
         builtin = sympy_to_mathics.get(name)
         if builtin is not None:
             return builtin.from_sympy(tuple(args))
         return Expression(Symbol(name), *args)
 
-    if isinstance(expr, sympy.Tuple):
-        return to_mathics_list(*expr.args, elements_conversion_fn=from_sympy)
+    if isinstance(sympy_expr, sympy.Tuple):
+        return to_mathics_list(*sympy_expr.args, elements_conversion_fn=from_sympy)
 
-    # elif isinstance(expr, sympy.Sum):
+    # elif isinstance(sympy_expr, sympy.Sum):
     #    return Expression('Sum', )
 
-    if isinstance(expr, sympy.LessThan):
+    if isinstance(sympy_expr, sympy.LessThan):
         return to_expression(
-            SymbolLessEqual, *expr.args, elements_conversion_fn=from_sympy
+            SymbolLessEqual, *sympy_expr.args, elements_conversion_fn=from_sympy
         )
-    if isinstance(expr, sympy.StrictLessThan):
-        return to_expression(SymbolLess, *expr.args, elements_conversion_fn=from_sympy)
-    if isinstance(expr, sympy.GreaterThan):
+    if isinstance(sympy_expr, sympy.StrictLessThan):
         return to_expression(
-            SymbolGreaterEqual, *expr.args, elements_conversion_fn=from_sympy
+            SymbolLess, *sympy_expr.args, elements_conversion_fn=from_sympy
         )
-    if isinstance(expr, sympy.StrictGreaterThan):
+    if isinstance(sympy_expr, sympy.GreaterThan):
         return to_expression(
-            SymbolGreater, *expr.args, elements_conversion_fn=from_sympy
+            SymbolGreaterEqual, *sympy_expr.args, elements_conversion_fn=from_sympy
         )
-    if isinstance(expr, sympy.Unequality):
+    if isinstance(sympy_expr, sympy.StrictGreaterThan):
         return to_expression(
-            SymbolUnequal, *expr.args, elements_conversion_fn=from_sympy
+            SymbolGreater, *sympy_expr.args, elements_conversion_fn=from_sympy
         )
-    if isinstance(expr, sympy.Equality):
-        return to_expression(SymbolEqual, *expr.args, elements_conversion_fn=from_sympy)
+    if isinstance(sympy_expr, sympy.Unequality):
+        return to_expression(
+            SymbolUnequal, *sympy_expr.args, elements_conversion_fn=from_sympy
+        )
+    if isinstance(sympy_expr, sympy.Equality):
+        return to_expression(
+            SymbolEqual, *sympy_expr.args, elements_conversion_fn=from_sympy
+        )
 
-    if isinstance(expr, sympy.O):
-        if expr.args[0].func == sympy.core.power.Pow:
-            [var, power] = [from_sympy(arg) for arg in expr.args[0].args]
+    if isinstance(sympy_expr, sympy.O):
+        if sympy_expr.args[0].func == sympy.core.power.Pow:
+            [var, power] = [from_sympy(arg) for arg in sympy_expr.args[0].args]
             o_expr = Expression(SymbolO, var)
             return Expression(SymbolPower, o_expr, power)
         else:
-            return Expression(SymbolO, from_sympy(expr.args[0]))
+            return Expression(SymbolO, from_sympy(sympy_expr.args[0]))
 
     # FIXME: this should be an Interval, but we currently do
     # not have intervals. The primary place this appears is in
     # Limit, so check that as well for adjusting.
-    if isinstance(expr, AccumulationBounds):
+    if isinstance(sympy_expr, AccumulationBounds):
         return SymbolIndeterminate
 
     raise ValueError(
         "Unknown SymPy expression: {} (instance of {})".format(
-            expr, str(expr.__class__)
+            sympy_expr, str(sympy_expr.__class__)
         )
     )
-
-
-from_sympy = old_from_sympy

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -134,7 +134,7 @@ def is_Cn_expr(name: str) -> bool:
     return number != "" and number.isdigit()
 
 
-def to_sympy_matrix(data, **kwargs) -> Optional[sympy.MutableDenseMatrix]:
+def to_sympy_matrix(data, **__) -> Optional[sympy.MutableDenseMatrix]:
     """Convert a Mathics3 matrix to one that can be used by Sympy.
     None is returned if we can't convert to a Sympy matrix.
     """
@@ -184,7 +184,7 @@ class SympyExpression(sympy.Expr):
         class SympyExpressionFunc:
             """A class to mimic the behavior of sympy.Function"""
 
-            def __new__(cls, *args):
+            def __new__(cls, *_):
                 return SympyExpression(self.expr)
                 # return SympyExpression(expression.Expression(self.expr.head,
                 # *(from_sympy(arg) for arg in args[1:])))

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -371,8 +371,10 @@ class Symbol(Atom, NumericOperators, EvalMixin):
         self = cls._symbols.get(name)
 
         if self is None:
+
             self = super().__new__(cls)
             self.name = name
+            self.sympy = None
 
             # Cache object so we don't allocate again.
             cls._symbols[name] = self
@@ -599,7 +601,7 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def user_hash(self, update) -> None:
         update(b"System`Symbol>" + self.name.encode("utf8"))
 
-    def to_python(self, *args, python_form: bool = False, **kwargs):
+    def to_python(self, *_, __: bool = False, **kwargs):
         if self is SymbolTrue:
             return True
         if self is SymbolFalse:
@@ -638,7 +640,10 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     def to_sympy(self, **kwargs):
         from mathics.core.convert.sympy import symbol_to_sympy
 
-        return symbol_to_sympy(self, **kwargs)
+        if self.sympy is not None:
+            return self.sympy
+        self.sympy = symbol_to_sympy(self, **kwargs)
+        return self.sympy
 
 
 class SymbolConstant(Symbol):


### PR DESCRIPTION
Cache sympy values for Complex numbers, and Symbol.

PrecisionReal values are already a SymPy value, so allow `.sympy`  method access.

Some linting has been done.