### PR TITLE
Miscellaneous code smells and performance adjustments

### DIFF
--- a/mathics/builtin/box/expression.py
+++ b/mathics/builtin/box/expression.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence, Union
 
 from mathics.core.attributes import A_PROTECTED, A_READ_PROTECTED
 from mathics.core.builtin import BuiltinElement
-from mathics.core.element import BoxElementMixin
+from mathics.core.element import BaseElement, BoxElementMixin
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
 from mathics.core.symbols import Symbol, SymbolHoldForm, ensure_context
@@ -193,7 +193,9 @@ class BoxExpression(BuiltinElement, BoxElementMixin):
         """
         return False
 
-    def replace_vars(self, vars, options=None, in_scoping=True, in_function=True):
+    def replace_vars(
+        self, vars, options=None, in_scoping=True, in_function=True
+    ) -> BaseElement:
         expr = self.to_expression()
         result = expr.replace_vars(vars, options, in_scoping, in_function)
         return result

--- a/mathics/builtin/list/eol.py
+++ b/mathics/builtin/list/eol.py
@@ -363,7 +363,6 @@ class Delete(Builtin):
         # Delete *can* take more than 2 arguments.
         "argr": "Delete called with 1 argument; 2 arguments are expected.",
         "argt": "Delete called with `1` arguments; 2 arguments are expected.",
-        "pkspec": "The expression `1` cannot be used as a part specification. Use `2` instead.",
     }
     summary_text = "delete elements from a list at given positions"
 

--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -212,9 +212,9 @@ class General(Builtin):
         "infy": "Infinite expression `1` encountered.",
         "innf": "Non-negative integer or Infinity expected at position `1` in `2`",
         "int": "Integer expected.",
-        "intp": "Positive integer expected.",
-        "intnn": "Non-negative integer expected.",
         "intnm": "Non-negative machine-sized integer expected at position `1` in `2`.",
+        "intnn": "Non-negative integer expected.",
+        "intp": "Positive integer expected.",
         "invak": "The argument `1` is not a valid Association.",
         "invlb": "The argument `1` is not a list, Rule or Association.",
         "invrl": "The argument `1` is not a valid Association or a list of rules.",
@@ -243,10 +243,13 @@ class General(Builtin):
         "plld": "Endpoints in `1` must be distinct machine-size real numbers.",
         "plln": "Limiting value `1` in `2` is not a machine-size real number.",
         "pkspec": (
-            "Part specification `1` is neither an integer nor a list of integer."
+            "The expression `1` cannot be used as a part specification. Use `2` instead."
         ),
         "pkspec1": ("The expression `1` cannot be used as a part specification."),
         "psl": "Position specification `1` in `2` is not a machine-sized integer or a list of machine-sized integers.",
+        "pspec": (
+            "Part specification `1` is neither an integer nor a list of integer."
+        ),
         "readf": "`1` is not a valid format specification.",
         "rvalue": "`1` is not a variable with a value, so its value cannot be changed.",
         "seqs": "Sequence specification expected, but got `1`.",

--- a/mathics/builtin/scoping.py
+++ b/mathics/builtin/scoping.py
@@ -9,9 +9,10 @@ from mathics.core.assignment import get_symbol_list
 from mathics.core.atoms import Integer, String
 from mathics.core.attributes import A_HOLD_ALL, A_PROTECTED, attribute_string_to_number
 from mathics.core.builtin import Builtin, Predefined
+from mathics.core.element import fully_qualified_symbol_name
 from mathics.core.evaluation import Evaluation
 from mathics.core.list import ListExpression
-from mathics.core.symbols import Symbol, fully_qualified_symbol_name
+from mathics.core.symbols import Symbol
 from mathics.eval.scoping import eval_contexts, eval_contexts_with_string
 
 

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -7,7 +7,7 @@ Here we have the base class and related function for element inside an Expressio
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Final, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Final, Optional, Sequence, Tuple, Union
 
 from mathics.core.attributes import A_NO_ATTRIBUTES
 from mathics.core.keycomparable import KeyComparable
@@ -107,7 +107,7 @@ class BaseElement(KeyComparable, ABC):
     Some important subclasses: Atom and Expression.
     """
 
