### PR TITLE
Improve expression cache documentation

### DIFF
--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -174,6 +174,72 @@ class BoxError(Exception):
 
 
 class ExpressionCache:
+    """
+    Metadata Cache to accelerate the evaluation of an Expression.
+
+    This cache does not stores the result of an evaluation, but the structural
+    information and dependencies allowing to quicly answer the question:
+
+        Given the current state of the Definitions object, is it necesary reevaluate
+        the expression from the beginning?
+
+    The strategy combines a global timestamp (definitions.now) with a tracking of
+    the symbols appearing into the expression.
+
+
+    Fields:
+    -------
+
+    * time (int|None): the value of Definitions.now at the time of the last
+      full evaluation of the expression. If its value is ``None``, the expression
+      is a new expression, or was marked for reevaluation.
+
+    * symbols (Set[str] | None): Set of fully qualified names of all the symbols
+      that appears into the expression and its subexpressions.
+      If its value is ``None``, the cache must be reconstructed.
+
+    * sequences (Tuple[int]|None): a Tuple with the indices of all the
+      elements (in ``self._elements``) whose head is exactly ``System`Sequence``.
+      If ``None``, the information is not available. If it is an empty tuple,
+      we known certantly that there are not Sequences at the first level,
+      which allows to avoid the cost of ``flatten_sequence`` during the evaluation.
+
+
+    CRITICAL INVARIANTS:
+    --------------------
+
+    * In any expression, ``self.elements_properties.is_flat`` must imply
+      ``len(self._cache.sequences) == 0``.
+    * ANY structural change of the expression (change the head or any of its elements,
+      flat or re-order the elements of the expression) MUST establish ``self._cache = None``.
+    * the attribute ``time`` must be updated through the call ``_timestamp_cache(evaluation)``
+      when the expression went through a full ``evaluate()`` loop, and after that,
+      the expression have not been structuraly modified.
+
+    USAGE:
+    ------
+
+    * At the start of the evaluation loop, a call to ``is_uncertain_final_definitions(definitions)``
+      determines if a pass through the ``rewrite_apply_eval_step`` is needed.
+    * If the cache exists, ``time`` is not None, and ``symbols`` is already computed.
+      ``definitions.is_uncertain_final_value(time, symbols)`` determines whether some of the symbols
+      have been changed since ``time``.
+    * If they was not changed, it is assumed that the previous evaluation is still valid and the
+      evaluation loop stops, saving time.
+    * If it has changed, it proceeds with the ``rewrite_apply_eval_step``.
+
+
+    NOTE ON COMPUTATIONAL COST:
+    ---------------------------
+
+    The cache reconstruction cost (``_rebuild_cache``) is expensive (O(n) in the size
+    of the expression) because it run recursively over all the expression.
+    However, this only happens when a full cache, or some information is missing.
+
+    The validity check (``is_uncertain_final_definitions``) is O(1).
+
+    """
+
     def __init__(self, time=None, symbols=None, sequences=None, copy=None):
         if copy is not None:
             time = time or copy.time
@@ -488,9 +554,25 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
 
     @elements.setter
     def elements(self, values: Iterable):
+        """
+        Setter for elements.
+        """
+        #  This setter should invalidate both ``element_properties`` and
+        # ``_cache`` properties. The ``_cache`` property holds a set of symbols
+        # that can become outdated when the elements tuple changes.
+        #
+        # If we do not clean `_cache`, `is_uncertain_final_definitions` could
+        # return `True` by tracking symbols that are not in the structure
+        # anymore, forcing an unneeded evaluation, or worst,
+        # return `False`, if some new symbols present in the expression
+        # changes and are not marked in the ``_cache``, leaving unevaluated
+        # an expression that must be reevaluated, silently producing a wrong
+        # evaluation.
+
         self._elements = tuple(values)
         # Set to build self.elements_properties on next evaluation()
         self.elements_properties = None
+        self._cache = None
 
     def equal2(self, rhs: Any) -> Optional[bool]:
         """Mathics3 two-argument Equal (==)
@@ -1878,10 +1960,21 @@ def structure(head, origins, evaluation, structure_cache={}):
     originating (exclusively) from "origins" (elements are passed into the functions
     of Structure further down).
 
-    "origins" may either be an Expression (i.e. all elements must originate from that
-    expression), a Structure (all elements passed in this "self" Structure must be
-    manufactured using that Structure), or a list of Expressions (i.e. all elements
-    must originate from one of the listed Expressions).
+    Parameters:
+    ===========
+
+    ``head``: the head of the new expression.
+    ``origins`` Expression|Structure|List[Expression]: the source of the new elements.
+       If it is a List of expressions,  all its elements must originate from one of the listed Expressions.
+       When it is an Expression,  all elements must originate from that expression).
+       If it is a Structure, all elements passed in this "self" Structure must be
+       manufactured using that Structure.
+    ``evaluation`` (Evaluation): the current evaluation object.
+    ``structure_cache`` (Dict[str,Symbol]): is an optional dict that helps to memoize the result of the
+       *neutrality* of the heads, avoiding repeat the query. A symbol is *neutral* if it does not have
+       evaluation rules attached to its definition.
+
+
     """
     from mathics.core.structure import Structure, UnlinkedStructure
 

