### PR TITLE
Improve PredefinedExpressions and add Python dict to Mathics3 Association conversion

### DIFF
--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -40,7 +40,7 @@ from mathics.core.exceptions import (
     PartError,
     PartRangeError,
 )
-from mathics.core.expression import Expression, ExpressionInfinity
+from mathics.core.expression import Expression
 from mathics.core.expression_predefined import MATHICS3_INFINITY
 from mathics.core.list import ListExpression
 from mathics.core.rules import Rule
@@ -482,7 +482,7 @@ class DeleteCases(Builtin):
 
         levelspec = python_levelspec(levelspec)
 
-        if n is SymbolInfinity or ExpressionInfinity == n:
+        if n is SymbolInfinity or n == MATHICS3_INFINITY:
             n = -1
         elif isinstance(n, Integer):
             n = n.value
@@ -1609,7 +1609,7 @@ class Select(Builtin):
         "Select[items_, expr_, n_]"
 
         count_is_valid = True
-        if n is SymbolInfinity or ExpressionInfinity == n:
+        if n is SymbolInfinity or MATHICS3_INFINITY == n:
             count = None
         elif isinstance(n, Integer):
             count = n.value

--- a/mathics/builtin/patterns/rules.py
+++ b/mathics/builtin/patterns/rules.py
@@ -75,7 +75,8 @@ from mathics.core.builtin import AtomBuiltin, Builtin, InfixOperator, PatternErr
 from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation
 from mathics.core.exceptions import InvalidLevelspecError
