### PR TITLE
Restore compatibility with mpmath 1.4

### DIFF
--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -112,7 +112,7 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         # Anything that is in a number class is Numeric, so return True.
         return True
 
-    def to_mpmath(self, precision: Optional[int] = None) -> mpmath.ctx_mp_python.mpf:
+    def to_mpmath(self, precision: Optional[int] = None) -> mpmath.mpf:
         """
         Convert self.value to an mpmath number with precision ``precision``
         If ``precision`` is None, use mpmath's default precision.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 description = "A general-purpose computer algebra system."
 dependencies = [
     "Mathics3_Scanner>=10.0",
-    "mpmath>=1.2.0,<1.4.0",
+    "mpmath>=1.2.0",
     "numpy",
     "palettable",
     "packaging",


### PR DESCRIPTION
## Summary

mpmath 1.4 removed an internal pickle workaround that had incidentally exposed
`ctx_mp_python.mpf` as a module attribute. Mathics referenced that private name
in an eagerly evaluated return annotation, so importing Mathics failed with
mpmath 1.4 and later.

Use the public `mpmath.mpf` type and remove the temporary `<1.4.0` dependency
cap. The runtime numeric conversion code is unchanged.

This follows up on #1865 and was triggered by sagemath/sage#41877. The relevant
mpmath change is mpmath/mpmath@3ac151e385365f87840f31f1fce0856595a691e7.

## Testing

- mpmath 1.2.1, 1.3.0, 1.4.0, and 1.4.1: 44 relevant conversion, constant,
  and Bessel tests passed on each version
- mpmath 1.4.1 editable install and CLI tests: 3 passed
- consistency and style tests: 114 passed
- Black, isort, mypy, `pip check`, and `git diff --check` passed

## Performance

The `to_mpmath` function body has identical bytecode before and after this
change. Fixed-CPU, randomly interleaved paired benchmarks found no statistically
detectable regression in import, `to_mpmath`, `N[Pi, 50]`, `N[Sin[1], 50]`, or
`N[BesselK[2, I], 50]`; all bootstrap 95% confidence intervals included 1.0.
