### PR TITLE
Cache Python-equivalent values in an Association.

### DIFF
--- a/mathics/core/atoms/associations.py
+++ b/mathics/core/atoms/associations.py
@@ -34,7 +34,9 @@ class Association(Atom, BoxElementMixin):
 
         # Save the Expression form rewrite rule or pattern matching.
         self._expr: Optional[Expression] = expr
+
         self._python: Optional[dict] = None
+        self.__hash__: Optional[int] = None
 
         self.collection = {}
         if elements:
@@ -64,6 +66,12 @@ class Association(Atom, BoxElementMixin):
             raise KeyError(key)
 
         del self.collection[key]
+        if self._python:
+            try:
+                del self._python[key.value]
+            except Exception:
+                self._python = None
+        self.__hash__ = None
 
     def __eq__(self, other: Any) -> bool:
         """Check equality with another Association."""
@@ -106,12 +114,13 @@ class Association(Atom, BoxElementMixin):
         raise KeyError(key)
 
     def __hash__(self) -> int:
-        hash_elements = []
-        for key, value in self.collection.items():
-            # Update hash component
-            hash_elements.append((hash(key), hash(value)))
+        if self._hash is None:
+            hash_elements = []
+            for key, value in self.collection.items():
+                # Update hash component
+                hash_elements.append((hash(key), hash(value)))
 
-        self._hash = hash(("Association", tuple(hash_elements)))
+            self._hash = hash(("Association", tuple(hash_elements)))
         return self._hash
 
     def __setitem__(self, key: BaseElement, value: BaseElement) -> None:
@@ -267,3 +276,4 @@ class Association(Atom, BoxElementMixin):
         self.collection.update(e)
         self._expr = None
         self._python = None
+        self.__hash__ = None

--- a/mathics/core/atoms/associations.py
+++ b/mathics/core/atoms/associations.py
@@ -36,7 +36,7 @@ class Association(Atom, BoxElementMixin):
         self._expr: Optional[Expression] = expr
 
         self._python: Optional[dict] = None
-        self.__hash__: Optional[int] = None
+        self._hash: Optional[int] = None
 
         self.collection = {}
         if elements:
@@ -68,10 +68,10 @@ class Association(Atom, BoxElementMixin):
         del self.collection[key]
         if self._python:
             try:
-                del self._python[key.value]
+                del self._python[key.to_python()]
             except Exception:
                 self._python = None
-        self.__hash__ = None
+        self._hash = None
 
     def __eq__(self, other: Any) -> bool:
         """Check equality with another Association."""
@@ -215,7 +215,7 @@ class Association(Atom, BoxElementMixin):
         return self.collection.keys()
 
     @property
-    def python(self):
+    def python(self) -> Optional[dict]:
         if self._python is None:
             return self.to_python()
         return self._python
@@ -262,7 +262,7 @@ class Association(Atom, BoxElementMixin):
     def to_sympy(self, **kwargs):
         return None
 
-    def values(self):
+    def values(self) -> Iterable:
         """Return the values of an the association.
         Behaves like dict.values().
         """
@@ -276,4 +276,4 @@ class Association(Atom, BoxElementMixin):
         self.collection.update(e)
         self._expr = None
         self._python = None
-        self.__hash__ = None
+        self._hash = None

--- a/mathics/core/atoms/associations.py
+++ b/mathics/core/atoms/associations.py
@@ -34,6 +34,7 @@ class Association(Atom, BoxElementMixin):
 
         # Save the Expression form rewrite rule or pattern matching.
         self._expr: Optional[Expression] = expr
+        self._python: Optional[dict] = None
 
         self.collection = {}
         if elements:
@@ -42,7 +43,6 @@ class Association(Atom, BoxElementMixin):
                     raise TypeError(f"Association keys must be Rules, got {rule_expr}")
                 self.collection[rule_expr.elements[0]] = rule_expr.elements[1]
 
-        self.update_for_change()
         return
 
     # Add some dictionary like methods so that we can treat an Association object
@@ -106,6 +106,12 @@ class Association(Atom, BoxElementMixin):
         raise KeyError(key)
 
     def __hash__(self) -> int:
+        hash_elements = []
+        for key, value in self.collection.items():
+            # Update hash component
+            hash_elements.append((hash(key), hash(value)))
+
+        self._hash = hash(("Association", tuple(hash_elements)))
         return self._hash
 
     def __setitem__(self, key: BaseElement, value: BaseElement) -> None:
@@ -183,12 +189,6 @@ class Association(Atom, BoxElementMixin):
 
     get_string_value = __str__
 
-    def keys(self):
-        """Return the keys of an the association.
-        Behaves like dict.keys().
-        """
-        return self.collection.keys()
-
     @property
     def head(self) -> Symbol:
         return SymbolRule
@@ -198,6 +198,18 @@ class Association(Atom, BoxElementMixin):
         Behaves like dict.items().
         """
         return self.collection.items()
+
+    def keys(self):
+        """Return the keys of an the association.
+        Behaves like dict.keys().
+        """
+        return self.collection.keys()
+
+    @property
+    def python(self):
+        if self._python is None:
+            return self.to_python()
+        return self._python
 
     def sameQ(self, other: Any) -> bool:
         """
@@ -221,8 +233,22 @@ class Association(Atom, BoxElementMixin):
         return True
 
     def to_python(self, *args, **kwargs) -> Optional[dict]:
-        # FIXME
-        return None
+        """
+        Convert to Python. Caching simple expressions as
+        a Python dictionary can speed things up.
+        """
+        if self._python is not None:
+            return self._python
+
+        self._python = {}
+        for key, value in self.collection.items():
+            try:
+                self._python[key.to_python(*args, **kwargs)] = value.to_python(
+                    *args, **kwargs
+                )
+            except Exception:
+                return None
+        return self._python
 
     def to_sympy(self, **kwargs):
         return None
@@ -239,16 +265,5 @@ class Association(Atom, BoxElementMixin):
         value
         """
         self.collection.update(e)
-        self.update_for_change()
         self._expr = None
-
-    def update_for_change(self):
-        """
-        Things we have to do when the Association is changed.
-        """
-        hash_elements = []
-        for key, value in self.collection.items():
-            # Update hash component
-            hash_elements.append((hash(key), hash(value)))
-
-        self._hash = hash(("Association", tuple(hash_elements)))
+        self._python = None

--- a/test/core/atoms/test_associations.py
+++ b/test/core/atoms/test_associations.py
@@ -2,6 +2,7 @@ from mathics.core.atoms import Integer1, Integer2
 from mathics.core.atoms.associations import Association
 from mathics.core.convert.expression import to_mathics_list
 from mathics.core.expression import Expression
+from mathics.core.rules import is_rule
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolRule
 
@@ -13,8 +14,14 @@ def make_rule(lhs, rhs) -> Expression:
 def test_association_is_literal():
     # Not much here yet.
     rule1 = make_rule(Integer1, Integer2)
+    assert is_rule(rule1)
     rule_list = to_mathics_list(rule1)
-    assert Association(rule_list)
+    association1 = Association(rule_list)
+    assert isinstance(association1, Association)
+    assert association1.python == {1: 2}
+    association1.update([(Integer1, Integer1)])
+    assert association1.python == {1: 1}
     rule2 = make_rule(Symbol("x"), Integer2)
     rule_list = to_mathics_list(rule2)
-    assert Association(rule_list)
+    association2 = Association(rule_list)
+    assert isinstance(association2, Association)


### PR DESCRIPTION
Cache Python-equivalent values in an Association. Extend unit test a little.