-from mathics.core.expression import Expression, ExpressionInfinity
+from mathics.core.expression import Expression
+from mathics.core.expression_predefined import MATHICS3_INFINITY
 from mathics.core.list import ListExpression
 from mathics.core.symbols import SymbolTrue
 from mathics.core.systemsymbols import (
@@ -370,7 +371,7 @@ class ReplaceList(Builtin):
         # default argument, when it is passed explicitly, e.g.
         # ReplaceList[expr, {}, Infinity], then Infinity
         # comes in as DirectedInfinity[1].
-        if maxidx == SymbolInfinity or ExpressionInfinity == maxidx:
+        if maxidx == SymbolInfinity or MATHICS3_INFINITY == maxidx:
             max_count = None
         else:
             max_count = maxidx.get_int_value()

--- a/mathics/builtin/scipy_utils/optimizers.py
+++ b/mathics/builtin/scipy_utils/optimizers.py
@@ -6,7 +6,8 @@ from mathics.core.builtin import check_requires_list
 from mathics.core.convert.function import expression_to_callable_and_args
 from mathics.core.element import BaseElement
 from mathics.core.evaluation import Evaluation
-from mathics.core.expression import Expression, ExpressionInfinity
+from mathics.core.expression import Expression
+from mathics.core.expression_predefined import MATHICS3_INFINITY
 from mathics.core.systemsymbols import SymbolAutomatic, SymbolFailed
 from mathics.eval.nevaluator import eval_N
 
@@ -30,7 +31,7 @@ def get_tolerance_and_maxit(opts: dict, scale: float, evaluation: Evaluation):
         acc_goal = eval_N(acc_goal, evaluation)
         if acc_goal is SymbolAutomatic:
             acc_goal = Real(12.0)
-        elif ExpressionInfinity == acc_goal:
+        elif MATHICS3_INFINITY == acc_goal:
             acc_goal = None
         elif not isinstance(acc_goal, Number):
             acc_goal = None
@@ -40,7 +41,7 @@ def get_tolerance_and_maxit(opts: dict, scale: float, evaluation: Evaluation):
         prec_goal = eval_N(prec_goal, evaluation)
         if prec_goal is SymbolAutomatic:
             prec_goal = Real(12.0)
-        elif ExpressionInfinity == prec_goal:
+        elif MATHICS3_INFINITY == prec_goal:
             prec_goal = None
         elif not isinstance(prec_goal, Number):
             prec_goal = None

--- a/mathics/core/convert/python.py
+++ b/mathics/core/convert/python.py
@@ -3,7 +3,8 @@
 Conversions between Python and Mathics3
 """
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Final, Optional
 
 import numpy
 
@@ -24,7 +25,7 @@ from mathics.core.symbols import (
     SymbolNull,
     SymbolTrue,
 )
-from mathics.core.systemsymbols import SymbolRule
+from mathics.core.systemsymbols import SymbolAssociation, SymbolRule
 
 
 def from_bool(arg: bool) -> BooleanType:
@@ -48,6 +49,46 @@ def from_complex(arg: complex) -> Complex:
     return Complex(real_value, imag_value)
 
 
+@dataclass(frozen=True)
+class ToPythonOptions:
+    """
+    Stores options associated with the to_python[] builtin.
+
+    One initialized, this structure is immutable or frozen.
+    """
+
+    use_associations: Optional[bool] = None
+    """'True" if ordering should be lowercase first, 'False" if should uppercase first,
+      and 'None' if we should use the natural alphabet ordering case."""
+
+    @classmethod
+    def from_dict(cls, options: dict[str, Any]) -> "ToPythonOptions":
+        """Factory method that normalizes, type-checks, and builds the frozen structure
+        from a raw dict[str, str].
+        """
+
+        # This will hold our cleaned, type-converted parameters
+        processed_args: dict[str, Any] = {
+            "use_associations": False,
+        }
+
+        # Iterate through the user-provided options dictionary
+        for key, option_value in options.items():
+
+            if not key:
+                raise TypeError(f"ToPythonOptions: bad key: {key}")
+
+            # Type parsing and validation based on the target field name
+            processed_args[key] = option_value
+
+        # Initialize and return the frozen dataclass using our verified arguments
+        return cls(**processed_args)
+
+
+DEFAULT_PYTHON_OPTIONS: Final[ToPythonOptions] = ToPythonOptions.from_dict(
+    {"use_associations": False}
+)
+
 # Historically, from_python() was identified as a bottleneck.
 
 # A large part of this was due to the inefficient monolithic
@@ -63,7 +104,6 @@ def from_complex(arg: complex) -> Complex:
 # of a bottleneck. So care may be warranted to make
 # sure from_python() isn't too slow.
 
-
 # TODO:
 #  I think there are number of subtleties to be explained here.
 #  In particular, the expression might been the result of evaluation
@@ -76,7 +116,7 @@ def from_complex(arg: complex) -> Complex:
 #  symbol like underscore.
 
 
-def from_python(arg: Any) -> BaseElement:
+def from_python(arg: Any, options=DEFAULT_PYTHON_OPTIONS) -> BaseElement:
     """Converts a Python expression into a Mathics3 expression."""
     from mathics.core.convert.expression import to_mathics_list
     from mathics.core.expression import Expression
@@ -108,13 +148,15 @@ def from_python(arg: Any) -> BaseElement:
         # else:
         #     return Symbol(arg)
     elif isinstance(arg, dict):
+        if options.use_associations:
+            return association_from_dict(arg, options)
         entries = [
             Expression(
                 SymbolRule,
                 from_python(key),
-                from_python(arg[key]),
+                from_python(value),
             )
-            for key in arg
+            for key, value in arg.items()
         ]
         return ListExpression(*entries)
     elif isinstance(arg, list) or isinstance(arg, tuple):
@@ -125,3 +167,17 @@ def from_python(arg: Any) -> BaseElement:
         return NumericArray(arg)
     else:
         raise NotImplementedError
+
+
+def association_from_dict(arg: dict, options: ToPythonOptions) -> BaseElement:
+    from mathics.core.expression import Expression
+
+    entries = [
+        Expression(
+            SymbolRule,
+            from_python(key, options),
+            from_python(value, options),
+        )
+        for key, value in arg.items()
+    ]
+    return Expression(SymbolAssociation, *entries)

--- a/mathics/core/convert/python.py
+++ b/mathics/core/convert/python.py
@@ -3,6 +3,7 @@
 Conversions between Python and Mathics3
 """
 
+import math
 from dataclasses import dataclass
 from typing import Any, Final, Optional
 
@@ -17,6 +18,7 @@ from mathics.core.atoms import (
     Real,
     String,
 )
+from mathics.core.element import ELEMENTS_FULLY_EVALUATED
 from mathics.core.number import get_type
 from mathics.core.symbols import (
     BaseElement,
@@ -150,26 +152,43 @@ def from_python(arg: Any, options=DEFAULT_PYTHON_OPTIONS) -> BaseElement:
     elif isinstance(arg, dict):
         if options.use_associations:
             return association_from_dict(arg, options)
+        # List of Rules was used before Associations came
+        # into use in Wolfram Language. List of Rules
+        # is still used a bit.
+        # Note that Python dictionaries from the standpoint of
+        # evaluation are fully evaluated
         entries = [
             Expression(
                 SymbolRule,
                 from_python(key),
                 from_python(value),
+                elements_properties=ELEMENTS_FULLY_EVALUATED,
             )
             for key, value in arg.items()
         ]
-        return ListExpression(*entries)
+        return ListExpression(*entries, elements_properties=ELEMENTS_FULLY_EVALUATED)
     elif isinstance(arg, list) or isinstance(arg, tuple):
         return to_mathics_list(*arg, elements_conversion_fn=from_python)
     elif isinstance(arg, bytearray) or isinstance(arg, bytes):
         return ByteArray(arg)
     elif isinstance(arg, numpy.ndarray):
         return NumericArray(arg)
+    elif arg == math.inf:
+        from mathics.core.expression_predefined import MATHICS3_INFINITY
+
+        return MATHICS3_INFINITY
+    elif arg == -math.inf:
+        from mathics.core.expression_predefined import MATHICS3_NEG_INFINITY
+
+        return MATHICS3_NEG_INFINITY
     else:
         raise NotImplementedError
 
 
 def association_from_dict(arg: dict, options: ToPythonOptions) -> BaseElement:
+    """
+    Convert a Python dictionary into a Mathics3 Association.
+    """
     from mathics.core.expression import Expression
 
     entries = [
@@ -180,4 +199,9 @@ def association_from_dict(arg: dict, options: ToPythonOptions) -> BaseElement:
         )
         for key, value in arg.items()
     ]
-    return Expression(SymbolAssociation, *entries)
+    result = Expression(
+        SymbolAssociation,
+        *entries,
+        elements_properties=ELEMENTS_FULLY_EVALUATED,
+    )
+    return result

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -7,7 +7,7 @@ Here we have the base class and related function for element inside an Expressio
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Final, Optional, Sequence, Tuple, Union
 
 from mathics.core.attributes import A_NO_ATTRIBUTES
 from mathics.core.keycomparable import KeyComparable
@@ -79,6 +79,11 @@ class ElementsProperties:
 
     # Uniform expressions have all their elements with the same Head.
     is_uniform: bool = False
+
+
+ELEMENTS_FULLY_EVALUATED: Final[ElementsProperties] = ElementsProperties(
+    elements_fully_evaluated=True
+)
 
 
 class ImmutableValueMixin:

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -21,7 +21,7 @@ from typing import (
 import sympy
 from mathics_scanner.location import SourceRange, SourceRange2
 
-from mathics.core.atoms import Integer1, String
+from mathics.core.atoms import String
 from mathics.core.attributes import (
     A_FLAT,
     A_HOLD_ALL,
@@ -2025,6 +2025,3 @@ def convert_expression_elements(
 
 def string_list(head, elements, evaluation):
     return atom_list_constructor(evaluation, head, "String")(elements)
-
-
-ExpressionInfinity = Expression(SymbolDirectedInfinity, Integer1)

--- a/mathics/core/expression_predefined.py
+++ b/mathics/core/expression_predefined.py
@@ -1,3 +1,12 @@
+"""
+Module for defining constant compound Mathics3 expressions.
+"""
+
+import math
+from typing import Final
+
+from sympy import I, S
+
 from mathics.core.atoms import (
     MATHICS3_COMPLEX_I,
     MATHICS3_COMPLEX_I_NEG,
@@ -10,19 +19,35 @@ from mathics.core.systemsymbols import SymbolDirectedInfinity
 
 
 class PredefinedExpression(Expression):
+    """
+    (Compound) constant Mathics3 Expressions.
+    """
+
     def __init__(
         self,
         head: BaseElement,
         *elements: BaseElement,
+        sympy=None,
+        value=None,
     ):
         elements_properties = ElementsProperties(True, True, True)
         super().__init__(head, *elements, elements_properties=elements_properties)
+        if sympy is not None:
+            self._sympy = sympy
+        if value is not None:
+            self.value = value
 
 
-MATHICS3_COMPLEX_INFINITY = PredefinedExpression(SymbolDirectedInfinity)
-MATHICS3_INFINITY = PredefinedExpression(SymbolDirectedInfinity, Integer1)
-MATHICS3_NEG_INFINITY = PredefinedExpression(SymbolDirectedInfinity, IntegerM1)
-MATHICS3_I_INFINITY = PredefinedExpression(SymbolDirectedInfinity, MATHICS3_COMPLEX_I)
-MATHICS3_I_NEG_INFINITY = PredefinedExpression(
-    SymbolDirectedInfinity, MATHICS3_COMPLEX_I_NEG
+MATHICS3_COMPLEX_INFINITY: Final = PredefinedExpression(SymbolDirectedInfinity)
+MATHICS3_INFINITY: Final = PredefinedExpression(
+    SymbolDirectedInfinity, Integer1, value=math.inf, sympy=S.Infinity
+)
+MATHICS3_NEG_INFINITY: Final = PredefinedExpression(
+    SymbolDirectedInfinity, IntegerM1, value=-math.inf, sympy=S.NegativeInfinity
+)
+MATHICS3_I_INFINITY: Final = PredefinedExpression(
+    SymbolDirectedInfinity, MATHICS3_COMPLEX_I, sympy=S.ComplexInfinity
+)
+MATHICS3_I_NEG_INFINITY: Final = PredefinedExpression(
+    SymbolDirectedInfinity, MATHICS3_COMPLEX_I_NEG, sympy=-I
 )

--- a/mathics/core/list.py
+++ b/mathics/core/list.py
@@ -41,6 +41,7 @@ class ListExpression(Expression):
         self.pattern_sequence = False
         self._head = SymbolList
         self._sympy = None
+        self.value = None
 
         # For debugging:
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -232,7 +232,9 @@ class BaseRule(KeyComparable, ABC):
         return tuple((self.system, self.pattern.pattern_precedence))
 
 
-# FIXME: the class name would be better called RewriteRule.
+# FIXME: Given what is stated in the docstring below,
+# the class name would be better called RewriteRule, instead of the
+# more generic term Rule.
 class Rule(BaseRule):
     """There are two kinds of Rules.  This kind of is a rewrite rule
     and transforms an Expression into another Expression based on the

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -2,7 +2,17 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 from mathics.core.element import (
     BaseElement,
@@ -779,9 +789,16 @@ def sympy_name(mathics_symbol: Symbol):
 # more of the below and in systemsymbols
 # PredefineSymbol.
 
-SymbolFalse = BooleanType("System`False", value=False)
+# Note getting all checkers to agree is a nightmare.
+# Without that cast, some checkers complain in the *use* of SymbolFalse, that
+# there is a type mismatch because the Boolean __new__ seems to produce
+# BooleanType | Symbol | SymbolConstant rather that Boolean type.
+# But then without the '# type: ignore' addition, other checkers complain
+# that the cast is unnecessary!
+
+SymbolFalse = cast(BooleanType, BooleanType("System`False", value=False))  # type: ignore
 SymbolList = SymbolConstant("System`List", value=list)
-SymbolTrue = BooleanType("System`True", value=True)
+SymbolTrue = cast(BooleanType, BooleanType("System`True", value=True))  # type: ignore
 
 SymbolAbs = Symbol("Abs")
 SymbolDivide = Symbol("Divide")

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -785,7 +785,7 @@ def sympy_name(mathics_symbol: Symbol):
 # show that this does not change the output in any way.
 #
 # That said, for now we will proceed very conservatively and
-# cautiously. However we may decide in the future to
+# cautiously. However, we may decide in the future to
 # more of the below and in systemsymbols
 # PredefineSymbol.
 
@@ -793,7 +793,7 @@ def sympy_name(mathics_symbol: Symbol):
 # Without that cast, some checkers complain in the *use* of SymbolFalse, that
 # there is a type mismatch because the Boolean __new__ seems to produce
 # BooleanType | Symbol | SymbolConstant rather that Boolean type.
-# But then without the '# type: ignore' addition, other checkers complain
+# But then without the ignore "# type", other checkers complain
 # that the cast is unnecessary!
 
 SymbolFalse = cast(BooleanType, BooleanType("System`False", value=False))  # type: ignore

--- a/mathics/eval/numbers/calculus/optimizers.py
+++ b/mathics/eval/numbers/calculus/optimizers.py
@@ -19,7 +19,8 @@ from mathics.core.atoms import (
 )
 from mathics.core.convert.python import from_python
 from mathics.core.evaluation import Evaluation
-from mathics.core.expression import Expression, ExpressionInfinity
+from mathics.core.expression import Expression
+from mathics.core.expression_predefined import MATHICS3_INFINITY
 from mathics.core.symbols import BaseElement, SymbolPlus, SymbolTimes, SymbolTrue
 from mathics.core.systemsymbols import (
     SymbolAutomatic,
@@ -423,23 +424,23 @@ def get_accuracy_prec_and_maxit(opts: dict, evaluation: "Evaluation") -> tuple:
     # determined inside the methods that implements the specific
     # solvers.
 
-    def to_real_or_none(value) -> Optional[Real]:
-        if value:
+    def to_real_or_none(value: Optional[Real]) -> Optional[Real]:
+        if value is not None:
             value = eval_N(value, evaluation)
         if value is SymbolAutomatic:
             value = Real(12.0)
-        elif value is SymbolInfinity or ExpressionInfinity == value:
+        elif value is SymbolInfinity or MATHICS3_INFINITY == value:
             value = None
         elif not isinstance(value, Number):
             value = None
         return value
 
-    def to_integer_or_none(value) -> Optional[Integer]:
-        if value:
+    def to_integer_or_none(value: Optional[Integer]) -> Optional[Integer]:
+        if value is not None:
             value = eval_N(value, evaluation)
         if value is SymbolAutomatic:
             value = Integer(100)
-        elif value is SymbolInfinity or ExpressionInfinity == value:
+        elif value is SymbolInfinity or MATHICS3_INFINITY == value:
             value = None
         elif not isinstance(value, Number):
             value = None


### PR DESCRIPTION
* Add a way that  `from_python()` can convert a dictionary to an `Association`.
* Remove `ExpressionInfinity`. This is a duplicate of `MATHICS3_INFINITY`.
* Fill in more properties for predefined constants;  set Python and SymPy corresponding values
* Define `ELEMENTS_FULLY_EVALUATED` for use on fully-evaluated constants.
