### PR TITLE
Fix directed infinity

### DIFF
--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 import sympy
 
-from mathics.builtin.numeric import Abs
 from mathics.builtin.scoping import dynamic_scoping
 from mathics.core.atoms import (
     MATHICS3_COMPLEX_I,
@@ -22,7 +21,6 @@ from mathics.core.atoms import (
     Integer1,
     IntegerM1,
     Rational,
-    Real,
     String,
 )
 from mathics.core.attributes import (
@@ -75,7 +73,6 @@ from mathics.core.systemsymbols import (
 )
 from mathics.eval.arithmetic import eval_RealValuedNumberQ
 from mathics.eval.inference import get_assumptions_list
-from mathics.eval.nevaluator import eval_N
 from mathics.eval.numeric import eval_Sign
 
 # This tells documentation how to sort this module
@@ -506,11 +503,11 @@ class DirectedInfinity(SympyFunction):
             return MATHICS3_COMPLEX_INFINITY
 
         # try to reduce with sign
-        normalized_direction = eval_Sign(direction)
-        if normalized_direction is None:
+        direction = eval_Sign(direction)
+        if direction is None:
             return None
 
-        result = map_direction_infinity.get(normalized_direction, None)
+        result = map_direction_infinity.get(direction, None)
         if result is not None:
             return result
         if direction.is_zero:
@@ -518,7 +515,7 @@ class DirectedInfinity(SympyFunction):
 
         return PredefinedExpression(
             SymbolDirectedInfinity,
-            normalized_direction.evaluate(evaluation),
+            direction.evaluate(evaluation),
         )
 
     # We can't use generic_argument_error because 0 arguments are allowed

--- a/mathics/builtin/arithmetic.py
+++ b/mathics/builtin/arithmetic.py
@@ -456,6 +456,7 @@ class DirectedInfinity(SympyFunction):
         "DirectedInfinity[]": "HoldForm[ComplexInfinity]",
         "DirectedInfinity[DirectedInfinity[z_]]": "DirectedInfinity[z]",
         "DirectedInfinity[z_?NumericQ]": "HoldForm[z Infinity]",
+        "DirectedInfinity[z_Symbol]": "HoldForm[z Infinity]",
     }
     rules = {
         "DirectedInfinity[args___] ^ -1": "0",
@@ -498,35 +499,23 @@ class DirectedInfinity(SympyFunction):
     def eval_directed_infinity(self, direction, evaluation: Evaluation):
         """DirectedInfinity[direction_]"""
         result = map_direction_infinity.get(direction, None)
-        if result:
+        if result is not None:
             return result
 
         if direction.is_zero:
             return MATHICS3_COMPLEX_INFINITY
 
+        # try to reduce with sign
         normalized_direction = eval_Sign(direction)
-        # TODO: improve eval_Sign, to avoid the need of the
-        # following block:
-        #   ############################################
-        if normalized_direction is None:
-            ndir = eval_N(direction, evaluation)
-            if isinstance(ndir, (Integer, Rational, Real)):
-                if abs(ndir.value) == 1.0:
-                    normalized_direction = direction
-                else:
-                    normalized_direction = direction / Abs(direction)
-            elif isinstance(ndir, Complex):
-                re, im = ndir.real, ndir.imag
-                if abs(re.value**2 + im.value**2 - 1.0) < 1.0e-9:
-                    normalized_direction = direction
-                else:
-                    normalized_direction = direction / Abs(direction)
-            else:
-                return None
-        #  ##############################################
-
         if normalized_direction is None:
             return None
+
+        result = map_direction_infinity.get(normalized_direction, None)
+        if result is not None:
+            return result
+        if direction.is_zero:
+            return MATHICS3_COMPLEX_INFINITY
+
         return PredefinedExpression(
             SymbolDirectedInfinity,
             normalized_direction.evaluate(evaluation),

--- a/mathics/eval/numeric.py
+++ b/mathics/eval/numeric.py
@@ -319,7 +319,11 @@ def eval_Sign(expr: BaseElement) -> Optional[BaseElement]:
             return Integer1 if len(signs) == 0 else eval_multiply_numbers(*signs)
 
         # Try with Sympy
+    try:
         abs_expr = from_sympy(abs(n.to_sympy()))
+    except Exception:
+        # SymPy conversion failed; fall back.
+        return None
         if abs_expr.is_zero:
             return abs_expr
         if abs_expr is Integer1:

--- a/mathics/eval/numeric.py
+++ b/mathics/eval/numeric.py
@@ -319,11 +319,12 @@ def eval_Sign(expr: BaseElement) -> Optional[BaseElement]:
             return Integer1 if len(signs) == 0 else eval_multiply_numbers(*signs)
 
         # Try with Sympy
-    try:
-        abs_expr = from_sympy(abs(n.to_sympy()))
-    except Exception:
-        # SymPy conversion failed; fall back.
-        return None
+        try:
+            abs_expr = from_sympy(abs(n.to_sympy()))
+        except Exception:
+            # SymPy conversion failed; fall back.
+            return None
+
         if abs_expr.is_zero:
             return abs_expr
         if abs_expr is Integer1:

--- a/mathics/eval/numeric.py
+++ b/mathics/eval/numeric.py
@@ -183,16 +183,22 @@ def eval_RealSign(expr: BaseElement) -> Optional[Integer]:
         return Integer1
     if expr.has_form("Abs", 1):
         arg = expr.elements[0]
-        arg_sign = eval_Sign(arg)
-        if arg_sign is None:
-            return None
-        if arg_sign.is_zero:
+        if arg.is_zero:
             return Integer0
-        if isinstance(arg_sign, Number):
+        if isinstance(arg, Number):
+            return Integer1
+        # Try evaluating to an inexact number
+        arg_inexact = to_inexact_value(arg)
+        if arg_inexact is None:
+            return None
+        if arg_inexact.is_zero:
+            return Integer0
+        if isinstance(arg_inexact, Number):
             return Integer1
         return None
     if expr.has_form("Sqrt", 1):
-        return Integer1 if eval_Sign(expr.elements[0]) is Integer1 else None
+        inner_sign = eval_Sign(expr.elements[0])
+        return inner_sign if inner_sign in (Integer0, Integer1) else None
     if expr.has_form("Exp", 1):
         return Integer1 if test_arithmetic_expr(expr.elements[0]) else None
     if expr.has_form("Log", 1) or expr.has_form("DirectedInfinity", 1):
@@ -312,10 +318,16 @@ def eval_Sign(expr: BaseElement) -> Optional[BaseElement]:
                     signs.append(factor_sign)
             return Integer1 if len(signs) == 0 else eval_multiply_numbers(*signs)
 
-        try_inexact = to_inexact_value(n)
-        if try_inexact:
-            return eval_Sign(try_inexact)
-        return None
+        # Try with Sympy
+        abs_expr = from_sympy(abs(n.to_sympy()))
+        if abs_expr.is_zero:
+            return abs_expr
+        if abs_expr is Integer1:
+            return n
+        # Failed to reduce the absolute value:
+        if abs_expr.has_form("Abs", 1):
+            return None
+        return n / abs_expr
 
     sign = eval_RealSign(expr)
     return sign or eval_complex_sign(expr)

--- a/test/builtin/arithfns/test_basic.py
+++ b/test/builtin/arithfns/test_basic.py
@@ -135,7 +135,7 @@ def test_multiply(str_expr, str_expected, msg):
     )
 
 
-@pytest.mark.skip("DirectedInfinity Precedence needs going over")
+# @pytest.mark.skip("DirectedInfinity Precedence needs going over")
 @pytest.mark.parametrize(
     (
         "str_expr",
@@ -162,7 +162,7 @@ def test_multiply(str_expr, str_expected, msg):
         ),
         (
             "a  b (-1 + 2 Pi I) Infinity",
-            "a b (Infinity (-1 + 2 I Pi) / Sqrt[1 + 4 Pi ^ 2])",
+            "a b ((-1 + 2 I Pi) / Sqrt[1 + 4 Pi ^ 2] Infinity)",
             "complex irrational exact",
         ),
         (
@@ -433,7 +433,7 @@ def test_miscelanea_private_tests(str_expr, str_expected, msg):
         ),
     ],
 )
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="sympy bug...")
 def test_miscelanea_private_tests_xfail(str_expr, str_expected, msg):
     check_evaluation(str_expr, str_expected, failure_message=msg)
 

