### PR TITLE
Fix bug introduced in REPL split and Dialog introduction

### DIFF
--- a/mathics/__main__.py
+++ b/mathics/__main__.py
@@ -221,7 +221,7 @@ Please contribute to Mathics!""",
     if args.initfile:
         feeder = MathicsFileLineFeeder(args.initfile)
         eval_loop(feeder, shell)
-        definitions.set_line_no(0)
+        definitions.set_line_no(1)
 
     if args.post_mortem:
         try:
@@ -241,7 +241,7 @@ Please contribute to Mathics!""",
         eval_loop(feeder, shell)
 
         if args.persist:
-            definitions.set_line_no(0)
+            definitions.set_line_no(1)
         elif not args.code:
             return exit_rc
 

--- a/mathics/__main__.py
+++ b/mathics/__main__.py
@@ -208,7 +208,7 @@ Please contribute to Mathics!""",
     definitions = Definitions(
         add_builtin=True, extension_modules=tuple(extension_modules)
     )
-    definitions.set_line_no(0)
+    definitions.set_line_no(1)
 
     shell = mathics.session.shell_session = TerminalShell(
         definitions,

--- a/mathics/builtin/fileformats/__init__.py
+++ b/mathics/builtin/fileformats/__init__.py
@@ -38,3 +38,7 @@ For example, HTML` or Compress`.  This is done to not pollute the System` namesp
 # This tells documentation how to sort this module
 # Here we are also hiding "file_io" since this can erroneously appear at the top level.
 sort_order = "mathics.builtin.importing-export-file-formats"
+
+# The Built-in Functions are defined in a separate context under the
+# System`. For example System`HTML` and System`XML.  This is done to not
+# pollute the System` namespace.

--- a/mathics/builtin/import_export/importexport.py
+++ b/mathics/builtin/import_export/importexport.py
@@ -28,6 +28,7 @@ while <url>
 does the corresponding thing for <url>
 :Import:
 /doc/reference-of-built-in-symbols/inputoutput-files-and-filesystem/importing-and-exporting/import</url>.
+
 """
 
 import base64
@@ -467,6 +468,28 @@ class Import(Builtin):
     summary_text = (
         r"read and convert to \Mathics3 some or all elements of structured file"
     )
+
+    def import_setup(self, source, evaluation) -> tuple:
+        # Check filename
+        path = source.to_python()
+        if not (isinstance(path, str) and path[0] == path[-1] == '"'):
+            evaluation.message("Import", "chtype", source)
+            return SymbolFailed, None
+
+        # Load local file
+        if path[0] == path[-1] == '"':
+            path = path[1:-1]
+        findfile = eval_FindFile(path)
+
+        if findfile is None:
+            evaluation.message("Import", "nffil")
+            return SymbolFailed, None
+
+        return findfile, eval_FileFormat(findfile.value).value
+
+    def eval(self, source, evaluation, options={}):
+        "Import[source_, OptionsPattern[]]"
+        return self.eval_element_list(source, ListExpression(), evaluation, options)
 
     def eval_elements_query(self, source, evaluation, options={}):
         """Import[source_String, "Elements", OptionsPattern[]]"""

