### PR TITLE
Revise variables and functions, part 3

### DIFF
--- a/mathics/builtin/assignments/assignment.py
+++ b/mathics/builtin/assignments/assignment.py
@@ -282,13 +282,19 @@ class TagSet(Builtin):
     ) -> Optional[BaseElement]:
         "f_ /: lhs_ = rhs_"
 
-        tag_name = f.get_name()
-        if not tag_name:
+        target_symbol_name = f.get_name()
+        if not target_symbol_name:
             evaluation.message(self.get_name(), "sym", f, 1)
             return None
 
         rhs = rhs.evaluate(evaluation)
-        eval_assign(self.get_name(), lhs, rhs, evaluation, tags=[tag_name])
+        eval_assign(
+            self.get_name(),
+            lhs,
+            rhs,
+            evaluation,
+            target_symbol_names=[target_symbol_name],
+        )
         return rhs
 
 
@@ -320,12 +326,14 @@ class TagSetDelayed(TagSet):
     ) -> Optional[Symbol]:
         "f_ /: lhs_ := rhs_"
 
-        tag_name = f.get_name()
-        if not tag_name:
+        target_symbol = f.get_name()
+        if not target_symbol:
             evaluation.message(self.get_name(), "sym", f, 1)
             return None
 
-        if eval_assign(self.get_name(), lhs, rhs, evaluation, tags=[tag_name]):
+        if eval_assign(
+            self.get_name(), lhs, rhs, evaluation, target_symbol_names=[target_symbol]
+        ):
             return SymbolNull
 
         return SymbolFailed
@@ -407,7 +415,7 @@ class UpSetDelayed(UpSet):
 
     def eval(
         self, lhs: BaseElement, rhs: BaseElement, evaluation: Evaluation
-    ) -> Symbol:
+    ) -> Optional[Symbol]:
         "lhs_ ^:= rhs_"
         if isinstance(lhs, Atom):
             evaluation.message(
@@ -416,7 +424,7 @@ class UpSetDelayed(UpSet):
                 1,
                 Expression(Symbol(self.get_name()), lhs, rhs),
             )
