### PR TITLE
add TagUnset buitlin

### DIFF
--- a/SYMBOLS_MANIFEST.txt
+++ b/SYMBOLS_MANIFEST.txt
@@ -1218,6 +1218,7 @@ System`SyntaxQ
 System`Table
 System`TableForm
 System`TagBox
+System`TagUnset
 System`TagSet
 System`TagSetDelayed
 System`Take

--- a/admin-tools/check_benchmarks.py
+++ b/admin-tools/check_benchmarks.py
@@ -20,7 +20,6 @@ Output:
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/admin-tools/normalize_benchmarks.py
+++ b/admin-tools/normalize_benchmarks.py
@@ -25,7 +25,9 @@ def normalize_benchmarks(target_file):
             break
 
     if ref_bench is None:
-        print(f"⚠️ Benchmark for the reference task '{REFERENCE_NAME} not found'. Exit.")
+        print(
+            f"⚠️ Benchmark for the reference task '{NORMALIZATION_TASK_KEY} not found'. Exit."
+        )
         sys.exit(1)
 
     # Extract the reference value

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -17,19 +17,13 @@ from mathics.core.attributes import (
 )
 from mathics.core.builtin import Builtin, PostfixOperator
 from mathics.core.expression import Expression
-from mathics.core.symbols import Atom, Symbol, SymbolNull, symbol_set
+from mathics.core.symbols import Atom, Symbol, SymbolNull
 from mathics.core.systemsymbols import (
     SYSTEM_SYMBOL_VALUES,
     SymbolContext,
     SymbolContextPath,
-    SymbolDownValues,
     SymbolFailed,
-    SymbolMessages,
-    SymbolNValues,
     SymbolOptions,
-    SymbolOwnValues,
-    SymbolSubValues,
-    SymbolUpValues,
 )
 
 
@@ -351,6 +345,6 @@ class TagUnset(PostfixOperator):
         if not tag_name:
             return SymbolNull
         if not evaluation.definitions.unset(tag_name, expr):
-            evaluation.message("TagUnset", "norep", expr, Symbol(name))
+            evaluation.message("TagUnset", "norep", expr, tag)
             return SymbolFailed
         return SymbolNull

