### PR TITLE
Parse URLs from Python Builtin docs.

### DIFF
--- a/mathics/builtin/symbol/properties.py
+++ b/mathics/builtin/symbol/properties.py
@@ -378,6 +378,12 @@ class Information(PrefixOperator):
     >> Information[AtomQ, "Properties"]
     = {Attributes, DefaultValues, Definitions, Documentation, DownValues, FormatValues, FullName, NValues, Options, Ownvalues, SubValues, UpValues, Usage}
 
+    >> Information[AtomQ, "Documentation"]
+    = <|Web ⇾ https://reference.wolfram.com/language/ref/AtomQ.html|>
+
+    >> Information[AtomQ, "FullName"]
+    = System`AtomQ
+
     'Information' does not print information for 'ReadProtected' symbols.
 
     'Information' uses 'InputForm' to format values.

--- a/mathics/builtin/symbol/properties.py
+++ b/mathics/builtin/symbol/properties.py
@@ -383,6 +383,9 @@ class Information(PrefixOperator):
     >> Information[AtomQ, "Documentation"]
     = <|Web ⇾ https://reference.wolfram.com/language/ref/AtomQ.html|>
 
+    >> Information[Glaisher, "Documentation"]
+    = <|Wiki ⇾ https://en.wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant, mpmath ⇾ https://mpmath.org/doc/current/functions/constants.html#glaisher-s-constant-glaisher, Web ⇾ https://reference.wolfram.com/language/ref/Glaisher.html|>
+
     >> Information[AtomQ, "FullName"]
     = System`AtomQ
 

--- a/mathics/builtin/symbol/properties.py
+++ b/mathics/builtin/symbol/properties.py
@@ -1,5 +1,5 @@
 """
-Symbol properties
+Symbol Properties
 """
 
 from typing import Callable, Optional
@@ -376,7 +376,7 @@ class Information(PrefixOperator):
     given:
 
     >> Information[AtomQ, "Properties"]
-    = {Attributes, DefaultValues, DownValues, FormatValues, FullName, NValues, Options, Ownvalues, SubValues, UpValues, Usage}
+    = {Attributes, DefaultValues, Definitions, Documentation, DownValues, FormatValues, FullName, NValues, Options, Ownvalues, SubValues, UpValues, Usage}
 
     'Information' does not print information for 'ReadProtected' symbols.
 

--- a/mathics/builtin/symbol/properties.py
+++ b/mathics/builtin/symbol/properties.py
@@ -358,29 +358,6 @@ class DownValues(Builtin):
         return eval_values(name, evaluation, "DownValues")
 
 
