### PR TITLE
ClearAll was setting an empty list instead of an empty dict in defintions.options. 

### DIFF
--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -165,7 +165,7 @@ class ClearAll(Clear):
         super(ClearAll, self).do_clear(definition)
         definition.attributes = A_NO_ATTRIBUTES
         definition.messages = []
-        definition.options = []
+        definition.options = {}
         definition.defaultvalues = []
 
 

--- a/test/builtin/assignments/test_assignment.py
+++ b/test/builtin/assignments/test_assignment.py
@@ -742,6 +742,13 @@ def test_assignment(expr, expect, fail_msg, expected_msgs):
             [],
         ),
         (
+            "ClearAll[F]; F[x_, opt:OptionsPattern[]]:=x^2;F[2]",
+            "4",
+            "ensure that Definition.options is a dict",
+            False,
+            [],
+        ),
+        (
             "ClearAll[F, Q];F[Verbatim[_Q],Verbatim[_]]^:=1;{DownValues[F],UpValues[Q]}",
             "{{}, {}}",
             "Issue 1198 - Blanks are not tags.",


### PR DESCRIPTION
Mypy didn't detect it. This produced a crash if we apply ClearAll[] to a symbol, and  then we try to evaluate an expression. For example
```
ClearAll[F]; 
F[x_, opt:OptionsPattern[]]:=x^2;
F[32]
```
without this fix, produces an exception:
```

  File "/home/mauricio/Projects/mathics-core/mathics/core/pattern.py", line 1151, in yield_wrapping
    parms["element"].match(
    ~~~~~~~~~~~~~~~~~~~~~~^
        item,
        ^^^^^
    ...<8 lines>...
        },
        ^^
    )
    ^
  File "/home/mauricio/Projects/mathics-core/mathics/builtin/patterns/composite.py", line 342, in match
    for name, value in values.items():
                       ^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'items'

```