### PR TITLE
Move the `get_float_value()` method from the `BaseElement` class and move it to the `Number` and `Numeric` classes.

### DIFF
--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -369,10 +369,12 @@ class Power(InfixOperator, MPMathFunction):
     # Remember to up sympy doc link when this is corrected
     sympy_name = "Pow"
 
-    def eval_check(self, x, y, evaluation: Evaluation):
-        "Power[x_, y_]"
-        # FIXME remove self
-        return eval_Power(self, x, y, evaluation)
+    # Note: don't use the name "eval()"; that would hide inherited
+    # MPMathFunction.eval which may be needed.
+    def eval_base_exponent(self, base, exponent, evaluation: Evaluation):
+        "Power[base_, exponent_]"
+        # self.eval is MPMathFunction.eval.
+        return eval_Power(base, exponent, self.eval, evaluation)
 
 
 class Sqrt(SympyFunction):

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -366,11 +366,11 @@ class Power(InfixOperator, MPMathFunction):
     summary_text = "exponentiate a number"
 
     # FIXME Note this is deprecated in 1.11
-    # Remember to up sympy doc link when this is corrected
+    # Remember to update the sympy doc link when this is corrected
     sympy_name = "Pow"
 
     # Note: don't use the name "eval()"; that would hide inherited
-    # MPMathFunction.eval which may be needed.
+    # MPMathFunction.eval, which may be needed.
     def eval_base_exponent(self, base, exponent, evaluation: Evaluation):
         "Power[base_, exponent_]"
         # self.eval is MPMathFunction.eval.

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -7,15 +7,9 @@ on a calculator.
 
 """
 
-from mathics.core.atoms import (
-    Complex,
-    Integer,
-    Integer1,
-    Integer3,
-    IntegerM1,
-    Number,
-    RationalOneHalf,
-)
+from typing import Any
+
+from mathics.core.atoms import Integer, Integer1, Integer3, RationalOneHalf
 from mathics.core.attributes import (
     A_FLAT,
     A_LISTABLE,
@@ -34,16 +28,9 @@ from mathics.core.builtin import (
 )
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
-from mathics.core.symbols import Symbol, SymbolNull, SymbolPower, SymbolTimes
-from mathics.core.systemsymbols import (
-    SymbolBlank,
-    SymbolComplexInfinity,
-    SymbolIndeterminate,
-    SymbolPattern,
-    SymbolSequence,
-)
-from mathics.eval.arithfns.basic import eval_Plus, eval_Times
-from mathics.eval.nevaluator import eval_N
+from mathics.core.symbols import Symbol, SymbolPower
+from mathics.core.systemsymbols import SymbolBlank, SymbolPattern
+from mathics.eval.arithfns.basic import eval_Plus, eval_Power, eval_Times
 from mathics.eval.numerify import numerify
 from mathics.format.form_rule.arithfns import format_plus, format_times
 
@@ -344,7 +331,7 @@ class Power(InfixOperator, MPMathFunction):
         2: "1",
     }
 
-    formats = {
+    formats: dict[str | Any, Any] = {
         Expression(
             SymbolPower,
             Expression(SymbolPattern, Symbol("x"), Expression(SymbolBlank)),
@@ -373,6 +360,7 @@ class Power(InfixOperator, MPMathFunction):
     rules = {
         "Power[]": "1",
         "Power[x_]": "x",
+        "Power[x_, y_, z_]": "Power[Power[x, y], z]",
     }
 
     summary_text = "exponentiate a number"
@@ -383,37 +371,8 @@ class Power(InfixOperator, MPMathFunction):
 
     def eval_check(self, x, y, evaluation: Evaluation):
         "Power[x_, y_]"
-
-        # Power uses MPMathFunction but does some error checking first
-        if isinstance(x, Number) and x.is_zero:
-            if isinstance(y, Number):
-                y_err = y
-            else:
-                y_err = eval_N(y, evaluation)
-            if isinstance(y_err, Number):
-                py_y = y_err.round_to_float(permit_complex=True).real
-                if py_y > 0:
-                    return x
-                elif py_y == 0.0:
-                    evaluation.message(
-                        "Power", "indet", Expression(SymbolPower, x, y_err)
-                    )
-                    return SymbolIndeterminate
-                elif py_y < 0:
-                    evaluation.message(
-                        "Power", "infy", Expression(SymbolPower, x, y_err)
-                    )
-                    return SymbolComplexInfinity
-        if isinstance(x, Complex) and x.real.is_zero:
-            yhalf = Expression(SymbolTimes, y, RationalOneHalf)
-            factor = self.eval(Expression(SymbolSequence, x.imag, y), evaluation)
-            return Expression(
-                SymbolTimes, factor, Expression(SymbolPower, IntegerM1, yhalf)
-            )
-
-        result = self.eval(Expression(SymbolSequence, x, y), evaluation)
-        if result is None or result is not SymbolNull:
-            return result
+        # FIXME remove self
+        return eval_Power(self, x, y, evaluation)
 
 
 class Sqrt(SympyFunction):

--- a/mathics/builtin/arithfns/basic.py
+++ b/mathics/builtin/arithfns/basic.py
@@ -227,7 +227,7 @@ class Plus(InfixOperator, SympyFunction):
     >> a + b + 4.5 + a + b + a + 2 + 1.5 b
      = 6.5 + 3 a + 3.5 b
 
-    Apply 'Plus' on a list to sum up its elements:
+    Apply 'Plus' to a list to sum up its elements:
     >> Plus @@ {2, 4, 6}
      = 12
     The sum of the first 1000 integers:
@@ -263,7 +263,7 @@ class Plus(InfixOperator, SympyFunction):
     summary_text = "add a number"
 
     # FIXME Note this is deprecated in 1.11
-    # Remember to up sympy doc link when this is corrected
+    # Remember to update the sympy doc link when this is corrected
     sympy_name = "Add"
 
     def eval(self, elements, evaluation: Evaluation):
@@ -524,7 +524,7 @@ class Times(InfixOperator, SympyFunction):
     rules = {}
 
     # FIXME Note this is deprecated in 1.11
-    # Remember to up sympy doc link when this is corrected
+    # Remember to update the sympy doc link when this is corrected
     sympy_name = "Mul"
 
     summary_text = "multiply numbers"

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -161,12 +161,12 @@ class Chop(Builtin):
     def eval(self, expr, delta, evaluation: Evaluation):
         "Chop[expr_, delta_:(10^-10)]"
 
-        delta = delta.round_to_float(evaluation)
-        if delta is None or delta < 0:
+        rounded_delta = delta.round_to_float(evaluation)
+        if rounded_delta is None or rounded_delta < 0:
             evaluation.message("Chop", "tolnn")
             return
 
-        return chop(expr, delta=delta)
+        return chop(expr, delta=rounded_delta)
 
 
 class N(Builtin):

--- a/mathics/builtin/numeric.py
+++ b/mathics/builtin/numeric.py
@@ -2,7 +2,7 @@
 
 # Note: docstring is flowed in documentation. Line breaks in the
 # docstring will appear in the printed output, so be careful not to
-# add them mid-sentence. Line breaks like \ this work though.
+# add them mid-sentence. Line breaks like \ this work, though.
 
 """
 Numerical Functions