-class SymbolQ(Test):
-    """
-    <url>:WMA link:
-      https://resources.wolframcloud.com/FunctionRepository/resources/SymbolQ</url>
-    <dl>
-      <dt>'SymbolQ'[$x$]
-      <dd>is 'True' if $x$ is a symbol, or 'False' otherwise.
-    </dl>
-
-    >> SymbolQ[a]
-     = True
-    >> SymbolQ[1]
-     = False
-    >> SymbolQ[a + b]
-     = False
-    """
-
-    summary_text = "test whether is a symbol"
-
-    def test(self, expr) -> bool:
-        return eval_SymbolQ(expr)
-
-
 class Information(PrefixOperator):
     """
     <url>:WMA link:
@@ -509,7 +486,7 @@ class Information(PrefixOperator):
         # Print the "usage" message if available.
         # is_long_form = self.get_option(options, "LongForm", evaluation).to_python()
         is_long_form = True  # In WMA >=12.0 this option does not make much difference--
-        usagetext = online_doc_string(symbol, evaluation, is_long_form)
+        usagetext = online_doc_string(symbol, evaluation.definitions, is_long_form)
         if usagetext:
             lines.append(usagetext)
         else:
@@ -524,6 +501,29 @@ class Information(PrefixOperator):
             Expression(SymbolRule, Symbol("ColumnAlignments"), SymbolLeft),
         )
         return infoshow
+
+
+class SymbolQ(Test):
+    """
+    <url>:WMA link:
+      https://resources.wolframcloud.com/FunctionRepository/resources/SymbolQ</url>
+    <dl>
+      <dt>'SymbolQ'[$x$]
+      <dd>is 'True' if $x$ is a symbol, or 'False' otherwise.
+    </dl>
+
+    >> SymbolQ[a]
+     = True
+    >> SymbolQ[1]
+     = False
+    >> SymbolQ[a + b]
+     = False
+    """
+
+    summary_text = "test whether is a symbol"
+
+    def test(self, expr) -> bool:
+        return eval_SymbolQ(expr)
 
 
 class ValueQ(Builtin):

--- a/mathics/builtin/symbol/properties.py
+++ b/mathics/builtin/symbol/properties.py
@@ -280,7 +280,7 @@ class Definition(Builtin):
 
     def format_definition(
         self, symbol: Symbol, evaluation: Evaluation, grid: bool = True
-    ) -> Symbol:
+    ) -> Expression | Symbol:
         "(StandardForm,TraditionalForm,OutputForm,): Definition[symbol_]"
 
         lines = gather_and_format_definition_rules(symbol, evaluation)
@@ -297,7 +297,9 @@ class Definition(Builtin):
 
         return SymbolNull
 
-    def format_definition_input(self, symbol: Symbol, evaluation: Evaluation) -> Symbol:
+    def format_definition_input(
+        self, symbol: Symbol, evaluation: Evaluation
+    ) -> Expression | Symbol:
         "(InputForm,): Definition[symbol_]"
         return self.format_definition(symbol, evaluation, grid=False)
 
@@ -376,7 +378,7 @@ class Information(PrefixOperator):
     given:
 
     >> Information[AtomQ, "Properties"]
-    = {Attributes, DefaultValues, Definitions, Documentation, DownValues, FormatValues, FullName, NValues, Options, Ownvalues, SubValues, UpValues, Usage}
+    = {Attributes, DefaultValues, Definitions, Documentation, DownValues, FormatValues, FullName, NValues, ObjectType, Options, Ownvalues, SubValues, UpValues, Usage}
 
     >> Information[AtomQ, "Documentation"]
     = <|Web ⇾ https://reference.wolfram.com/language/ref/AtomQ.html|>
@@ -455,14 +457,14 @@ class Information(PrefixOperator):
         evaluation: Evaluation,
         options: dict,
         grid: bool = True,
-    ) -> Symbol:
+    ):
         "(StandardForm,TraditionalForm,InputForm,OutputForm,): Information[expr_, OptionsPattern[Information]]"
         # expr is not a Symbol. We should leave unchanged and let other formatting rules kick in.
         return None
 
     def format_information_string(
         self, strpat: String, evaluation: Evaluation, options: dict, grid: bool = True
-    ) -> Symbol:
+    ) -> Expression | Symbol:
         "(StandardForm,TraditionalForm,InputForm,OutputForm,): Information[strpat_String, OptionsPattern[Information]]"
         definitions = evaluation.definitions
         string_str = strpat.value
@@ -480,7 +482,7 @@ class Information(PrefixOperator):
 
     def format_information_symbol(
         self, symbol: Symbol, evaluation: Evaluation, options: dict, grid: bool = True
-    ) -> Symbol:
+    ) -> Expression | Symbol:
         "(StandardForm,TraditionalForm,InputForm,OutputForm,): Information[symbol_Symbol, OptionsPattern[Information]]"
         definitions = evaluation.definitions
         try:

--- a/mathics/core/convert/python.py
+++ b/mathics/core/convert/python.py
@@ -56,7 +56,7 @@ class FromPythonOptions:
     """
     Stores options associated with the to_python[] builtin.
 