-            return
+            return None
 
         if isinstance(lhs, Atom):
             evaluation.message(

--- a/mathics/builtin/patterns/basic.py
+++ b/mathics/builtin/patterns/basic.py
@@ -44,8 +44,8 @@ class _Blank(PatternObject, ABC):
             cls._instance = super().__new__(cls, *args, **kwargs)
         return cls._instance
 
-    def determine_value_role(self, tag_symbol: Symbol) -> OptionalType[str]:
-        if self.target_head is tag_symbol:
+    def determine_value_role(self, target_symbol: Symbol) -> OptionalType[str]:
+        if self.target_head is target_symbol:
             return "downvalues"
         return None
 

--- a/mathics/builtin/patterns/composite.py
+++ b/mathics/builtin/patterns/composite.py
@@ -210,8 +210,8 @@ class HoldPattern(PatternObject):
         super().init(expr, evaluation=evaluation)
         self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
 
-    def determine_value_role(self, tag_symbol: Symbol) -> OptionalType[str]:
-        return self.pattern.determine_value_role(tag_symbol)
+    def determine_value_role(self, target_symbol: Symbol) -> OptionalType[str]:
+        return self.pattern.determine_value_role(target_symbol)
 
     def match(self, expression: Expression, pattern_context: dict):
         # for new_vars_dict, rest in self.pattern.match(
@@ -479,8 +479,8 @@ class Pattern(PatternObject):
     def __repr__(self):
         return "<Pattern: %s>" % repr(self.pattern)
 
-    def determine_value_role(self, tag_symbol: Symbol) -> OptionalType[str]:
-        return self.pattern.determine_value_role(tag_symbol)
+    def determine_value_role(self, target_symbol: Symbol) -> OptionalType[str]:
+        return self.pattern.determine_value_role(target_symbol)
 
     def get_match_count(
         self, vars_dict: OptionalType[dict] = None

--- a/mathics/builtin/patterns/restrictions.py
+++ b/mathics/builtin/patterns/restrictions.py
@@ -74,8 +74,8 @@ class Condition(InfixOperator, PatternObject):
         # else:
         self.pattern = BasePattern.create(expr.elements[0], evaluation=evaluation)
 
-    def determine_value_role(self, tag_symbol: Symbol) -> OptionalType[str]:
-        return self.pattern.determine_value_role(tag_symbol)
+    def determine_value_role(self, target_symbol: Symbol) -> OptionalType[str]:
+        return self.pattern.determine_value_role(target_symbol)
 
     def match(self, expression: Expression, pattern_context: dict):
         """Match with Condition pattern"""

--- a/mathics/core/pattern/base.py
+++ b/mathics/core/pattern/base.py
@@ -241,7 +241,7 @@ class BasePattern(ABC):
         """The sequence of elements in the expression"""
         return self.expr.get_sequence()
 
-    def determine_value_role(self, tag_symbol: Symbol) -> Optional[str]:
+    def determine_value_role(self, target_symbol: Symbol) -> Optional[str]:
         """
         Return the position relative to the Symbol `target`.
         When the position cannot be decided, returns `None`.
@@ -384,8 +384,8 @@ class AtomPattern(BasePattern):
     def __repr__(self):
         return f"<AtomPattern: {self.atom}>"
 
-    def determine_value_role(self, tag_symbol: Symbol) -> Optional[str]:
-        if tag_symbol is self.atom:
+    def determine_value_role(self, target_symbol: Symbol) -> Optional[str]:
+        if target_symbol is self.atom:
             return "ownvalues"
         return None
 
@@ -491,10 +491,10 @@ class ExpressionPattern(BasePattern):
             element for element in self.elements if element.get_head_name() == head_name
         ]
 
-    def determine_value_role(self, tag_symbol: Symbol) -> Optional[str]:
+    def determine_value_role(self, target_symbol: Symbol) -> Optional[str]:
         # Special case: Nvalues
         if self.expr.has_form(SymbolN, 2):
-            tag = self.elements[0].determine_value_role(tag_symbol)
+            tag = self.elements[0].determine_value_role(target_symbol)
             if tag in (
                 None,
                 "upvalues",
@@ -503,13 +503,13 @@ class ExpressionPattern(BasePattern):
             return "nvalues"
 
         head = self.head
-        head_pos = head.determine_value_role(tag_symbol)
+        head_pos = head.determine_value_role(target_symbol)
         if head_pos == "ownvalues":
             return "downvalues"
         if head_pos in ("downvalues", "subvalues"):
             return "subvalues"
         for element in self.elements:
-            elem_tag = element.determine_value_role(tag_symbol)
+            elem_tag = element.determine_value_role(target_symbol)
             if elem_tag in ("ownvalues", "downvalues", "subvalues"):
                 return "upvalues"
         return None

--- a/mathics/eval/assignments/assignment.py
+++ b/mathics/eval/assignments/assignment.py
@@ -83,7 +83,7 @@ def eval_assign(
     lhs: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: Optional[list] = None,
+    target_symbol_names: Optional[list[str]] = None,
     upset: bool = False,
 ) -> bool:
     """
@@ -97,7 +97,7 @@ def eval_assign(
         The RHS.
     evaluation : Evaluation
         The evaluation object.
-    tags : Optional[list], optional
+    target_symbol_names : Optional[list[str]]
         The list of symbol names for which the rule must be associated.
         The default is None.
     upset : bool, optional
@@ -120,7 +120,11 @@ def eval_assign(
     if isinstance(lhs_unwrapped, Symbol):
         if upset:
             evaluation.message(op_name, "nosym", lhs)
-        if tags and (lhs_unwrapped_name := lhs_unwrapped.get_name()) not in tags:
+        if (
+            target_symbol_names
+            and (lhs_unwrapped_name := lhs_unwrapped.get_name())
+            not in target_symbol_names
+        ):
             evaluation.message(lhs_unwrapped_name, "tagnf", lhs)
 
         try:
@@ -137,7 +141,7 @@ def eval_assign(
         assignment_func = ASSIGNMENT_FUNCTION_MAP.get(lookup_name, None)
         if assignment_func:
             return assignment_func(
-                op_name, lhs, lhs_target, rhs, evaluation, tags, upset
+                op_name, lhs, lhs_target, rhs, evaluation, target_symbol_names, upset
             )
 
         if True or lhs.has_form(SymbolCondition, 2):
@@ -152,7 +156,7 @@ def eval_assign(
             )
 
         return eval_assign_store_rules_by_tag(
-            op_name, lhs, lhs_target, rhs, evaluation, tags, upset
+            op_name, lhs, lhs_target, rhs, evaluation, target_symbol_names, upset
         )
     except AssignmentException:
         return False
@@ -164,7 +168,7 @@ def eval_assign_attributes(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list[str],
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -184,7 +188,7 @@ def eval_assign_attributes(
         the expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbol names to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -199,7 +203,7 @@ def eval_assign_attributes(
         True if the assignment was successful.
 
     """
-    # UpSet and TagSet for this symbol are handled in
+    # UpSet and Target_symbol_nameset for this symbol are handled in
     # the standard way. The same if the expression is wrapped:
     if lhs.get_head() is not lhs_unwrapped:
         return eval_assign_store_rules_by_tag(
@@ -216,7 +220,7 @@ def eval_assign_attributes(
     if not tag:
         evaluation.message(op_name, "sym", lhs.elements[0], 1)
         raise AssignmentException(lhs, rhs)
-    if tags is not None and tags != [tag]:
+    if target_symbol_names is not None and target_symbol_names != [tag]:
         evaluation.message(op_name, "tag", Symbol(name), Symbol(tag))
         raise AssignmentException(lhs, rhs)
     attributes_list = get_symbol_list(
@@ -381,7 +385,7 @@ def eval_assign_default(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list[str],
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -400,7 +404,7 @@ def eval_assign_default(
         the expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -415,7 +419,7 @@ def eval_assign_default(
         True if the assignment was successful.
 
     """
-    # UpSet and TagSet for this symbol are handled in
+    # UpSet and Target_symbol_nameset for this symbol are handled in
     # the standard way. The same if the expression is wrapped:
     if lhs.get_head() is not lhs_unwrapped:
         return eval_assign_store_rules_by_tag(
@@ -432,11 +436,11 @@ def eval_assign_default(
     lhs_unwrapped = (
         lhs_unwrapped if isinstance(lhs_unwrapped, Symbol) else lhs_unwrapped.get_head()
     )
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, op_name, lhs, lhs_unwrapped, evaluation
+    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+        target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
-    for tag in tags:
+    for tag in target_symbol_names:
         if rejected_because_protected(op_name, lhs, tag, evaluation):
             continue
         count += 1
@@ -450,7 +454,7 @@ def eval_assign_definition_values(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -467,7 +471,7 @@ def eval_assign_definition_values(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbols to be associated to the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -488,7 +492,7 @@ def eval_assign_definition_values(
         )
 
     lhs_name = lhs.get_head_name()
-    tag = find_value_role_symbol_name(lhs, tags, evaluation)
+    tag = find_value_role_symbol_name(lhs, target_symbol_names, evaluation)
     rules = rhs.get_rules_list()
     if rules is None:
         evaluation.message(op_name, "vrule", lhs, rhs)
@@ -503,7 +507,7 @@ def eval_assign_format(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -520,7 +524,7 @@ def eval_assign_format(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbols to be associated to the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -569,11 +573,11 @@ def eval_assign_format(
         if not isinstance(lhs_unwrapped, Symbol)
         else lhs_unwrapped
     )
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, op_name, lhs, lhs_unwrapped, evaluation
+    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+        target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
-    for tag in tags:
+    for tag in target_symbol_names:
         if rejected_because_protected(op_name, lhs, tag, evaluation):
             continue
         count += 1
@@ -642,7 +646,7 @@ def eval_assign_list(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -661,7 +665,7 @@ def eval_assign_list(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         The list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -694,7 +698,7 @@ def eval_assign_makeboxes(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -713,7 +717,7 @@ def eval_assign_makeboxes(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -735,15 +739,17 @@ def eval_assign_makeboxes(
     # Check second argument
 
     makeboxes_rule = RewriteRule(lhs, rhs, evaluation=evaluation)
-    tags = [] if tags is None else tags
+    target_symbol_names = [] if target_symbol_names is None else target_symbol_names
     if upset:
-        tags = tags + [target.get_symbol_definition_name()]
+        target_symbol_names = target_symbol_names + [
+            target.get_symbol_definition_name()
+        ]
     else:
-        if not tags:
-            tags = ["System`MakeBoxes"]
+        if not target_symbol_names:
+            target_symbol_names = ["System`MakeBoxes"]
 
     definitions = evaluation.definitions
-    for tag in tags:
+    for tag in target_symbol_names:
         if is_protected(tag, definitions):
             evaluation.message(op_name, "wrsym", Symbol(tag))
             return False
@@ -845,7 +851,7 @@ def eval_assign_messagename(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -862,7 +868,7 @@ def eval_assign_messagename(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         The list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -890,11 +896,11 @@ def eval_assign_messagename(
         evaluation.message_args("MessageName", len(lhs.elements), 2)
         raise AssignmentException(lhs, None)
     lhs_unwrapped = lhs.elements[0]
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, op_name, lhs, lhs_unwrapped, evaluation
+    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+        target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
-    for tag in tags:
+    for tag in target_symbol_names:
         # Messages can be assigned even if the symbol is protected...
         # if rejected_because_protected(op_name, lhs, tag, evaluation):
         #    continue
@@ -922,7 +928,7 @@ def eval_assign_options(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -938,7 +944,7 @@ def eval_assign_options(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         The list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -967,7 +973,7 @@ def eval_assign_options(
     if not tag:
         evaluation.message(lhs_name, "sym", lhs_elements[0], 1)
         raise AssignmentException(lhs, rhs)
-    if tags is not None and tags != [tag]:
+    if target_symbol_names is not None and target_symbol_names != [tag]:
         evaluation.message(lhs_name, "tag", Symbol(lhs_name), Symbol(tag))
         raise AssignmentException(lhs, rhs)
     if is_protected(tag, evaluation.definitions):
@@ -987,7 +993,7 @@ def eval_assign_numericq(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -1006,7 +1012,7 @@ def eval_assign_numericq(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -1052,7 +1058,7 @@ def eval_assign_n(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: list,
+    target_symbol_names: list[str],
     upset: bool,
 ) -> bool:
     """
@@ -1070,7 +1076,7 @@ def eval_assign_n(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         the list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -1103,12 +1109,12 @@ def eval_assign_n(
 
     lhs_unwrapped = unwrap_expression(lhs.elements[0])
 
-    tags = process_tags_and_upset_dont_allow_custom(
-        tags, upset, op_name, lhs, lhs_unwrapped, evaluation
+    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+        target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     count = 0
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
-    for tag in tags:
+    for tag in target_symbol_names:
         if rejected_because_protected(op_name, lhs, tag, evaluation):
             continue
         count += 1
@@ -1122,7 +1128,7 @@ def eval_assign_part(
     lhs_unwrapped: BaseElement,
     rhs: BaseElement,
     evaluation: Evaluation,
-    tags: Optional[list],
+    target_symbol_names: Optional[list[str]],
     upset: bool,
 ):
     """
@@ -1141,7 +1147,7 @@ def eval_assign_part(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         The list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -1250,11 +1256,17 @@ def eval_assign_recursion_limit(
 
 
 def eval_assign_store_rules_by_tag(
-    op_name: str, lhs, lhs_unwrapped, rhs, evaluation, tags, upset=False
+    op_name: str,
+    lhs,
+    lhs_unwrapped,
+    rhs,
+    evaluation: Evaluation,
+    target_symbol_names: list[str],
+    upset=False,
 ) -> bool:
     """
     This is the default assignment. Stores a rule of the form lhs->rhs
-    as a value associated with each symbol listed in tags.
+    as a value associated with each symbol listed in target_symbol_names.
     For special cases, such as conditions or patterns in the lhs,
     lhs and rhs are rewritten in a normal form, where
     conditions are associated to the lhs.
@@ -1272,7 +1284,7 @@ def eval_assign_store_rules_by_tag(
         The expression representing the replacement.
     evaluation : Evaluation
         DESCRIPTION.
-    tags : list
+    target_symbol_names : list[str]
         The list of symbols to be associated with the rule.
     upset : bool
         `True` if the rule is an Up value.
@@ -1288,8 +1300,8 @@ def eval_assign_store_rules_by_tag(
 
     """
     defs = evaluation.definitions
-    tags, lhs_unwrapped = process_tags_and_upset_allow_custom(
-        tags, upset, op_name, lhs, rhs, evaluation
+    target_symbol_names, lhs_unwrapped = process_tags_and_upset_allow_custom(
+        target_symbol_names, upset, op_name, lhs, rhs, evaluation
     )
     # In WMA, this does not happen. However, if we remove this,
     # some combinatorica tests fail.
@@ -1297,7 +1309,7 @@ def eval_assign_store_rules_by_tag(
     count = 0
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
     position = "upvalues" if upset else None
-    for tag in tags:
+    for tag in target_symbol_names:
         if rejected_because_protected(op_name, lhs, tag, evaluation, False):
             continue
         count += 1
@@ -1544,7 +1556,7 @@ def unwrap_expression(lhs: BaseElement) -> BaseElement:
 
 
 def process_tags_and_upset_allow_custom(
-    tags: Optional[list],
+    target_symbol_names: Optional[list[str]],
     upset: bool,
     op_name: str,
     lhs: BaseElement,
@@ -1554,13 +1566,13 @@ def process_tags_and_upset_allow_custom(
     """
     If `upset` is `True`,  collect a list of tag candidates from the elements of
     the lhs.
-    If `upset` is `False`, and `tags` is given, check if the elements
-    in `tags` are all names of symbols in the `lhs` elements. If `tags` is
-    `None`, the list of tags contains just the `lookup_name` of the LHS.
+    If `upset` is `False`, and `target_symbol_names` is given, check if the elements
+    in `target_symbol_names` are all names of symbols in the `lhs` elements. If `target_symbol_names` is
+    `None`, the list of target_symbol_names contains just the `lookup_name` of the LHS.
 
     Parameters
     ----------
-    tags : Optional[list]
+    target_symbol_names : Optional[list[str]]
         The list of symbols to which the rule must be associated.
     upset : bool
         If `True`, assign as an UpValue.
@@ -1579,7 +1591,7 @@ def process_tags_and_upset_allow_custom(
 
     Returns
     -------
-    (tags, lhs_unwrapped,): tuple[list, BaseElement]
+    (target_symbol_names, lhs_unwrapped,): tuple[list, BaseElement]
         tags: the list of symbols to which the rule must be associated.
         lhs_unwrapped: the lhs
 
@@ -1610,28 +1622,28 @@ def process_tags_and_upset_allow_custom(
                 tags_set.add(element_name)
         return list(tags_set), lhs_unwrapped
 
-    if tags is None:
+    if target_symbol_names is None:
         lhs_name = get_unwrapped_name(lhs_unwrapped)
-        if not lhs_name:
+        if lhs_name is None:
             evaluation.message(op_name, "setraw", lhs_unwrapped)
             raise AssignmentException(lhs, None)
-        tags = [lhs_name]
+        target_symbol_names = [lhs_name]
     else:
         allowed_names = set()
         lhs_name = get_unwrapped_name(lhs_unwrapped)
-        if lhs_name:
+        if lhs_name is not None:
             allowed_names.add(lhs_name)
 
         for element in lhs_unwrapped.get_elements():
             element_name = get_unwrapped_name(element)
             if element_name:
                 allowed_names.add(element_name)
-        for lhs_name in tags:
+        for lhs_name in target_symbol_names:
             if lhs_name not in allowed_names:
                 evaluation.message(op_name, "tagnfd", Symbol(lhs_name))
                 raise AssignmentException(lhs, None)
 
-    return tags, lhs_unwrapped
+    return target_symbol_names, lhs_unwrapped
 
 
 def process_tags_and_upset_dont_allow_custom(

--- a/mathics/eval/assignments/assignment.py
+++ b/mathics/eval/assignments/assignment.py
@@ -42,9 +42,6 @@ from mathics.core.symbols import (
 )
 from mathics.core.systemsymbols import (
     BLANK_PATTERN_HEADS,
-    SymbolBlank,
-    SymbolBlankNullSequence,
-    SymbolBlankSequence,
     SymbolCondition,
     SymbolDefault,
     SymbolDirectedInfinity,
@@ -436,7 +433,7 @@ def eval_assign_default(
     lhs_unwrapped = (
         lhs_unwrapped if isinstance(lhs_unwrapped, Symbol) else lhs_unwrapped.get_head()
     )
-    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+    target_symbol_names = collect_lhs_names_and_upset_dont_allow_custom(
         target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
@@ -573,7 +570,7 @@ def eval_assign_format(
         if not isinstance(lhs_unwrapped, Symbol)
         else lhs_unwrapped
     )
-    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+    target_symbol_names = collect_lhs_names_and_upset_dont_allow_custom(
         target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
@@ -832,7 +829,7 @@ def eval_assign_maxprecision(
 
     """
     lhs_name = lhs.get_name()
-    if rhs.has_form(SymbolDirectedInfinity, 1) and rhs.elements[0].int_value == 1:
+    if rhs.has_form(SymbolDirectedInfinity, 1) and get_int_value(rhs.elements[0]) == 1:
         return False
     if (rhs_int_value := get_int_value(rhs)) is not None and rhs_int_value > 0:
         min_prec = evaluation.definitions.get_config_value("$MinPrecision")
@@ -896,7 +893,7 @@ def eval_assign_messagename(
         evaluation.message_args("MessageName", len(lhs.elements), 2)
         raise AssignmentException(lhs, None)
     lhs_unwrapped = lhs.elements[0]
-    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+    target_symbol_names = collect_lhs_names_and_upset_dont_allow_custom(
         target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     rule = RewriteRule(lhs, rhs, evaluation=evaluation)
@@ -915,8 +912,8 @@ def eval_assign_module_number(
     """
     Set ownvalue for the $ModuleNumber symbol.
     """
-    rhs_int_value = rhs.int_value
-    if not rhs_int_value or rhs_int_value <= 0:
+    rhs_int_value = get_int_value(rhs)
+    if rhs_int_value is None or rhs_int_value <= 0:
         evaluation.message("$ModuleNumber", "set", rhs)
         raise AssignmentException(lhs, None)
     return False
@@ -1109,7 +1106,7 @@ def eval_assign_n(
 
     lhs_unwrapped = unwrap_expression(lhs.elements[0])
 
-    target_symbol_names = process_tags_and_upset_dont_allow_custom(
+    target_symbol_names = collect_lhs_names_and_upset_dont_allow_custom(
         target_symbol_names, upset, op_name, lhs, lhs_unwrapped, evaluation
     )
     count = 0
@@ -1239,12 +1236,8 @@ def eval_assign_recursion_limit(
     """
     Set ownvalue for the $RecursionLimit symbol.
     """
-    rhs_int_value = rhs.int_value
-    # if (not rhs_int_value or rhs_int_value < 20) and not
-    # rhs.get_name() == 'System`Infinity':
-    if (
-        not rhs_int_value or rhs_int_value < 20 or rhs_int_value > MAX_RECURSION_DEPTH
-    ):  # nopep8
+    rhs_int_value = get_int_value(rhs)
+    if rhs_int_value is None or not (20 <= rhs_int_value <= MAX_RECURSION_DEPTH):
         evaluation.message("$RecursionLimit", "limset", rhs)
         raise AssignmentException(lhs, None)
     try:
@@ -1300,7 +1293,7 @@ def eval_assign_store_rules_by_tag(
 
     """
     defs = evaluation.definitions
-    target_symbol_names, lhs_unwrapped = process_tags_and_upset_allow_custom(
+    target_symbol_names, lhs_unwrapped = collect_lhs_names_and_update_allow_custom(
         target_symbol_names, upset, op_name, lhs, rhs, evaluation
     )
     # In WMA, this does not happen. However, if we remove this,
@@ -1555,7 +1548,7 @@ def unwrap_expression(lhs: BaseElement) -> BaseElement:
     return lhs
 
 
-def process_tags_and_upset_allow_custom(
+def collect_lhs_names_and_update_allow_custom(
     target_symbol_names: Optional[list[str]],
     upset: bool,
     op_name: str,
@@ -1646,25 +1639,25 @@ def process_tags_and_upset_allow_custom(
     return target_symbol_names, lhs_unwrapped
 
 
-def process_tags_and_upset_dont_allow_custom(
-    tags: Optional[list],
+def collect_lhs_names_and_upset_dont_allow_custom(
+    lhs_symbol_names: list[str],
     upset: bool,
     op_name: str,
     lhs: BaseElement,
     lhs_unwrapped: BaseElement,
     evaluation: Evaluation,
-) -> list:
+) -> Optional[list[str]]:
     """
     If `upset` is `True`,  collect a list of tag candidates from the elements of
     the lhs.
-    If `upset` is `False`, and `tags` is given, check if the elements
-    in `tags` are all names of symbols in the `lhs` elements. If `tags` is
-    `None`, the list of tags contains just the `lookup_name` of the LHS.
+    If `upset` is `False`, and `lhs_symbol_names` is given, check if the elements
+    in `lhs_symbol_names` are all names of symbols in the `lhs` elements. If `lhs_symbol_names` is
+    `None`, the list of lhs_symbol_names contains just the `lookup_name` of the LHS.
 
     Parameters
     ----------
-    tags : Optional[list]
-        The list of symbols that the rule must be associated with.
+    lhs_symbol_names : list[str]
+        The list of symbols that the rule must associate with.
     upset : bool
         If `True`, assign as an UpValue.
     op_name : str
@@ -1682,12 +1675,12 @@ def process_tags_and_upset_dont_allow_custom(
 
     Returns
     -------
-    tags: list
-        the list of allowed tags.
+    lhs_symbol_names: Optional[list[str]]
+        the list of allowed lhs_symbol_names.
 
     """
 
-    def get_symbol_definition_name(expr):
+    def get_symbol_definition_name(expr) -> Optional[str]:
         """Return the string symbol name that is to be used in
         determining which definition key of a definitions object to
         use in symbol-table operations.
@@ -1697,35 +1690,35 @@ def process_tags_and_upset_dont_allow_custom(
         expression is pattern-matched.
         """
         expr = unwrap_expression(expr)
-        if expr.has_form(SymbolPattern, 2):
-            return get_symbol_definition_name(expr.elements[1])
-        if expr.has_form(
-            (SymbolBlank, SymbolBlankSequence, SymbolBlankNullSequence), None
-        ):
-            if len(expr.elements) == 1:
-                return get_symbol_definition_name(expr.elements[0])
-            return None
+        if isinstance(expr, Expression):
+            if expr.has_form(SymbolPattern, 2):
+                return get_symbol_definition_name(expr.elements[1])
+            if expr.head in BLANK_PATTERN_HEADS:
+                if len(expr.elements) == 1:
+                    return get_symbol_definition_name(expr.elements[0])
+                return None
         return expr.get_symbol_definition_name()
 
     if isinstance(lhs_unwrapped, Expression):
         lhs_unwrapped = lhs_unwrapped.evaluate_elements(evaluation)
     if upset:
         lhs_name = get_symbol_definition_name(lhs_unwrapped)
-        tags = [lhs_name] if lhs_name is not None else None
-    elif tags is None:
+        returned_lhs_symbol_names = [lhs_name] if lhs_name is not None else None
+    elif lhs_symbol_names is None:
         lhs_name = get_symbol_definition_name(lhs_unwrapped)
         if not lhs_name:
             evaluation.message(op_name, "setraw", lhs_unwrapped)
             raise AssignmentException(lhs, None)
-        tags = [lhs_name]
+        returned_lhs_symbol_names = [lhs_name]
     else:
         lhs_name = get_symbol_definition_name(lhs_unwrapped)
         allowed_names = [lhs_name] if lhs_name else []
-        for lhs_name in tags:
+        for lhs_name in lhs_symbol_names:
             if lhs_name not in allowed_names:
                 evaluation.message(op_name, "tagnfd", Symbol(lhs_name))
                 raise AssignmentException(lhs, None)
-    return tags
+        returned_lhs_symbol_names = lhs_symbol_names
+    return returned_lhs_symbol_names
 
 
 # Below is a mapping from Symbol name (as a string) into an assignment eval function.

--- a/mathics/eval/assignments/assignment.py
+++ b/mathics/eval/assignments/assignment.py
@@ -110,10 +110,10 @@ def eval_assign(
 
     """
     # An expression can be wrapped inside structures like `Condition[...]`
-    # or HoldPattern[...]. The `lhs_reference` is the head of the expression once
+    # or HoldPattern[...]. The `lhs_target` is the head of the expression once
     # we strip out all these wrappings.
     lhs_unwrapped = unwrap_expression(lhs)
-    lhs_reference = (
+    lhs_target = (
         lhs_unwrapped if isinstance(lhs_unwrapped, Symbol) else lhs_unwrapped.get_head()
     )
 
@@ -129,7 +129,7 @@ def eval_assign(
             return False
 
     try:
-        # Handle special cases using the lookup name associated to the lhs_reference
+        # Handle special cases using the lookup name associated to the lhs_target
         if lhs_unwrapped.has_form(SymbolVerbatim, 1):
             lookup_name = lhs_unwrapped.elements[0].get_symbol_definition_name()
         else:
@@ -137,24 +137,22 @@ def eval_assign(
         assignment_func = ASSIGNMENT_FUNCTION_MAP.get(lookup_name, None)
         if assignment_func:
             return assignment_func(
-                op_name, lhs, lhs_reference, rhs, evaluation, tags, upset
+                op_name, lhs, lhs_target, rhs, evaluation, tags, upset
             )
 
         if True or lhs.has_form(SymbolCondition, 2):
-            lhs, lhs_reference = process_condition_lhs(lhs, evaluation)
+            lhs, lhs_target = process_condition_lhs(lhs, evaluation)
         elif isinstance(lhs, Expression) and not lhs.has_form(
             (SymbolVerbatim, SymbolHoldPattern), 1
         ):
             lhs = lhs.evaluate_elements(evaluation)
-            lhs_reference = unwrap_expression(lhs)
-            lhs_reference = (
-                lhs_reference
-                if isinstance(lhs_reference, Symbol)
-                else lhs_reference.get_head()
+            lhs_target = unwrap_expression(lhs)
+            lhs_target = (
+                lhs_target if isinstance(lhs_target, Symbol) else lhs_target.get_head()
             )
 
         return eval_assign_store_rules_by_tag(
-            op_name, lhs, lhs_reference, rhs, evaluation, tags, upset
+            op_name, lhs, lhs_target, rhs, evaluation, tags, upset
         )
     except AssignmentException:
         return False


### PR DESCRIPTION
*  `tags` -> `target_symbol_names`
* `tag_name` -> `target_symbol_name`
* `lhs_reference` -> `lhs_target`
* `tag_symbol` -> `target_symbol`
* `process_tags_and...` -> `collect_lhs_names_and..`
* revise `eval_assign_recursion_limit()`

See also #1943. 

In WMA, the use of " tag " in `TagSet` is intended as an adjective for Symbol, synonymous with "targeted" (as in targeted Symbol) in an assignment function. In an error message, the parameter with the tag "tagfn" is a Symbol, though. 

In our code, "tag" is used inconsistently to refer to this tagged or targeted symbol. In every other place in the code, "tag" refers to a label, like the tag on an error message (but not the error message symbol being referred to), or the tag of a Box (not the boxing symbol). 

Avoid this confusing use.