@@ -132,7 +132,7 @@ class Chop(Builtin):
 
     <dl>
       <dt>'Chop'[$expr$]
-      <dd>replaces floating point numbers close to 0 by 0.
+      <dd>replaces floating-point numbers close to 0 with 0.
 
       <dt>'Chop'[$expr$, $delta$]
       <dd>uses a tolerance of $delta$. The default tolerance is '10^-10'.
@@ -256,8 +256,8 @@ class N(Builtin):
     >> % // Precision
      = 20.
 
-    N can also accept an option "Method". This establishes what is the \
-    prefrered underlying method to compute numerical values:
+    N can also accept an option "Method". This establishes the \
+    preferred underlying method to compute numerical values:
     >> N[F[Pi], 30, Method->"numpy"]
      = F[3.14159265358979300000000000000]
     >> N[F[Pi], 30, Method->"sympy"]
@@ -288,7 +288,7 @@ class N(Builtin):
 
         # If options are passed, set the preference in evaluation, and call again
         # without options set.
-        # This also prevents to store this as an nvalue (nvalues always have two elements).
+        # This also prevents storing this as an nvalue (nvalues always have two elements).
         preference = None
         # If a Method is passed, and the method is not either "Automatic" or
         # the last preferred method, according to evaluation._preferred_n_method,
@@ -348,7 +348,7 @@ class Piecewise(SympyFunction):
     >> Integrate[Piecewise[{{1, x <= 0}, {-1, x > 0}}], {x, -1, 2}]
      = -1
 
-    Piecewise defaults to 0 if no other case is matching.
+    Piecewise defaults to 0 if no other case matches.
     >> Piecewise[{{1, False}}]
      = 0
 
@@ -815,7 +815,7 @@ class UnitStep(Builtin):
       <dt>'UnitStep'[$x$]
       <dd>return 0 if $x$ < 0, and 1 if $x$ >= 0.
       <dt>'UnitStep'[$x_1$, $x_2$, ...]
-      <dd>return the multidimensional unit step function which is 1 only if none of the $xi$ are negative.
+      <dd>return the multidimensional unit step function, which is 1 only if none of the $xi$ are negative.
     </dl>
 
     Evaluation numerically:

--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -93,14 +93,6 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         )
 
     @property
-    def pattern_precedence(self) -> tuple:
-        """
-        Return a precedence value, a tuple, which is used in selecting
-        which pattern to select when several match.
-        """
-        return super().pattern_precedence
-
-    @property
     def is_literal(self) -> bool:
         """Number can't change and has a Python representation,
         i.e., a value is set and it does not depend on definition
@@ -111,6 +103,28 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
     def is_numeric(self, evaluation=None) -> bool:
         # Anything that is in a number class is Numeric, so return True.
         return True
+
+    @property
+    def pattern_precedence(self) -> tuple:
+        """
+        Return a precedence value, a tuple, which is used in selecting
+        which pattern to select when several match.
+        """
+        return super().pattern_precedence
+
+    def round(self, d: Optional[int] = None) -> "Number":
+        """
+        Produce a Real approximation of ``self`` with decimal precision ``d``.
+        """
+        return self
+
+    def round_to_float(
+        self, evaluation=None, permit_complex: bool = True
+    ) -> float | None:
+        try:
+            return float(self._value)
+        except Exception:
+            return None
 
     def to_mpmath(self, precision: Optional[int] = None) -> mpmath.mpf:
         """
@@ -136,12 +150,6 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         https://github.com/Mathics3/mathics-core/pull/551
         """
         return self.value
-
-    def round(self, d: Optional[int] = None) -> "Number":
-        """
-        Produce a Real approximation of ``self`` with decimal precision ``d``.
-        """
-        return self
 
     @property
     def value(self) -> T:
@@ -300,9 +308,6 @@ class Integer(Number[int]):
 
     def get_int_value(self) -> int:
         return self._value
-
-    def get_float_value(self, permit_complex=False) -> float:
-        return float(self._value)
 
     @property
     def is_zero(self) -> bool:
@@ -871,6 +876,7 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
         # = {1+2I, 1.+2.I, 1.`2+2.`7 I, 1.`4+2.`5I}
         return order_real + order_imag
 
+    # FIXME: remove permit_complex and adjust callers.
     def get_float_value(self, permit_complex=False) -> Optional[Union[complex, float]]:
         if self.imag == 0:
             return self.real.get_float_value()

--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -2,7 +2,7 @@
 Numeric types: Number, Integer Real, MachineReal, PrecisionReal, Complex, Rational
 """
 
-# Note: Python warns of ambiguity numpy's module numpy.numerics if we name this file this numeric.py
+# Note: Python warns of ambiguity with NumPy's module numpy.numerics if we name this file numeric.py
 
 import math
 import re
@@ -64,7 +64,7 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         called with the right value.
 
         Most of the time a number takes one argument - its value
-        When there is a kind of number, like Rational, or Complex,
+        When there is a kind of number, like Rational or Complex,
         that has more than one argument, it should define this method
         accordingly.
         """
@@ -103,7 +103,7 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
     @property
     def is_literal(self) -> bool:
         """Number can't change and has a Python representation,