-    One initialized, this structure is immutable or frozen.
+    Once initialized, this structure is immutable or frozen.
     """
 
     use_associations: Optional[bool] = None
@@ -94,11 +94,11 @@ DEFAULT_PYTHON_OPTIONS: Final[FromPythonOptions] = FromPythonOptions.from_dict(
 # Historically, from_python() was identified as a bottleneck.
 
 # A large part of this was due to the inefficient monolithic
-# non-specialized interpreter that forced everything into an single
+# non-specialized interpreter that forced everything into a single
 # Expression class which tried to handle anything given it using
 # conversions.
 
-# Also, through vague or lazy coding this cause a lot of
+# Also, through vague or lazy coding, this caused a lot of
 # unnecessary conversions.
 
 # We may be out of those days, but we should still
@@ -107,13 +107,13 @@ DEFAULT_PYTHON_OPTIONS: Final[FromPythonOptions] = FromPythonOptions.from_dict(
 # sure from_python() isn't too slow.
 
 # TODO:
-#  I think there are number of subtleties to be explained here.
-#  In particular, the expression might been the result of evaluation
+#  I think there are several subtleties to be explained here.
+#  In particular, the expression might have been the result of evaluating
 #  a SymPy expression which contains SymPy symbols.
 #
-#  If the end result is to go back into Mathics3 for further
-#  evaluation, then probably no problem.  However if the end result
-#  is produce say a Python string, then at a minimum we may want to
+#  If the result is to go back into Mathics3 for further
+#  evaluation, then probably no problem.  However, if the result
+#  produces, say, a Python string, then at a minimum we may want to
 #  convert backtick (context) symbols into some Python identifier
 #  symbol like underscore.
 

--- a/mathics/core/convert/python.py
+++ b/mathics/core/convert/python.py
@@ -27,7 +27,7 @@ from mathics.core.symbols import (
     SymbolNull,
     SymbolTrue,
 )
-from mathics.core.systemsymbols import SymbolAssociation, SymbolRule
+from mathics.core.systemsymbols import SymbolRule
 
 
 def from_bool(arg: bool) -> BooleanType:
@@ -185,23 +185,23 @@ def from_python(arg: Any, options=DEFAULT_PYTHON_OPTIONS) -> BaseElement:
         raise NotImplementedError
 
 
-def association_from_dict(arg: dict, options: FromPythonOptions) -> BaseElement:
+def association_from_dict(
+    python_dict: dict, options: FromPythonOptions = DEFAULT_PYTHON_OPTIONS
+):
     """
     Convert a Python dictionary into a Mathics3 Association.
     """
+    from mathics.core.atoms.associations import Association
     from mathics.core.expression import Expression
 
-    entries = [
+    elements = [
         Expression(
             SymbolRule,
             from_python(key, options),
             from_python(value, options),
         )
-        for key, value in arg.items()
+        for key, value in python_dict.items()
     ]
-    result = Expression(
-        SymbolAssociation,
-        *entries,
-        elements_properties=ELEMENTS_FULLY_EVALUATED,
-    )
-    return result
+    association = Association(elements)
+    association._python = python_dict
+    return association

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -222,6 +222,14 @@ class BasePattern(ABC):
         """The elements of the expression."""
         return self.expr.get_elements()
 
+    @property
+    def element_order(self) -> tuple:
+        """
+        Return a tuple value that is used in ordering elements
+        of an expression. The tuple is ultimately compared lexicographically.
+        """
+        return self.expr.element_order
+
     def get_head(self):
         """The head of the expression"""
         return self.expr.get_head()
@@ -253,22 +261,6 @@ class BasePattern(ABC):
     def get_sequence(self):
         """The sequence of elements in the expression"""
         return self.expr.get_sequence()
-
-    @property
-    def element_order(self) -> tuple:
-        """
-        Return a tuple value that is used in ordering elements
-        of an expression. The tuple is ultimately compared lexicographically.
-        """
-        return self.expr.element_order
-
-    @property
-    def pattern_precedence(self) -> tuple:
-        """
-        Return a precedence value, a tuple, which is used in selecting
-        which pattern to select when several match.
-        """
-        return build_pattern_sort_key(self)
 
     def has_form(
         self, heads: Union[Sequence[str], str], *element_counts: Optional[int]
@@ -343,6 +335,14 @@ class BasePattern(ABC):
     ) -> Union[int, tuple]:
         """Return the number of candidates that match with the pattern."""
         return len(self.get_match_candidates(elements, pattern_context))
+
+    @property
+    def pattern_precedence(self) -> tuple:
+        """
+        Return a precedence value, a tuple, which is used in selecting
+        which pattern to select when several match.
+        """
+        return build_pattern_sort_key(self)
 
     @overload
     def sameQ(self, other: "BasePattern") -> bool: ...

--- a/mathics/core/pattern.py
+++ b/mathics/core/pattern.py
@@ -1,12 +1,12 @@
 # cython: language_level=3
 # cython: profile=False
 # -*- coding: utf-8 -*-
-"""Core to Mathics3 is are patterns which match symbolic expressions. Patterns
+"""Core to Mathics3 are patterns which match symbolic expressions. Patterns
 are built up in a custom pattern notation.
 The parts of a pattern are called "Pattern Objects".
 
 While there is a built-in function which allows users to match parts of
-expressions, patterns are also used in applying of transformation
+expressions, patterns are also used in applying transformation
 rules and deciding functions that get applied.
 
 See also: mathics.core.rules and
@@ -109,7 +109,7 @@ class BasePattern(ABC):
 
     A Pattern is a way to represent classes of expressions.
     For example, ``F[x_Symbol]`` is a pattern which matches an expression whose
-    Head is ``F`` and that has a single parameter which is kind of Symbol.
+    Head is ``F`` and that has a single parameter which is a kind of Symbol.
     When the pattern matches, the symbol is bound to the parameter ``x``.
     """
 
