### PR TITLE
Second round of import/export revision and gmp2 tolerance

### DIFF
--- a/mathics/autoload/formats/Image/Export.m
+++ b/mathics/autoload/formats/Image/Export.m
@@ -1,4 +1,5 @@
 (* Image Exporter *)
+(* FIXME: There is no RegisterImageImport builtin in WMA. Rewrite in Python. *)
 
 Begin["System`Convert`Image`"]
 
@@ -10,6 +11,7 @@ RegisterImageExport[type_] := ImportExport`RegisterExport[
 	BinaryFormat -> True
 ];
 
-RegisterImageExport[#]& /@ {"BMP", "GIF", "JPEG2000", "JPEG", "PCX", "PNG", "PPM", "PBM", "PGM", "TIFF"};
+(* FIXME: RegisterImageImport shoudl work with MIME types, not psuedo-canonicalized file extensions. *)
+RegisterImageExport[#]& /@ {"BMP", "GIF", "JPEG2000", "JPEG", "JPG", "PCX", "PNG", "PPM", "PBM", "PGM", "TIFF"};
 
 End[]

--- a/mathics/autoload/formats/Image/Import.m
+++ b/mathics/autoload/formats/Image/Import.m
@@ -1,4 +1,5 @@
 (* Image Importer *)
+(* FIXME: There is no RegisterImageImport builtin in WMA. Rewrite in Python. *)
 
 Begin["System`Convert`Image`"]
 
@@ -11,6 +12,7 @@ RegisterImageImport[type_] := ImportExport`RegisterImport[
     FunctionChannels -> {"FileNames"}
 ];
 
-RegisterImageImport[#]& /@ {"BMP", "GIF", "JPEG2000", "JPEG", "PCX", "PNG", "PPM", "PBM", "PGM", "TIFF", "ICO", "TGA"};
+(* FIXME: RegisterImageImport shoudl work with MIME types, not psuedo-canonicalized file extensions. *)
+RegisterImageImport[#]& /@ {"BMP", "GIF", "JPEG2000", "JPEG", "JPG", "PCX", "PNG", "PPM", "PBM", "PGM", "TIFF", "ICO", "TGA"};
 
 End[]

--- a/mathics/autoload/formats/Text/Export.m
+++ b/mathics/autoload/formats/Text/Export.m
@@ -1,4 +1,5 @@
 (* Text Exporter *)
+(* FIXME: There is no RegisterImageImport builtin in WMA. Rewrite in Python. *)
 
 Begin["System`Convert`TextDump`"]
 
@@ -7,12 +8,12 @@ Options[TextExport] = {
 };
 
 TextExport[filename_, expr_, OptionsPattern[]] :=
-  Module[{strm, data},
-    strm = OpenWrite[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
-    If[strm === $Failed, Return[$Failed]];
-    data = ToString[expr];
-    WriteString[strm, data];
-    Close[strm];
+    Module[{strm, data},
+        strm = OpenWrite[filename, CharacterEncoding -> OptionValue["CharacterEncoding"]];
+        If[strm === $Failed, Return[$Failed]];
+        data = ToString[expr];
+        WriteString[strm, data];
+        Close[strm];
   ]
 
 ImportExport`RegisterExport[

--- a/mathics/autoload/formats/Text/Import.m
+++ b/mathics/autoload/formats/Text/Import.m
@@ -27,7 +27,7 @@ StringImport[stream_]:=
         {"String" -> string}
     ]
 
-WordsImport[stream_]:= 
+WordsImport[stream_]:=
     Module[{words},
         words = ReadList[stream, Word];
         {"Words" -> words}
@@ -47,7 +47,7 @@ ImportExport`RegisterImport[
 	AvailableElements -> {"Data", "Lines", "Plaintext", "String", "Words"},
 	BinaryFormat -> True,
 	DefaultElement -> "Plaintext",
-    FunctionChannels -> {"Streams"},
+        FunctionChannels -> {"Streams"},
 	Options -> {"CharacterEncoding"}
 ]
 

--- a/mathics/autoload/formats/Text/Import.m
+++ b/mathics/autoload/formats/Text/Import.m
@@ -44,11 +44,11 @@ ImportExport`RegisterImport[
         System`Convert`TextDump`PlaintextImport
     },
     {},
-	AvailableElements -> {"Data", "Lines", "Plaintext", "String", "Words"},
-	BinaryFormat -> True,
-	DefaultElement -> "Plaintext",
-        FunctionChannels -> {"Streams"},
-	Options -> {"CharacterEncoding"}
+    AvailableElements -> {"Data", "Lines", "Plaintext", "String", "Words"},
+    BinaryFormat -> True,
+    DefaultElement -> "Plaintext",
+    FunctionChannels -> {"Streams"},
+    Options -> {"CharacterEncoding"}
 ]
 
 