--- a/mathics/builtin/assignments/clear.py
+++ b/mathics/builtin/assignments/clear.py
@@ -19,6 +19,7 @@ from mathics.core.builtin import Builtin, PostfixOperator
 from mathics.core.expression import Expression
 from mathics.core.symbols import Atom, Symbol, SymbolNull, symbol_set
 from mathics.core.systemsymbols import (
+    SYSTEM_SYMBOL_VALUES,
     SymbolContext,
     SymbolContextPath,
     SymbolDownValues,
@@ -285,12 +286,71 @@ class Unset(PostfixOperator):
         return SymbolNull
 
 
-SYSTEM_SYMBOL_VALUES = symbol_set(
-    SymbolDownValues,
-    SymbolMessages,
-    SymbolNValues,
-    SymbolOptions,
-    SymbolOwnValues,
-    SymbolSubValues,
-    SymbolUpValues,
-)
+class TagUnset(PostfixOperator):
+    """
+    <url>
+    :WMA link:
+    https://reference.wolfram.com/language/ref/TagUnset.html</url>
+
+    <dl>
+      <dt>'TagUnset'[$f$, $patt$]
+      <dt>'f/: $patt$=.'
+      <dd>removes any value belonging to the patter $patt$ from $f$.
+    </dl>
+
+
+
+    Let's consider we define an UpValue for a symbol g:
+    >> Sin[g[x_]]^:=Sing[x];
+    in a way that
+    >> Sin[g[3]]
+     = Sing[3]
+
+    TagUset allows to remove the rule:
+    >> g/: Sin[g[x_]]=.
+    >> Sin[g[3]]
+     = Sin[g[3]]
+    """
+
+    attributes = A_HOLD_ALL | A_PROTECTED
+
+    messages = {
+        "norep": "Assignment on `2` for `1` not found.",
+        "sym": "Argument `1` at position 1 is expected to be a symbol.",
+        "tag": "Rule for `1` of `2` can only be attached to `3`.",
+    }
+    summary_text = "unset a value of the LHS, associated to a symbol."
+
+    def eval_general(self, tag, expr, evaluation):
+        "TagUnset[tag_, expr_]"
+
+        if not isinstance(tag, Symbol):
+            evaluation.message("TagSet", "sym", tag)
+            return SymbolNull
+        tag_name = tag.get_name()
+        head = expr.get_head()
+        if head in SYSTEM_SYMBOL_VALUES:
+            if len(expr.elements) != 1:
+                evaluation.message_args(expr.get_head_name(), len(expr.elements), 1)
+                return SymbolFailed
+            target_symbol = expr.elements[0]
+            if not target_symbol.sameQ(tag):
+                evaluation.message("TagUnset", "tag", target_symbol, expr, tag)
+                return SymbolFailed
+            symbol = target_symbol.get_name()
+            if not symbol:
+                evaluation.message(expr.get_head_name(), "fnsym", expr)
+                return SymbolFailed
+            if head is SymbolOptions:
+                empty = {}
+            else:
+                empty = []
+            evaluation.definitions.set_values(symbol, expr.get_head_name(), empty)
+            return SymbolNull
+
+        if not tag_name:
+            return SymbolNull
+        if not evaluation.definitions.unset(tag_name, expr):
+            evaluation.message("TagUnset", "norep", expr, Symbol(name))
+            return SymbolFailed
+        return SymbolNull

--- a/mathics/core/systemsymbols.py
+++ b/mathics/core/systemsymbols.py
@@ -447,3 +447,14 @@ SYSTEM_SYMBOLS_PATTERNS = symbol_set(
     SymbolRepeated,
     SymbolRepeatedNull,
 )
+
+
+SYSTEM_SYMBOL_VALUES = symbol_set(
+    SymbolDownValues,
+    SymbolMessages,
+    SymbolNValues,
+    SymbolOptions,
+    SymbolOwnValues,
+    SymbolSubValues,
+    SymbolUpValues,
+)

--- a/mathics/eval/options/values.py
+++ b/mathics/eval/options/values.py
@@ -1,5 +1,5 @@
 from mathics.core.parser import parse_builtin_rule
-from mathics.core.symbols import SymbolList, strip_context
+from mathics.core.symbols import strip_context
 
 
 def filter_non_default_values(builtin):

--- a/test/builtin/assumptions/test_assumptions.py
+++ b/test/builtin/assumptions/test_assumptions.py
@@ -152,7 +152,7 @@ def test_assumptions_integrate(str_expr, str_expected, message):
     LIST_TEST_ASSUMPTIONS_INTEGRATE_FAILING,
 )
 @pytest.mark.xfail(reason="the Assumptions with Integrate is not fully working")
-def test_assumptions_integrate(str_expr, str_expected, message):
+def test_assumptions_integrate2(str_expr, str_expected, message):
     check_evaluation(str_expr, str_expected)
 
 

--- a/test/core/convert/test_sympy.py
+++ b/test/core/convert/test_sympy.py
@@ -39,16 +39,7 @@ Symbol_y = Symbol("Global`y")
 Symbol_F = Symbol("Global`F")
 Symbol_G = Symbol("Global`G")
 
-from mathics.core.expression import Expression
-from mathics.core.expression_predefined import MATHICS3_COMPLEX_INFINITY
-from mathics.core.symbols import (
-    Symbol,
-    SymbolNull,
-    SymbolPlus,
-    SymbolPower,
-    SymbolTimes,
-)
-from mathics.core.systemsymbols import SymbolE, SymbolExp, SymbolI, SymbolPi, SymbolSin
+from mathics.core.symbols import Symbol
 
 Symbol_a = Symbol("Global`a")
 Symbol_b = Symbol("Global`b")

--- a/test/timings/test_regressions.py
+++ b/test/timings/test_regressions.py
@@ -152,9 +152,6 @@ for category, tasks in REGRESSION_BENCHMARKS.items():
 param_ids = [name for name, _, _, _ in BENCHMARK_TASKS]
 
 
-import pytest
-
-
 @pytest.mark.skipif(
     not os.environ.get("BENCHMARKS", 0), reason="benchmarks not required"
 )


### PR DESCRIPTION
Looking over the MakeBoxes stuff, I realize that this basic built-in symbol is still missing. TagUnset allows surgically removing rules from UpValues.