### PR TITLE
Address a StandardOutput Format bug; 1849: 

### DIFF
--- a/mathics/format/form/outputform.py
+++ b/mathics/format/form/outputform.py
@@ -3,6 +3,15 @@ This module implements the "OutputForm" textual representation of expressions.
 
 OutputForm is two-dimensional keyboard-character-only output, suitable for CLI
 and text terminals.
+
+The entry point of this module is the function `render_output_form`. This function takes an expression and an evaluation object as parameters, and returns a string representing the expression in its OutputForm.
+
+To do this, `render_output_form` looks for the head of the expression, and uses its name to lookup one of the registered functions
+to process specific kind of expressions. Callback functions are registered using the decorator `@register_outputform([lookupname])`.
+
+If the callback function cannot process its argument, it raises a `_WrongFormattedExpression`, to make it know `render_output_form`
+it must use the default callback function. This default function is also called when an specific callback function is not available.
+
 """
 
 import re

--- a/mathics/format/form/outputform.py
+++ b/mathics/format/form/outputform.py
@@ -851,7 +851,7 @@ def _slotsequence_outputform_text(expr: Expression, evaluation: Evaluation, **kw
 
 
 @register_outputform("System`String")
-def string_render_output_form(expr: String, evaluation: Evaluation, **kwargs) -> str:
+def string_render_output_form(expr: BaseElement, evaluation: Evaluation, **kwargs) -> str:
     from mathics.format.render.text import string as render_string
 
     if not isinstance(expr, String):

--- a/mathics/format/form/outputform.py
+++ b/mathics/format/form/outputform.py
@@ -247,6 +247,7 @@ def render_output_form(expr: BaseElement, evaluation: Evaluation, **kwargs):
     """
     Build a pretty-print text from an `Expression`
     """
+    lookup_name: str
     format_expr: Expression = do_format(expr, evaluation, SymbolOutputForm)  # type: ignore
 
     while format_expr.has_form("HoldForm", 1):  # type: ignore
@@ -256,7 +257,7 @@ def render_output_form(expr: BaseElement, evaluation: Evaluation, **kwargs):
         return ""
 
     head = format_expr.get_head()
-    lookup_name: str = head.get_name() or head.get_lookup_name()
+    lookup_name = head.get_name() or head.get_lookup_name()
     callback = EXPR_TO_OUTPUTFORM_TEXT_MAP.get(lookup_name, None)
     if callback is None:
         if head in evaluation.definitions.outputforms:
@@ -843,6 +844,9 @@ def _slotsequence_outputform_text(expr: Expression, evaluation: Evaluation, **kw
 @register_outputform("System`String")
 def string_render_output_form(expr: String, evaluation: Evaluation, **kwargs) -> str:
     from mathics.format.render.text import string as render_string
+
+    if not isinstance(expr, String):
+        raise _WrongFormattedExpression
 
     # To render a string in OutputForm, we use the
     # function that render strings from Boxed expressions.

--- a/mathics/format/form/outputform.py
+++ b/mathics/format/form/outputform.py
@@ -851,7 +851,9 @@ def _slotsequence_outputform_text(expr: Expression, evaluation: Evaluation, **kw
 
 
 @register_outputform("System`String")
-def string_render_output_form(expr: BaseElement, evaluation: Evaluation, **kwargs) -> str:
+def string_render_output_form(
+    expr: BaseElement, evaluation: Evaluation, **kwargs
+) -> str:
     from mathics.format.render.text import string as render_string
 
     if not isinstance(expr, String):


### PR DESCRIPTION
The origin of the issue was that when `string_render_output_form` does not get a string, fall back to the default format function. In the example, `
```
 mathics -c 'xx="a string"; StringTake[xx[0]]'
```
produced an expression with a `String` as the head:
```
In[1]:= xx="a string"
Out[1]= "a string"

In[2]:= xx[0] //FullForm
Out[2]//FullForm= "a string"[0]
````
When `render_output_form` asks for the `lookup_name` of the callback function, it get `System`String`. But that function just processes `String` atoms, not expressions with a `String` as its head. This patch just raise the exception that produces to the parent function to use the default render function.

So, now we get

````
StringTake::argr: StringTake called with 1 argument; 2 arguments are expected.
StringTake[a string[0]]
```

Notice that if instead of a string, the head was an integer, the result was already right:
```
(Mathics3) mauricio@mauricio-T15thinkpad:~/Projects/mathics-core$ mathics -c 'xx=7; StringTake[xx[0]]'
StringTake::argr: StringTake called with 1 argument; 2 arguments are expected.
StringTake[7[0]]
```