--- a/mathics/builtin/files_io/importexport.py
+++ b/mathics/builtin/files_io/importexport.py
@@ -18,11 +18,11 @@ does the corresponding thing for <url>
 """
 
 import base64
-import mimetypes
 import os
 import sys
 import urllib.request as request
 from itertools import chain
+from typing import Dict, Final
 from urllib.error import HTTPError, URLError
 
 from mathics.core.atoms import ByteArray
@@ -50,7 +50,7 @@ from mathics.eval.files_io.importexport import (
     IMPORTERS,
     MIMETYPE_TO_SHORTNAME,
     eval_Import,
-    filetype_from_MIME_content,
+    filetype_from_mime_content,
     filetype_from_path,
     importer_exporter_options,
 )
@@ -59,16 +59,10 @@ from mathics.eval.files_io.importexport import (
 # Here we are also hiding "file_io" since this can erroneously appear at the top level.
 sort_order = "mathics.builtin.importing-and-exporting"
 
-SymbolStringToStream = Symbol("StringToStream")
-SymbolWriteString = Symbol("WriteString")
-
-# Seems that JSON is not registered on the mathics.net server, so we do it manually here.
-# Keep in mind that mimetypes has system-dependent aspects (it inspects "/etc/mime.types" and other files).
-mimetypes.add_type("application/json", ".json")
-
-# TODO: Add more file formats
-
 EXPORTERS = {}
+
+# TODO: Remove EXTENSIONMAPPINGS. Instead make better
+# use of mimetypes package.
 EXTENSIONMAPPINGS = {
     "*.3ds": "3DS",
     "*.3fr": "Raw",
@@ -335,6 +329,8 @@ EXTENSIONMAPPINGS = {
 }
 
 
+# TODO: Remove FORMATMAPPINGS. Instead make better
+# use of mimetypes package.
 FORMATMAPPINGS = {
     "3DS": "3DS",
     "ACO": "ACO",
@@ -785,6 +781,7 @@ FORMATMAPPINGS = {
 }
 
 
+# FIXME: remove this.
 class ConverterDumpsExtensionMappings(Predefined):
     r"""
     ## <url>:internal native symbol:</url>
@@ -809,6 +806,7 @@ class ConverterDumpsExtensionMappings(Predefined):
         return from_python(EXTENSIONMAPPINGS)
 
 