-        i.e., a value is set and it does not depend on definition
+        i.e., a value is set, and it does not depend on definition
         bindings. So we say it is a literal.
         """
         return True
@@ -140,7 +140,7 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
         If ``precision`` is None, use mpmath's default precision.
 
         A mpmath number is the default implementation for Number.
-        There are kinds of numbers, like Rational, or Complex, that
+        There are kinds of numbers, like Rational or Complex, that
         need to work differently than this default, and they will
         change the implementation accordingly.
         """
@@ -328,7 +328,7 @@ class Integer(Number[int]):
         decimal precision ``d``.
 
         If ``d`` is ``None`` we force the mantissa to fit the entire
-        integer value, provided it is less than magical number
+        integer value, provided it is less than the magical number
         1024. 1024 is a common internal Mathematica implementation limit where
         it switches from using MachineReal to PrecisionReal.
 
@@ -341,7 +341,7 @@ class Integer(Number[int]):
         if d is None:
             d = self.value.bit_length()
             # Many WMA implementations seem to change behavior of the integer
-            # representation that have more than 1024 digits. In theory this is
+            # representation that has more than 1024 digits. In theory, this is
             # number can vary depending on hardware characteristics.
             # In practice, a reasonable
             if d <= 1024:
@@ -451,12 +451,12 @@ class Real(Number[T]):
 
 # This has to come before PrecisionReal, which uses MachineReal.
 # FIXME: rocky: float is not right. It should be Union[float, mpmath.mpf]
-# but I don't understand how to get the type annotation system to handle his.
+# but I don't understand how to get the type annotation system to handle this.
 class MachineReal(Real[float]):
     """
     Machine precision real number.
 
-    Stored internally as a Python float or a mpmath.mpf
+    Stored internally as a Python float or an mpmath.mpf
 
     Precision for these numbers is `MachinePrecision`.
     """

--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -92,6 +92,14 @@ class Number(Atom, ImmutableValueMixin, NumericOperators, Generic[T]):
             1,
         )
 
+    def get_float_value(
+        self, evaluation=None, permit_complex: bool = False
+    ) -> Optional[Union[complex, float]]:
+        try:
+            return float(self._value)
+        except Exception:
+            return None
+
     @property
     def is_literal(self) -> bool:
         """Number can't change and has a Python representation,
@@ -522,7 +530,7 @@ class MachineReal(Real[float]):
         """Returns the default specification for precision in N and other numerical functions."""
         return FP_MANTISA_BINARY_DIGITS
 
-    def get_float_value(self, permit_complex=False) -> float:
+    def get_float_value(self, evaluation=None, permit_complex=False) -> float:
         return self._value
 
     @property
@@ -676,8 +684,8 @@ class PrecisionReal(Real[sympy_Float]):
     def round(self, d: Optional[int] = None) -> Union[MachineReal, "PrecisionReal"]:
         if d is None:
             return MachineReal(float(self.value))
-        _prec = min(prec(d), self.value._prec)
-        return PrecisionReal(sympy_Float(self.value, precision=_prec))
+        min_prec = min(prec(d), self.value._prec)
+        return PrecisionReal(sympy_Float(self.value, precision=min_prec))
 
     def sameQ(self, rhs) -> bool:
         """Mathics3 SameQ for PrecisionReal"""
@@ -688,11 +696,12 @@ class PrecisionReal(Real[sympy_Float]):
         else:
             return False
         value = self.value
-        # If sympy would handle properly
-        # the precision, this wold be enough
-        if (value - other_value).is_zero:
+
+        # Keep math entirely inside SymPy to use its arbitrary precision.
+        diff = sympy.Add(value, -other_value)
+        if diff.simplify().is_zero:
             return True
-        # in the meantime, let's use this comparison.
+
         value = self.value
         prec = min(value._prec, other_value._prec)
         diff = abs(value - other_value)
@@ -877,7 +886,9 @@ class Complex(Number[Tuple[Number[T], Number[T], Optional[int]]]):
         return order_real + order_imag
 
     # FIXME: remove permit_complex and adjust callers.
-    def get_float_value(self, permit_complex=False) -> Optional[Union[complex, float]]:
+    def get_float_value(
+        self, evaluation=None, permit_complex=False
+    ) -> Optional[Union[complex, float]]:
         if self.imag == 0:
             return self.real.get_float_value()
         if permit_complex:
@@ -1025,7 +1036,7 @@ class Rational(Number[sympy.Rational]):
         else:
             return PrecisionReal(self.value.n(d))
 
-    def round_to_float(self, permit_complex: bool = True) -> float:
+    def round_to_float(self, evaluation=None, permit_complex: bool = True) -> float:
         return float(self.value)
 
     def sameQ(self, rhs) -> bool:

--- a/mathics/core/atoms/numerics.py
+++ b/mathics/core/atoms/numerics.py
@@ -998,6 +998,9 @@ class Rational(Number[sympy.Rational]):
 
         return format_element(self, evaluation, f)
 
+    def do_copy(self) -> "Rational":
+        return Rational(self.value)
+
     @property
     def is_zero(self) -> bool:
         return (
@@ -1015,6 +1018,9 @@ class Rational(Number[sympy.Rational]):
             return MachineReal(float(self.value))
         else:
             return PrecisionReal(self.value.n(d))
+
+    def round_to_float(self, permit_complex: bool = True) -> float:
+        return float(self.value)
 
     def sameQ(self, rhs) -> bool:
         """Mathics3 SameQ"""
@@ -1052,9 +1058,6 @@ class Rational(Number[sympy.Rational]):
         which pattern to select when several match.
         """
         return super().pattern_precedence
-
-    def do_copy(self) -> "Rational":
-        return Rational(self.value)
 
     def user_hash(self, update) -> None:
         update(

--- a/mathics/core/convert/mpmath.py
+++ b/mathics/core/convert/mpmath.py
@@ -7,14 +7,16 @@ import mpmath
 import sympy
 
 from mathics.core.atoms import Complex, MachineReal, MachineReal0, PrecisionReal
-from mathics.core.element import BaseElement
+from mathics.core.atoms.numerics import Number
 from mathics.core.expression_predefined import (
     MATHICS3_COMPLEX_INFINITY,
     MATHICS3_I_INFINITY,
     MATHICS3_I_NEG_INFINITY,
     MATHICS3_INFINITY,
     MATHICS3_NEG_INFINITY,
+    PredefinedExpression,
 )
+from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import SymbolIndeterminate
 
 
@@ -22,7 +24,7 @@ from mathics.core.systemsymbols import SymbolIndeterminate
 def from_mpmath(
     value: Union[mpmath.mpf, mpmath.mpc],
     precision: Optional[int] = None,
-) -> BaseElement:
+) -> Optional[Number] | Symbol | PredefinedExpression:
     """
     Converts mpf or mpc to Number.
     The optional parameter `precision` represents

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -195,12 +195,12 @@ class BaseElement(KeyComparable, ABC):
         """
         raise NotImplementedError
 