@@ -165,7 +165,7 @@ class BasePattern(ABC):
     # ```
     #
     # At this point, the rule `rule` was created. As the head of the pattern
-    # is an expression, it does not provides special attributes to the pattern.
+    # is an expression, it does not provide special attributes to the pattern.
     # As expected, the pattern does not match with `Q[a, 1]` because the order of the
     # parameters:
     # ```
@@ -271,14 +271,14 @@ class BasePattern(ABC):
     def match(self, expression: BaseElement, pattern_context: dict):
         """
         Check if the expression matches the pattern (self).
-        If it does, calls `yield_func`.
-        vars collects subexpressions associated to named subpatterns.
+        If it does, it calls `yield_func`.
+        vars collects subexpressions associated with named subpatterns.
         head: Symbol. Provided by match_element, used by `Optional`.
-        element_index: int  the position
-        element_count: int and the number of optional elements. Used by `Optional`
+        element_index: int,  the position
+        element_count: int, the number of optional elements. Used by `Optional`
         for calling `get_default_value`.
 
-        Note: this complexity would disappear if Defaults would be stored as in WMA
+        Note: this complexity would disappear if `Defaults` were stored as in WMA
         at the creation time of the object.
 
         fully is used in `match_element`, for the case of Orderless patterns.
@@ -318,8 +318,8 @@ class BasePattern(ABC):
         self, elements: Tuple[BaseElement], pattern_context: dict
     ) -> tuple:
         """
-        Get the a sub-tuple of elements that are candidates
-        matching with the pattern.
+        Get a sub-tuple of elements that are candidates
+        matching the pattern.
 
         Optional parameters provide information
         about the context where the elements and the
@@ -333,7 +333,7 @@ class BasePattern(ABC):
     def get_match_candidates_count(
         self, elements: Tuple[BaseElement], pattern_context: dict
     ) -> Union[int, tuple]:
-        """Return the number of candidates that match with the pattern."""
+        """Return the number of candidates that match the pattern."""
         return len(self.get_match_candidates(elements, pattern_context))
 
     @property
@@ -388,11 +388,11 @@ class AtomPattern(BasePattern):
     def get_match_symbol_candidates(
         self, elements: tuple, pattern_context: dict
     ) -> tuple:
-        """Find the sub-tuple of elements that matches with the pattern"""
+        """Find the sub-tuple of elements that matches the pattern"""
         return tuple((element for element in elements if element is self.atom))
 
     def match(self, expression: BaseElement, pattern_context: dict):
-        """Try to match the patterh with the expression."""
+        """Try to match the pattern with the expression."""
 
         if isinstance(expression, Atom) and expression.sameQ(self.atom):
             # yield vars, None