--- a/test/builtin/associations/test_associations.py
+++ b/test/builtin/associations/test_associations.py
@@ -57,6 +57,18 @@ import pytest
         #            "RowBox[{<|, RowBox[{RowBox[{a, ->, x}], ,, RowBox[{b, ->, y}], ,, RowBox[{c, ->, RowBox[{<|, RowBox[{RowBox[{d, ->, t}], ,, RowBox[{e, ->, u}]}], |>}]}]}], |>}]",
         #            None,
         #        ),
+        (
+            "Map[F, Q[a->1, b:>Association[p->3,q->4]]]",
+            None,
+            "Q[F[a->1], F[b:>Association[p->3, q->4]]]",
+            "Acting on a nested association, the inner association is treated as normal.",
+        ),
+        (
+            "Map[F, Q[a->1, b:>Association[p->3,q->4]],{2}]",
+            None,
+            "Q[F[a]->F[1], F[b]:>F[Association[p->3, q->4]]]",
+            "Acting on a nested association, the inner association is treated as normal.",
+        ),
     ],
 )
 def test_associations(str_expr, expected_messages, str_expected, assert_message):
@@ -71,18 +83,6 @@ def test_associations(str_expr, expected_messages, str_expected, assert_message)
 @pytest.mark.parametrize(
     ("str_expr", "expected_messages", "str_expected", "assert_message"),
     [
-        (
-            "Map[F, Q[a->1, b:>Association[p->3,q->4]]]",
-            None,
-            "Q[F[a->1], F[b:>Association[p->3, q->4]]]",
-            "Acting on a nested association, the inner association is treated as normal.",
-        ),
-        (
-            "Map[F, Q[a->1, b:>Association[p->3,q->4]],{2}]",
-            None,
-            "Q[F[a]->F[1], F[b]:>F[Association[p->3, q->4]]]",
-            "Acting on a nested association, the inner association is treated as normal.",
-        ),
         (
             "Map[F, Association[a->1, b:>Association[p->3,q->4]], {0}]",
             None,

--- a/test/builtin/test_rules.py
+++ b/test/builtin/test_rules.py
@@ -140,94 +140,92 @@ def test_orderless_on_rules(str_expr, str_expected, msg):
     check_evaluation(str_expr, str_expected, failure_message=msg)
 
 
-@pytest.mark.parametrize(
-    ("str_expr", "str_expected", "msg"),
-    [
+@pytest.mark.xfail
+def test_flat_on_rules():
+    for str_expr, str_expected, msg in [
         (None, None, None),
         (
-            "rule = Q[_Integer,_Symbol]->True;\
-	 ruled = Dispatch[{rule}];\
-	 {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
+            (
+                "rule = Q[_Integer,_Symbol]->True;"
+                "ruled = Dispatch[{rule}];"
+                "{Q[a,1,b]/.rule, Q[a,1,b]/.ruled}"
+            ),
             "{Q[a,1,b],Q[a,1,b]}",
             "1. Check the rules. Here are not applied.",
         ),
         (
             "SetAttributes[Q, {Flat}];\
-            {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
+                {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
             "{Q[a,1,b], Q[a,1,b]}",
             "2. Set the attribute. Application is not affected.",
         ),
         (
             "rule = Q[_Integer,_Symbol]->True;\
-  	  ruled = Dispatch[{rule}];\
-	  {Q[a, 1, b]/.rule, Q[a, 1, b]/.ruled}",
+  	        ruled = Dispatch[{rule}];\
+	        {Q[a, 1, b]/.rule, Q[a, 1, b]/.ruled}",
             "{Q[a, True],Q[a, True]}",
             "3 .Rebuilt rules. Rules applied.",
         ),
         (
             "Attributes[Q] = {};\
-          {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
+                {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
             "{Q[a,1,b], Q[a,1,b]}",
             "4. Unset the attribute. Application is not affected.",
         ),
         (
             "rule = Q[a, _Integer,_Symbol]->True;\
-  	  ruled = Dispatch[{rule}];\
-	  {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
+  	        ruled = Dispatch[{rule}];\
+	        {Q[a,1,b]/.rule, Q[a,1,b]/.ruled}",
             "{Q[a, 1, b],Q[a, 1, b]}",
             "5. Rebuilt rules. Rules applied.",
         ),
         (None, None, None),
-    ],
-)
+    ]:
+
+        check_evaluation(str_expr, str_expected, failure_message=msg)
+
+
 @pytest.mark.xfail
-def test_flat_on_rules(str_expr, str_expected, msg):
-    check_evaluation(str_expr, str_expected, failure_message=msg)
-
-
-@pytest.mark.parametrize(
-    ("str_expr", "str_expected", "msg"),
-    [
+def test_default_optional_on_rules():
+    for str_expr, str_expected, msg in [
         (None, None, None),
         (
             "rule = Q[x_,y_.]->{x, y};\
-	 ruled = Dispatch[{rule}];\
-	 {Q[a]/.rule, Q[a]/.ruled}",
+	        ruled = Dispatch[{rule}];\
+	        {Q[a]/.rule, Q[a]/.ruled}",
             "{Q[a],Q[a]}",
             "1. Check the rules. Here are not applied.",
         ),
         (
             "Default[Q]=37;\
-          {Q[a]/.rule, Q[a]/.ruled}",
+                {Q[a]/.rule, Q[a]/.ruled}",
             "{Q[a], Q[a]}",
             "2. Set the Default value. Application is not affected.",
         ),
         (
             "rule = Q[x_,y_.]->{x,y};\
-  	  ruled = Dispatch[{rule}];\
-	  {Q[a]/.rule, Q[a]/.ruled}",
+  	        ruled = Dispatch[{rule}];\
+	        {Q[a]/.rule, Q[a]/.ruled}",
             "{{a, 37}, {a, 37}}",
             "3 .Rebuilt rules. Rules applied.",
         ),
         (
             "Default[Q] = .;\
-            {Q[a]/.rule, Q[a]/.ruled}",
+                {Q[a]/.rule, Q[a]/.ruled}",
             "{{a, 37}, {a, 37}}",
             "4. Unset the attribute. Application is not affected.",
         ),
         (
             "rule = Q[x_,y_.]->{x,y};\
-  	    ruled = Dispatch[{rule}];\
-	    {Q[a]/.rule, Q[a]/.ruled}",
+  	        ruled = Dispatch[{rule}];\
+	        {Q[a]/.rule, Q[a]/.ruled}",
             "{Q[a],Q[a]}",
             "5. Rebuilt rules. Rules not applied.",
         ),
         (None, None, None),
-    ],
-)
-@pytest.mark.xfail
-def test_default_optional_on_rules(str_expr, str_expected, msg):
-    check_evaluation(str_expr, str_expected, failure_message=msg)
+    ]:
+
+        check_evaluation(str_expr, str_expected, failure_message=msg)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Fix some old issues associated to `DirectedInfinity` (see modified xfailed tests)
* Improve `eval_Abs`, `eval_RealSign` and `evalSign`.
* remove xfail from passing pytests.
* reorganize `test_rules.py` to avoiding see setup commands as independent tests.