+# FIXME: remove this.
 class ConverterDumpsFormatMappings(Predefined):
     r"""
     ## <url>:internal native symbol:</url>
@@ -1120,7 +1118,7 @@ class URLFetch(Builtin):
                 return MIMETYPE_TO_SHORTNAME.get(content_type, "Text")
 
             result = eval_Import(
-                temp_path,
+                String(temp_path),
                 determine_filetype,
                 elements,
                 evaluation,
@@ -1300,7 +1298,7 @@ class ImportString(Builtin):
             return SymbolFailed
 
         def determine_filetype(py_data: str) -> str:
-            return filetype_from_MIME_content(py_data)
+            return filetype_from_mime_content(py_data)
 
         return eval_Import(
             None, determine_filetype, elements, evaluation, options, data=data.value
@@ -1363,6 +1361,7 @@ class Export(Builtin):
 
     summary_text = "export elements to a file"
 
+    # FIXME: move to mathics.eval
     def _check_filename(self, filename, evaluation: Evaluation):
         path = filename.to_python()
         if isinstance(path, str) and path[0] == path[-1] == '"':
@@ -1370,6 +1369,7 @@ class Export(Builtin):
         evaluation.message("Export", "chtype", filename)
         return False
 
+    # FIXME: move to mathics.eval
     def _infer_form(self, filename, evaluation: Evaluation):
         ext = Expression(SymbolFileExtension, filename).evaluate(evaluation)
         ext = ext.get_string_value().lower()

--- a/mathics/builtin/image/misc.py
+++ b/mathics/builtin/image/misc.py
@@ -14,8 +14,9 @@ from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
-from mathics.core.symbols import Symbol, SymbolNull
+from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolFailed, SymbolRule
+from mathics.eval.files_io.importexport import eval_ImageExport
 from mathics.eval.image import extract_exif
 
 # The following classes are used to allow inclusion of
@@ -41,8 +42,7 @@ class ImageExport(Builtin):
     def eval(self, path: String, expr, opts, evaluation: Evaluation):
         """ImageExport[path_String, expr_, opts___]"""
         if isinstance(expr, Image):
-            expr.pil().save(path.value)
-            return SymbolNull
+            return eval_ImageExport(expr, path.value)
         else:
             evaluation.message("ImageExport", "noimage")
             return

--- a/mathics/core/convert/sympy.py
+++ b/mathics/core/convert/sympy.py
@@ -73,6 +73,11 @@ from mathics.core.systemsymbols import (
     SymbolUnequal,
 )
 
+try:
+    import gmpy2
+except ImportError:
+    gmpy2 = None
+
 if TYPE_CHECKING:
     from mathics.core.builtin import SympyObject
 
@@ -379,6 +384,11 @@ def from_sympy(sympy_expr) -> BaseElement:
         return Expression(
             SymbolMatrixPower, from_sympy(sympy_expr.base), from_sympy(sympy_expr.exp)
         )
+    if gmpy2 and isinstance(sympy_expr, gmpy2.mpz):
+        if sympy_expr.is_integer():
+            return Integer(int(sympy_expr))
+        return Rational(*sympy_expr.as_integer_ratio())
+
     if sympy_expr.is_Atom:
         name = None
         if sympy_expr.is_Symbol:

--- a/mathics/core/streams.py
+++ b/mathics/core/streams.py
@@ -203,7 +203,7 @@ class StreamsManager:
         io=None,
         num: Optional[int] = None,
         is_temporary_file: bool = False,
-    ) -> Optional["Stream"]:
+    ) -> "Stream":
         if num is None:
             num = self.next
             assert isinstance(num, int)
@@ -270,7 +270,7 @@ class StreamsManager:
         return self.STREAMS.get(n, None)
 
     @property
-    def next(self):
+    def next(self) -> int:
         numbers = [stream.n for stream in self.STREAMS.values()] + [2]
         return max(numbers) + 1
 

--- a/mathics/eval/files_io/importexport.py
+++ b/mathics/eval/files_io/importexport.py
@@ -6,7 +6,7 @@ file path.
 import mimetypes
 import os.path as osp
 from itertools import chain
-from typing import Dict, Final, Optional, Union
+from typing import Dict, Final, Optional
 
 from mathics.core.atoms import ByteArray
 from mathics.core.builtin import String, get_option
@@ -19,7 +19,6 @@ from mathics.core.systemsymbols import (
     SymbolDeleteFile,
     SymbolFailed,
     SymbolInputStream,
-    SymbolNone,
     SymbolOpenWrite,
     SymbolRule,
     SymbolStringToStream,
@@ -31,7 +30,7 @@ from mathics.eval.files_io.files import eval_Close, eval_Open
 # match what the mimetypes (and thereofre MIME) extensions
 # that would be reported. So we have this table to
 # convert these mismatches
-MIME_FILE_EXTENSION_TO_WMA: Final[Dict[str, str]] = {"JPG": "JPEG", "TXT": "Text"}
+MIME_SHORTNAME_TO_WMA: Final[Dict[str, str]] = {"JPG": "JPEG", "TXT": "Text"}
 
 IMPORTERS = {}
 
@@ -68,33 +67,39 @@ except ImportError:
         return f"{description} data"
 
 
-# Note Matlab and Objective C also use the ".m" extension!
 mimetypes.init()
 
 # As of 2026, file extension ".wl" is not known to be Mathematica or anything else.
 # but ".m" is associated with Mathematica rather than Objective C.
 # So we add ".wl" (which probably will be added in the future of MIME mappings),
-# and will make explicit our choice of ".m" for "mathematica package", even though
+# and we will make explicit our choice of ".m" for "mathematica package", even though
 # that is currently the default.
 mimetypes.add_type("application/vnd.wolfram.mathematica.package", ".wl")
+# Note Matlab and Objective C also use the ".m" extension!
 mimetypes.add_type("application/vnd.wolfram.mathematica.package", ".m")
 
-# MIMETYPE_TO_SHORTNAME is a mapping form MIME type name to a short common name.
-# The short common names are typically used as a file extension.
-# Some MIME types like application/octet-stream are associated with more than one
+# MIMETYPE_TO_SHORTNAME is a mapping from a MIME type to a short common
+# name.  The short common names are similar, but not quite the same as the
+# name of a file extension, uppercased and without a leading dot.
+
+# Also, note that the short name derived from a MIME type is not always the same
+# name that WMA uses in builtin FileFormat. In particular, the shortname "JPG" is noted
+# in WMA as "JPEG"; "TXT" in WMA is "Text". See MIME_SHORTNAME_TO_WMA for the full list of
+# mismatch mappings.
+
+# Some MIME types, like "application/octet-stream", are associated with more than one
 # extension. For example "video/mpeg" can have file extensions ".mpeg", ".m1v", ".mpa",
 # ".mpe", or "mpg".
 #
-# Given this, we might want to rethink the use of MIMETYPE_TO_SHORTNAME.
-#
-# The table we use strips off the "." extension and uppercases the extension.
+# The MIME short names given by FileFormat, strips off the "." extension
+# and uppercases the extension.
 #
 # For example in mimetypes.types_map , you may find:
-#   "application/epub+zip" -> ".epub"
-# while we use "EPUB"
+#   "image/png" -> ".png"
+# We and WMA use "PNG" as the short name for MIME type "image/png".
 #
 # Also note that /etc/mimetypes also strips the leading ".",
-# and can list multiple extensions for a mime type. For example:
+# and can list multiple extensions for a MIME type. For example:
 #   application/postscript	ps ai eps epsi epsf eps2 eps3
 
 MIMETYPE_TO_SHORTNAME: Final[Dict[str, str]] = {
@@ -123,7 +128,7 @@ def filetype_from_path(path: str) -> Optional[str]:
     except Exception:
         return None
     mime_file_extension = filetype_from_mime_content(mime_content_type).lstrip(".")
-    return MIME_FILE_EXTENSION_TO_WMA.get(mime_file_extension, mime_file_extension)
+    return MIME_SHORTNAME_TO_WMA.get(mime_file_extension, mime_file_extension)
 
 
 def eval_ImageExport(expr, path: Optional[str] = None) -> Expression:
@@ -220,7 +225,7 @@ def eval_Import(
             break
     else:
         filetype = determine_filetype(data)
-        filetype = MIME_FILE_EXTENSION_TO_WMA.get(filetype, filetype)
+        filetype = MIME_SHORTNAME_TO_WMA.get(filetype, filetype)
 
     if filetype not in IMPORTERS.keys():
         evaluation.message("Import", "fmtnosup", filetype)

--- a/mathics/eval/files_io/importexport.py
+++ b/mathics/eval/files_io/importexport.py
@@ -6,23 +6,32 @@ file path.
 import mimetypes
 import os.path as osp
 from itertools import chain
-from typing import Dict, Final, Optional
+from typing import Dict, Final, Optional, Union
 
+from mathics.core.atoms import ByteArray
 from mathics.core.builtin import String, get_option
 from mathics.core.convert.python import from_python
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolTrue, strip_context
 from mathics.core.systemsymbols import (
+    SymbolByteArray,
     SymbolDeleteFile,
     SymbolFailed,
     SymbolInputStream,
+    SymbolNone,
     SymbolOpenWrite,
     SymbolRule,
     SymbolStringToStream,
     SymbolWriteString,
 )
 from mathics.eval.files_io.files import eval_Close, eval_Open
+
+# Some WMA file types reported by FileFormat do not
+# match what the mimetypes (and thereofre MIME) extensions
+# that would be reported. So we have this table to
+# convert these mismatches
+MIME_FILE_EXTENSION_TO_WMA: Final[Dict[str, str]] = {"JPG": "JPEG", "TXT": "Text"}
 
 IMPORTERS = {}
 
@@ -60,141 +69,41 @@ except ImportError:
 
 
 # Note Matlab and Objective C also use the ".m" extension!
+mimetypes.init()
+
+# As of 2026, file extension ".wl" is not known to be Mathematica or anything else.
+# but ".m" is associated with Mathematica rather than Objective C.
+# So we add ".wl" (which probably will be added in the future of MIME mappings),
+# and will make explicit our choice of ".m" for "mathematica package", even though
+# that is currently the default.
+mimetypes.add_type("application/vnd.wolfram.mathematica.package", ".wl")
 mimetypes.add_type("application/vnd.wolfram.mathematica.package", ".m")
 
-# Do we need the below?
-# mimetypes.add_type("application/vnd.wolfram.mathematica.package", ".wl")
-
-# MIMETYPE_TO_SHORTNAME is a mapping form MIME type names to short common names.
+# MIMETYPE_TO_SHORTNAME is a mapping form MIME type name to a short common name.
 # The short common names are typically used as a file extension.
+# Some MIME types like application/octet-stream are associated with more than one
+# extension. For example "video/mpeg" can have file extensions ".mpeg", ".m1v", ".mpa",
+# ".mpe", or "mpg".
+#
+# Given this, we might want to rethink the use of MIMETYPE_TO_SHORTNAME.
+#
+# The table we use strips off the "." extension and uppercases the extension.
+#
+# For example in mimetypes.types_map , you may find:
+#   "application/epub+zip" -> ".epub"
+# while we use "EPUB"
+#
+# Also note that /etc/mimetypes also strips the leading ".",
+# and can list multiple extensions for a mime type. For example:
+#   application/postscript	ps ai eps epsi epsf eps2 eps3
 
-# Here we should have *only* the names used when the name differs
-# from mimetypes.guess_extension(mimetype).upper() gives a name different
-# from what we have here. This happens for lowercase or mixed-case names.
-
-# TODO: go over to remove names that do not need to be on this list.
 MIMETYPE_TO_SHORTNAME: Final[Dict[str, str]] = {
-    "application/dbase": "DBF",
-    "application/dbf": "DBF",
-    "application/dicom": "DICOM",
-    "application/eps": "EPS",
-    "application/fits": "FITS",
-    "application/json": "JSON",
-    "application/mathematica": "NB",
-    "application/mbox": "MBOX",
-    "application/mdb": "MDB",
-    "application/msaccess": "MDB",
-    "application/octet-stream": "OBJ",
-    "application/pcx": "PCX",
-    "application/pdf": "PDF",
-    "application/postscript": "EPS",
-    "application/rss+xml": "RSS",
-    "application/rtf": "RTF",
-    "application/sla": "STL",
-    "application/tga": "TGA",
-    "application/vnd.google-earth.kml+xml": "KML",
-    "application/vnd.ms-excel": "XLS",
-    "application/vnd.ms-pki.stl": "STL",
-    "application/vnd.msaccess": "MDB",
-    "application/vnd.oasis.opendocument.spreadsheet": "ODS",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",  # nopep8
-    "application/vnd.sun.xml.calc": "SXC",
-    "application/vnd.wolfram.cdf": "CDF",
-    "application/vnd.wolfram.cdf.text": "CDF",
-    "application/vnd.wolfram.mathematica.package": "Package",
-    "application/x-3ds": "3DS",
-    "application/x-cdf": "NASACDF",
-    "application/x-eps": "EPS",
-    "application/x-flac": "FLAC",
-    "application/x-font-bdf": "BDF",
-    "application/x-hdf": "HDF",
-    "application/x-msaccess": "MDB",
-    "application/x-netcdf": "NetCDF",
-    "application/x-shockwave-flash": "SWF",
-    "application/x-tex": "TeX",  # Also TeX
-    "application/xhtml+xml": "XHTML",
-    "application/xml": "XML",
-    "application/zip": "ZIP",
-    "audio/aiff": "AIFF",
-    "audio/basic": "AU",  # Also SND
-    "audio/midi": "MIDI",
-    "audio/x-aifc": "AIFF",
-    "audio/x-aiff": "AIFF",
-    "audio/x-flac": "FLAC",
-    "audio/x-wav": "WAV",
-    "chemical/seq-aa-fasta": "FASTA",
-    "chemical/seq-na-fasta": "FASTA",
-    "chemical/seq-na-fastq": "FASTQ",
-    "chemical/seq-na-genbank": "GenBank",
-    "chemical/seq-na-sff": "SFF",
-    "chemical/x-cif": "CIF",
-    "chemical/x-daylight-smiles": "SMILES",
-    "chemical/x-hin": "HIN",
-    "chemical/x-jcamp-dx": "JCAMP-DX",
-    "chemical/x-mdl-molfile": "MOL",
-    "chemical/x-mdl-sdf": "SDF",
-    "chemical/x-mdl-sdfile": "SDF",
-    "chemical/x-mdl-tgf": "TGF",
-    "chemical/x-mmcif": "CIF",
-    "chemical/x-mol2": "MOL2",
-    "chemical/x-mopac-input": "Table",
-    "chemical/x-pdb": "PDB",
-    "chemical/x-xyz": "XYZ",
-    "image/bmp": "BMP",
-    "image/eps": "EPS",
-    "image/fits": "FITS",
-    "image/gif": "GIF",
-    "image/jp2": "JPEG2000",
-    "image/jpeg": "JPEG",
-    "image/pbm": "PNM",
-    "image/pcx": "PCX",
-    "image/pict": "PICT",
-    "image/png": "PNG",
-    "image/svg+xml": "SVG",
-    "image/tga": "TGA",
-    "image/tiff": "TIFF",
-    "image/vnd.dxf": "DXF",
-    "image/vnd.microsoft.icon": "ICO",
-    "image/x-3ds": "3DS",
-    "image/x-dxf": "DXF",
-    "image/x-exr": "OpenEXR",
-    "image/x-icon": "ICO",
-    "image/x-ms-bmp": "BMP",
-    "image/x-pcx": "PCX",
-    "image/x-portable-anymap": "PNM",
-    "image/x-portable-bitmap": "PBM",
-    "image/x-portable-graymap": "PGM",
-    "image/x-portable-pixmap": "PPM",
-    "image/x-xbitmap": "XBM",
-    "model/vrml": "VRML",
-    "model/x-lwo": "LWO",
-    "model/x-pov": "POV",
-    "model/x3d+xml": "X3D",
-    "text/calendar": "ICS",
-    "text/comma-separated-values": "CSV",
-    "text/csv": "CSV",
-    "text/html": "HTML",
-    "text/mathml": "MathML",
-    "text/plain": "Text",
-    "text/rtf": "RTF",
-    "text/scriptlet": "SCT",
-    "text/tab-separated-values": "TSV",
-    "text/texmacs": "Text",
-    "text/vnd.graphviz": "DOT",
-    "text/x-comma-separated-values": "CSV",
-    "text/x-csrc": "C",
-    "text/x-tex": "TeX",
-    "text/x-vcalendar": "VCS",
-    "text/x-vcard": "VCF",
-    "text/xml": "XML",
-    "video/avi": "AVI",
-    "video/quicktime": "QuickTime",
-    "video/x-flv": "FLV",
-    # None: 'Binary',
+    file_extension.upper().lstrip("."): mime_type
+    for mime_type, file_extension in mimetypes.types_map.items()
 }
 
 
-def filetype_from_path(path: str) -> Optional[String]:
+def filetype_from_path(path: str) -> Optional[str]:
     """Classifies what kind of file `path` is.
     A Mathics3 String is return if we can do this and None, if
     there was some sort of error, e.g., `path` is not found.