--- a/mathics/core/structure.py
+++ b/mathics/core/structure.py
@@ -6,11 +6,36 @@ from typing import Optional
 
 class Structure(ABC):
     """
+    Factory for new Expression objects from existing elements, keeping track of the
+    cache metadata when it is required.
+
+    The main contract is that EVERY element in the new expression comes from the origin expression,
+    which was passed as arguments when ``Structure`` was built. This ensures that all the symbols
+    contained into the new expression are a subset of the original ones, so the cache can be
+    safely reused.
+
     Structure helps implementations make the ExpressionCache not invalidate across simple commands
     such as Take[], Most[], etc. without this, constant reevaluation of lists happens, which results
     in quadratic runtimes for command like Fold[#1+#2&, Range[x]].
 
     A good performance test case for Structure: x = Range[50000]; First[Timing[Partition[x, 15, 1]]]
+
+
+    Methods
+    -------
+
+    *  ``__call__(elements)``: build a new expression with the given elements.
+    *  ``filter(expr, cond, count=None)``: filter elements in ``expr`` according
+       the condition ``cond`` and returns a new expression.
+    * ``slice(expr, py_slice)``: take an slice of the elements in ``expr`` and returns
+      a new expression build on them.
+
+    Note:
+    -----
+    This mechanism does not modify the original expression; just create new expressions
+    sharing the original elements.
+
+
     """
 
     def __call__(self, elements):
@@ -83,6 +108,33 @@ class LinkedStructure(Structure):
     LinkedStructure produces Expressions that are linked to "origins" in terms of cache. This
     carries over information from the cache of the originating Expressions into the Expressions
     that are newly created.
+
+    This is crucial for operations like  Take, Drop, Part, Most, Rest, etc.,
+    where the elements of the new expression are a subset or reordering of the
+    original elements. When the cache is reused, a cache invalidation is avoided,
+    and prevent that the metadata be recomputed, reducing the complexity from O(n^2)
+    to O(n).
+
+
+    How the cache is adjusted:
+
+        - In ``__call__`` (for the general re-ordering):
+          ``cache.reordered()`` is used, preserving the set of ``symbols``
+          but ``sequences`` are marked as ``None`` (because the order have been changed
+          and we can not know wheter the indices of elements containing ``Sequence``
+          expressions are still valid).
+        - In ``slice``: ``cache.sliced(lower, upper)`` is used. It reindex
+          the positions of ``Sequence`` elements in the selected range (if ``step==1``)
+          keeping the ``symbols`` set without changes.
+
+    RESTRICTION:  ``slice`` just support  ``step=1`` because the reindexing of sequences
+    is based on linear indices. For other steps,
+    UnlinkedStructure should be used.
+
+    IMPORTANT: even when the cache is inherited, elements_properties are not automatically preserved.
+    The new expression will have ``elements_properties=None``, and must be reconstructed on demand,
+    at evaluation time. This behavior can be improved.
+
     """
 
     def __init__(self, head, cache):

--- a/mathics/core/subexpression.py
+++ b/mathics/core/subexpression.py
@@ -172,22 +172,34 @@ class ExpressionPointer:
         # At this point, we hit the expression, and we have
         # the path to reach the position
         i = pos.pop()
+        # Variables to track the parent and the position of that parent.
+        current = parent
+        current_parent = None
+        current_index = None
+
         try:
             while pos:
+                current_parent = current
+                current_index = i
                 if i == 0:
-                    parent = parent._head
+                    current = current._head
                 else:
-                    parent = parent.elements[i - 1]
+                    current = current.elements[i - 1]
                 i = pos.pop()
-        except Exception:
+        except IndexError:
             raise MessageException("Part", "span", pos)
 
-        # Now, we have a pointer to an element in a true `Expression`.
-        # Now, set it to the new value.
+        # Now, current is the subexpression to be modified, and current_parent
+        # is the expression that holds it (if exists).
         if i == 0:
-            parent.set_head(new)
+            current.set_head(new)
         else:
-            parent.set_element(i - 1, new)
+            current.set_element(i - 1, new)
+
+        # If the modified subexpression is not the root,
+        # invalidate the parent cache.
+        if current_parent is not None:
+            current_parent._cache = None
 
 
 class SubExpression:


### PR DESCRIPTION
* Improve the documentation of ``ExpressionCache`` and ``Structure`` classes. 
* Improve `ExpressionPointer.replace()` to notify parent expressions that the cache and ExpressionProperties got invalidated.