-    # FIXME: this behavior -- defining a specific default implementation
-    # that is basically saying: "it isn't implemented" -- is wrong.
-    # To remove this method, we need to fix up calls that expect this behavior,
-    # that I am not certain how to do right now. - rocky
-    def get_float_value(self, permit_complex=False) -> Optional[complex]:
-        return None
+    # # FIXME: this behavior -- defining a specific default implementation
+    # # that is basically saying: "it isn't implemented" -- is wrong.
+    # # To remove this method, we need to fix up calls that expect this behavior,
+    # # that I am not certain how to do right now. - rocky
+    # def get_float_value(self, permit_complex=False) -> Optional[complex]:
+    #     return None
 
     # FIXME: this behavior -- defining a specific default implementation
     # that is basically saying: "it isn't implemented" -- is wrong.

--- a/mathics/core/element.py
+++ b/mathics/core/element.py
@@ -195,13 +195,6 @@ class BaseElement(KeyComparable, ABC):
         """
         raise NotImplementedError
 
-    # # FIXME: this behavior -- defining a specific default implementation
-    # # that is basically saying: "it isn't implemented" -- is wrong.
-    # # To remove this method, we need to fix up calls that expect this behavior,
-    # # that I am not certain how to do right now. - rocky
-    # def get_float_value(self, permit_complex=False) -> Optional[complex]:
-    #     return None
-
     # FIXME: this behavior -- defining a specific default implementation
     # that is basically saying: "it isn't implemented" -- is wrong.
     # To remove this method, we need to fix up calls that expect this behavior,

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -1516,7 +1516,9 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         elif isinstance(evaluation, sympy.core.numbers.NaN):
             return None
         else:
-            value = self.create_expression(SymbolN, self).evaluate(evaluation)
+            from mathics.eval.nevaluator import eval_N
+
+            value = eval_N(self, evaluation)
         if hasattr(value, "round") and hasattr(value, "get_float_value"):
             value = value.round()
             return value.get_float_value(permit_complex=permit_complex)

--- a/mathics/core/expression.py
+++ b/mathics/core/expression.py
@@ -11,6 +11,7 @@ import sympy
 from mathics_scanner.location import SourceRange, SourceRange2
 
 from mathics.core.atoms import String
+from mathics.core.atoms.numerics import Number
 from mathics.core.attributes import (
     A_FLAT,
     A_HOLD_ALL,
@@ -1512,17 +1513,19 @@ class Expression(BaseElement, NumericOperators, EvalMixin):
         """
 
         if evaluation is None:
-            value = self
+            value: Optional[BaseElement] = self
         elif isinstance(evaluation, sympy.core.numbers.NaN):
             return None
         else:
             from mathics.eval.nevaluator import eval_N
 
             value = eval_N(self, evaluation)
-        if hasattr(value, "round") and hasattr(value, "get_float_value"):
-            value = value.round()
-            return value.get_float_value(permit_complex=permit_complex)
-        return None
+
+        if value is None or not isinstance(value, Number):
+            return None
+
+        rounded = value.round()
+        return rounded.get_float_value(permit_complex=permit_complex)
 
     def sameQ(self, other: BaseElement) -> bool:
         """Mathics3 SameQ"""

--- a/mathics/core/number.py
+++ b/mathics/core/number.py
@@ -15,6 +15,7 @@ from mathics.core.symbols import (
     SymbolMaxPrecision,
     SymbolMinPrecision,
 )
+from mathics.core.systemsymbols import SymbolDirectedInfinity
 
 LOG2_10 = mpmath.log(10.0, 2.0)  # ~ 3.3219280948873626
 
@@ -57,15 +58,15 @@ class SpecialValueError(Exception):
 
 
 def _get_float_inf(value, evaluation) -> Optional[float]:
-    value = value.evaluate(evaluation)
-    if value.has_form("DirectedInfinity", 1):
-        if value.elements[0].get_int_value() == 1:
+    evaled_value = value.evaluate(evaluation)
+    if evaled_value.has_form(SymbolDirectedInfinity, 1):
+        if evaled_value.elements[0].get_int_value() == 1:
             return float("inf")
-        elif value.elements[0].get_int_value() == -1:
+        elif evaled_value.elements[0].get_int_value() == -1:
             return float("-inf")
         else:
             return None