@@ -210,28 +119,20 @@ def filetype_from_path(path: str) -> Optional[String]:
         return None
 
     try:
-        MIME_content_type = from_file(path, mime=True)
-        return filetype_from_MIME_content(MIME_content_type)
-        if MIME_content_type in MIMETYPE_TO_SHORTNAME:
-            short_name = MIMETYPE_TO_SHORTNAME[MIME_content_type]
-        else:
-            # Map MIME type to a standard extension using the stdlib
-            # mimetypes.guess_extension returns things like '.zip' or '.py'
-            ext = mimetypes.guess_extension(MIME_content_type)
-
-            if ext:
-                # Clean up the extension (remove trailing dot and uppercase)
-                short_name = ext.rstrip(".").upper()
-            else:
-                short_name = MIME_content_type
-
-        return String(short_name)
-
+        mime_content_type = from_file(path, mime=True)
     except Exception:
         return None
+    mime_file_extension = filetype_from_mime_content(mime_content_type).lstrip(".")
+    return MIME_FILE_EXTENSION_TO_WMA.get(mime_file_extension, mime_file_extension)
 
 
-def filetype_from_MIME_content(mime_content_name: str) -> str:
+def eval_ImageExport(expr, path: Optional[str] = None) -> Expression:
+    expr_pil = expr.pil()
+    expr_pil.save(path)
+    return Expression(SymbolByteArray, ByteArray(expr_pil.tobytes()))
+
+
+def filetype_from_mime_content(mime_content_name: str) -> str:
 
     if mime_content_name in MIMETYPE_TO_SHORTNAME:
         short_name = MIMETYPE_TO_SHORTNAME[mime_content_name]
