### PR TITLE
Now `Repeated` and `RepeatedNull` can use regular format rules

### DIFF
--- a/mathics/builtin/patterns/composite.py
+++ b/mathics/builtin/patterns/composite.py
@@ -577,7 +577,7 @@ class Repeated(PostfixOperator, PatternObject):
             "expected at position `1` in `2`."
         )
     }
-
+    needs_verbatim = True
     summary_text = "match to one or more occurrences of a pattern"
 
     def init(

--- a/mathics/core/builtin.py
+++ b/mathics/core/builtin.py
@@ -1503,7 +1503,7 @@ class UnaryOperator(Operator):
 
         self.precedence = self.get_precedence(name)
         if self.needs_verbatim:
-            name = f"Verbatim[{name}"
+            name = f"Verbatim[{name}]"
         if self.default_formats:
             op_pattern = f"{name}[item_]"
             if op_pattern not in self.formats:

--- a/mathics/format/box/formatvalues.py
+++ b/mathics/format/box/formatvalues.py
@@ -13,7 +13,6 @@ from mathics.core.convert.expression import to_expression_with_specialization
 from mathics.core.element import BaseElement, EvalMixin
 from mathics.core.evaluation import Evaluation
 from mathics.core.expression import Expression
-from mathics.core.list import ListExpression
 from mathics.core.symbols import (
     Atom,
     Symbol,
@@ -22,12 +21,8 @@ from mathics.core.symbols import (
     SymbolGraphics,
     SymbolGraphics3D,
     SymbolHoldForm,
-    SymbolList,
     SymbolNumberForm,
     SymbolPlus,
-    SymbolPostfix,
-    SymbolRepeated,
-    SymbolRepeatedNull,
     SymbolTimes,
 )
 from mathics.core.systemsymbols import SymbolInputForm, SymbolMinus, SymbolOutputForm
@@ -94,35 +89,6 @@ def do_format_element(
             if include_form:
                 expr = Expression(form, expr)
             return expr
-
-        # Repeated and RepeatedNull confuse the formatter,
-        # so we need to hardlink their format rules:
-        if head is SymbolRepeated:
-            if len(elements) == 1:
-                return Expression(
-                    SymbolHoldForm,
-                    Expression(
-                        SymbolPostfix,
-                        ListExpression(elements[0]),
-                        StringRepeated,
-                        Integer(170),
-                    ),
-                )
-            else:
-                return Expression(SymbolHoldForm, expr)
-        elif head is SymbolRepeatedNull:
-            if len(elements) == 1:
-                return Expression(
-                    SymbolHoldForm,
-                    Expression(
-                        SymbolPostfix,
-                        Expression(SymbolList, elements[0]),
-                        StringElipsis,
-                        Integer(170),
-                    ),
-                )
-            else:
-                return Expression(SymbolHoldForm, expr)
 
         # If expr is not an atom, looks for formats in its definition
         # and apply them.


### PR DESCRIPTION
This PR provides a first payoff of the previous fixes #1938 and #1939: we can move the special cases of Repeated and RepeatedNull format rules that had to be handled in a hard-coded way to the regular format rules mechanism.
The issue with the infinite recursion in Condition seems to be related to the infinite recursion these patterns produced. 