### PR TITLE
Add mypy pre-commit hook and sync up benchmark.yml to v6

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14' # Just check against the current Python version.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
     rev: 0.31.0  # Use the latest version
     hooks:
       - id: check-github-workflows
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        args:
+          - --install-types
+          - --ignore-missing-imports
+          - --non-interactive


### PR DESCRIPTION
* `pre-commit-config.yml`: run `mypy` over Python code in the pre-commit hook.
* `workflows.benchmark.yml` : use v6 in checkout and Python setup like the other yml files.