@@ -319,6 +220,7 @@ def eval_Import(
             break
     else:
         filetype = determine_filetype(data)
+        filetype = MIME_FILE_EXTENSION_TO_WMA.get(filetype, filetype)
 
     if filetype not in IMPORTERS.keys():
         evaluation.message("Import", "fmtnosup", filetype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
 ]
 full = [
     "ipywidgets",
+    "gmp2",  # Faster long integers, and ratios. This is *optional* in SymPy
     "llvmlite",
     "lxml",
     "psutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dev = [
 ]
 full = [
     "ipywidgets",
-    "gmp2",  # Faster long integers, and ratios. This is *optional* in SymPy
     "llvmlite",
     "lxml",
     "psutil",
@@ -85,6 +84,10 @@ full = [
 cython = [
     "cython",
 ]
+gmp2 = [
+    "gmp2", # Faster long integers, and ratios. This is *optional* in SymPy
+]
+
 
 [project.scripts]
 mathics = "mathics.__main__:main"

--- a/test/builtin/files_io/test_importexport.py
+++ b/test/builtin/files_io/test_importexport.py
@@ -273,7 +273,7 @@ if not (os.environ.get("CI", False) or sys.platform in ("win32",)):
             'FileFormat["ExampleData/Einstein.txt"]',
             None,
             "JPEG",
-            "JPEG stored as with .txt exension",
+            "Detect JPEG which we stored with a .txt exension",
         ),
     ],
 )


### PR DESCRIPTION
Change `MIME_TO_SHORTNAME` to use information from `mimetypes` library.

Also, tolerate gmp2, and use that SymPy will use if gmp2 is installed. Add a "gmp2" install target in pyproject.toml.