### PR TITLE
fix Information

### DIFF
--- a/mathics/builtin/symbol/properties.py
+++ b/mathics/builtin/symbol/properties.py
@@ -518,7 +518,7 @@ class Information(PrefixOperator):
 
         infoshow = Expression(
             SymbolGrid,
-            ListExpression(line for line in lines),
+            ListExpression(*(line for line in lines)),
             Expression(SymbolRule, Symbol("ColumnAlignments"), SymbolLeft),
         )
         return infoshow


### PR DESCRIPTION
This PR fixes an error that slipped into the Information refactor. Without this, `?? Plus` raises an error.