--- a/mathics/repl.py
+++ b/mathics/repl.py
@@ -59,9 +59,9 @@ class TerminalShell(MathicsLineFeeder, SessionShell):
     def __init__(
         self,
         definitions,
-        colors,
-        want_readline,
-        want_completion,
+        colors: str,
+        want_readline: bool,
+        want_completion: bool,
         autoload=False,
         in_prefix: str = "In",
         out_prefix: str = "Out",
@@ -76,6 +76,10 @@ class TerminalShell(MathicsLineFeeder, SessionShell):
         self.lineno = 0
         self.in_prefix = in_prefix
         self.out_prefix = out_prefix
+
+        # Keep track of whether input of a command spans more than one line.
+        # In prompting we omit "In[x]:= after the first line.
+        self.multiline_input = False
 
         if want_readline:
             want_readline = have_readline
@@ -183,7 +187,14 @@ class TerminalShell(MathicsLineFeeder, SessionShell):
         return False
 
     def feed(self):
+        """
+        Prompt for and read another line of input.
+        Keep track of the line number and note, after reading,
+        in self.multiline_input that if we need to read again, we have already prompted
+        for the input.
+        """
         result = self.read_line(self.in_prompt) + "\n"
+        self.multiline_input = True
         if mathics_scanner.location.TRACK_LOCATIONS:
             self.container.append(self.source_text)
         if result == "\n":
@@ -201,11 +212,17 @@ class TerminalShell(MathicsLineFeeder, SessionShell):
     def in_prompt(self) -> str:
         """
         Return the prompt string to be shown before reading input.
+        If this is a continuation line for some logical input,
+        the prefix returned contains spaces only.
         """
-        next_line_number = self.last_line_number + 1
-        return "{2}{0}[{3}{1}{4}]:= {5}".format(
-            self.in_prefix, next_line_number, *self.incolors
-        )
+        line_number = self.last_line_number
+        if self.multiline_input:
+            indent = len(f"In[{line_number}]:= ")
+            return " " * indent
+        else:
+            return "{2}{0}[{3}{1}{4}]:= {5}".format(
+                self.in_prefix, line_number, *self.incolors
+            )
 
     @property
     def last_line_number(self):
@@ -340,6 +357,7 @@ def interactive_eval_loop(
                 # has access to this
                 evaluation.shell = shell
 
+            shell.multiline_input = False
             query, source_code = evaluation.parse_feeder_returning_code(shell)
             if mathics_core.PRE_EVALUATION_HOOK is not None:
                 mathics_core.PRE_EVALUATION_HOOK(query, evaluation)

--- a/mathics/repl.py
+++ b/mathics/repl.py
@@ -208,6 +208,19 @@ class TerminalShell(MathicsLineFeeder, SessionShell):
             matches = [strip_context(m) for m in matches]
         return matches
 
+    def get_out_prompt(self, form=None) -> str:
+        """
+        Return a prompt string to be shown before showing output.
+        """
+        line_number = self.last_line_number
+        if form:
+            return "{3}{0}[{4}{1}{5}]//{2}= {6}".format(
+                self.out_prefix, line_number, form, *self.outcolors
+            )
+        return "{2}{0}[{3}{1}{4}]= {5}".format(
+            self.out_prefix, line_number, *self.outcolors
+        )
+
     @property
     def in_prompt(self) -> str:
         """
@@ -230,19 +243,6 @@ class TerminalShell(MathicsLineFeeder, SessionShell):
         Return the line number associated with the next input to be read.
         """
         return self.definitions.get_line_no()
-
-    def get_out_prompt(self, form=None) -> str:
-        """
-        Return a prompt string to be shown before showing output.
-        """
-        line_number = self.last_line_number
-        if form:
-            return "{3}{0}[{4}{1}{5}]//{2}= {6}".format(
-                self.out_prefix, line_number, form, *self.outcolors
-            )
-        return "{2}{0}[{3}{1}{4}]= {5}".format(
-            self.out_prefix, line_number, *self.outcolors
-        )
 
     def out_callback(self, out, fmt=None):
         print(self.to_output(str(out), fmt))
@@ -324,6 +324,7 @@ def eval_loop(feeder: MathicsFileLineFeeder, shell: TerminalShell):
                 catch_interrupt=False,
             )
 
+            shell.multiline_input = False
             query = evaluation.parse_feeder(feeder)
             if query is None:
                 continue

--- a/test/test_repl.py
+++ b/test/test_repl.py
@@ -1,0 +1,46 @@
+"""
+Test mathics.repl
+"""
+
+from mathics.core.definitions import Definitions
+from mathics.repl import TerminalShell
+
+
+def fake_readline(prompt: str) -> str:
+    return "Fake readline"
+
+
+definitions = Definitions(add_builtin=False, extension_modules=tuple())
+definitions.set_line_no(1)
+
+shell = TerminalShell(
+    definitions,
+    "NoColor",
+    want_readline=False,
+    want_completion=False,
+    autoload=False,
+)
+
+
+def test_in_prompt():
+    shell.read_line = fake_readline
+    assert shell.in_prompt == "In[1]:= ", "We should start out with In[1]:="
+    shell.feed()
+    assert (
+        shell.in_prompt == "        "
+    ), "Multiline prompt should be blanks of the length of 'In[1]:= '"
+    definitions.set_line_no(9)
+    shell.multiline_input = False
+    assert (
+        shell.in_prompt == "In[9]:= "
+    ), "Setting line number to the last length-one digit"
+    shell.feed()
+    assert (
+        shell.in_prompt == "        "
+    ), "Multiline prompt should be blanks of the length of 'In[9]:= '"
+    definitions.set_line_no(10)
+    shell.multiline_input = False
+    shell.feed()
+    assert (
+        shell.in_prompt == "         "
+    ), "Multiline prompt should be blanks of the length of 'In[10]:= '"


### PR DESCRIPTION
Address a bug introduced when adding the `Dialog` built-in.

In this, we were not detecting multi-line input  properly, so we would see `In[xxx]:=` on subsequent multi-line input.