-    options: Optional[Dict[str, Any]]
+    options: Optional[dict[str, Any]]
     last_evaluated: Any
     unevaluated: bool
     # this variable holds a function defined in mathics.core.expression that creates an expression
@@ -359,7 +359,7 @@ class BaseElement(KeyComparable, ABC):
 
     def replace_vars(
         self,
-        vars: Dict[str, "BaseElement"],
+        vars: dict[str, "BaseElement"],
         options=None,
         in_scoping=True,
         in_function=True,

--- a/mathics/core/parser/operators.py
+++ b/mathics/core/parser/operators.py
@@ -9,19 +9,19 @@ Mathics3 parser.
 """
 
 from collections import defaultdict
-from typing import Dict, Final
+from typing import Any, Final
 
 from mathics_scanner.characters import OPERATOR_DATA
 
-box_operators: Final[Dict[str, str]] = OPERATOR_DATA["box-operators"]
-flat_binary_operators: Final[Dict[str, int]] = OPERATOR_DATA["flat-binary-operators"]
+box_operators: Final[dict[str, str]] = OPERATOR_DATA["box-operators"]
+flat_binary_operators: Final[dict[str, int]] = OPERATOR_DATA["flat-binary-operators"]
 left_binary_operators = OPERATOR_DATA["left-binary-operators"]
-misc_operators: Final[Dict[str, int]] = OPERATOR_DATA["miscellaneous-operators"]
-nonassoc_binary_operators: Final[Dict[str, int]] = OPERATOR_DATA[
+misc_operators: Final[dict[str, int]] = OPERATOR_DATA["miscellaneous-operators"]
+nonassoc_binary_operators: Final[dict[str, int]] = OPERATOR_DATA[
     "non-associative-binary-operators"
 ]
-operator_precedences: Final[Dict[str, int]] = OPERATOR_DATA["operator-precedences"]
-operator_to_amslatex: Final[Dict[str, str]] = OPERATOR_DATA["operator-to-amslatex"]
+operator_precedences: Final[dict[str, int]] = OPERATOR_DATA["operator-precedences"]
+operator_to_amslatex: Final[dict[str, str]] = OPERATOR_DATA["operator-to-amslatex"]
 operator_to_string: Final[dict] = OPERATOR_DATA.get(
     "operator-to-string", OPERATOR_DATA.get("operator-to_string", {})
 )
@@ -41,10 +41,12 @@ inequality_operators: Final[tuple] = (
 )
 
 # binary_operators = left_binary_operators V right_binary_operators V flat_binary_operators V nonassoc_binary_operators
-binary_operators: Dict[str, int] = {}
+binary_operators: dict[str, int] = {}
 
 # all ops - check they're disjoint
-OPERATOR_PRECEDENCE = defaultdict(lambda: operator_precedences["FunctionApply"])
+OPERATOR_PRECEDENCE: defaultdict[Any, int] = defaultdict(
+    lambda: operator_precedences["FunctionApply"]
+)
 BOX_OPERATOR_PRECEDENCE: Final[int] = operator_precedences["BoxGroup"]
 PLUS_PRECEDENCE: Final[int] = operator_precedences["Plus"]
 

--- a/mathics/core/rules.py
+++ b/mathics/core/rules.py
@@ -125,12 +125,12 @@ class BaseRule(KeyComparable, ABC):
         self,
         pattern: BaseElement,
         system: bool = False,
-        evaluation: Optional[Evaluation] = None,
         attributes: Optional[int] = None,
     ) -> None:
         self.location: Optional[Callable] = None
         self.pattern = BasePattern.create(
-            pattern, attributes=attributes, evaluation=evaluation
+            pattern,
+            attributes=attributes,
         )
 
     def apply(
@@ -317,9 +317,7 @@ class RewriteRule(BaseRule):
         evaluation: Optional[Evaluation] = None,
         attributes: Optional[int] = None,
     ) -> None:
-        super(RewriteRule, self).__init__(
-            pattern, evaluation=evaluation, attributes=attributes
-        )
+        super(RewriteRule, self).__init__(pattern, attributes=attributes)
         self.replace = replace
 
     def __repr__(self) -> str:

--- a/mathics/core/symbols.py
+++ b/mathics/core/symbols.py
@@ -2,24 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    FrozenSet,
-    List,
-    Optional,
-    Sequence,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, FrozenSet, Optional, Sequence, Union, cast
 
-from mathics.core.element import (
-    BaseElement,
-    EvalMixin,
-    ensure_context,
-    fully_qualified_symbol_name,
-)
+from mathics.core.element import BaseElement, EvalMixin, ensure_context
 
 if TYPE_CHECKING:
     from mathics.core.atoms import String
@@ -212,7 +197,7 @@ class Atom(BaseElement):
     def get_atom_name(self) -> str:
         return self.__class__.__name__
 
-    def get_atoms(self, include_heads=True) -> List["Atom"]:
+    def get_atoms(self, include_heads=True) -> list["Atom"]:
         return [self]
 
     # We seem to need this because the caller doesn't distinguish
@@ -307,11 +292,11 @@ class Atom(BaseElement):
 
     def replace_vars(
         self,
-        vars: Dict[str, BaseElement],
+        vars: dict[str, BaseElement],
         options=None,
         in_scoping=True,
         in_function=True,
-    ) -> "Atom":
+    ) -> BaseElement:
         return self
 
     def replace_slots(self, slots, evaluation) -> "Atom":
@@ -359,7 +344,7 @@ class Symbol(Atom, NumericOperators, EvalMixin):
     # We use this for object uniqueness.
     # The key is the Symbol object's string name, and the
     # diectionary's value is the Mathics3 object for the Symbol.
-    _symbols: Dict[str, "Symbol"] = {}
+    _symbols: dict[str, "Symbol"] = {}
 
     class_head_name = "System`Symbol"
 
@@ -592,7 +577,8 @@ class Symbol(Atom, NumericOperators, EvalMixin):
         return super(Symbol, self).pattern_precedence
 
     def replace_vars(self, vars, options={}, in_scoping=True):
-        assert all(fully_qualified_symbol_name(v) for v in vars)
+        # "assert" below can really slow things down when there are lots of variables.
+        # assert all(fully_qualified_symbol_name(v) for v in vars)
         var = vars.get(self.name, None)
         if var is None:
             return self
@@ -685,7 +671,7 @@ class SymbolConstant(Symbol):
     # We use this for object uniqueness.
     # The key is the SymbolConstant's value, and the
     # diectionary's value is the Mathics3 object representing that Python value.
-    _symbol_constants: Dict[str, "SymbolConstant"] = {}
+    _symbol_constants: dict[str, "SymbolConstant"] = {}
 
     # We use __new__ here to unsure that two Integer's that have the same value
     # return the same object.

--- a/mathics/eval/scoping.py
+++ b/mathics/eval/scoping.py
@@ -6,9 +6,10 @@ import re
 
 from mathics.core.atoms import String
 from mathics.core.definitions import Definitions
+from mathics.core.element import fully_qualified_symbol_name
 from mathics.core.evaluation import Evaluation
 from mathics.core.list import ListExpression
-from mathics.core.symbols import Symbol, fully_qualified_symbol_name
+from mathics.core.symbols import Symbol
 
 
 def dynamic_scoping(func, vars, evaluation: Evaluation):


### PR DESCRIPTION
1 Remove evaluation parameter on BaseRule. This is a huge serialization bloat. If there is a serialization problem, it needs to be solved some other way.
2. Comment out slow assert checking over all variables.
3. Adjust imports to the module that defines the import instead of where it used to be.
4. Replace some "Dict", "List" uses with Python 3.10+ "dict" and "list".
5. Some type linting.