-    return value.round_to_float(evaluation)
+    return evaled_value.round_to_float(evaluation)
 
 
 def get_precision(

--- a/mathics/core/number.py
+++ b/mathics/core/number.py
@@ -58,15 +58,15 @@ class SpecialValueError(Exception):
 
 
 def _get_float_inf(value, evaluation) -> Optional[float]:
-    evaled_value = value.evaluate(evaluation)
-    if evaled_value.has_form(SymbolDirectedInfinity, 1):
-        if evaled_value.elements[0].get_int_value() == 1:
+    evaluated_value = value.evaluate(evaluation)
+    if evaluated_value.has_form(SymbolDirectedInfinity, 1):
+        if evaluated_value.elements[0].get_int_value() == 1:
             return float("inf")
-        elif evaled_value.elements[0].get_int_value() == -1:
+        elif evaluated_value.elements[0].get_int_value() == -1:
             return float("-inf")
         else:
             return None
-    return evaled_value.round_to_float(evaluation)
+    return evaluated_value.round_to_float(evaluation)
 
 
 def get_precision(
@@ -203,9 +203,9 @@ def convert_base(x, base, precision=10) -> str:
 
     if isinstance(x, (float, sympy.Float)):
         fexps = list(range(-1, -int(precision + 1), -1))
-        real_part = convert(x - int(x), base, fexps)
+        real_part = convert(sympy.Add(x, -int(x)), base, fexps)
 
-        return "%s.%s" % ("".join(int_part), "".join(real_part))
+        return f"{''.join(int_part)}.{''.join(real_part)}"
     elif isinstance(x, int):
         return "".join(int_part)
     else:

--- a/mathics/eval/arithfns/basic.py
+++ b/mathics/eval/arithfns/basic.py
@@ -7,12 +7,13 @@ Many of these depend on the evaluation context. Conversions to SymPy are
 used just as a last resource.
 """
 
-from typing import Optional
+from typing import Optional, cast
 
 import mpmath
 import sympy
 
 from mathics.core.atoms import (
+    Complex,
     Integer,
     Integer0,
     Integer1,
@@ -20,23 +21,54 @@ from mathics.core.atoms import (
     IntegerM1,
     Number,
     Rational,
+    RationalOneHalf,
     Real,
 )
 from mathics.core.convert.mpmath import from_mpmath
 from mathics.core.convert.sympy import from_sympy
 from mathics.core.element import BaseElement, ElementsProperties
+from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
 from mathics.core.number import min_prec
-from mathics.core.symbols import SymbolPlus, SymbolPower, SymbolTimes
-from mathics.core.systemsymbols import SymbolIndeterminate
+from mathics.core.symbols import (
+    Symbol,
+    SymbolNull,
+    SymbolPlus,
+    SymbolPower,
+    SymbolTimes,
+)
+from mathics.core.systemsymbols import (
+    SymbolComplexInfinity,
+    SymbolIndeterminate,
+    SymbolSequence,
+)
 from mathics.eval.arithmetic import (
     eval_Power_number,
     segregate_numbers_from_sorted_list,
 )
+from mathics.eval.nevaluator import eval_N
 
-RationalMOneHalf = Rational(-1, 2)
 RealM0p5 = Real(-0.5)
 RealOne = Real(1.0)
+
+
+def classify_zero_power(exponent) -> Integer | Symbol:
+    """
+    Classifies the behavior of 0**exponent for a Complex exponent.
+    returns SymbolComplexInfinity, SymbolIndeterminate, or Integer0.
+    """
+    # Extract the real part of the exponent.
+    sympy_real_part = cast(sympy.Expr, sympy.re(exponent))
+
+    if sympy_real_part.is_zero:
+        # Oscillates cleanly on a unit circle radius of 1. Never settles.
+        return SymbolIndeterminate
+    elif sympy_real_part.is_negative:
+        # The real part forces the magnitude to explode to infinity as base -> 0.
+        return SymbolComplexInfinity
+    else:
+        # Real part > 0 forces the expression to cleanly collapse to 0.
+        return Integer0
 
 
 def eval_Plus(*items: BaseElement) -> BaseElement:
@@ -105,6 +137,51 @@ def eval_Plus(*items: BaseElement) -> BaseElement:
         *elements,
         elements_properties=ElementsProperties(False, False, True),
     )
+
+
+# FIXME: remove self
+def eval_Power(self, base, exponent, evaluation: Evaluation):
+    if isinstance(base, Number) and base.is_zero:
+        if isinstance(exponent, Number):
+            n_exponent = exponent
+        else:
+            n_exponent = eval_N(exponent, evaluation)
+        if isinstance(n_exponent, Number):
+            if (n_exponent_float := n_exponent.round_to_float()) is not None:
+                if n_exponent_float > 0.0:
+                    return base
+                elif n_exponent_float == 0.0 or isinstance(n_exponent, Complex):
+                    evaluation.message(
+                        "Power", "indet", Expression(SymbolPower, base, n_exponent)
+                    )
+                    return SymbolIndeterminate
+                elif n_exponent_float < 0.0:
+                    evaluation.message(
+                        "Power", "infy", Expression(SymbolPower, base, n_exponent)
+                    )
+                    return SymbolComplexInfinity
+            elif isinstance(n_exponent, Complex):
+                result = classify_zero_power(exponent.to_sympy())
+                expr = Expression(SymbolPower, Integer0, n_exponent)
+                if result is SymbolIndeterminate:
+                    evaluation.message("Power", "indet", expr)
+                    return result
+                elif result is SymbolComplexInfinity:
+                    evaluation.message("Power", "infy", expr)
+                    return result
+
+    if isinstance(base, Complex) and base.real.is_zero:
+        yhalf = Expression(SymbolTimes, exponent, RationalOneHalf)
+        factor = self.eval(Expression(SymbolSequence, base.imag, exponent), evaluation)
+        return Expression(
+            SymbolTimes, factor, Expression(SymbolPower, IntegerM1, yhalf)
+        )
+
+    result = self.eval(Expression(SymbolSequence, base, exponent), evaluation)
+    if result is SymbolIndeterminate:
+        evaluation.message("Power", "indet", Expression(SymbolPower, base, exponent))
+    if result is None or result is not SymbolNull:
+        return result
 
 
 def eval_Times(*items: BaseElement) -> Optional[BaseElement]:

--- a/mathics/eval/arithfns/basic.py
+++ b/mathics/eval/arithfns/basic.py
@@ -7,7 +7,7 @@ Many of these depend on the evaluation context. Conversions to SymPy are
 used just as a last resource.
 """
 
-from typing import Optional, cast
+from typing import Callable, Optional, cast
 
 import mpmath
 import sympy
@@ -58,6 +58,7 @@ def classify_zero_power(exponent) -> Integer | Symbol:
     returns SymbolComplexInfinity, SymbolIndeterminate, or Integer0.
     """
     # Extract the real part of the exponent.
+    # For mysterious reasons, mypy will complain if we don't cast.
     sympy_real_part = cast(sympy.Expr, sympy.re(exponent))
 
     if sympy_real_part.is_zero:
@@ -139,8 +140,7 @@ def eval_Plus(*items: BaseElement) -> BaseElement:
     )
 
 
-# FIXME: remove self
-def eval_Power(self, base, exponent, evaluation: Evaluation):
+def eval_Power(base, exponent, power_fn_eval: Callable, evaluation: Evaluation):
     if isinstance(base, Number) and base.is_zero:
         if isinstance(exponent, Number):
             n_exponent = exponent
@@ -173,12 +173,14 @@ def eval_Power(self, base, exponent, evaluation: Evaluation):
 
     if isinstance(base, Complex) and base.real.is_zero:
         yhalf = Expression(SymbolTimes, exponent, RationalOneHalf)
-        factor = self.eval(Expression(SymbolSequence, base.imag, exponent), evaluation)
+        factor = power_fn_eval(
+            Expression(SymbolSequence, base.imag, exponent), evaluation
+        )
         return Expression(
             SymbolTimes, factor, Expression(SymbolPower, IntegerM1, yhalf)
         )
 
-    result = self.eval(Expression(SymbolSequence, base, exponent), evaluation)
+    result = power_fn_eval(Expression(SymbolSequence, base, exponent), evaluation)
     if result is SymbolIndeterminate:
         evaluation.message("Power", "indet", Expression(SymbolPower, base, exponent))
     if result is None or result is not SymbolNull:

--- a/mathics/eval/arithfns/basic.py
+++ b/mathics/eval/arithfns/basic.py
@@ -165,10 +165,11 @@ def eval_Power(self, base, exponent, evaluation: Evaluation):
                 expr = Expression(SymbolPower, Integer0, n_exponent)
                 if result is SymbolIndeterminate:
                     evaluation.message("Power", "indet", expr)
-                    return result
                 elif result is SymbolComplexInfinity:
                     evaluation.message("Power", "infy", expr)
-                    return result
+                elif result is Integer0:
+                    pass
+                return result
 
     if isinstance(base, Complex) and base.real.is_zero:
         yhalf = Expression(SymbolTimes, exponent, RationalOneHalf)

--- a/mathics/eval/arithfns/basic.py
+++ b/mathics/eval/arithfns/basic.py
@@ -55,7 +55,7 @@ RealOne = Real(1.0)
 def classify_zero_power(exponent) -> Integer | Symbol:
     """
     Classifies the behavior of 0**exponent for a Complex exponent.
-    returns SymbolComplexInfinity, SymbolIndeterminate, or Integer0.
+    Returns SymbolComplexInfinity, SymbolIndeterminate, or Integer0.
     """
     # Extract the real part of the exponent.
     # For mysterious reasons, mypy will complain if we don't cast.
@@ -80,7 +80,7 @@ def eval_Plus(*items: BaseElement) -> BaseElement:
     number = eval_add_numbers(*numbers) if numbers else Integer0
 
     # This reduces common factors
-    # TODO: Check if it possible to avoid the conversions back and forward to sympy.
+    # TODO: Check if it is possible to avoid the conversions back and forth to sympy.
     def append_last():
         if last_item is not None:
             if last_count == 1:
@@ -122,7 +122,7 @@ def eval_Plus(*items: BaseElement) -> BaseElement:
             last_count = count
     append_last()
 
-    # now elements contains the symbolic terms which can not be simplified.
+    # "elements" now contains the symbolic terms that can not be simplified.
     # by collecting common symbolic factors.
     if not elements:
         return number

--- a/mathics/eval/nevaluator.py
+++ b/mathics/eval/nevaluator.py
@@ -90,9 +90,9 @@ def eval_NValues(
         return
 
     # If the expression is a number, just round it to the required
-    # precision
+    # precision.
     if isinstance(expr, Number):
-        return expr.round(d)
+        return expr.round() if d is None else expr.round(int(d))
 
     # Special case for the Root builtin
     # This should be implemented as an NValue

--- a/mathics/eval/nevaluator.py
+++ b/mathics/eval/nevaluator.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 """
-This module contains basic low-level functions that combines an Expression
-with an Evaluation objects to produce a new Expression following generic
+This module contains basic low-level functions that combine an Expression
+with an Evaluation object to produce a new Expression following generic
 algorithms.
 
 
@@ -53,7 +53,7 @@ def eval_NValues(
     """
     Looks for the numeric value of ```expr`` with precision ``prec`` by applying NValues rules
     stored in ``evaluation.definitions``.
-    If ``prec`` can not be evaluated as a number, returns None, otherwise, returns an expression.
+    If ``prec`` can not be evaluated as a number, returns None; otherwise, returns an expression.
     """
     from mathics.core.convert.sympy import from_sympy
 
@@ -82,10 +82,10 @@ def eval_NValues(
     # Get the precision goal to use in non-integer numbers
     try:
         # Here ``get_precision`` is called with ``show_messages``
-        # set to ``False`` to avoid show the same warnings repeatedly.
+        # set to ``False`` to avoid showing the same warnings repeatedly.
         d = get_precision(prec, evaluation, show_messages=False)
     except PrecisionValueError:
-        # We can ensure that the function always return an expression if
+        # We can ensure that the function always returns an expression if
         # the exception was captured by the caller.
         return
 
@@ -120,8 +120,8 @@ def eval_NValues(
                 result = eval_NValues(result, prec, evaluation)
                 return result
 
-    # If we are here, is because there are not NValues that matches
-    # to the expression. In such a case, if we arrive to an atomic expression,
+    # If we are here, it is because there are no NValues that match
+    # the expression. Here, if we arrive at an atomic expression,
     # just return it.
     if isinstance(expr, Atom):
         return expr
@@ -159,7 +159,7 @@ def eval_NValues(
         return result
 
 
-# TODO:  Revisit - can this be simplified? Is some broader framework this fits into?
+# TODO:  Revisit - can this be simplified? Is there some broader framework this fits into?
 
 
 # comment mmatera: Other methods that I would like to have here, as non-member methods are

--- a/test/builtin/arithfns/test_basic.py
+++ b/test/builtin/arithfns/test_basic.py
@@ -2,6 +2,7 @@
 """
 Unit tests for mathics.builtins.arithmetic.basic
 """
+
 from test.helper import check_evaluation, check_wrong_number_of_arguments
 
 import pytest
@@ -19,7 +20,7 @@ import pytest
         (
             "a + 2 a + 3 a q",
             "3 a + 3 a q",
-            "WMA do not collect the common factor `a` in the last expression neither",
+            "WMA do not collect the common factor `a` in the last expression",
         ),
         ("a - 2 a + 3 a q", "-a + 3 a q", None),
         (
@@ -30,7 +31,7 @@ import pytest
         (
             "a - 2 (5+ a+ 2 b) + 3 a q",
             "a + 3 a q - 2 (5 + a + 2 b)",
-            "WMA do not distribute neither in the general case",
+            "WMA does not distribute in the general case",
         ),
     ],
 )
@@ -188,106 +189,112 @@ def test_directed_infinity_precedence(str_expr, str_expected, msg):
 
 
 @pytest.mark.parametrize(
-    ("str_expr", "str_expected", "expected_message", "fail_msg"),
+    ("str_expr", "str_expected", "assert_msg"),
     [
-        ("2^0", "1", None, None),
-        ("(2/3)^0", "1", None, None),
-        ("2.^0", "1.", None, None),
-        ("2^1", "2", None, None),
-        ("(2/3)^1", "2 / 3", None, None),
-        ("2.^1", "2.", None, None),
-        ("2^(3)", "8", None, None),
-        ("(1/2)^3", "1 / 8", None, None),
-        ("2^(-3)", "1 / 8", None, None),
-        ("(1/2)^(-3)", "8", None, None),
-        ("(-7)^(5/3)", "-7 (-7) ^ (2 / 3)", None, None),
-        ("3^(1/2)", "Sqrt[3]", None, None),
+        ("2^0", "1", None),
+        ("2^3^0", "2", "Power to the Power is right associative"),
+        ("2^3^0^4", "2", "Power to the Power to the Power is right associative"),
+        ("(2/3)^0", "1", None),
+        ("2.^0", "1.", None),
+        ("2^1", "2", None),
+        ("(2/3)^1", "2 / 3", None),
+        ("2.^1", "2.", None),
+        ("2^(3)", "8", None),
+        ("(1/2)^3", "1 / 8", None),
+        ("2^(-3)", "1 / 8", None),
+        ("(1/2)^(-3)", "8", None),
+        ("(-7)^(5/3)", "-7 (-7) ^ (2 / 3)", None),
+        ("3^(1/2)", "Sqrt[3]", None),
         # WMA do not rationalize numbers
-        ("(1/5)^(1/2)", "Sqrt[5] / 5", None, None),
+        ("(1/5)^(1/2)", "Sqrt[5] / 5", None),
         # WMA do not rationalize numbers
-        ("(3)^(-1/2)", "Sqrt[3] / 3", None, None),
-        ("(1/3)^(-1/2)", "Sqrt[3]", None, None),
-        ("(5/3)^(1/2)", "Sqrt[5 / 3]", None, None),
-        ("(5/3)^(-1/2)", "Sqrt[3 / 5]", None, None),
-        ("1/Sqrt[Pi]", "1 / Sqrt[Pi]", None, None),
-        ("I^(2/3)", "(-1) ^ (1 / 3)", None, None),
+        ("(3)^(-1/2)", "Sqrt[3] / 3", None),
+        ("(1/3)^(-1/2)", "Sqrt[3]", None),
+        ("(5/3)^(1/2)", "Sqrt[5 / 3]", None),
+        ("(5/3)^(-1/2)", "Sqrt[3 / 5]", None),
+        ("1/Sqrt[Pi]", "1 / Sqrt[Pi]", None),
+        ("I^(2/3)", "(-1) ^ (1 / 3)", None),
         # In WMA, the next test would return ``-(-I)^(2/3)``
         # which is less compact and elegant...
         #        ("(-I)^(2/3)", "(-1) ^ (-1 / 3)", None),
-        ("(2+3I)^3", "-46 + 9 I", None, None),
-        ("(1.+3. I)^.6", "1.46069 + 1.35921 I", None, None),
-        ("3^(1+2 I)", "3 ^ (1 + 2 I)", None, None),
-        ("3.^(1+2 I)", "-1.75876 + 2.43038 I", None, None),
-        ("3^(1.+2 I)", "-1.75876 + 2.43038 I", None, None),
+        ("(2+3I)^3", "-46 + 9 I", None),
+        ("(1.+3. I)^.6", "1.46069 + 1.35921 I", None),
+        ("3^(1+2 I)", "3 ^ (1 + 2 I)", None),
+        ("3.^(1+2 I)", "-1.75876 + 2.43038 I", None),
+        ("3^(1.+2 I)", "-1.75876 + 2.43038 I", None),
         # In WMA, the following expression returns
         # ``(Pi/3)^I``. By now, this is handled by
         # sympy, which produces the result
-        ("(3/Pi)^(-I)", "(3 / Pi) ^ (-I)", None, None),
+        ("(3/Pi)^(-I)", "(3 / Pi) ^ (-I)", None),
         # Association rules
         #        ('(a^"w")^2', 'a^(2 "w")', "Integer power of a power with string exponent"),
-        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None, None),
-        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None, None),
-        ("(a^2)^(1/2)", "Sqrt[a ^ 2]", None, None),
-        ("(a^(1/2))^2", "a", None, None),
-        ("(a^(1/2))^2", "a", None, None),
-        ("(a^(3/2))^3.", "(a ^ (3 / 2)) ^ 3.", None, None),
+        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None),
+        ('(a^2)^"w"', '(a ^ 2) ^ "w"', None),
+        ("(a^2)^(1/2)", "Sqrt[a ^ 2]", None),
+        ("(a^(1/2))^2", "a", None),
+        ("(a^(1/2))^2", "a", None),
+        ("(a^(3/2))^3.", "(a ^ (3 / 2)) ^ 3.", None),
         #        ("(a^(1/2))^3.", "a ^ 1.5", "Power associativity rational, real"),
         #        ("(a^(.3))^3.", "a ^ 0.9", "Power associativity for real powers"),
-        ("(a^(1.3))^3.", "(a ^ 1.3) ^ 3.", None, None),
+        ("(a^(1.3))^3.", "(a ^ 1.3) ^ 3.", None),
         # Exponentials involving expressions
-        ("(a^(p-2 q))^3", "a ^ (3 p - 6 q)", None, None),
-        ("(a^(p-2 q))^3.", "(a ^ (p - 2 q)) ^ 3.", None, None),
-        # Indefinite / ComplexInfinity / Complex powers
-        ("1/0", "ComplexInfinity", "Infinite expression 1 / 0 encountered.", None),
+        ("(a^(p-2 q))^3", "a ^ (3 p - 6 q)", None),
+        ("(a^(p-2 q))^3.", "(a ^ (p - 2 q)) ^ 3.", None),
         (
             "0 ^ -2",
             "ComplexInfinity",
             "Infinite expression 1 / 0 ^ 2 encountered.",
-            None,
         ),
         (
             "0 ^ (-1/2)",
             "ComplexInfinity",
             "Infinite expression 1 / Sqrt[0] encountered.",
-            None,
         ),
         (
             "0 ^ -Pi",
             "ComplexInfinity",
             "Infinite expression 1 / 0 ^ 3.14159 encountered.",
-            None,
         ),
-        (
-            "0 ^ (2 I E)",
-            "Indeterminate",
-            "Indeterminate expression 0 ^ (0. + 5.43656 I) encountered.",
-            None,
-        ),
-        (
-            "0 ^ - (Pi + 2 E I)",
-            "ComplexInfinity",
-            "Infinite expression 0 ^ (-3.14159 - 5.43656 I) encountered.",
-            None,
-        ),
-        ("0 ^ 0", "Indeterminate", "Indeterminate expression 0 ^ 0 encountered.", None),
-        ("Sqrt[-3+2. I]", "0.550251 + 1.81735 I", None, None),
-        ("(3/2+1/2I)^2", "2 + 3 I / 2", None, None),
-        ("I ^ I", "(-1) ^ (I / 2)", None, None),
-        ("2 ^ 2.0", "4.", None, None),
-        ("Pi ^ 4.", "97.4091", None, None),
-        ("a ^ b", "a ^ b", None, None),
+        ("Sqrt[-3+2. I]", "0.550251 + 1.81735 I", None),
+        ("(3/2+1/2I)^2", "2 + 3 I / 2", None),
+        ("I ^ I", "(-1) ^ (I / 2)", None),
+        ("2 ^ 2.0", "4.", None),
+        ("Pi ^ 4.", "97.4091", None),
+        ("a ^ b", "a ^ b", None),
     ],
 )
-def test_power(str_expr, str_expected, expected_message, fail_msg):
-    if expected_message is None:
-        check_evaluation(str_expr, str_expected, failure_message=fail_msg)
-    else:
-        check_evaluation(
-            str_expr,
-            str_expected,
-            failure_message=fail_msg,
-            expected_messages=[expected_message],
-        )
+def test_power(str_expr, str_expected, assert_msg):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        failure_message=assert_msg,
+    )
+
+
+@pytest.mark.parametrize(
+    ("str_expr", "str_expected", "expected_message"),
+    # Indefinite / ComplexInfinity / Complex powers
+    [
+        ("1/0", "ComplexInfinity", "Infinite expression 1 / 0 encountered."),
+        ("0 ^ 0", "Indeterminate", "Indeterminate expression 0 ^ 0 encountered."),
+        (
+            "0 ^ - (I E)",
+            "Indeterminate",
+            "Indeterminate expression 0 ^ (0. - 2.71828 I) encountered.",
+        ),
+        (
+            "0 ^ - (Pi + E I)",
+            "ComplexInfinity",
+            "Infinite expression 0 ^ (-3.14159 - 2.71828 I) encountered.",
+        ),
+    ],
+)
+def test_power_with_messages(str_expr, str_expected, expected_message):
+    check_evaluation(
+        str_expr,
+        str_expected,
+        expected_messages=(expected_message,),
+    )
 
 
 @pytest.mark.parametrize(
@@ -466,7 +473,7 @@ def test_cuberoot(str_expr, str_expected, msgs, failmsg):
 
 
 @pytest.mark.parametrize(
-    ("str_expr", "msgs", "str_expected", "fail_msg"),
+    ("str_expr", "msgs", "str_expected", "assert_msg"),
     [
         ## Issue #302
         ## The sum should not converge since the first term is 1/0.
@@ -484,7 +491,7 @@ def test_cuberoot(str_expr, str_expected, msgs, failmsg):
         ),
     ],
 )
-def test_arithmetic(str_expr, msgs, str_expected, fail_msg):
+def test_arithmetic(str_expr, msgs, str_expected, assert_msg):
     """ """
     check_evaluation(
         str_expr,
@@ -492,7 +499,7 @@ def test_arithmetic(str_expr, msgs, str_expected, fail_msg):
         to_string_expr=True,
         to_string_expected=True,
         hold_expected=True,
-        failure_message=fail_msg,
+        failure_message=assert_msg,
         expected_messages=msgs,
     )
 

--- a/test/builtin/arithfns/test_basic.py
+++ b/test/builtin/arithfns/test_basic.py
@@ -194,6 +194,7 @@ def test_directed_infinity_precedence(str_expr, str_expected, msg):
         ("2^0", "1", None),
         ("2^3^0", "2", "Power to the Power is right associative"),
         ("2^3^0^4", "2", "Power to the Power to the Power is right associative"),
+        ("0^(1 + I)", "0", "Zero raised to a complex with a positive real part"),
         ("(2/3)^0", "1", None),
         ("2.^0", "1.", None),
         ("2^1", "2", None),
@@ -214,8 +215,8 @@ def test_directed_infinity_precedence(str_expr, str_expected, msg):
         ("(5/3)^(-1/2)", "Sqrt[3 / 5]", None),
         ("1/Sqrt[Pi]", "1 / Sqrt[Pi]", None),
         ("I^(2/3)", "(-1) ^ (1 / 3)", None),
-        # In WMA, the next test would return ``-(-I)^(2/3)``
-        # which is less compact and elegant...
+        # In WMA, the next test gives ``-(-I)^(2/3)``
+        # which is less compact and elegant than Mathics3's 1
         #        ("(-I)^(2/3)", "(-1) ^ (-1 / 3)", None),
         ("(2+3I)^3", "-46 + 9 I", None),
         ("(1.+3. I)^.6", "1.46069 + 1.35921 I", None),


### PR DESCRIPTION
* Remove get_float_value from the `BaseElement` class and add it to the `Rational` class.
* Go over the `Power` built-in e.g., add `eval_Power()`, and handle the case when the base is zero more correctly. 
Use SymPy's zero detection instead of Python's float zero test for better accuracy.
Go over some comments, and make the code more stringent for `mypy`