@@ -402,7 +402,7 @@ class AtomPattern(BasePattern):
         self, elements: Tuple[BaseElement], pattern_context: dict
     ) -> tuple:
         """
-        Return a sub-tuple of elements that matches with the pattern.
+        Return a sub-tuple of elements that matches the pattern.
         """
         return tuple(
             (
@@ -572,7 +572,7 @@ class ExpressionPattern(BasePattern):
         If items has length 1, apply yield_func to the unique element.
         Otherwise, apply it to a sequence. If the expression has the
         attribute `Orderless`, apply it to all the possible orders.
-        Finally , if the expression is `Flat`, and the parameter `include_flattened`
+        Finally, if the expression is `Flat`, and the parameter `include_flattened`
         is `True`, apply yield_func to the expression with the head of the original
         expression applied to the original sequence.
         """
@@ -747,7 +747,7 @@ def match_expression_with_one_identity(
     # each time because at some point we should need
     # to check the default values each time...
 
-    # This tries to reduce the pattern to a non empty
+    # This tries to reduce the pattern to a non-empty
     # set of default values, and a single pattern.
     from mathics.builtin.patterns.composite import Pattern
     from mathics.core.builtin import PatternObject

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -49,6 +49,8 @@ def get_builtin_documentation(builtin_class: Builtin) -> Optional[Association]:
     Key: "Web" has a WMA reference.
     """
     docstr = builtin_class.__doc__
+    if docstr is None:
+        return None
     links_association = {}
     if link_section := docstr[0 : docstr.find("<dl>")]:
         start_position = 0
@@ -93,8 +95,8 @@ def online_doc_string(
 
     if builtin_class := get_builtin_class(symbol.name, definitions):
         docstr = builtin_class.__doc__
-        title = builtin_class.__name__
-        if docstr is None:
+        title = builtin_class.name
+        if docstr is None or title is None:
             return usagetext
         docstr = docstr[docstr.find("<dl>") : (docstr.find("</dl>") + 6)]
         usagetext = DocumentationEntry(docstr, title).text()

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -65,7 +65,7 @@ def get_builtin_documentation(builtin_class: Builtin) -> Optional[Association]:
             ):
                 links_key = "Wiki"
             links_association[links_key] = url
-            start_position = matched.end()
+            start_position += matched.end()
         pass
     if links_association:
         return association_from_dict(links_association)

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -3,20 +3,82 @@ Functions used in the inline (Information[]) help.
 
 """
 
-from mathics.core.evaluation import Evaluation
+import re
+from typing import Optional
+
+from mathics.core.atoms.associations import Association
+from mathics.core.builtin import Builtin
+from mathics.core.convert.python import association_from_dict
+from mathics.core.definitions import Definitions
 from mathics.core.symbols import Symbol
 from mathics.doc.doc_entries import DocumentationEntry
 
+URL_RE = re.compile(r"(?:[^<]*)<url>\s*:(.+?):\s*(.+?)\s*</url>", flags=re.DOTALL)
+COMMON_DOCUMENT_KEYS: set[str] = {"SymPy", "NumPy"}
+
+
+def get_builtin_class(name_str: str, definitions: Definitions) -> Optional[Builtin]:
+    """
+    If Symbol is a implemented as a builtin function,
+    return the builtin class object for it.
+
+    Parameters
+    ----------
+    name_str : str
+        The fully-qualified string name we for the Builtin.
+    definitions : Definitions
+        definitions The evaluation object.
+
+    Returns
+    -------
+    Buitin
+        The Python Builtin function class implementing name_str, if it exists.
+
+    """
+    for builtin_group in (definitions.builtin, definitions.pymathics):
+        if (bio := builtin_group.get(name_str)) is not None:
+            return bio.builtin.__class__
+    return None
+
+
+# FIXME: This will get less regular-expression based and less hacky
+# when the documentation is revised.
+def get_builtin_documentation(builtin_class: Builtin) -> Optional[Association]:
+    """
+    Returns an Association of documentation links or None if we can't find any.
+    Key: "Web" has a WMA reference.
+    """
+    docstr = builtin_class.__doc__
+    links_association = {}
+    if link_section := docstr[0 : docstr.find("<dl>")]:
+        start_position = 0
+        while matched := re.match(URL_RE, link_section[start_position:]):
+            links_key = matched.group(1)
+            url = matched.group(2)
+            if links_key in ("WMA link", "WMA"):
+                # Follow WMA naming convention for the key name.
+                links_key = "Web"
+            elif links_key not in COMMON_DOCUMENT_KEYS and url.startswith(
+                "https://en.wikipedia.org"
+            ):
+                links_key = "Wiki"
+            links_association[links_key] = url
+            start_position = matched.end()
+        pass
+    if links_association:
+        return association_from_dict(links_association)
+    return None
+
 
 def online_doc_string(
-    symbol: Symbol, evaluation: Evaluation, is_long_form: bool
+    symbol: Symbol, definitions: Definitions, is_long_form: bool
 ) -> str:
     """
-    Returns a python string with the documentation associated to a given symbol.
+    Returns a Python string with the documentation associated to a given symbol.
     """
     usagetext = ""
     try:
-        definition = evaluation.definitions.get_definition(symbol.name)
+        definition = definitions.get_definition(symbol.name)
         ruleusage = definition.get_values_list("messages")
     except KeyError:
         ruleusage = []
@@ -29,13 +91,9 @@ def online_doc_string(
     if not is_long_form and usagetext:
         return usagetext
 
-    builtins = evaluation.definitions.builtin
-    pymathics = evaluation.definitions.pymathics
-    bio = pymathics.get(definition.name) or builtins.get(definition.name)
-
-    if bio is not None:
-        docstr = bio.builtin.__class__.__doc__
-        title = bio.builtin.__class__.__name__
+    if builtin_class := get_builtin_class(symbol.name, definitions):
+        docstr = builtin_class.__doc__
+        title = builtin_class.__name__
         if docstr is None:
             return usagetext
         docstr = docstr[docstr.find("<dl>") : (docstr.find("</dl>") + 6)]

--- a/mathics/doc/online.py
+++ b/mathics/doc/online.py
@@ -19,13 +19,13 @@ COMMON_DOCUMENT_KEYS: set[str] = {"SymPy", "NumPy"}
 
 def get_builtin_class(name_str: str, definitions: Definitions) -> Optional[Builtin]:
     """
-    If Symbol is a implemented as a builtin function,
+    If Symbol is implemented as a builtin function,
     return the builtin class object for it.
 
     Parameters
     ----------
     name_str : str
-        The fully-qualified string name we for the Builtin.
+        The fully-qualified string name for the Builtin.
     definitions : Definitions
         definitions The evaluation object.
 
@@ -41,11 +41,11 @@ def get_builtin_class(name_str: str, definitions: Definitions) -> Optional[Built
     return None
 
 
-# FIXME: This will get less regular-expression based and less hacky
+# FIXME: This will get less regular-expression-based and less hacky
 # when the documentation is revised.
 def get_builtin_documentation(builtin_class: Builtin) -> Optional[Association]:
     """
-    Returns an Association of documentation links or None if we can't find any.
+    Returns an Association of documentation links, or `None` if none are found.
     Key: "Web" has a WMA reference.
     """
     docstr = builtin_class.__doc__

--- a/mathics/eval/symbol/properties.py
+++ b/mathics/eval/symbol/properties.py
@@ -7,12 +7,12 @@ from typing import Final
 
 from mathics.core.assignment import get_symbol_values
 from mathics.core.atoms import String
+from mathics.core.atoms.associations import Association
 from mathics.core.attributes import A_READ_PROTECTED
 from mathics.core.definitions import Definitions
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.list import ListExpression
-from mathics.core.pattern import AtomPattern
 from mathics.core.rules import RewriteRule
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import (
@@ -35,6 +35,7 @@ ALL_PROPERTIES: Final[ListExpression] = ListExpression(
     String("FormatValues"),
     String("FullName"),
     String("NValues"),
+    String("ObjectType"),
     String("Options"),
     String("Ownvalues"),
     String("SubValues"),
@@ -45,7 +46,12 @@ ALL_PROPERTIES: Final[ListExpression] = ListExpression(
 
 def eval_Information_with_property(name, property_name: str, evaluation: Evaluation):
     """
-    Evaluation routine for: Information[xxx, property]
+    Evaluation routine for: Information[name, property]
+
+    We do not handle:
+       * Knowledgebase Entity,
+       * Resource Function or
+       * a Fitted Module Object.
     """
 
     # If "name" is String, look up the name to get its Symbol.
@@ -54,7 +60,7 @@ def eval_Information_with_property(name, property_name: str, evaluation: Evaluat
     elif isinstance(name, Symbol):
         name_symbol = name
     else:
-        # We only handle Symbols and Strings.
+        # We only handle Symbols and Strings for now.
         return None
 
     # Symbol's "name" field should have the fully qualified string value.
@@ -81,6 +87,10 @@ def eval_Information_with_property(name, property_name: str, evaluation: Evaluat
             return information_documentation(name_str, evaluation.definitions)
         case "FullName":
             return String(name_str)
+        case "ObjectType":
+            # This needs filling out when we handle Knowledgebase Entity, etc
+            # return information_object_type(name_symbol, name_str, evaluation.definitions)
+            return information_object_type()
         case "Options":
             name_symbol = (
                 Symbol(evaluation.definitions.lookup_name(name_str))
@@ -89,12 +99,15 @@ def eval_Information_with_property(name, property_name: str, evaluation: Evaluat
             )
             return eval_Options(name_symbol, evaluation, empty_is_none=True)
         case "Properties":
+            # TODO: The property names change depending on "name"
+            # However for now we do not handle Knowledgebase Entity,
+            # Resource Function or a Fitted Module Object.
+            # So for now, we can return a static list.
             return ALL_PROPERTIES
         case "Usage":
             return information_usage(name_symbol, name_str, evaluation.definitions)
         case _:
             return missing_property(property_name)
-    return
 
 
 def eval_values(name, evaluation: Evaluation, attribute: str):
@@ -113,9 +126,105 @@ def eval_values(name, evaluation: Evaluation, attribute: str):
     return get_symbol_values(name_symbol, attribute, attribute.lower(), evaluation)
 
 
+def information_documentation(
+    name_str: str, definitions: Definitions
+) -> Association | None:
+    """
+    Informaton[symbol, "Documentation"]
+
+    Retrieve symbol's usage URL.
+
+    Parameters
+    ----------
+    name_str : str
+        The symbol that we want "usage" for
+    definitions : Definitions
+        definitions The evaluation object.
+
+    Returns
+    -------
+    Association or None
+        An association whose values are URLs and the key is some indication of what that URL is for,
+        e.g. Web (WMA documentation), Wiki, SymPy, NumPy, etc.
+    """
+
+    builtin_class = get_builtin_class(name_str, definitions)
+    if builtin_class:
+        return get_builtin_documentation(builtin_class)
+    return None
+
+
+def information_object_type() -> String:
+    """
+    Information[symbol, "ObjectType"]
+
+    Parameters
+    ----------
+    name_str : str
+        The symbol that we want "usage" for
+    definitions : Definitions
+        definitions The evaluation object.
+
+    Returns
+    -------
+    String "Symbol" for now.
+
+    """
+
+    # For now, we do not distinguish, "Entity", "ResourceFunction", or "DeviceObject"]
+    return String("Symbol")
+
+
+def information_usage(
+    name_symbol: Symbol, name_str: str, definitions: Definitions
+) -> String | Symbol:
+    """Retrieve symbol's usage message string.
+
+    For user variables, use "usage" message value stored.
+
+    For builtin functions, when "usage" message does not exist, which is probably most of the time,
+    for now, we return the "summary_text" class value of the builtin function..
+
+    Parameters
+    ----------
+    name_symbol : Symbol
+        The symbol that we want "usage" for
+    name_str : str
+        The Python str value for name_symbol. This string has the full context in it.
+    definitions : Definitions
+        definitions The evaluation object.
+
+    Returns
+    -------
+    String or Symbol
+        The usage string if one exists or the symbol name no usage string.
+
+    """
+
+    definition = definitions.get_definition(name_str)
+    if not definition:
+        # Definition not found
+        return name_symbol
+
+    for rule in definition.get_values_list("messages"):
+        if isinstance(rule, RewriteRule) and rule.lhs.get_head() is SymbolMessageName:
+            return rule.rhs
+
+    # No "usage" message has been defined on this symbol definition.
+    # If the symbol is a builtin-funciton, we should be able to get the "summary_text"
+    # value from the Python builtin class that defines the Builtin Function.
+    if builtin_class := get_builtin_class(name_str, definitions):
+        # I, rocky, take full responsibility for propagating
+        # "summary_text", which at the time matched the crappy
+        # Django homegrown documentation better.
+        return String(builtin_class.summary_text)
+
+    return name_symbol
+
+
 def information_values(name_symbol: Symbol, name_str: str, evaluation, value_type: str):
     """
-    Evaluation function for Information[name, xxxValues].
+    Evaluation function for Information[name, <value_type>Values].
     This is similar to eval_values, however the results change slightly
      1. 'None' returned in the key is not found
      2. The READ_PROTECTED attribute is is respected
@@ -134,74 +243,6 @@ def information_values(name_symbol: Symbol, name_str: str, evaluation, value_typ
         return SymbolNone
     values = get_symbol_values(name_symbol, value_type, value_type.lower(), evaluation)
     return SymbolNone if not values else values
-
-
-def information_documentation(name_str: str, definitions: Definitions) -> String:
-    """
-    Retrieve symbol's usage URL.
-
-    Parameters
-    ----------
-    name_str : str
-        The symbol that we want "usage" for
-    definitions : Definitions
-        definitions The evaluation object.
-
-    Returns
-    -------
-    String
-        The usage string if one exists or the symbol name no usage string.
-
-    """
-
-    builtin_class = get_builtin_class(name_str, definitions)
-    print(builtin_class)
-    return get_builtin_documentation(builtin_class)
-
-
-def information_usage(
-    name_symbol: Symbol, name_str: str, definitions: Definitions
-) -> String:
-    """
-    Retrieve symbol's usage message string.
-
-    Parameters
-    ----------
-    name_symbol : Symbol
-        The symbol that we want "usage" for
-    name_str : str
-        The Python str value for name_symbol. This string has the full context in it.
-    definitions : Definitions
-        definitions The evaluation object.
-
-    Returns
-    -------
-    String
-        The usage string if one exists or the symbol name no usage string.
-
-    """
-
-    try:
-        definition = definitions.get_user_definition(name_str, True)
-    except KeyError:
-        # As a last resort:
-        return name_symbol
-
-    for rule in definition.get_values_list("messages"):
-        if isinstance(rule, RewriteRule) and isinstance(rule.lhs.head, AtomPattern):
-            if rule.lhs.head.expr is SymbolMessageName:
-                return rule.rhs
-
-    # No "usage" message has been defined on this symbol definition.
-    # If the symbol is a builtin-funciton, we should be able to get the "summary_text"
-    # value from the Python builtin class that defines the Builtin Function.
-    if builtin_class := get_builtin_class(name_str, definitions):
-        # I, rocky, take full responsibility for propagating
-        # "summary_text", which at the time matched the crappy
-        # Django homegrown documentation better.
-        return String(builtin_class.summary_text)
-
-    return name_symbol
 
 
 @cache

--- a/mathics/eval/symbol/properties.py
+++ b/mathics/eval/symbol/properties.py
@@ -22,13 +22,15 @@ from mathics.core.systemsymbols import (
     SymbolUnknownProperty,
     SymbolUnknownSymbol,
 )
+from mathics.doc.online import get_builtin_class, get_builtin_documentation
 from mathics.eval.attributes import eval_Attributes
 from mathics.eval.options import eval_Options
 
 ALL_PROPERTIES: Final[ListExpression] = ListExpression(
     String("Attributes"),
     String("DefaultValues"),
-    # String("Definitions"),
+    String("Definitions"),
+    String("Documentation"),
     String("DownValues"),
     String("FormatValues"),
     String("FullName"),
@@ -75,6 +77,8 @@ def eval_Information_with_property(name, property_name: str, evaluation: Evaluat
             return information_values(name_symbol, name_str, evaluation, property_name)
             # case "Definitions":
             #     return information_values(expr, evaluation.definitions, "defaultvalues")
+        case "Documentation":
+            return information_documentation(name_str, evaluation.definitions)
         case "FullName":
             return String(name_str)
         case "Options":
@@ -132,6 +136,29 @@ def information_values(name_symbol: Symbol, name_str: str, evaluation, value_typ
     return SymbolNone if not values else values
 
 
+def information_documentation(name_str: str, definitions: Definitions) -> String:
+    """
+    Retrieve symbol's usage URL.
+
+    Parameters
+    ----------
+    name_str : str
+        The symbol that we want "usage" for
+    definitions : Definitions
+        definitions The evaluation object.
+
+    Returns
+    -------
+    String
+        The usage string if one exists or the symbol name no usage string.
+
+    """
+
+    builtin_class = get_builtin_class(name_str, definitions)
+    print(builtin_class)
+    return get_builtin_documentation(builtin_class)
+
+
 def information_usage(
     name_symbol: Symbol, name_str: str, definitions: Definitions
 ) -> String:
@@ -140,8 +167,10 @@ def information_usage(
 
     Parameters
     ----------
-    symbol : Symbol
+    name_symbol : Symbol
         The symbol that we want "usage" for
+    name_str : str
+        The Python str value for name_symbol. This string has the full context in it.
     definitions : Definitions
         definitions The evaluation object.
 
@@ -166,25 +195,11 @@ def information_usage(
     # No "usage" message has been defined on this symbol definition.
     # If the symbol is a builtin-funciton, we should be able to get the "summary_text"
     # value from the Python builtin class that defines the Builtin Function.
-
-    # I, rocky, take full responsibility for propagating
-    # "summary_text", which at the time matched the crappy
-    # Django homegrown documentation better.
-    if (
-        builtin_definition := definitions.builtin.get(name_str)
-    ) and builtin_definition.downvalues:
-        first_apply_rule = builtin_definition.downvalues[0]
-        try:
-            # FIXME: This is really weird and hoaky. Is there a better
-            # way?  Fnd an apply rule for this builtin. From that take
-            # the RHS of the rule, which gives a bound method of some
-            # eval method. From the bound eval method we get the self
-            # object from which we can find the Buitin class of the
-            # object.  And then finally we take its summary text.
-            # "summary_text" is the closest we have to "usage".
-            return String(first_apply_rule.rhs.__self__.__class__.summary_text)
-        except Exception:
-            pass
+    if builtin_class := get_builtin_class(name_str, definitions):
+        # I, rocky, take full responsibility for propagating
+        # "summary_text", which at the time matched the crappy
+        # Django homegrown documentation better.
+        return String(builtin_class.summary_text)
 
     return name_symbol
 


### PR DESCRIPTION
Also, handle Mathics3 Modules in definition lookup. 
And the usual cleanup:
  * Put in alphabetical order the methods in `BasePattern`
  * Strengthen/correct some annotation types
  
Handle `Information[xxx,  "ObjectType"]``