### PR TITLE
Add tag "obsfun" error message. Align better "obspkg".

### DIFF
--- a/mathics/builtin/messages.py
+++ b/mathics/builtin/messages.py
@@ -201,9 +201,7 @@ class General(Builtin):
         "fnsym": (
             "First argument in `1` is not a symbol " "or a string naming a symbol."
         ),
-        "fstr": (
-            "File specification `1` is not a string of " "one or more characters."
-        ),
+        "fstr": ("File specification `1` is not a string of one or more characters."),
         "hdiv": "`1` does not exist. Arguments are not consistent.",
         "heads": "Heads `1` and `2` are expected to be the same.",
         "ilsnn": (
@@ -221,7 +219,7 @@ class General(Builtin):
         "invrl": "The argument `1` is not a valid Association or a list of rules.",
         "iterb": "Iterator does not have appropriate bounds.",
         "ivar": "`1` is not a valid variable.",
-        "level": ("Level specification `1` is not of the form n, " "{n}, or {m, n}."),
+        "level": "Level specification `1` is not of the form n, {n}, or {m, n}.",
         "list": "Expected a list or a rule with equally sized lists at position 1 in ``.",
         "locked": "Symbol `1` is locked.",
         "matsq": "Argument `1` is not a non-empty square matrix.",
@@ -234,8 +232,9 @@ class General(Builtin):
         "nord": "Invalid comparison with `1` attempted.",
         "normal": "Nonatomic expression expected at position `1` in `2`.",
         "notnorm": "Argument `1` must be a nonatomic expression.",
-        "noval": ("Symbol `1` in part assignment does not have an immediate value."),
-        "obspkg": "In WL, this package is obsolete.",
+        "noval": "Symbol `1` in part assignment does not have an immediate value.",
+        "obsfun": "The function `1` is now obsolete and has been superseded by `2`.",
+        "obspkg": "`1` is now obsolete. The legacy version being loaded may conflict with current functionality.",
         "openx": "`1` is not open.",
         "optb": "Optional object `1` in `2` is not a single blank.",
         "optnf": "Option name `1` is not a known option for `2`.",

--- a/test/builtin/test_messages.py
+++ b/test/builtin/test_messages.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests from mathics.builtin.messages.
+Unit tests for mathics.builtin.messages.
 """
 
 
-from test.helper import check_evaluation_as_in_cli
+from test.helper import check_evaluation
 
 import pytest
 
-print("\n***Rocky will address this soon.***")
 
-
-@pytest.mark.skip(reason="Rocky will address this soon")
 @pytest.mark.parametrize(
     ("str_expr", "msgs", "str_expected", "fail_msg"),
     [
@@ -79,6 +76,22 @@ print("\n***Rocky will address this soon.***")
             "Check[1 + 2, err, {a::b, 2 + 5}]",
             None,
         ),
+        (
+            "Message[General::obsfun, Calendar`DayOfWeek, System`DayName]",
+            (
+                "The function Calendar`DayOfWeek is now obsolete and has been superseded by DayName"
+            ),
+            None,
+            "Test the addition of obsfun",
+        ),
+        (
+            "Message[General::obspkg, Miscellaneous`Calendar]",
+            (
+                "Miscellaneous`Calendar is now obsolete. The legacy version being loaded may conflict with current functionality."
+            ),
+            None,
+            "Test the addition of obsfun",
+        ),
         ("Off[Power::infy];Check[1 / 0, err]", None, "ComplexInfinity", None),
         (
             "On[Power::infy];Check[1 / 0, err]",
@@ -139,4 +152,4 @@ print("\n***Rocky will address this soon.***")
 )
 def test_messages(str_expr, msgs, str_expected, fail_msg):
     """These tests check the behavior the module messages"""
-    check_evaluation_as_in_cli(str_expr, str_expected, fail_msg, msgs)
+    check_evaluation(str_expr, str_expected, fail_msg, msgs)


### PR DESCRIPTION
Add tag "obsfun" error message. Align " obspkg " better with WMA's message.

Also, reenable the `test_message` tests.